### PR TITLE
Improve build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,19 +14,6 @@ updates:
     assignees:
       - spicelang/compiler-team
 
-  # VS Code integration
-  - package-ecosystem: npm
-    directory: /integration/vscode
-    schedule:
-      interval: daily
-      time: "04:00"
-    open-pull-requests-limit: 20
-    target-branch: develop
-    reviewers:
-    - spicelang/compiler-team
-    assignees:
-    - spicelang/compiler-team
-
   # Dockerfile
   - package-ecosystem: docker
     directory: /

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           mkdir ./compiler/bin
           cd ./compiler/bin
-          cmake -DCMAKE_BUILD_TYPE=Release -G "Unix Makefiles" -Wattributes ..
+          cmake -DCMAKE_BUILD_TYPE=Release -GNinja -DCMAKE_CXX_FLAGS_RELEASE="-O2" -Wattributes ..
           cmake --build . --target Spice_test
 
       - name: Run Test target

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Setup Ninja
+        run: sudo apt-get install ninja-build
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v2
@@ -34,7 +37,7 @@ jobs:
           git clone --depth  1 --branch llvmorg-13.0.1 https://github.com/llvm/llvm-project llvm
           mkdir ./llvm/build
           cd ./llvm/build
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS_RELEASE="-O2" -G "Unix Makefiles" ../llvm
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS_RELEASE="-O2" -GNinja ../llvm
           cmake --build .
 
       - name: Download Libs

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Configure & compile project
         run: |
           mkdir bin
-          ./dockcross --image dockcross/${{ matrix.config.arch }}:${{ matrix.config.dockcross }} -a "-e LLVM_DIR=/work/llvm/build/lib/cmake/llvm" bash -c "sudo mkdir -p /usr/share/man/man1 && sudo apt-get update -y && sudo apt-get install --ignore-missing --no-install-recommends --yes libc6-i386 openjdk-11-jre uuid-dev && cd ./bin && cmake -GNinja ../compiler && cmake --build ."
+          ./dockcross --image dockcross/${{ matrix.config.arch }}:${{ matrix.config.dockcross }} -a "-e LLVM_DIR=/work/llvm/build/lib/cmake/llvm" bash -c "sudo mkdir -p /usr/share/man/man1 && sudo apt-get update -y && sudo apt-get install --ignore-missing --no-install-recommends --yes libc6-i386 openjdk-11-jre uuid-dev && cd ./bin && cmake -GNinja -DCMAKE_CXX_FLAGS_RELEASE="-O2" ../compiler && cmake --build ."
 
       - name: Process build output - Linux
         if: ${{ startsWith(matrix.config.arch, 'linux') }}

--- a/compiler/.gitignore
+++ b/compiler/.gitignore
@@ -1,6 +1,7 @@
 # Build output
 build/*
 cmake-build-debug/*
+cmake-build-release/*
 
 # Third party libs
 lib/*

--- a/compiler/CMakeLists.txt
+++ b/compiler/CMakeLists.txt
@@ -13,7 +13,7 @@ set(ANTLR_EXECUTABLE ${CMAKE_CURRENT_SOURCE_DIR}/src/thirdparty/antlr/antlr-4.9.
 # LLVM
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
-message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
+message(STATUS "Using LLVMConfig.cmake from ${LLVM_DIR}")
 include_directories(${LLVM_INCLUDE_DIRS})
 separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 add_definitions(${LLVM_DEFINITIONS_LIST})

--- a/compiler/src/cmake/ExternalAntlr4Cpp.cmake
+++ b/compiler/src/cmake/ExternalAntlr4Cpp.cmake
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.7)
 
+cmake_policy(SET CMP0114 NEW)
+
 include(ExternalProject)
 
 set(ANTLR4_ROOT ${CMAKE_CURRENT_BINARY_DIR}/antlr4_runtime/src/antlr4_runtime)

--- a/compiler/src/main.cpp
+++ b/compiler/src/main.cpp
@@ -31,8 +31,10 @@ int main(int argc, char** argv) { // Call ./spicec filePath targetArch targetVen
     // Add relative prefix to filename
     if (mainSourceFile.find("/\\") != std::string::npos) mainSourceFile = "./" + mainSourceFile;
 
-    /* Compile main source file. All files, that are included by the main source file will call the 'compileSourceFile'
-     * function again. */
+    /*
+     * Compile main source file. All files, that are included by the main source file will call the 'compileSourceFile'
+     * function again.
+     */
     try {
         CompilerInstance::CompileSourceFile(mainSourceFile, targetArch, targetVendor, targetOs, objectDir, debugOutput,
                                             optLevel, true, false);


### PR DESCRIPTION
- Use -O2 build for release and debug
- Set cmake compatibility policy explicitly to avoid configuration warnings
- Remove obsolete vscode integration dependabot config