### PR TITLE
Migrate to new LLVM pass manager

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -42,6 +42,8 @@ jobs:
           mkdir ./compiler/lib
           cd ./compiler/lib
           git clone --depth 1 --branch 4.9.3 https://github.com/antlr/antlr4.git
+          mkdir json
+          curl -SsL "https://github.com/nlohmann/json/releases/download/v3.10.5/json.hpp" --output json/json.hpp
 
       - name: Build Test target
         env:

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -25,13 +25,13 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/work/spice/llvm
-          key: llvm-13-0-0
+          key: llvm-13-0-1
 
       - name: Setup LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
         run: |
           cd ..
-          git clone --depth  1 --branch llvmorg-13.0.0 https://github.com/llvm/llvm-project llvm
+          git clone --depth  1 --branch llvmorg-13.0.1 https://github.com/llvm/llvm-project llvm
           mkdir ./llvm/build
           cd ./llvm/build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS_RELEASE="-O2" -G "Unix Makefiles" ../llvm

--- a/.github/workflows/ci-go.yml
+++ b/.github/workflows/ci-go.yml
@@ -55,3 +55,8 @@ jobs:
 
       - name: Run security scan
         run: gosec -exclude=G204 ./...
+
+      - name: Validate Goreleaser config
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          args: check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -90,6 +90,8 @@ jobs:
           mkdir -p ./compiler/lib
           cd ./compiler/lib
           git clone --branch 4.9.3 --depth 1 https://github.com/antlr/antlr4.git
+          mkdir json
+          curl -SsL "https://github.com/nlohmann/json/releases/download/v3.10.5/json.hpp" --output json/json.hpp
       
       - name: Configure & compile project
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,11 +69,11 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /home/runner/work/spice/spice/llvm
-          key: llvm-13-0-0-${{ matrix.config.arch }}-clear1
+          key: llvm-13-0-1-${{ matrix.config.arch }}
 
       - name: Clone LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: git clone --depth 1 --branch llvmorg-13.0.0 https://github.com/llvm/llvm-project.git llvm
+        run: git clone --depth 1 --branch llvmorg-13.0.1 https://github.com/llvm/llvm-project.git llvm
 
       - name: Setup LLVM - Configure
         if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/compiler/setup-libs.bat
+++ b/compiler/setup-libs.bat
@@ -3,3 +3,6 @@ mkdir lib
 cd lib
 
 git clone --depth 1 --branch 4.9.3 https://github.com/antlr/antlr4.git
+
+mkdir json
+curl -SsL "https://github.com/nlohmann/json/releases/download/v3.10.5/json.hpp" --output json/json.hpp

--- a/compiler/src/CompilerInstance.cpp
+++ b/compiler/src/CompilerInstance.cpp
@@ -65,7 +65,7 @@ SymbolTable* CompilerInstance::CompileSourceFile(
     if (debugOutput) {
         // Print symbol table
         std::cout << "\nSymbol table of file " << sourceFile << ":\n" << std::endl;
-        std::cout << symbolTable->toString() << std::endl;
+        std::cout << symbolTable->toJSON().dump(2) << std::endl;
     }
 
     // Get file name from file path

--- a/compiler/src/CompilerInstance.cpp
+++ b/compiler/src/CompilerInstance.cpp
@@ -2,6 +2,14 @@
 
 #include "CompilerInstance.h"
 
+#include <SpiceLexer.h>
+#include <SpiceParser.h>
+
+#include <analyzer/AnalyzerVisitor.h>
+#include <generator/GeneratorVisitor.h>
+#include <util/FileUtil.h>
+#include <exception/AntlrThrowingErrorListener.h>
+
 /**
  * Compiles a single source file to an object
  *

--- a/compiler/src/CompilerInstance.h
+++ b/compiler/src/CompilerInstance.h
@@ -4,14 +4,7 @@
 
 #include <string>
 
-#include <SpiceLexer.h>
-#include <SpiceParser.h>
-
-#include <analyzer/AnalyzerVisitor.h>
-#include <generator/GeneratorVisitor.h>
 #include <symbol/SymbolTable.h>
-#include <util/FileUtil.h>
-#include <exception/AntlrThrowingErrorListener.h>
 
 /**
  * Represents the compilation process of a single source file to a LLVM module / object file

--- a/compiler/src/CompilerInstance.h
+++ b/compiler/src/CompilerInstance.h
@@ -7,10 +7,10 @@
 #include <SpiceLexer.h>
 #include <SpiceParser.h>
 
-#include <util/FileUtil.h>
-#include <symbol/SymbolTable.h>
 #include <analyzer/AnalyzerVisitor.h>
 #include <generator/GeneratorVisitor.h>
+#include <symbol/SymbolTable.h>
+#include <util/FileUtil.h>
 #include <exception/AntlrThrowingErrorListener.h>
 
 /**

--- a/compiler/src/analyzer/AnalyzerVisitor.cpp
+++ b/compiler/src/analyzer/AnalyzerVisitor.cpp
@@ -2,6 +2,15 @@
 
 #include "AnalyzerVisitor.h"
 
+#include <CompilerInstance.h>
+#include <analyzer/OpRuleManager.h>
+#include <symbol/SymbolSpecifiers.h>
+#include <util/ModuleRegistry.h>
+#include <util/ScopeIdUtil.h>
+#include <util/FileUtil.h>
+#include "util/CompilerWarning.h"
+#include <exception/SemanticError.h>
+
 antlrcpp::Any AnalyzerVisitor::visitEntry(SpiceParser::EntryContext* ctx) {
     // --- Pre-traversing actions
     // ...

--- a/compiler/src/analyzer/AnalyzerVisitor.h
+++ b/compiler/src/analyzer/AnalyzerVisitor.h
@@ -2,16 +2,18 @@
 
 #pragma once
 
+#include <utility>
+
 #include "SpiceBaseVisitor.h"
 #include "SpiceLexer.h"
 
 #include <CompilerInstance.h>
-#include "symbol/SymbolTable.h"
-#include "symbol/ScopePath.h"
-#include "util/ModuleRegistry.h"
-#include "symbol/SymbolType.h"
-#include "symbol/SymbolSpecifiers.h"
-#include "OpRuleManager.h"
+#include <analyzer/OpRuleManager.h>
+#include <symbol/SymbolTable.h>
+#include <symbol/ScopePath.h>
+#include <symbol/SymbolType.h>
+#include <symbol/SymbolSpecifiers.h>
+#include <util/ModuleRegistry.h>
 #include <util/ScopeIdUtil.h>
 #include <util/FileUtil.h>
 #include <exception/SemanticError.h>
@@ -19,7 +21,6 @@
 #include <llvm/ADT/Triple.h>
 #include <llvm/Support/Host.h>
 
-#include <utility>
 
 const static std::string MAIN_FUNCTION_NAME = "main";
 const static std::string RETURN_VARIABLE_NAME = "result";

--- a/compiler/src/analyzer/AnalyzerVisitor.h
+++ b/compiler/src/analyzer/AnalyzerVisitor.h
@@ -4,8 +4,8 @@
 
 #include <utility>
 
-#include "SpiceBaseVisitor.h"
-#include "SpiceLexer.h"
+#include <SpiceBaseVisitor.h>
+#include <SpiceLexer.h>
 
 #include <CompilerInstance.h>
 #include <analyzer/OpRuleManager.h>
@@ -20,7 +20,6 @@
 
 #include <llvm/ADT/Triple.h>
 #include <llvm/Support/Host.h>
-
 
 const static std::string MAIN_FUNCTION_NAME = "main";
 const static std::string RETURN_VARIABLE_NAME = "result";

--- a/compiler/src/analyzer/AnalyzerVisitor.h
+++ b/compiler/src/analyzer/AnalyzerVisitor.h
@@ -2,21 +2,11 @@
 
 #pragma once
 
-#include <utility>
-
 #include <SpiceBaseVisitor.h>
-#include <SpiceLexer.h>
 
-#include <CompilerInstance.h>
-#include <analyzer/OpRuleManager.h>
 #include <symbol/SymbolTable.h>
 #include <symbol/ScopePath.h>
 #include <symbol/SymbolType.h>
-#include <symbol/SymbolSpecifiers.h>
-#include <util/ModuleRegistry.h>
-#include <util/ScopeIdUtil.h>
-#include <util/FileUtil.h>
-#include <exception/SemanticError.h>
 
 #include <llvm/ADT/Triple.h>
 #include <llvm/Support/Host.h>

--- a/compiler/src/analyzer/OpRuleManager.h
+++ b/compiler/src/analyzer/OpRuleManager.h
@@ -4,7 +4,10 @@
 
 #include <tuple>
 
+#include <Token.h>
+
 #include <symbol/SymbolType.h>
+#include <exception/SemanticError.h>
 
 // Types: double, int, short, long, byte, char, string, bool
 

--- a/compiler/src/analyzer/OpRuleManager.h
+++ b/compiler/src/analyzer/OpRuleManager.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include <tuple>
-#include "symbol/SymbolType.h"
+#include <symbol/SymbolType.h>
 
 // Types: double, int, short, long, byte, char, string, bool
 

--- a/compiler/src/analyzer/OpRuleManager.h
+++ b/compiler/src/analyzer/OpRuleManager.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <tuple>
+
 #include <symbol/SymbolType.h>
 
 // Types: double, int, short, long, byte, char, string, bool

--- a/compiler/src/exception/AntlrThrowingErrorListener.cpp
+++ b/compiler/src/exception/AntlrThrowingErrorListener.cpp
@@ -2,6 +2,8 @@
 
 #include "AntlrThrowingErrorListener.h"
 
+#include "LexerParserError.h"
+
 void AntlrThrowingErrorListener::syntaxError(antlr4::Recognizer* recognizer, antlr4::Token* offendingSymbol, size_t line,
                                              size_t charPositionInLine, const std::string& msg, std::exception_ptr e) {
     // Create message fragments

--- a/compiler/src/exception/AntlrThrowingErrorListener.h
+++ b/compiler/src/exception/AntlrThrowingErrorListener.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "BaseErrorListener.h"
+#include <BaseErrorListener.h>
 #include "LexerParserError.h"
 
 enum Mode {

--- a/compiler/src/exception/AntlrThrowingErrorListener.h
+++ b/compiler/src/exception/AntlrThrowingErrorListener.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <BaseErrorListener.h>
-#include "LexerParserError.h"
 
 enum Mode {
     LEXER,

--- a/compiler/src/exception/IRError.h
+++ b/compiler/src/exception/IRError.h
@@ -4,6 +4,7 @@
 
 #include <exception>
 #include <string>
+
 #include <Token.h>
 
 enum IRErrorType {

--- a/compiler/src/exception/LexerParserError.h
+++ b/compiler/src/exception/LexerParserError.h
@@ -2,8 +2,8 @@
 
 #pragma once
 
-#include <exception>
 #include <string>
+#include <exception>
 
 /**
  * Custom exception for errors, occurring in the semantic analysis phase

--- a/compiler/src/exception/LexerParserError.h
+++ b/compiler/src/exception/LexerParserError.h
@@ -4,6 +4,7 @@
 
 #include <string>
 #include <exception>
+#include <utility>
 
 /**
  * Custom exception for errors, occurring in the semantic analysis phase
@@ -11,7 +12,7 @@
 class LexerParserError : public std::exception {
 public:
     // Constructors
-    explicit LexerParserError(const std::string& message): errorMessage(message) {}
+    explicit LexerParserError(std::string  message): errorMessage(std::move(message)) {}
 
     // Public methods
     const char* what() const noexcept override;

--- a/compiler/src/exception/SemanticError.h
+++ b/compiler/src/exception/SemanticError.h
@@ -2,10 +2,11 @@
 
 #pragma once
 
-#include <exception>
 #include <string>
-#include <TokenSource.h>
+#include <exception>
+
 #include <Token.h>
+#include <TokenSource.h>
 
 enum SemanticErrorType {
     REFERENCED_UNDEFINED_FUNCTION_OR_PROCEDURE,

--- a/compiler/src/exception/SemanticError.h
+++ b/compiler/src/exception/SemanticError.h
@@ -6,7 +6,6 @@
 #include <exception>
 
 #include <Token.h>
-#include <TokenSource.h>
 
 enum SemanticErrorType {
     REFERENCED_UNDEFINED_FUNCTION_OR_PROCEDURE,

--- a/compiler/src/generator/GeneratorVisitor.cpp
+++ b/compiler/src/generator/GeneratorVisitor.cpp
@@ -15,87 +15,51 @@ void GeneratorVisitor::init() {
     llvm::InitializeAllTargetMCs();
     llvm::InitializeAllAsmParsers();
     llvm::InitializeAllAsmPrinters();
-}
 
-void GeneratorVisitor::optimize() {
-    if (debugOutput) std::cout << "\nOptimizing on level " + std::to_string(optLevel) << " ..." << std::endl;
-
-    // Declare map with all optimization passes in the required order
-    llvm::Pass* passes[] = {
-            llvm::createCFGSimplificationPass(),
-            llvm::createSROAPass(),
-            llvm::createEarlyCSEPass(),
-            llvm::createPromoteMemoryToRegisterPass(),
-            llvm::createInstructionCombiningPass(true),
-            llvm::createCFGSimplificationPass(),
-            llvm::createSROAPass(),
-            llvm::createEarlyCSEPass(true),
-            llvm::createSpeculativeExecutionIfHasBranchDivergencePass(),
-            llvm::createJumpThreadingPass(),
-            llvm::createCorrelatedValuePropagationPass(),
-            llvm::createCFGSimplificationPass(),
-            llvm::createInstructionCombiningPass(true),
-            llvm::createLibCallsShrinkWrapPass(),
-            llvm::createTailCallEliminationPass(),
-            llvm::createCFGSimplificationPass(),
-            llvm::createReassociatePass(),
-            llvm::createLoopRotatePass(-1),
-            llvm::createGVNPass(),
-            llvm::createLICMPass(),
-            llvm::createLoopUnswitchPass(),
-            llvm::createCFGSimplificationPass(),
-            llvm::createInstructionCombiningPass(true),
-            llvm::createIndVarSimplifyPass(),
-            llvm::createLoopIdiomPass(),
-            llvm::createLoopDeletionPass(),
-            llvm::createCFGSimplificationPass(),
-            llvm::createSimpleLoopUnrollPass(optLevel),
-            llvm::createMergedLoadStoreMotionPass(),
-            llvm::createGVNPass(),
-            llvm::createMemCpyOptPass(),
-            llvm::createSCCPPass(),
-            llvm::createBitTrackingDCEPass(),
-            llvm::createInstructionCombiningPass(true),
-            llvm::createJumpThreadingPass(),
-            llvm::createCorrelatedValuePropagationPass(),
-            llvm::createDeadStoreEliminationPass(),
-            llvm::createLICMPass(),
-            llvm::createAggressiveDCEPass(),
-            llvm::createCFGSimplificationPass(),
-            llvm::createInstructionCombiningPass(true),
-            llvm::createFloat2IntPass()
-    };
-
-    // Register optimization passes
-    std::unique_ptr<llvm::legacy::FunctionPassManager> fpm =
-            std::make_unique<llvm::legacy::FunctionPassManager>(module.get());
-    for (llvm::Pass* pass : passes) fpm->add(pass);
-
-    // Run optimizing passes for all functions
-    fpm->doInitialization();
-    for (llvm::Function* fct : functions) fpm->run(*fct);
-}
-
-void GeneratorVisitor::emit() {
     // Configure output target
     std::string tripletString = targetTriple.getTriple();
     module->setTargetTriple(tripletString);
-
-    if (debugOutput)
-        std::cout << "\nEmitting executable for triplet '" << tripletString << "' to path: " << objectDir << std::endl;
 
     // Search after selected target
     std::string error;
     const llvm::Target* target = llvm::TargetRegistry::lookupTarget(tripletString, error);
     if (!target) throw IRError(TARGET_NOT_AVAILABLE, "Selected target was not found: " + error);
 
-    std::string cpu = "generic";
-
     llvm::TargetOptions opt;
     llvm::Optional rm = llvm::Optional<llvm::Reloc::Model>();
-    llvm::TargetMachine* targetMachine = target->createTargetMachine(tripletString, cpu, "", opt, rm);
+    targetMachine = target->createTargetMachine(tripletString, "generic", "", opt, rm);
 
     module->setDataLayout(targetMachine->createDataLayout());
+}
+
+void GeneratorVisitor::optimize() {
+    if (debugOutput) std::cout << "\nOptimizing on level " + std::to_string(optLevel) << " ..." << std::endl;
+
+    llvm::LoopAnalysisManager loopAnalysisMgr;
+    llvm::FunctionAnalysisManager functionAnalysisMgr;
+    llvm::CGSCCAnalysisManager cgsccAnalysisMgr;
+    llvm::ModuleAnalysisManager moduleAnalysisMgr;
+    llvm::PassBuilder passBuilder(targetMachine);
+
+    functionAnalysisMgr.registerPass([&] {
+        return passBuilder.buildDefaultAAPipeline();
+    });
+
+    passBuilder.registerModuleAnalyses(moduleAnalysisMgr);
+    passBuilder.registerCGSCCAnalyses(cgsccAnalysisMgr);
+    passBuilder.registerFunctionAnalyses(functionAnalysisMgr);
+    passBuilder.registerLoopAnalyses(loopAnalysisMgr);
+    passBuilder.crossRegisterProxies(loopAnalysisMgr, functionAnalysisMgr, cgsccAnalysisMgr, moduleAnalysisMgr);
+
+    // Run passes
+    llvm::PassBuilder::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
+    llvm::ModulePassManager modulePassMgr = passBuilder.buildPerModuleDefaultPipeline(llvmOptLevel);
+    modulePassMgr.run(*module, moduleAnalysisMgr);
+}
+
+void GeneratorVisitor::emit() {
+    if (debugOutput)
+        std::cout << "\nEmitting executable for triplet '" << targetTriple.getTriple() << "' to path: " << objectDir << std::endl;
 
     // Open file output stream
     std::error_code errorCode;
@@ -2053,4 +2017,14 @@ llvm::Value* GeneratorVisitor::doImplicitCast(llvm::Value* srcValue, llvm::Type*
         srcValue = newActualArg;
     }
     return srcValue;
+}
+
+llvm::PassBuilder::OptimizationLevel GeneratorVisitor::getLLVMOptLevelFromSpiceOptLevel() const {
+    // Get LLVM opt level from Spice opt level
+    switch (optLevel) {
+        case 1: return llvm::PassBuilder::OptimizationLevel::O1;
+        case 2: return llvm::PassBuilder::OptimizationLevel::O2;
+        case 3: return llvm::PassBuilder::OptimizationLevel::O3;
+        default: case 0: return llvm::PassBuilder::OptimizationLevel::O0;
+    }
 }

--- a/compiler/src/generator/GeneratorVisitor.h
+++ b/compiler/src/generator/GeneratorVisitor.h
@@ -2,12 +2,17 @@
 
 #pragma once
 
-#include <SpiceBaseVisitor.h>
-#include <exception/IRError.h>
-#include "symbol/SymbolTable.h"
-#include "symbol/ScopePath.h"
-#include <util/ScopeIdUtil.h>
+#include <utility>
+#include <regex>
+
 #include <analyzer/AnalyzerVisitor.h>
+#include <generator/OpRuleConversionsManager.h>
+#include <symbol/SymbolTable.h>
+#include <symbol/ScopePath.h>
+#include <util/ScopeIdUtil.h>
+#include <exception/IRError.h>
+
+#include <SpiceBaseVisitor.h>
 
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/LLVMContext.h>
@@ -20,14 +25,9 @@
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Target/TargetOptions.h>
-#include <llvm/Transforms/InstCombine/InstCombine.h>
-#include <llvm/Transforms/Scalar.h>
-#include <llvm/Transforms/Scalar/GVN.h>
-#include <llvm/Transforms/Utils.h>
-
-#include <utility>
-#include <regex>
-#include "OpRuleConversionsManager.h"
+#include <llvm/IR/PassManager.h>
+#include <llvm/Passes/PassBuilder.h>
+#include <llvm/Analysis/AliasAnalysis.h>
 
 class GeneratorVisitor : public SpiceBaseVisitor {
 public:
@@ -97,6 +97,7 @@ private:
     std::unique_ptr<OpRuleConversionsManager> conversionsManager;
     std::string mainSourceFile;
     llvm::Triple targetTriple;
+    llvm::TargetMachine* targetMachine;
     std::string objectDir;
     bool debugOutput;
     int optLevel;
@@ -135,4 +136,5 @@ private:
     void initExtStruct(const std::string&, const std::string&);
     bool compareLLVMTypes(llvm::Type*, llvm::Type*);
     llvm::Value* doImplicitCast(llvm::Value*, llvm::Type*);
+    llvm::PassBuilder::OptimizationLevel getLLVMOptLevelFromSpiceOptLevel() const;
 };

--- a/compiler/src/generator/GeneratorVisitor.h
+++ b/compiler/src/generator/GeneratorVisitor.h
@@ -2,32 +2,17 @@
 
 #pragma once
 
-#include <utility>
 #include <regex>
 
-#include <analyzer/AnalyzerVisitor.h>
 #include <generator/OpRuleConversionsManager.h>
 #include <symbol/SymbolTable.h>
 #include <symbol/ScopePath.h>
-#include <util/ScopeIdUtil.h>
-#include <exception/IRError.h>
 
 #include <SpiceBaseVisitor.h>
 
-#include <llvm/IR/IRBuilder.h>
-#include <llvm/IR/LLVMContext.h>
-#include <llvm/IR/LegacyPassManager.h>
-#include <llvm/IR/Module.h>
-#include <llvm/IR/Verifier.h>
-#include <llvm/Support/FileSystem.h>
-#include <llvm/Support/Host.h>
-#include <llvm/Support/TargetRegistry.h>
-#include <llvm/Support/TargetSelect.h>
 #include <llvm/Target/TargetMachine.h>
-#include <llvm/Target/TargetOptions.h>
-#include <llvm/IR/PassManager.h>
+#include <llvm/Support/Host.h>
 #include <llvm/Passes/PassBuilder.h>
-#include <llvm/Analysis/AliasAnalysis.h>
 
 class GeneratorVisitor : public SpiceBaseVisitor {
 public:
@@ -97,7 +82,7 @@ private:
     std::unique_ptr<OpRuleConversionsManager> conversionsManager;
     std::string mainSourceFile;
     llvm::Triple targetTriple;
-    llvm::TargetMachine* targetMachine;
+    llvm::TargetMachine* targetMachine{};
     std::string objectDir;
     bool debugOutput;
     int optLevel;
@@ -120,8 +105,8 @@ private:
     bool currentVarSigned = false;
     std::string currentVarName;
     std::string lhsVarName;
-    llvm::Type* structAccessType;
-    llvm::Value* structAccessAddress;
+    llvm::Type* structAccessType = nullptr;
+    llvm::Value* structAccessAddress = nullptr;
     std::vector<llvm::Value*> structAccessIndices;
 
     // Private methods

--- a/compiler/src/generator/OpRuleConversionsManager.cpp
+++ b/compiler/src/generator/OpRuleConversionsManager.cpp
@@ -2,6 +2,9 @@
 
 #include "OpRuleConversionsManager.h"
 
+#include <symbol/SymbolType.h>
+#include <exception/IRError.h>
+
 llvm::Value* OpRuleConversionsManager::getPlusEqualInst(llvm::Value* lhs, llvm::Value* rhs) {
     llvm::Type* lhsTy = lhs->getType();
     llvm::Type* rhsTy = rhs->getType();

--- a/compiler/src/generator/OpRuleConversionsManager.h
+++ b/compiler/src/generator/OpRuleConversionsManager.h
@@ -2,11 +2,11 @@
 
 #pragma once
 
+#include <symbol/SymbolType.h>
+#include <exception/IRError.h>
+
 #include <llvm/IR/Value.h>
 #include <llvm/IR/IRBuilder.h>
-
-#include "exception/IRError.h"
-#include "symbol/SymbolType.h"
 
 enum PrimitiveType {
     P_TY_DOUBLE,

--- a/compiler/src/generator/OpRuleConversionsManager.h
+++ b/compiler/src/generator/OpRuleConversionsManager.h
@@ -2,9 +2,6 @@
 
 #pragma once
 
-#include <symbol/SymbolType.h>
-#include <exception/IRError.h>
-
 #include <llvm/IR/Value.h>
 #include <llvm/IR/IRBuilder.h>
 

--- a/compiler/src/main.cpp
+++ b/compiler/src/main.cpp
@@ -2,6 +2,10 @@
 
 #include "CompilerInstance.h"
 
+#include <exception/LexerParserError.h>
+#include <exception/SemanticError.h>
+#include <exception/IRError.h>
+
 /**
  * Entry point to the Spice compiler
  *

--- a/compiler/src/symbol/ScopePath.h
+++ b/compiler/src/symbol/ScopePath.h
@@ -5,7 +5,8 @@
 #include <string>
 #include <vector>
 #include <tuple>
-#include "SymbolTable.h"
+
+#include <symbol/SymbolTable.h>
 
 class ScopePath {
 public:

--- a/compiler/src/symbol/SymbolSpecifiers.h
+++ b/compiler/src/symbol/SymbolSpecifiers.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "SymbolType.h"
+#include <symbol/SymbolType.h>
 
 // Bit indices from right to left
 const unsigned short BIT_INDEX_SIGNED = 0;

--- a/compiler/src/symbol/SymbolTable.cpp
+++ b/compiler/src/symbol/SymbolTable.cpp
@@ -366,19 +366,36 @@ void SymbolTable::printCompilerWarnings() {
 /**
  * Stringify a symbol table to a human-readable form. This is used to realize dumps of symbol tables
  *
+ * Example:
+ * {
+ *   "symbols": [
+ *     ... (SymbolTableEntry)
+ *   ],
+ *   "children": [
+ *     ... (SymbolTable)
+ *   ]
+ * }
+ *
  * @return Symbol table if form of a string
  */
-std::string SymbolTable::toString() {
-    std::string symbolsString, childrenString;
-    // Build symbols string
+nlohmann::ordered_json SymbolTable::toJSON() {
+    // Collect all symbols
+    std::vector<nlohmann::json> jsonSymbols;
+    jsonSymbols.reserve(symbols.size());
     for (auto& symbol : symbols)
-        symbolsString.append("(" + symbol.second.toString() + ")\n");
-    // Build children string
+        jsonSymbols.push_back(symbol.second.toJSON());
+
+    // Collect all children
+    std::vector<nlohmann::json> jsonChildren;
+    jsonChildren.reserve(symbols.size());
     for (auto& child : children)
-        childrenString.append(child.first + ": " + child.second.toString() + "\n");
-    if (childrenString.empty())
-        return "SymbolTable(\n" + symbolsString + ")";
-    return "SymbolTable(\n" + symbolsString + ") {\n" + childrenString + "}";
+        jsonChildren.push_back(child.second.toJSON());
+
+    // Generate json
+    nlohmann::json result;
+    result["symbols"] = jsonSymbols;
+    result["children"] = jsonChildren;
+    return result;
 }
 
 /**
@@ -393,6 +410,6 @@ void SymbolTable::setImported() {
  *
  * @return Imported / not imported
  */
-bool SymbolTable::isImported() {
+bool SymbolTable::isImported() const {
     return imported;
 }

--- a/compiler/src/symbol/SymbolTable.cpp
+++ b/compiler/src/symbol/SymbolTable.cpp
@@ -1,7 +1,9 @@
 // Copyright (c) 2021-2022 ChilliBits. All rights reserved.
 
 #include "symbol/SymbolTable.h"
-#include "analyzer/AnalyzerVisitor.h" // Must remain here due to circular import
+
+#include <analyzer/AnalyzerVisitor.h>
+#include <util/CompilerWarning.h>
 
 /**
  * Insert a new symbol into the current symbol table. If it is a parameter, append its name to the paramNames vector

--- a/compiler/src/symbol/SymbolTable.h
+++ b/compiler/src/symbol/SymbolTable.h
@@ -3,20 +3,15 @@
 #pragma once
 
 #include <string>
-#include <utility>
 #include <map>
 #include <vector>
 #include <queue>
 
-#include <SpiceParser.h>
-
 #include <symbol/SymbolTableEntry.h>
 #include <symbol/SymbolType.h>
 #include <util/FunctionSignature.h>
-#include <util/CompilerWarning.h>
 
 #include <llvm/IR/BasicBlock.h>
-#include <llvm/IR/DerivedTypes.h>
 
 #include "../../lib/json/json.hpp"
 

--- a/compiler/src/symbol/SymbolTable.h
+++ b/compiler/src/symbol/SymbolTable.h
@@ -8,7 +8,7 @@
 #include <vector>
 #include <queue>
 
-#include "SpiceParser.h"
+#include <SpiceParser.h>
 
 #include <symbol/SymbolTableEntry.h>
 #include <symbol/SymbolType.h>

--- a/compiler/src/symbol/SymbolTable.h
+++ b/compiler/src/symbol/SymbolTable.h
@@ -7,13 +7,18 @@
 #include <map>
 #include <vector>
 #include <queue>
-#include "symbol/SymbolType.h"
-#include "util/FunctionSignature.h"
-#include "util/CompilerWarning.h"
+
+#include "SpiceParser.h"
+
+#include <symbol/SymbolTableEntry.h>
+#include <symbol/SymbolType.h>
+#include <util/FunctionSignature.h>
+#include <util/CompilerWarning.h>
+
 #include <llvm/IR/BasicBlock.h>
 #include <llvm/IR/DerivedTypes.h>
-#include "SpiceParser.h"
-#include "SymbolTableEntry.h"
+
+#include "../../lib/json/json.hpp"
 
 /**
  * Class for storing information about symbols of the AST. Symbol tables are meant to be arranged in a tree structure,
@@ -63,10 +68,10 @@ public:
 
     void printCompilerWarnings();
 
-    std::string toString();
+    nlohmann::ordered_json toJSON();
 
     void setImported();
-    bool isImported();
+    bool isImported() const;
 
 private:
     // Members

--- a/compiler/src/symbol/SymbolTableEntry.cpp
+++ b/compiler/src/symbol/SymbolTableEntry.cpp
@@ -147,13 +147,28 @@ void SymbolTableEntry::setUsed() {
 /**
  * Stringify the current symbol to a human-readable form. Used to dump whole symbol tables with their contents.
  *
- * @return Symbol table entry in form of a string
+ * Example:
+ * {
+ *   "name": "testIden",
+ *   "type": "int[]*",
+ *   "orderIndex": 4,
+ *   "state": "initialized",
+ *   "specifiers: [
+ *     "const": true,
+ *     "signed": false
+ *   ],
+ *   "isGlobal": false
+ * }
+ *
+ * @return Symbol table entry as a JSON object
  */
-std::string SymbolTableEntry::toString() {
-    std::string stateStr = state == INITIALIZED ? "initialized" : "declared";
-    std::string constStr = specifiers.isConst() ? "yes" : "no";
-    std::string signedStr = specifiers.isSigned() ? "yes" : "no";
-    std::string globalStr = isGlobal ? "yes" : "no";
-    return "Name: " + name + ", Type: " + type.getName(true) + ", OrderIndex: " + std::to_string(orderIndex) + ", State: " +
-        stateStr + ", Const: " + constStr + ", Signed: " + signedStr + ", IsGlobal: " + globalStr;
+nlohmann::ordered_json SymbolTableEntry::toJSON() {
+    nlohmann::json result;
+    result["name"] = name;
+    result["type"] = type.getName(true);
+    result["orderIndex"] = orderIndex;
+    result["state"] = state == INITIALIZED ? "initialized" : "declared";
+    result["specifiers"] = { { "const", specifiers.isConst() }, { "signed", specifiers.isSigned() } };
+    result["isGlobal"] = isGlobal;
+    return result;
 }

--- a/compiler/src/symbol/SymbolTableEntry.cpp
+++ b/compiler/src/symbol/SymbolTableEntry.cpp
@@ -2,6 +2,8 @@
 
 #include "SymbolTableEntry.h"
 
+#include <exception/SemanticError.h>
+
 /**
  * Retrieve the name of the current symbol
  *

--- a/compiler/src/symbol/SymbolTableEntry.h
+++ b/compiler/src/symbol/SymbolTableEntry.h
@@ -3,12 +3,12 @@
 #pragma once
 
 #include <string>
-#include <stdexcept>
 #include <utility>
+
+#include "Token.h"
 
 #include <symbol/SymbolType.h>
 #include <symbol/SymbolSpecifiers.h>
-#include <exception/SemanticError.h>
 
 #include <llvm/IR/Value.h>
 

--- a/compiler/src/symbol/SymbolTableEntry.h
+++ b/compiler/src/symbol/SymbolTableEntry.h
@@ -6,10 +6,13 @@
 #include <stdexcept>
 #include <utility>
 
-#include "symbol/SymbolType.h"
-#include "exception/SemanticError.h"
-#include "SymbolSpecifiers.h"
+#include <symbol/SymbolType.h>
+#include <symbol/SymbolSpecifiers.h>
+#include <exception/SemanticError.h>
+
 #include <llvm/IR/Value.h>
+
+#include "../../lib/json/json.hpp"
 
 enum SymbolState {
     DECLARED,
@@ -43,7 +46,7 @@ public:
     void updateLLVMType(llvm::Type*);
     void updateAddress(llvm::Value*);
     void setUsed();
-    std::string toString();
+    nlohmann::ordered_json toJSON();
 
 private:
     // Members

--- a/compiler/src/symbol/SymbolType.cpp
+++ b/compiler/src/symbol/SymbolType.cpp
@@ -2,6 +2,8 @@
 
 #include "SymbolType.h"
 
+#include <exception/SemanticError.h>
+
 SymbolType SymbolType::toPointer() {
     // Do not allow pointers of dyn
     if (std::get<0>(typeChain.top()) == TY_DYN)

--- a/compiler/src/symbol/SymbolType.h
+++ b/compiler/src/symbol/SymbolType.h
@@ -9,7 +9,7 @@
 #include <stack>
 #include <tuple>
 
-#include "exception/SemanticError.h"
+#include <exception/SemanticError.h>
 
 enum SymbolSuperType {
     TY_INVALID,

--- a/compiler/src/symbol/SymbolType.h
+++ b/compiler/src/symbol/SymbolType.h
@@ -2,14 +2,12 @@
 
 #pragma once
 
-#include <utility>
-#include <algorithm>
+//#include <utility>
+//#include <algorithm>
 #include <string>
 #include <vector>
 #include <stack>
 #include <tuple>
-
-#include <exception/SemanticError.h>
 
 enum SymbolSuperType {
     TY_INVALID,

--- a/compiler/src/util/CompilerWarning.h
+++ b/compiler/src/util/CompilerWarning.h
@@ -5,7 +5,6 @@
 #include <string>
 
 #include <Token.h>
-#include <TokenSource.h>
 
 enum CompilerWarningType {
     UNUSED_FUNCTION,

--- a/compiler/src/util/CompilerWarning.h
+++ b/compiler/src/util/CompilerWarning.h
@@ -2,9 +2,10 @@
 
 #pragma once
 
-#include "string"
-#include <TokenSource.h>
+#include <string>
+
 #include <Token.h>
+#include <TokenSource.h>
 
 enum CompilerWarningType {
     UNUSED_FUNCTION,

--- a/compiler/src/util/FileUtil.cpp
+++ b/compiler/src/util/FileUtil.cpp
@@ -2,6 +2,11 @@
 
 #include "FileUtil.h"
 
+#include <iostream>
+#include <fstream>
+#include <sys/types.h>
+#include <sys/stat.h>
+
 /**
  * Checks if a certain file exists on the file system
  *

--- a/compiler/src/util/FileUtil.h
+++ b/compiler/src/util/FileUtil.h
@@ -3,10 +3,6 @@
 #pragma once
 
 #include <string>
-#include <iostream>
-#include <fstream>
-#include <sys/types.h>
-#include <sys/stat.h>
 
 /**
  * Util class for file-related work

--- a/compiler/src/util/FunctionSignature.h
+++ b/compiler/src/util/FunctionSignature.h
@@ -6,7 +6,7 @@
 #include <utility>
 #include <vector>
 
-#include <symbol/SymbolTableEntry.h>
+#include <symbol/SymbolType.h>
 
 /**
  * Util class for generating function/procedure signatures

--- a/compiler/src/util/FunctionSignature.h
+++ b/compiler/src/util/FunctionSignature.h
@@ -5,7 +5,8 @@
 #include <string>
 #include <utility>
 #include <vector>
-#include "symbol/SymbolTableEntry.h"
+
+#include <symbol/SymbolTableEntry.h>
 
 /**
  * Util class for generating function/procedure signatures

--- a/compiler/src/util/ModuleRegistry.cpp
+++ b/compiler/src/util/ModuleRegistry.cpp
@@ -1,8 +1,9 @@
 // Copyright (c) 2021-2022 ChilliBits. All rights reserved.
 
 #include <algorithm>
-#include "exception/SemanticError.h"
-#include "ModuleRegistry.h"
+
+#include <util/ModuleRegistry.h>
+#include <exception/SemanticError.h>
 
 // Instance of the module registry
 ModuleRegistry* ModuleRegistry::instance = nullptr;

--- a/compiler/src/util/ScopeIdUtil.h
+++ b/compiler/src/util/ScopeIdUtil.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <string>
+
 #include <SpiceParser.h>
 
 /**

--- a/compiler/test/AnalyzerTest.cpp
+++ b/compiler/test/AnalyzerTest.cpp
@@ -10,6 +10,10 @@
 #include <SpiceParser.h>
 
 #include <analyzer/AnalyzerVisitor.h>
+#include "exception/AntlrThrowingErrorListener.h"
+#include "exception/LexerParserError.h"
+#include "exception/SemanticError.h"
+
 #include "TestUtil.h"
 
 struct AnalyzerTestCase {

--- a/compiler/test/AnalyzerTest.cpp
+++ b/compiler/test/AnalyzerTest.cpp
@@ -1,13 +1,16 @@
 // Copyright (c) 2021-2022 ChilliBits. All rights reserved.
 
-#include <gtest/gtest.h>
 #include <iostream>
-#include "antlr4-runtime.h"
 
-#include "SpiceLexer.h"
-#include "SpiceParser.h"
-#include "TestUtil.h"
+#include <gtest/gtest.h>
+
+#include <antlr4-runtime.h>
+
+#include <SpiceLexer.h>
+#include <SpiceParser.h>
+
 #include <analyzer/AnalyzerVisitor.h>
+#include "TestUtil.h"
 
 struct AnalyzerTestCase {
     const std::string testName;

--- a/compiler/test/AnalyzerTest.cpp
+++ b/compiler/test/AnalyzerTest.cpp
@@ -95,10 +95,10 @@ void executeTest(const AnalyzerTestCase& testCase) {
         }*/
 
         // Check if the symbol table matches the expected output
-        std::string symbolTableFileName = testCase.testPath + "/symbol-table.txt";
+        std::string symbolTableFileName = testCase.testPath + "/symbol-table.json";
         if (TestUtil::fileExists(symbolTableFileName)) {
             std::string expectedSymbolTable = TestUtil::getFileContent(symbolTableFileName);
-            EXPECT_EQ(expectedSymbolTable, symbolTable->toString());
+            EXPECT_EQ(expectedSymbolTable, symbolTable->toJSON().dump(2));
         }
 
         SUCCEED();

--- a/compiler/test/GeneratorTest.cpp
+++ b/compiler/test/GeneratorTest.cpp
@@ -9,6 +9,8 @@
 #include "TestUtil.h"
 #include <analyzer/AnalyzerVisitor.h>
 
+const unsigned int IR_FILE_SKIP_LINES = 4;
+
 struct GeneratorTestCase {
     const std::string testName;
     const std::string testPath;
@@ -77,7 +79,7 @@ void executeTest(const GeneratorTestCase& testCase) {
                 "",
                 ".",
                 false,
-                3,
+                0,
                 true,
                 false
         );
@@ -99,7 +101,7 @@ void executeTest(const GeneratorTestCase& testCase) {
         std::string irCodeO2FileName = testCase.testPath + "/ir-code-O2.ll";
         std::string irCodeO3FileName = testCase.testPath + "/ir-code-O3.ll";
         std::string expectedOptIR;
-        unsigned int expectedOptLevel = 0;
+        int expectedOptLevel = 0;
         if (TestUtil::fileExists(irCodeO1FileName)) {
             expectedOptLevel = 1;
             expectedOptIR = TestUtil::getFileContent(irCodeO1FileName);
@@ -120,7 +122,7 @@ void executeTest(const GeneratorTestCase& testCase) {
                 "",
                 "./source.spice.o",
                 false,
-                3,
+                expectedOptLevel,
                 true
         );
         generator.init(); // Initialize code generation
@@ -130,13 +132,25 @@ void executeTest(const GeneratorTestCase& testCase) {
         std::string irCodeFileName = testCase.testPath + "/ir-code.ll";
         if (TestUtil::fileExists(irCodeFileName)) {
             std::string expectedIR = TestUtil::getFileContent(irCodeFileName);
-            EXPECT_EQ(expectedIR, generator.getIRString());
+            std::string actualIR = generator.getIRString();
+            // Cut of first n lines to have a target independent
+            for (int i = 0; i < IR_FILE_SKIP_LINES; i++) {
+                expectedIR.erase(0, expectedIR.find('\n') + 1);
+                actualIR.erase(0, actualIR.find('\n') + 1);
+            }
+            EXPECT_EQ(expectedIR, actualIR);
         }
 
         // Check if the optimized ir code matches the expected output
         if (expectedOptLevel > 0) {
             generator.optimize();
-            EXPECT_EQ(expectedOptIR, generator.getIRString());
+            std::string actualOptimizedIR = generator.getIRString();
+            // Cut of first n lines to have a target independent
+            for (int i = 0; i < IR_FILE_SKIP_LINES; i++) {
+                expectedOptIR.erase(0, expectedOptIR.find('\n') + 1);
+                actualOptimizedIR.erase(0, actualOptimizedIR.find('\n') + 1);
+            }
+            EXPECT_EQ(expectedOptIR, actualOptimizedIR);
         }
 
         // Check if the execution output matches the expected output

--- a/compiler/test/GeneratorTest.cpp
+++ b/compiler/test/GeneratorTest.cpp
@@ -1,13 +1,16 @@
 // Copyright (c) 2021-2022 ChilliBits. All rights reserved.
 
-#include <gtest/gtest.h>
 #include <iostream>
-#include "antlr4-runtime.h"
 
-#include "SpiceLexer.h"
-#include "SpiceParser.h"
-#include "TestUtil.h"
+#include <gtest/gtest.h>
+
+#include <antlr4-runtime.h>
+
+#include <SpiceLexer.h>
+#include <SpiceParser.h>
+
 #include <analyzer/AnalyzerVisitor.h>
+#include "TestUtil.h"
 
 const unsigned int IR_FILE_SKIP_LINES = 4;
 

--- a/compiler/test/GeneratorTest.cpp
+++ b/compiler/test/GeneratorTest.cpp
@@ -90,10 +90,10 @@ void executeTest(const GeneratorTestCase& testCase) {
             FAIL() << "Expected error, but got no error";
 
         // Check if the symbol table matches the expected output
-        std::string symbolTableFileName = testCase.testPath + "/symbol-table.txt";
+        std::string symbolTableFileName = testCase.testPath + "/symbol-table.json";
         if (TestUtil::fileExists(symbolTableFileName)) {
             std::string expectedSymbolTable = TestUtil::getFileContent(symbolTableFileName);
-            EXPECT_EQ(expectedSymbolTable, symbolTable->toString());
+            EXPECT_EQ(expectedSymbolTable, symbolTable->toJSON().dump(2));
         }
 
         // Determine the expected opt level

--- a/compiler/test/GeneratorTest.cpp
+++ b/compiler/test/GeneratorTest.cpp
@@ -10,6 +10,11 @@
 #include <SpiceParser.h>
 
 #include <analyzer/AnalyzerVisitor.h>
+#include "generator/GeneratorVisitor.h"
+#include "exception/AntlrThrowingErrorListener.h"
+#include "exception/LexerParserError.h"
+#include "exception/SemanticError.h"
+
 #include "TestUtil.h"
 
 const unsigned int IR_FILE_SKIP_LINES = 4;

--- a/compiler/test/TestUtil.cpp
+++ b/compiler/test/TestUtil.cpp
@@ -6,6 +6,7 @@
 #include <dirent.h>
 #include <sstream>
 #include <memory>
+#include <cstring>
 
 bool TestUtil::fileExists(const std::string& filePath) {
     return std::ifstream(filePath.c_str()).good();

--- a/compiler/test/TestUtil.cpp
+++ b/compiler/test/TestUtil.cpp
@@ -2,6 +2,11 @@
 
 #include "TestUtil.h"
 
+#include <fstream>
+#include <dirent.h>
+#include <sstream>
+#include <memory>
+
 bool TestUtil::fileExists(const std::string& filePath) {
     return std::ifstream(filePath.c_str()).good();
 }

--- a/compiler/test/TestUtil.h
+++ b/compiler/test/TestUtil.h
@@ -9,13 +9,7 @@
 #endif
 
 #include <string>
-#include <memory>
-#include <cstring>
-#include <iostream>
-#include <fstream>
 #include <vector>
-#include <dirent.h>
-#include <sstream>
 
 class TestUtil {
 public:

--- a/compiler/test/test-files/analyzer/arbitrary/success-function-overloading/symbol-table.json
+++ b/compiler/test/test-files/analyzer/arbitrary/success-function-overloading/symbol-table.json
@@ -1,19 +1,131 @@
-SymbolTable(
-(Name: calledFunction(int,bool), Type: function, OrderIndex: 0, State: initialized, Const: yes, Signed: no, IsGlobal: yes)
-(Name: calledFunction(string), Type: function, OrderIndex: 1, State: initialized, Const: yes, Signed: no, IsGlobal: yes)
-(Name: main(), Type: function, OrderIndex: 2, State: initialized, Const: yes, Signed: no, IsGlobal: yes)
-) {
-calledFunction(int,bool): SymbolTable(
-(Name: mandatoryParam, Type: int, OrderIndex: 0, State: declared, Const: no, Signed: yes, IsGlobal: no)
-(Name: optionalParam, Type: bool, OrderIndex: 1, State: initialized, Const: no, Signed: no, IsGlobal: no)
-(Name: result, Type: double, OrderIndex: 2, State: initialized, Const: no, Signed: no, IsGlobal: no)
-)
-calledFunction(string): SymbolTable(
-(Name: result, Type: double, OrderIndex: 1, State: initialized, Const: no, Signed: no, IsGlobal: no)
-(Name: testString, Type: string, OrderIndex: 0, State: declared, Const: no, Signed: no, IsGlobal: no)
-)
-main(): SymbolTable(
-(Name: res, Type: double, OrderIndex: 1, State: initialized, Const: no, Signed: yes, IsGlobal: no)
-(Name: result, Type: int, OrderIndex: 0, State: initialized, Const: no, Signed: yes, IsGlobal: no)
-)
+{
+  "children": [
+    {
+      "children": [],
+      "symbols": [
+        {
+          "isGlobal": false,
+          "name": "mandatoryParam",
+          "orderIndex": 0,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "declared",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "optionalParam",
+          "orderIndex": 1,
+          "specifiers": {
+            "const": false,
+            "signed": false
+          },
+          "state": "initialized",
+          "type": "bool"
+        },
+        {
+          "isGlobal": false,
+          "name": "result",
+          "orderIndex": 2,
+          "specifiers": {
+            "const": false,
+            "signed": false
+          },
+          "state": "initialized",
+          "type": "double"
+        }
+      ]
+    },
+    {
+      "children": [],
+      "symbols": [
+        {
+          "isGlobal": false,
+          "name": "result",
+          "orderIndex": 1,
+          "specifiers": {
+            "const": false,
+            "signed": false
+          },
+          "state": "initialized",
+          "type": "double"
+        },
+        {
+          "isGlobal": false,
+          "name": "testString",
+          "orderIndex": 0,
+          "specifiers": {
+            "const": false,
+            "signed": false
+          },
+          "state": "declared",
+          "type": "string"
+        }
+      ]
+    },
+    {
+      "children": [],
+      "symbols": [
+        {
+          "isGlobal": false,
+          "name": "res",
+          "orderIndex": 1,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "double"
+        },
+        {
+          "isGlobal": false,
+          "name": "result",
+          "orderIndex": 0,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        }
+      ]
+    }
+  ],
+  "symbols": [
+    {
+      "isGlobal": true,
+      "name": "calledFunction(int,bool)",
+      "orderIndex": 0,
+      "specifiers": {
+        "const": true,
+        "signed": false
+      },
+      "state": "initialized",
+      "type": "function"
+    },
+    {
+      "isGlobal": true,
+      "name": "calledFunction(string)",
+      "orderIndex": 1,
+      "specifiers": {
+        "const": true,
+        "signed": false
+      },
+      "state": "initialized",
+      "type": "function"
+    },
+    {
+      "isGlobal": true,
+      "name": "main()",
+      "orderIndex": 2,
+      "specifiers": {
+        "const": true,
+        "signed": false
+      },
+      "state": "initialized",
+      "type": "function"
+    }
+  ]
 }

--- a/compiler/test/test-files/generator/arbitrary/success-faculty/ir-code-O3.ll
+++ b/compiler/test/test-files/generator/arbitrary/success-faculty/ir-code-O3.ll
@@ -1,34 +1,131 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [21 x i8] c"Faculty of %d is: %d\00", align 1
 
-declare i32 @printf(i8*, ...)
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(i8* nocapture noundef readonly, ...) local_unnamed_addr #0
 
-; Function Attrs: nounwind
-define i32 @"faculty(int)"(i32 %0) #0 {
+; Function Attrs: nofree nosync nounwind readnone
+define i32 @"faculty(int)"(i32 %0) local_unnamed_addr #1 {
 entry:
   %1 = icmp slt i32 %0, 2
-  br i1 %1, label %common.ret, label %if.end
+  br i1 %1, label %common.ret, label %if.end.preheader
 
-common.ret:                                       ; preds = %if.end, %entry
-  %accumulator.tr.lcssa = phi i32 [ 1, %entry ], [ %3, %if.end ]
+if.end.preheader:                                 ; preds = %entry
+  %2 = add i32 %0, -1
+  %min.iters.check = icmp ult i32 %2, 8
+  br i1 %min.iters.check, label %if.end.preheader12, label %vector.ph
+
+vector.ph:                                        ; preds = %if.end.preheader
+  %n.vec = and i32 %2, -8
+  %ind.end = sub i32 %0, %n.vec
+  %.splatinsert = insertelement <4 x i32> poison, i32 %0, i32 0
+  %.splat = shufflevector <4 x i32> %.splatinsert, <4 x i32> poison, <4 x i32> zeroinitializer
+  %induction = add <4 x i32> %.splat, <i32 0, i32 -1, i32 -2, i32 -3>
+  %3 = add i32 %n.vec, -8
+  %4 = lshr exact i32 %3, 3
+  %5 = add nuw nsw i32 %4, 1
+  %xtraiter = and i32 %5, 3
+  %6 = icmp ult i32 %3, 24
+  br i1 %6, label %middle.block.unr-lcssa, label %vector.ph.new
+
+vector.ph.new:                                    ; preds = %vector.ph
+  %unroll_iter = and i32 %5, 1073741820
+  br label %vector.body
+
+vector.body:                                      ; preds = %vector.body, %vector.ph.new
+  %vec.ind = phi <4 x i32> [ %induction, %vector.ph.new ], [ %vec.ind.next.3, %vector.body ]
+  %vec.phi = phi <4 x i32> [ <i32 1, i32 1, i32 1, i32 1>, %vector.ph.new ], [ %13, %vector.body ]
+  %vec.phi11 = phi <4 x i32> [ <i32 1, i32 1, i32 1, i32 1>, %vector.ph.new ], [ %14, %vector.body ]
+  %niter = phi i32 [ %unroll_iter, %vector.ph.new ], [ %niter.nsub.3, %vector.body ]
+  %step.add = add <4 x i32> %vec.ind, <i32 -4, i32 -4, i32 -4, i32 -4>
+  %7 = mul <4 x i32> %vec.ind, %vec.phi
+  %8 = mul <4 x i32> %step.add, %vec.phi11
+  %vec.ind.next = add <4 x i32> %vec.ind, <i32 -8, i32 -8, i32 -8, i32 -8>
+  %step.add.1 = add <4 x i32> %vec.ind, <i32 -12, i32 -12, i32 -12, i32 -12>
+  %9 = mul <4 x i32> %vec.ind.next, %7
+  %10 = mul <4 x i32> %step.add.1, %8
+  %vec.ind.next.1 = add <4 x i32> %vec.ind, <i32 -16, i32 -16, i32 -16, i32 -16>
+  %step.add.2 = add <4 x i32> %vec.ind, <i32 -20, i32 -20, i32 -20, i32 -20>
+  %11 = mul <4 x i32> %vec.ind.next.1, %9
+  %12 = mul <4 x i32> %step.add.2, %10
+  %vec.ind.next.2 = add <4 x i32> %vec.ind, <i32 -24, i32 -24, i32 -24, i32 -24>
+  %step.add.3 = add <4 x i32> %vec.ind, <i32 -28, i32 -28, i32 -28, i32 -28>
+  %13 = mul <4 x i32> %vec.ind.next.2, %11
+  %14 = mul <4 x i32> %step.add.3, %12
+  %vec.ind.next.3 = add <4 x i32> %vec.ind, <i32 -32, i32 -32, i32 -32, i32 -32>
+  %niter.nsub.3 = add i32 %niter, -4
+  %niter.ncmp.3 = icmp eq i32 %niter.nsub.3, 0
+  br i1 %niter.ncmp.3, label %middle.block.unr-lcssa, label %vector.body, !llvm.loop !0
+
+middle.block.unr-lcssa:                           ; preds = %vector.body, %vector.ph
+  %.lcssa14.ph = phi <4 x i32> [ undef, %vector.ph ], [ %13, %vector.body ]
+  %.lcssa13.ph = phi <4 x i32> [ undef, %vector.ph ], [ %14, %vector.body ]
+  %vec.ind.unr = phi <4 x i32> [ %induction, %vector.ph ], [ %vec.ind.next.3, %vector.body ]
+  %vec.phi.unr = phi <4 x i32> [ <i32 1, i32 1, i32 1, i32 1>, %vector.ph ], [ %13, %vector.body ]
+  %vec.phi11.unr = phi <4 x i32> [ <i32 1, i32 1, i32 1, i32 1>, %vector.ph ], [ %14, %vector.body ]
+  %lcmp.mod.not = icmp eq i32 %xtraiter, 0
+  br i1 %lcmp.mod.not, label %middle.block, label %vector.body.epil
+
+vector.body.epil:                                 ; preds = %middle.block.unr-lcssa, %vector.body.epil
+  %vec.ind.epil = phi <4 x i32> [ %vec.ind.next.epil, %vector.body.epil ], [ %vec.ind.unr, %middle.block.unr-lcssa ]
+  %vec.phi.epil = phi <4 x i32> [ %15, %vector.body.epil ], [ %vec.phi.unr, %middle.block.unr-lcssa ]
+  %vec.phi11.epil = phi <4 x i32> [ %16, %vector.body.epil ], [ %vec.phi11.unr, %middle.block.unr-lcssa ]
+  %epil.iter = phi i32 [ %epil.iter.sub, %vector.body.epil ], [ %xtraiter, %middle.block.unr-lcssa ]
+  %step.add.epil = add <4 x i32> %vec.ind.epil, <i32 -4, i32 -4, i32 -4, i32 -4>
+  %15 = mul <4 x i32> %vec.ind.epil, %vec.phi.epil
+  %16 = mul <4 x i32> %step.add.epil, %vec.phi11.epil
+  %vec.ind.next.epil = add <4 x i32> %vec.ind.epil, <i32 -8, i32 -8, i32 -8, i32 -8>
+  %epil.iter.sub = add i32 %epil.iter, -1
+  %epil.iter.cmp.not = icmp eq i32 %epil.iter.sub, 0
+  br i1 %epil.iter.cmp.not, label %middle.block, label %vector.body.epil, !llvm.loop !2
+
+middle.block:                                     ; preds = %vector.body.epil, %middle.block.unr-lcssa
+  %.lcssa14 = phi <4 x i32> [ %.lcssa14.ph, %middle.block.unr-lcssa ], [ %15, %vector.body.epil ]
+  %.lcssa13 = phi <4 x i32> [ %.lcssa13.ph, %middle.block.unr-lcssa ], [ %16, %vector.body.epil ]
+  %bin.rdx = mul <4 x i32> %.lcssa13, %.lcssa14
+  %17 = call i32 @llvm.vector.reduce.mul.v4i32(<4 x i32> %bin.rdx)
+  %cmp.n = icmp eq i32 %2, %n.vec
+  br i1 %cmp.n, label %common.ret, label %if.end.preheader12
+
+if.end.preheader12:                               ; preds = %if.end.preheader, %middle.block
+  %.tr9.ph = phi i32 [ %0, %if.end.preheader ], [ %ind.end, %middle.block ]
+  %accumulator.tr8.ph = phi i32 [ 1, %if.end.preheader ], [ %17, %middle.block ]
+  br label %if.end
+
+common.ret:                                       ; preds = %if.end, %middle.block, %entry
+  %accumulator.tr.lcssa = phi i32 [ 1, %entry ], [ %17, %middle.block ], [ %19, %if.end ]
   ret i32 %accumulator.tr.lcssa
 
-if.end:                                           ; preds = %entry, %if.end
-  %.tr9 = phi i32 [ %2, %if.end ], [ %0, %entry ]
-  %accumulator.tr8 = phi i32 [ %3, %if.end ], [ 1, %entry ]
-  %2 = add nsw i32 %.tr9, -1
-  %3 = mul i32 %.tr9, %accumulator.tr8
-  %4 = icmp slt i32 %.tr9, 3
-  br i1 %4, label %common.ret, label %if.end
+if.end:                                           ; preds = %if.end.preheader12, %if.end
+  %.tr9 = phi i32 [ %18, %if.end ], [ %.tr9.ph, %if.end.preheader12 ]
+  %accumulator.tr8 = phi i32 [ %19, %if.end ], [ %accumulator.tr8.ph, %if.end.preheader12 ]
+  %18 = add nsw i32 %.tr9, -1
+  %19 = mul i32 %.tr9, %accumulator.tr8
+  %20 = icmp slt i32 %.tr9, 3
+  br i1 %20, label %common.ret, label %if.end, !llvm.loop !4
 }
 
-define i32 @main() {
+; Function Attrs: nofree nounwind
+define i32 @main() local_unnamed_addr #0 {
 entry:
-  %0 = tail call i32 @"faculty(int)"(i32 10)
-  %1 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([21 x i8], [21 x i8]* @0, i64 0, i64 0), i32 10, i32 %0)
+  %0 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([21 x i8], [21 x i8]* @0, i64 0, i64 0), i32 10, i32 3628800)
   ret i32 0
 }
 
-attributes #0 = { nounwind }
+; Function Attrs: nofree nosync nounwind readnone willreturn
+declare i32 @llvm.vector.reduce.mul.v4i32(<4 x i32>) #2
+
+attributes #0 = { nofree nounwind }
+attributes #1 = { nofree nosync nounwind readnone }
+attributes #2 = { nofree nosync nounwind readnone willreturn }
+
+!0 = distinct !{!0, !1}
+!1 = !{!"llvm.loop.isvectorized", i32 1}
+!2 = distinct !{!2, !3}
+!3 = !{!"llvm.loop.unroll.disable"}
+!4 = distinct !{!4, !5, !1}
+!5 = !{!"llvm.loop.unroll.runtime.disable"}

--- a/compiler/test/test-files/generator/arbitrary/success-faculty/ir-code.ll
+++ b/compiler/test/test-files/generator/arbitrary/success-faculty/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [21 x i8] c"Faculty of %d is: %d\00", align 1
 

--- a/compiler/test/test-files/generator/arbitrary/success-faculty/symbol-table.json
+++ b/compiler/test/test-files/generator/arbitrary/success-faculty/symbol-table.json
@@ -10,7 +10,7 @@
       "symbols": [
         {
           "isGlobal": false,
-          "name": "n",
+          "name": "input",
           "orderIndex": 0,
           "specifiers": {
             "const": false,
@@ -37,6 +37,28 @@
       "symbols": [
         {
           "isGlobal": false,
+          "name": "faculty",
+          "orderIndex": 2,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "input",
+          "orderIndex": 1,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
           "name": "result",
           "orderIndex": 0,
           "specifiers": {
@@ -52,7 +74,7 @@
   "symbols": [
     {
       "isGlobal": true,
-      "name": "fibo(int)",
+      "name": "faculty(int)",
       "orderIndex": 0,
       "specifiers": {
         "const": true,

--- a/compiler/test/test-files/generator/arbitrary/success-fibonacci/ir-code-O3.ll
+++ b/compiler/test/test-files/generator/arbitrary/success-fibonacci/ir-code-O3.ll
@@ -1,12 +1,15 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [20 x i8] c"Fibonacci of %d: %d\00", align 1
 
-declare i32 @printf(i8*, ...)
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(i8* nocapture noundef readonly, ...) local_unnamed_addr #0
 
-; Function Attrs: nounwind
-define i32 @"fib(int)"(i32 %0) #0 {
+; Function Attrs: nofree nosync nounwind readnone
+define i32 @"fib(int)"(i32 %0) local_unnamed_addr #1 {
 entry:
   %1 = icmp slt i32 %0, 3
   br i1 %1, label %common.ret, label %if.end
@@ -30,11 +33,13 @@ if.end:                                           ; preds = %entry, %if.end
   br i1 %6, label %common.ret.loopexit, label %if.end
 }
 
-define i32 @main() {
+; Function Attrs: nofree nounwind
+define i32 @main() local_unnamed_addr #0 {
 entry:
   %0 = tail call i32 @"fib(int)"(i32 46)
-  %1 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @0, i64 0, i64 0), i32 46, i32 %0)
+  %1 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @0, i64 0, i64 0), i32 46, i32 %0)
   ret i32 0
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { nofree nounwind }
+attributes #1 = { nofree nosync nounwind readnone }

--- a/compiler/test/test-files/generator/arbitrary/success-fibonacci/ir-code.ll
+++ b/compiler/test/test-files/generator/arbitrary/success-fibonacci/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [20 x i8] c"Fibonacci of %d: %d\00", align 1
 

--- a/compiler/test/test-files/generator/arbitrary/success-fibonacci/symbol-table.json
+++ b/compiler/test/test-files/generator/arbitrary/success-fibonacci/symbol-table.json
@@ -37,6 +37,17 @@
       "symbols": [
         {
           "isGlobal": false,
+          "name": "base",
+          "orderIndex": 1,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
           "name": "result",
           "orderIndex": 0,
           "specifiers": {
@@ -52,7 +63,7 @@
   "symbols": [
     {
       "isGlobal": true,
-      "name": "fibo(int)",
+      "name": "fib(int)",
       "orderIndex": 0,
       "specifiers": {
         "const": true,

--- a/compiler/test/test-files/generator/arbitrary/success-pidigits/ir-code-O3.ll
+++ b/compiler/test/test-files/generator/arbitrary/success-pidigits/ir-code-O3.ll
@@ -1,18 +1,19 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
-declare i32 @printf(i8*, ...)
-
-; Function Attrs: nounwind
-define i32 @"makePi()"() #0 {
+; Function Attrs: nofree norecurse nosync nounwind readnone
+define i32 @"makePi()"() local_unnamed_addr #0 {
 entry:
   ret i32 3
 }
 
-define i32 @main() {
+; Function Attrs: mustprogress nofree norecurse nosync nounwind readnone willreturn
+define i32 @main() local_unnamed_addr #1 {
 entry:
-  %0 = tail call i32 @"makePi()"()
   ret i32 0
 }
 
-attributes #0 = { nounwind }
+attributes #0 = { nofree norecurse nosync nounwind readnone }
+attributes #1 = { mustprogress nofree norecurse nosync nounwind readnone willreturn }

--- a/compiler/test/test-files/generator/arbitrary/success-pidigits/ir-code.ll
+++ b/compiler/test/test-files/generator/arbitrary/success-pidigits/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 declare i32 @printf(i8*, ...)
 

--- a/compiler/test/test-files/generator/arbitrary/success-pidigits/symbol-table.json
+++ b/compiler/test/test-files/generator/arbitrary/success-pidigits/symbol-table.json
@@ -1,0 +1,163 @@
+{
+  "children": [
+    {
+      "children": [],
+      "symbols": [
+        {
+          "isGlobal": false,
+          "name": "result",
+          "orderIndex": 0,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        }
+      ]
+    },
+    {
+      "children": [
+        {
+          "children": [
+            {
+              "children": [],
+              "symbols": []
+            },
+            {
+              "children": [],
+              "symbols": []
+            }
+          ],
+          "symbols": [
+            {
+              "isGlobal": false,
+              "name": "i",
+              "orderIndex": 0,
+              "specifiers": {
+                "const": false,
+                "signed": true
+              },
+              "state": "initialized",
+              "type": "int"
+            }
+          ]
+        }
+      ],
+      "symbols": [
+        {
+          "isGlobal": false,
+          "name": "k",
+          "orderIndex": 4,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "m",
+          "orderIndex": 5,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "outputCounter",
+          "orderIndex": 7,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "q",
+          "orderIndex": 1,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "r",
+          "orderIndex": 2,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "result",
+          "orderIndex": 0,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "t",
+          "orderIndex": 3,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "isGlobal": false,
+          "name": "x",
+          "orderIndex": 6,
+          "specifiers": {
+            "const": false,
+            "signed": true
+          },
+          "state": "initialized",
+          "type": "int"
+        }
+      ]
+    }
+  ],
+  "symbols": [
+    {
+      "isGlobal": true,
+      "name": "main()",
+      "orderIndex": 1,
+      "specifiers": {
+        "const": true,
+        "signed": false
+      },
+      "state": "initialized",
+      "type": "function"
+    },
+    {
+      "isGlobal": true,
+      "name": "makePi()",
+      "orderIndex": 0,
+      "specifiers": {
+        "const": true,
+        "signed": false
+      },
+      "state": "initialized",
+      "type": "function"
+    }
+  ]
+}

--- a/compiler/test/test-files/generator/arrays/success-arrays/ir-code.ll
+++ b/compiler/test/test-files/generator/arrays/success-arrays/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [23 x i8] c"Item 0: %d, item 2: %d\00", align 1
 

--- a/compiler/test/test-files/generator/arrays/success-arrays2/ir-code.ll
+++ b/compiler/test/test-files/generator/arrays/success-arrays2/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @intArray = dso_local constant [10 x i32] [i32 1, i32 2, i32 4, i32 8, i32 16, i32 32, i32 64, i32 128, i32 256, i32 512]
 @0 = private unnamed_addr constant [17 x i8] c"intArray[3]: %d\0A\00", align 1

--- a/compiler/test/test-files/generator/arrays/success-string-char-access/ir-code.ll
+++ b/compiler/test/test-files/generator/arrays/success-string-char-access/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [5 x i8] c"test\00", align 1
 @1 = private unnamed_addr constant [10 x i8] c"Char: %c\0A\00", align 1

--- a/compiler/test/test-files/generator/builtins/success-printf/ir-code-O2.ll
+++ b/compiler/test/test-files/generator/builtins/success-printf/ir-code-O2.ll
@@ -1,12 +1,18 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [13 x i8] c"Hello World!\00", align 1
 
-declare i32 @printf(i8*, ...)
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(i8* nocapture noundef readonly, ...) local_unnamed_addr #0
 
-define i32 @main() {
+; Function Attrs: nofree nounwind
+define i32 @main() local_unnamed_addr #0 {
 entry:
-  %0 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([13 x i8], [13 x i8]* @0, i64 0, i64 0))
+  %0 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([13 x i8], [13 x i8]* @0, i64 0, i64 0))
   ret i32 0
 }
+
+attributes #0 = { nofree nounwind }

--- a/compiler/test/test-files/generator/builtins/success-printf/ir-code.ll
+++ b/compiler/test/test-files/generator/builtins/success-printf/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [13 x i8] c"Hello World!\00", align 1
 

--- a/compiler/test/test-files/generator/builtins/success-sizeof/ir-code-O2.ll
+++ b/compiler/test/test-files/generator/builtins/success-sizeof/ir-code-O2.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [20 x i8] c"Size of double: %d\0A\00", align 1
 @1 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1
@@ -8,23 +10,26 @@ source_filename = "source.spice"
 @4 = private unnamed_addr constant [18 x i8] c"Size of byte: %d\0A\00", align 1
 @5 = private unnamed_addr constant [18 x i8] c"Size of char: %d\0A\00", align 1
 @6 = private unnamed_addr constant [20 x i8] c"Size of string: %d\0A\00", align 1
-@7 = private unnamed_addr constant [13 x i8] c"Hello Spice!\00", align 1
-@8 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
-@intArray = dso_local constant [7 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7]
-@9 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
+@7 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
+@intArray = dso_local local_unnamed_addr constant [7 x i32] [i32 1, i32 2, i32 3, i32 4, i32 5, i32 6, i32 7]
+@8 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
 
-declare i32 @printf(i8*, ...)
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(i8* nocapture noundef readonly, ...) local_unnamed_addr #0
 
-define i32 @main() {
+; Function Attrs: nofree nounwind
+define i32 @main() local_unnamed_addr #0 {
 entry:
-  %0 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @0, i64 0, i64 0), i32 64)
-  %1 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([17 x i8], [17 x i8]* @1, i64 0, i64 0), i32 32)
-  %2 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @2, i64 0, i64 0), i32 16)
-  %3 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @3, i64 0, i64 0), i32 64)
-  %4 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @4, i64 0, i64 0), i32 8)
-  %5 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @5, i64 0, i64 0), i32 8)
-  %6 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @6, i64 0, i64 0), i32 0)
-  %7 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @8, i64 0, i64 0), i32 1)
-  %8 = tail call i32 (i8*, ...) @printf(i8* noundef nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @9, i64 0, i64 0), i32 7)
+  %0 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @0, i64 0, i64 0), i32 64)
+  %1 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([17 x i8], [17 x i8]* @1, i64 0, i64 0), i32 32)
+  %2 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @2, i64 0, i64 0), i32 16)
+  %3 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @3, i64 0, i64 0), i32 64)
+  %4 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @4, i64 0, i64 0), i32 8)
+  %5 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @5, i64 0, i64 0), i32 8)
+  %6 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([20 x i8], [20 x i8]* @6, i64 0, i64 0), i32 0)
+  %7 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([18 x i8], [18 x i8]* @7, i64 0, i64 0), i32 1)
+  %8 = tail call i32 (i8*, ...) @printf(i8* nonnull dereferenceable(1) getelementptr inbounds ([19 x i8], [19 x i8]* @8, i64 0, i64 0), i32 7)
   ret i32 0
 }
+
+attributes #0 = { nofree nounwind }

--- a/compiler/test/test-files/generator/builtins/success-sizeof/ir-code.ll
+++ b/compiler/test/test-files/generator/builtins/success-sizeof/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [20 x i8] c"Size of double: %d\0A\00", align 1
 @1 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1
@@ -65,8 +67,8 @@ entry:
   store i32 16, i32* %5, align 4
   %36 = load i32, i32* %5, align 4
   %37 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([19 x i8], [19 x i8]* @2, i32 0, i32 0), i32 %36)
-  store i64 9223372036854775807, i64* %6, align 4
-  %38 = load i64, i64* %6, align 4
+  store i64 9223372036854775807, i64* %6, align 8
+  %38 = load i64, i64* %6, align 8
   store i32 64, i32* %7, align 4
   %39 = load i32, i32* %7, align 4
   %40 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @3, i32 0, i32 0), i32 %39)

--- a/compiler/test/test-files/generator/cli-args/success-cli-args/ir-code.ll
+++ b/compiler/test/test-files/generator/cli-args/success-cli-args/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [10 x i8] c"Argc: %d\0A\00", align 1
 @1 = private unnamed_addr constant [16 x i8] c"Argv no. 0: %s\0A\00", align 1

--- a/compiler/test/test-files/generator/for-loops/success-for-loop/ir-code.ll
+++ b/compiler/test/test-files/generator/for-loops/success-for-loop/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [9 x i8] c"Step %d\0A\00", align 1
 

--- a/compiler/test/test-files/generator/foreach-loops/success-foreach-loop-indexed-modified/ir-code.ll
+++ b/compiler/test/test-files/generator/foreach-loops/success-foreach-loop-indexed-modified/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @intArray = dso_local constant [7 x i32] [i32 1, i32 5, i32 4, i32 0, i32 12, i32 12345, i32 9]
 @0 = private unnamed_addr constant [23 x i8] c"Item for index %d, %d\0A\00", align 1

--- a/compiler/test/test-files/generator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
+++ b/compiler/test/test-files/generator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @intArray = dso_local constant [7 x i32] [i32 1, i32 5, i32 4, i32 0, i32 12, i32 12345, i32 9]
 @0 = private unnamed_addr constant [23 x i8] c"Item for index %d, %d\0A\00", align 1

--- a/compiler/test/test-files/generator/foreach-loops/success-foreach-loop-normal/ir-code.ll
+++ b/compiler/test/test-files/generator/foreach-loops/success-foreach-loop-normal/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @intArray = dso_local constant [7 x i32] [i32 1, i32 5, i32 4, i32 0, i32 12, i32 12345, i32 9]
 @0 = private unnamed_addr constant [22 x i8] c"Item at index %d: %d\0A\00", align 1

--- a/compiler/test/test-files/generator/if-stmts/success-if-else-stmt/ir-code.ll
+++ b/compiler/test/test-files/generator/if-stmts/success-if-else-stmt/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [10 x i8] c"If branch\00", align 1
 @1 = private unnamed_addr constant [10 x i8] c"Else if 1\00", align 1

--- a/compiler/test/test-files/generator/if-stmts/success-if-stmt/ir-code.ll
+++ b/compiler/test/test-files/generator/if-stmts/success-if-stmt/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [16 x i8] c"Condition true\0A\00", align 1
 @1 = private unnamed_addr constant [17 x i8] c"Condition false\0A\00", align 1

--- a/compiler/test/test-files/generator/imports/success-modules-std/ir-code.ll
+++ b/compiler/test/test-files/generator/imports/success-modules-std/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [12 x i8] c"Result: %d\0A\00", align 1
 

--- a/compiler/test/test-files/generator/imports/success-modules/ir-code.ll
+++ b/compiler/test/test-files/generator/imports/success-modules/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
 

--- a/compiler/test/test-files/generator/methods/success-methods/ir-code.ll
+++ b/compiler/test/test-files/generator/methods/success-methods/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 %Letter = type { i8* }
 

--- a/compiler/test/test-files/generator/operators/success-operators/ir-code.ll
+++ b/compiler/test/test-files/generator/operators/success-operators/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [11 x i8] c"Value: %d\0A\00", align 1
 

--- a/compiler/test/test-files/generator/pointers/success-nested-pointers/ir-code.ll
+++ b/compiler/test/test-files/generator/pointers/success-nested-pointers/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [7 x i8] c"1: %d\0A\00", align 1
 @1 = private unnamed_addr constant [7 x i8] c"2: %d\0A\00", align 1

--- a/compiler/test/test-files/generator/pointers/success-pointer-functions/ir-code.ll
+++ b/compiler/test/test-files/generator/pointers/success-pointer-functions/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 %Person = type { i8*, i8*, i32 }
 

--- a/compiler/test/test-files/generator/pointers/success-pointer/ir-code.ll
+++ b/compiler/test/test-files/generator/pointers/success-pointer/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [6 x i8] c"Pizza\00", align 1
 @1 = private unnamed_addr constant [31 x i8] c"Pointer address: %p, value: %s\00", align 1

--- a/compiler/test/test-files/generator/structs/success-struct/ir-code.ll
+++ b/compiler/test/test-files/generator/structs/success-struct/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 %Nested = type { i8*, i1* }
 %TestStruct = type { i32*, double, %Nested* }

--- a/compiler/test/test-files/generator/variables/success-decl-default-value/ir-code.ll
+++ b/compiler/test/test-files/generator/variables/success-decl-default-value/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [17 x i8] c"Double value: %f\00", align 1
 

--- a/compiler/test/test-files/generator/variables/success-global-variables/ir-code.ll
+++ b/compiler/test/test-files/generator/variables/success-global-variables/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @test1 = dso_local global i32 10
 @test2 = dso_local global i8* getelementptr inbounds ([12 x i8], [12 x i8]* @0, i32 0, i32 0)

--- a/compiler/test/test-files/generator/while-loops/success-while-loop/ir-code.ll
+++ b/compiler/test/test-files/generator/while-loops/success-while-loop/ir-code.ll
@@ -1,5 +1,7 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
 
 @0 = private unnamed_addr constant [17 x i8] c"i is now at: %d\0A\00", align 1
 

--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -25,7 +25,7 @@ f<int> main() {
     a.destructor();
 }*/
 
-/*f<int> makePi() {
+f<int> makePi() {
     // Initialize variables
     int q = 1;
     int r = 0;
@@ -60,9 +60,4 @@ f<int> main() {
 
 f<int> main() {
     makePi();
-}*/
-
-f<int> main() {
-    double d = -4.5;
-    printf("Double: %f", d);
 }


### PR DESCRIPTION
- Migrate to new LLVM opt pass manager
- Upgrade LLVM to 13.0.1
- Validate Goreleaser config on every Go CI run
- Code improvements
- Optimize imports to reduce compile time and executable size