### PR TITLE
Add short and long literals & fix bugs

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -137,6 +137,7 @@ archives:
       - LICENSE
       - src: bin/spicec-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}/**
         dst: ./
+        strip_parent: true
     format_overrides:
       - goos: windows
         format: zip

--- a/compiler/src/analyzer/AnalyzerVisitor.cpp
+++ b/compiler/src/analyzer/AnalyzerVisitor.cpp
@@ -14,8 +14,8 @@ antlrcpp::Any AnalyzerVisitor::visitEntry(SpiceParser::EntryContext* ctx) {
     if (requiresMainFunction && !hasMainFunction)
         throw SemanticError(*ctx->start, MISSING_MAIN_FUNCTION, "No main function found");
 
-    // Print compiler warnings
-    if (!stdFile) { // Do not print compiler warnings for std files
+    // Print compiler warnings once the whole ast is present, but not for std files
+    if (requiresMainFunction && !stdFile) {
         SymbolTable* rootScope = currentScope;
         while (rootScope->getParent()) rootScope = rootScope->getParent();
         rootScope->printCompilerWarnings();
@@ -1287,6 +1287,8 @@ antlrcpp::Any AnalyzerVisitor::visitValue(SpiceParser::ValueContext* ctx) {
 antlrcpp::Any AnalyzerVisitor::visitPrimitiveValue(SpiceParser::PrimitiveValueContext* ctx) {
     if (ctx->DOUBLE()) return SymbolType(TY_DOUBLE);
     if (ctx->INTEGER()) return SymbolType(TY_INT);
+    if (ctx->SHORT()) return SymbolType(TY_SHORT);
+    if (ctx->LONG()) return SymbolType(TY_LONG);
     if (ctx->CHAR_LITERAL()) return SymbolType(TY_CHAR);
     if (ctx->STRING_LITERAL()) return SymbolType(TY_STRING);
     return SymbolType(TY_BOOL);

--- a/compiler/src/analyzer/AnalyzerVisitor.cpp
+++ b/compiler/src/analyzer/AnalyzerVisitor.cpp
@@ -286,7 +286,7 @@ antlrcpp::Any AnalyzerVisitor::visitGlobalVarDef(SpiceParser::GlobalVarDefContex
     // Check if symbol already exists in the symbol table
     if (currentScope->lookup(variableName))
         throw SemanticError(*ctx->start, VARIABLE_DECLARED_TWICE,
-                            "The variable '" + variableName + "' was declared more than once");
+                            "The global variable '" + variableName + "' was declared more than once");
 
     // Insert variable name to symbol table
     SymbolType symbolType = visit(ctx->dataType()).as<SymbolType>();

--- a/compiler/src/analyzer/OpRuleManager.h
+++ b/compiler/src/analyzer/OpRuleManager.h
@@ -508,6 +508,7 @@ const std::vector<UnaryOpRule> PREFIX_PLUS_OP_RULES = {
 // Prefix Minus op rules
 const std::vector<UnaryOpRule> PREFIX_MINUS_OP_RULES = {
         UnaryOpRule(TY_INT, TY_INT),                      // -int = int
+        UnaryOpRule(TY_DOUBLE, TY_DOUBLE),                // -double = double
         UnaryOpRule(TY_SHORT, TY_SHORT),                  // -short = short
         UnaryOpRule(TY_LONG, TY_LONG),                    // -long = long
 };

--- a/compiler/src/generator/GeneratorVisitor.cpp
+++ b/compiler/src/generator/GeneratorVisitor.cpp
@@ -1738,7 +1738,7 @@ antlrcpp::Any GeneratorVisitor::visitPrimitiveValue(SpiceParser::PrimitiveValueC
     if (ctx->DOUBLE()) {
         currentSymbolType = SymbolType(TY_DOUBLE);
         double value = std::stod(ctx->DOUBLE()->toString());
-        if (constNegate) value = -value;
+        if (constNegate) value *= -1;
         return (llvm::Constant*) llvm::ConstantFP::get(*context, llvm::APFloat(value));
     }
 
@@ -1746,11 +1746,35 @@ antlrcpp::Any GeneratorVisitor::visitPrimitiveValue(SpiceParser::PrimitiveValueC
     if (ctx->INTEGER()) {
         currentSymbolType = SymbolType(TY_INT);
         int value = std::stoi(ctx->INTEGER()->toString());
-        if (constNegate) value = -value;
+        if (constNegate) value *= -1;
         if (currentVarSigned) {
             return (llvm::Constant*) llvm::ConstantInt::getSigned(llvm::Type::getInt32Ty(*context), value);
         } else {
             return (llvm::Constant*) llvm::ConstantInt::get(llvm::Type::getInt32Ty(*context), value);
+        }
+    }
+
+    // Value is a short constant
+    if (ctx->SHORT()) {
+        currentSymbolType = SymbolType(TY_SHORT);
+        int value = std::stoi(ctx->SHORT()->toString());
+        if (constNegate) value *= -1;
+        if (currentVarSigned) {
+            return (llvm::Constant*) llvm::ConstantInt::getSigned(llvm::Type::getInt16Ty(*context), value);
+        } else {
+            return (llvm::Constant*) llvm::ConstantInt::get(llvm::Type::getInt16Ty(*context), value);
+        }
+    }
+
+    // Value is a long constant
+    if (ctx->LONG()) {
+        currentSymbolType = SymbolType(TY_LONG);
+        long long value = std::stoll(ctx->LONG()->toString());
+        if (constNegate) value = -value;
+        if (currentVarSigned) {
+            return (llvm::Constant*) llvm::ConstantInt::getSigned(llvm::Type::getInt64Ty(*context), value);
+        } else {
+            return (llvm::Constant*) llvm::ConstantInt::get(llvm::Type::getInt64Ty(*context), value);
         }
     }
 

--- a/compiler/src/generator/OpRuleConversionsManager.cpp
+++ b/compiler/src/generator/OpRuleConversionsManager.cpp
@@ -1227,7 +1227,7 @@ llvm::Value* OpRuleConversionsManager::getPrefixMinusInst(llvm::Value* lhs) {
     PrimitiveType lhsPTy = getPrimitiveTypeFromLLVMType(lhsTy);
     switch(lhsPTy) {
         case P_TY_DOUBLE:
-            return builder->CreateFMul(lhs, builder->getInt32(-1));
+            return builder->CreateFMul(lhs, llvm::ConstantFP::get(builder->getContext(), llvm::APFloat(double(-1))));
         case P_TY_INT:
             return builder->CreateAdd(lhs, builder->getInt32(-1));
         case P_TY_SHORT:

--- a/compiler/src/grammar/Spice.g4
+++ b/compiler/src/grammar/Spice.g4
@@ -57,7 +57,7 @@ atomicExpr: value | IDENTIFIER | builtinCall | LPAREN assignExpr RPAREN;
 
 // Values and types
 value: primitiveValue | LBRACE paramLst? RBRACE | IDENTIFIER (DOT IDENTIFIER)* LBRACE paramLst? RBRACE | NIL LESS dataType GREATER;
-primitiveValue: DOUBLE | INTEGER | CHAR_LITERAL | STRING_LITERAL | TRUE | FALSE;
+primitiveValue: DOUBLE | INTEGER | SHORT | LONG | CHAR_LITERAL | STRING_LITERAL | TRUE | FALSE;
 dataType: baseDataType (MUL | LBRACKET INTEGER? RBRACKET)*;
 baseDataType: TYPE_DOUBLE | TYPE_INT | TYPE_SHORT | TYPE_LONG | TYPE_BYTE | TYPE_CHAR | TYPE_STRING | TYPE_BOOL | TYPE_DYN | IDENTIFIER (DOT IDENTIFIER)*;
 
@@ -154,6 +154,8 @@ CHAR_LITERAL: '\'' (~['\\\r\n] | '\\' (. | EOF)) '\'';
 STRING_LITERAL: '"' (~["\\\r\n] | '\\' (. | EOF))* '"';
 INTEGER: NONZERO_DIGIT DIGIT* | ZERO;
 DOUBLE: DIGIT+ DOT DIGIT+;
+SHORT: INTEGER 's';
+LONG: INTEGER 'l';
 IDENTIFIER: NONDIGIT (NONDIGIT | DIGIT)*;
 
 fragment ZERO: [0];

--- a/compiler/test/test-files/analyzer/variables/error-global-variable-declared-twice/exception.out
+++ b/compiler/test/test-files/analyzer/variables/error-global-variable-declared-twice/exception.out
@@ -1,0 +1,1 @@
+Semantic error at 3:2: Multiple declarations of the same variable: The global variable 'GLOBAL_VAR' was declared more than once

--- a/compiler/test/test-files/analyzer/variables/error-global-variable-declared-twice/source.spice
+++ b/compiler/test/test-files/analyzer/variables/error-global-variable-declared-twice/source.spice
@@ -1,0 +1,9 @@
+ const unsigned int GLOBAL_INT = 12;
+ string GLOBAL_VAR = "Test";
+ double GLOBAL_VAR = 4.567;
+
+ f<int> main() {
+    printf("Global int: %d\n", GLOBAL_INT);
+    printf("Global string: %s\n", GLOBAL_VAR);
+    printf("Global double: %f\n", GLOBAL_VAR);
+ }

--- a/compiler/test/test-files/generator/builtins/success-sizeof/cout.out
+++ b/compiler/test/test-files/generator/builtins/success-sizeof/cout.out
@@ -1,5 +1,7 @@
+Size of double: 64
 Size of int: 32
 Size of short: 16
+Size of long: 64
 Size of byte: 8
 Size of char: 8
 Size of string: 0

--- a/compiler/test/test-files/generator/builtins/success-sizeof/ir-code-O2.ll
+++ b/compiler/test/test-files/generator/builtins/success-sizeof/ir-code-O2.ll
@@ -1,26 +1,30 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
 
-@0 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1
-@1 = private unnamed_addr constant [19 x i8] c"Size of short: %d\0A\00", align 1
-@2 = private unnamed_addr constant [18 x i8] c"Size of byte: %d\0A\00", align 1
-@3 = private unnamed_addr constant [18 x i8] c"Size of char: %d\0A\00", align 1
-@4 = private unnamed_addr constant [20 x i8] c"Size of string: %d\0A\00", align 1
-@5 = private unnamed_addr constant [13 x i8] c"Hello Spice!\00", align 1
-@6 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
+@0 = private unnamed_addr constant [20 x i8] c"Size of double: %d\0A\00", align 1
+@1 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1
+@2 = private unnamed_addr constant [19 x i8] c"Size of short: %d\0A\00", align 1
+@3 = private unnamed_addr constant [18 x i8] c"Size of long: %d\0A\00", align 1
+@4 = private unnamed_addr constant [18 x i8] c"Size of byte: %d\0A\00", align 1
+@5 = private unnamed_addr constant [18 x i8] c"Size of char: %d\0A\00", align 1
+@6 = private unnamed_addr constant [20 x i8] c"Size of string: %d\0A\00", align 1
+@7 = private unnamed_addr constant [13 x i8] c"Hello Spice!\00", align 1
+@8 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
 @intArray = dso_local constant [7 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7]
-@7 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
+@9 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
 
 declare i32 @printf(i8*, ...)
 
 define i32 @main() {
 entry:
-  %0 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([17 x i8], [17 x i8]* @0, i64 0, i64 0), i32 32)
-  %1 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @1, i64 0, i64 0), i32 16)
-  %2 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @2, i64 0, i64 0), i32 8)
-  %3 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @3, i64 0, i64 0), i32 8)
-  %4 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @4, i64 0, i64 0), i32 0)
-  %5 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @6, i64 0, i64 0), i32 1)
-  %6 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @7, i64 0, i64 0), i32 7)
+  %0 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @0, i64 0, i64 0), i32 64)
+  %1 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([17 x i8], [17 x i8]* @1, i64 0, i64 0), i32 32)
+  %2 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @2, i64 0, i64 0), i32 16)
+  %3 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @3, i64 0, i64 0), i32 64)
+  %4 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @4, i64 0, i64 0), i32 8)
+  %5 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @5, i64 0, i64 0), i32 8)
+  %6 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @6, i64 0, i64 0), i32 0)
+  %7 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @8, i64 0, i64 0), i32 1)
+  %8 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @9, i64 0, i64 0), i32 7)
   ret i32 0
 }

--- a/compiler/test/test-files/generator/builtins/success-sizeof/ir-code.ll
+++ b/compiler/test/test-files/generator/builtins/success-sizeof/ir-code.ll
@@ -1,99 +1,114 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
 
-@0 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1
-@1 = private unnamed_addr constant [19 x i8] c"Size of short: %d\0A\00", align 1
-@2 = private unnamed_addr constant [18 x i8] c"Size of byte: %d\0A\00", align 1
-@3 = private unnamed_addr constant [18 x i8] c"Size of char: %d\0A\00", align 1
-@4 = private unnamed_addr constant [20 x i8] c"Size of string: %d\0A\00", align 1
-@5 = private unnamed_addr constant [13 x i8] c"Hello Spice!\00", align 1
-@6 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
+@0 = private unnamed_addr constant [20 x i8] c"Size of double: %d\0A\00", align 1
+@1 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1
+@2 = private unnamed_addr constant [19 x i8] c"Size of short: %d\0A\00", align 1
+@3 = private unnamed_addr constant [18 x i8] c"Size of long: %d\0A\00", align 1
+@4 = private unnamed_addr constant [18 x i8] c"Size of byte: %d\0A\00", align 1
+@5 = private unnamed_addr constant [18 x i8] c"Size of char: %d\0A\00", align 1
+@6 = private unnamed_addr constant [20 x i8] c"Size of string: %d\0A\00", align 1
+@7 = private unnamed_addr constant [13 x i8] c"Hello Spice!\00", align 1
+@8 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
 @intArray = dso_local constant [7 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7]
-@7 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
+@9 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
 
 declare i32 @printf(i8*, ...)
 
 define i32 @main() {
 entry:
   %result = alloca i32, align 4
-  %0 = alloca i32, align 4
+  %0 = alloca double, align 8
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
-  %3 = alloca i16, align 2
-  %4 = alloca i32, align 4
+  %3 = alloca i32, align 4
+  %4 = alloca i16, align 2
   %5 = alloca i32, align 4
-  %6 = alloca i8, align 1
+  %6 = alloca i64, align 8
   %7 = alloca i32, align 4
   %8 = alloca i32, align 4
   %9 = alloca i8, align 1
   %10 = alloca i32, align 4
-  %11 = alloca i8*, align 8
-  %12 = alloca i32, align 4
-  %13 = alloca i1, align 1
-  %14 = alloca i32, align 4
-  %intArray = alloca [7 x i32], align 4
-  %15 = alloca [7 x i32], align 4
-  %16 = alloca i32, align 4
+  %11 = alloca i32, align 4
+  %12 = alloca i8, align 1
+  %13 = alloca i32, align 4
+  %14 = alloca i8*, align 8
+  %15 = alloca i32, align 4
+  %16 = alloca i1, align 1
   %17 = alloca i32, align 4
-  %18 = alloca i32, align 4
+  %intArray = alloca [7 x i32], align 4
+  %18 = alloca [7 x i32], align 4
   %19 = alloca i32, align 4
   %20 = alloca i32, align 4
   %21 = alloca i32, align 4
   %22 = alloca i32, align 4
   %23 = alloca i32, align 4
+  %24 = alloca i32, align 4
+  %25 = alloca i32, align 4
+  %26 = alloca i32, align 4
   store i32 0, i32* %result, align 4
-  store i32 353, i32* %0, align 4
-  %24 = load i32, i32* %0, align 4
-  store i32 32, i32* %1, align 4
-  %25 = load i32, i32* %1, align 4
-  %26 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @0, i32 0, i32 0), i32 %25)
-  store i32 35, i32* %2, align 4
-  %27 = load i32, i32* %2, align 4
-  %28 = trunc i32 %27 to i16
-  store i16 %28, i16* %3, align 2
-  %29 = load i16, i16* %3, align 2
-  store i32 16, i32* %4, align 4
-  %30 = load i32, i32* %4, align 4
-  %31 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([19 x i8], [19 x i8]* @1, i32 0, i32 0), i32 %30)
-  store i32 13, i32* %5, align 4
-  %32 = load i32, i32* %5, align 4
-  %33 = trunc i32 %32 to i8
-  store i8 %33, i8* %6, align 1
-  %34 = load i8, i8* %6, align 1
-  store i32 8, i32* %7, align 4
-  %35 = load i32, i32* %7, align 4
-  %36 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @2, i32 0, i32 0), i32 %35)
-  store i32 65, i32* %8, align 4
-  %37 = load i32, i32* %8, align 4
-  %38 = trunc i32 %37 to i8
-  store i8 %38, i8* %9, align 1
-  %39 = load i8, i8* %9, align 1
+  store double 0x40335992641B328B, double* %0, align 8
+  %27 = load double, double* %0, align 8
+  %28 = fmul double %27, -1.000000e+00
+  store double %28, double* %0, align 8
+  %29 = load double, double* %0, align 8
+  store i32 64, i32* %1, align 4
+  %30 = load i32, i32* %1, align 4
+  %31 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @0, i32 0, i32 0), i32 %30)
+  store i32 353, i32* %2, align 4
+  %32 = load i32, i32* %2, align 4
+  store i32 32, i32* %3, align 4
+  %33 = load i32, i32* %3, align 4
+  %34 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([17 x i8], [17 x i8]* @1, i32 0, i32 0), i32 %33)
+  store i16 35, i16* %4, align 2
+  %35 = load i16, i16* %4, align 2
+  store i32 16, i32* %5, align 4
+  %36 = load i32, i32* %5, align 4
+  %37 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([19 x i8], [19 x i8]* @2, i32 0, i32 0), i32 %36)
+  store i64 9223372036854775807, i64* %6, align 4
+  %38 = load i64, i64* %6, align 4
+  store i32 64, i32* %7, align 4
+  %39 = load i32, i32* %7, align 4
+  %40 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @3, i32 0, i32 0), i32 %39)
+  store i32 13, i32* %8, align 4
+  %41 = load i32, i32* %8, align 4
+  %42 = trunc i32 %41 to i8
+  store i8 %42, i8* %9, align 1
+  %43 = load i8, i8* %9, align 1
   store i32 8, i32* %10, align 4
-  %40 = load i32, i32* %10, align 4
-  %41 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @3, i32 0, i32 0), i32 %40)
-  store i8* getelementptr inbounds ([13 x i8], [13 x i8]* @5, i32 0, i32 0), i8** %11, align 8
-  %42 = load i8*, i8** %11, align 8
-  store i32 0, i32* %12, align 4
-  %43 = load i32, i32* %12, align 4
-  %44 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @4, i32 0, i32 0), i32 %43)
-  store i1 false, i1* %13, align 1
-  %45 = load i1, i1* %13, align 1
-  store i32 1, i32* %14, align 4
-  %46 = load i32, i32* %14, align 4
-  %47 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @6, i32 0, i32 0), i32 %46)
-  store i32 1, i32* %16, align 4
-  store i32 2, i32* %17, align 4
-  store i32 3, i32* %18, align 4
-  store i32 4, i32* %19, align 4
-  store i32 5, i32* %20, align 4
-  store i32 6, i32* %21, align 4
-  store i32 7, i32* %22, align 4
-  %48 = load [7 x i32], [7 x i32]* @intArray, align 4
-  store [7 x i32] %48, [7 x i32]* %intArray, align 4
-  %49 = load [7 x i32], [7 x i32]* %intArray, align 4
-  store i32 7, i32* %23, align 4
-  %50 = load i32, i32* %23, align 4
-  %51 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([19 x i8], [19 x i8]* @7, i32 0, i32 0), i32 %50)
-  %52 = load i32, i32* %result, align 4
-  ret i32 %52
+  %44 = load i32, i32* %10, align 4
+  %45 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @4, i32 0, i32 0), i32 %44)
+  store i32 65, i32* %11, align 4
+  %46 = load i32, i32* %11, align 4
+  %47 = trunc i32 %46 to i8
+  store i8 %47, i8* %12, align 1
+  %48 = load i8, i8* %12, align 1
+  store i32 8, i32* %13, align 4
+  %49 = load i32, i32* %13, align 4
+  %50 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @5, i32 0, i32 0), i32 %49)
+  store i8* getelementptr inbounds ([13 x i8], [13 x i8]* @7, i32 0, i32 0), i8** %14, align 8
+  %51 = load i8*, i8** %14, align 8
+  store i32 0, i32* %15, align 4
+  %52 = load i32, i32* %15, align 4
+  %53 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([20 x i8], [20 x i8]* @6, i32 0, i32 0), i32 %52)
+  store i1 false, i1* %16, align 1
+  %54 = load i1, i1* %16, align 1
+  store i32 1, i32* %17, align 4
+  %55 = load i32, i32* %17, align 4
+  %56 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @8, i32 0, i32 0), i32 %55)
+  store i32 1, i32* %19, align 4
+  store i32 2, i32* %20, align 4
+  store i32 3, i32* %21, align 4
+  store i32 4, i32* %22, align 4
+  store i32 5, i32* %23, align 4
+  store i32 6, i32* %24, align 4
+  store i32 7, i32* %25, align 4
+  %57 = load [7 x i32], [7 x i32]* @intArray, align 4
+  store [7 x i32] %57, [7 x i32]* %intArray, align 4
+  %58 = load [7 x i32], [7 x i32]* %intArray, align 4
+  store i32 7, i32* %26, align 4
+  %59 = load i32, i32* %26, align 4
+  %60 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([19 x i8], [19 x i8]* @9, i32 0, i32 0), i32 %59)
+  %61 = load i32, i32* %result, align 4
+  ret i32 %61
 }

--- a/compiler/test/test-files/generator/builtins/success-sizeof/source.spice
+++ b/compiler/test/test-files/generator/builtins/success-sizeof/source.spice
@@ -5,10 +5,10 @@
 }*/
 
 f<int> main() {
-    //printf("Size of double: %d\n", sizeof(-19.34989));
+    printf("Size of double: %d\n", sizeof(-19.34989));
     printf("Size of int: %d\n", sizeof(353));
-    printf("Size of short: %d\n", sizeof((short) 35));
-    //printf("Size of long: %d\n", sizeof((long) 9223372036854775807));
+    printf("Size of short: %d\n", sizeof(35s));
+    printf("Size of long: %d\n", sizeof(9223372036854775807l));
     printf("Size of byte: %d\n", sizeof((byte) 13));
     printf("Size of char: %d\n", sizeof((char) 65));
     printf("Size of string: %d\n", sizeof("Hello Spice!"));

--- a/docs/docs/language/data-types.md
+++ b/docs/docs/language/data-types.md
@@ -32,10 +32,10 @@ Integers are signed, whole numbers of 16-bit, which have a range from a min of -
 
 In Spice, variables of type `short` can be defined like this:
 ```spice
-short variable1 = 15;
+short variable1 = 15s;
 
 short variable2;
-variable2 = 0;
+variable2 = 0s;
 ```
 
 ## The `long` data type
@@ -43,10 +43,10 @@ Integers are signed, whole numbers of 64-bit, which have a range from a min of -
 
 In Spice, variables of type `long` can be defined like this:
 ```spice
-long variable1 = 12492309573;
+long variable1 = 12492309573l;
 
 long variable2;
-variable2 = -34945968;
+variable2 = -34945968l;
 ```
 
 ## The `byte` data type
@@ -54,10 +54,10 @@ Bytes are unsigned, whole numbers of 8-bit, which have a range from a min of 0 t
 
 In Spice, variables of type `byte` can be defined like this:
 ```spice
-byte variable1 = 11;
+byte variable1 = (byte) 11;
 
 byte variable2;
-variable2 = 12;
+variable2 = (byte) 12;
 ```
 
 ## The `char` data type

--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -25,7 +25,7 @@ f<int> main() {
     a.destructor();
 }*/
 
-f<int> makePi() {
+/*f<int> makePi() {
     // Initialize variables
     int q = 1;
     int r = 0;
@@ -60,4 +60,9 @@ f<int> makePi() {
 
 f<int> main() {
     makePi();
+}*/
+
+f<int> main() {
+    double d = -4.5;
+    printf("Double: %f", d);
 }


### PR DESCRIPTION
- Add short and long literals: `short s = 4s` / `long l = 23948723948l`
- Fix #77 
- Fix #76 
- Code improvements
- Fix data types documentation
- Adjust tests