### PR TITLE
Support explicit inlining

### DIFF
--- a/compiler/src/generator/GeneratorVisitor.cpp
+++ b/compiler/src/generator/GeneratorVisitor.cpp
@@ -270,6 +270,7 @@ antlrcpp::Any GeneratorVisitor::visitFunctionDef(SpiceParser::FunctionDefContext
     llvm::Function* fct = llvm::Function::Create(fctType, llvm::Function::ExternalLinkage,
                                                  signature.toString(), module.get());
     fct->addFnAttr(llvm::Attribute::NoUnwind);
+    if (ctx->INLINE()) fct->addFnAttr(llvm::Attribute::AlwaysInline);
 
     // Create entry block
     llvm::BasicBlock* bEntry = allocaInsertBlock = llvm::BasicBlock::Create(*context, "entry");
@@ -377,6 +378,7 @@ antlrcpp::Any GeneratorVisitor::visitProcedureDef(SpiceParser::ProcedureDefConte
     llvm::Function* proc = llvm::Function::Create(procType, llvm::Function::ExternalLinkage,
                                                   signature.toString(), module.get());
     proc->addFnAttr(llvm::Attribute::NoUnwind);
+    if (ctx->INLINE()) proc->addFnAttr(llvm::Attribute::AlwaysInline);
 
     // Create entry block
     llvm::BasicBlock* bEntry = allocaInsertBlock = llvm::BasicBlock::Create(*context, "entry");

--- a/compiler/src/generator/GeneratorVisitor.cpp
+++ b/compiler/src/generator/GeneratorVisitor.cpp
@@ -23,6 +23,8 @@
 #include <llvm/Target/TargetOptions.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Analysis/AliasAnalysis.h>
+#include <llvm/Transforms/IPO/AlwaysInliner.h>
+#include <llvm/IR/GlobalValue.h>
 
 GeneratorVisitor::GeneratorVisitor(SymbolTable* symbolTable, const std::string& sourceFile, const std::string& targetArch,
                                    const std::string& targetVendor, const std::string& targetOs, const std::string& outputPath,
@@ -95,6 +97,7 @@ void GeneratorVisitor::optimize() {
     // Run passes
     llvm::PassBuilder::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
     llvm::ModulePassManager modulePassMgr = passBuilder.buildPerModuleDefaultPipeline(llvmOptLevel);
+    modulePassMgr.addPass(llvm::AlwaysInlinerPass());
     modulePassMgr.run(*module, moduleAnalysisMgr);
 }
 
@@ -267,8 +270,8 @@ antlrcpp::Any GeneratorVisitor::visitFunctionDef(SpiceParser::FunctionDefContext
 
     // Create function itself
     llvm::FunctionType* fctType = llvm::FunctionType::get(returnType, paramTypes, false);
-    llvm::Function* fct = llvm::Function::Create(fctType, llvm::Function::ExternalLinkage,
-                                                 signature.toString(), module.get());
+    llvm::GlobalValue::LinkageTypes linkage = ctx->INLINE() ? llvm::Function::InternalLinkage : llvm::Function::ExternalLinkage;
+    llvm::Function* fct = llvm::Function::Create(fctType, linkage, signature.toString(), module.get());
     fct->addFnAttr(llvm::Attribute::NoUnwind);
     if (ctx->INLINE()) fct->addFnAttr(llvm::Attribute::AlwaysInline);
 
@@ -375,8 +378,8 @@ antlrcpp::Any GeneratorVisitor::visitProcedureDef(SpiceParser::ProcedureDefConte
     // Create procedure itself
     llvm::FunctionType* procType = llvm::FunctionType::get(llvm::Type::getVoidTy(*context),
                                                            paramTypes, false);
-    llvm::Function* proc = llvm::Function::Create(procType, llvm::Function::ExternalLinkage,
-                                                  signature.toString(), module.get());
+    llvm::GlobalValue::LinkageTypes linkage = ctx->INLINE() ? llvm::Function::InternalLinkage : llvm::Function::ExternalLinkage;
+    llvm::Function* proc = llvm::Function::Create(procType, linkage, signature.toString(), module.get());
     proc->addFnAttr(llvm::Attribute::NoUnwind);
     if (ctx->INLINE()) proc->addFnAttr(llvm::Attribute::AlwaysInline);
 

--- a/compiler/src/grammar/Spice.g4
+++ b/compiler/src/grammar/Spice.g4
@@ -5,8 +5,8 @@ grammar Spice;
 // Control structures
 entry: (mainFunctionDef | functionDef | procedureDef | structDef | globalVarDef | importStmt | extDecl)*;
 mainFunctionDef: F LESS TYPE_INT GREATER MAIN LPAREN paramLstDef? RPAREN LBRACE stmtLst RBRACE;
-functionDef: F LESS dataType GREATER (IDENTIFIER DOT)? IDENTIFIER LPAREN paramLstDef? RPAREN LBRACE stmtLst RBRACE;
-procedureDef: P (IDENTIFIER DOT)? IDENTIFIER LPAREN paramLstDef? RPAREN LBRACE stmtLst RBRACE;
+functionDef: INLINE? F LESS dataType GREATER (IDENTIFIER DOT)? IDENTIFIER LPAREN paramLstDef? RPAREN LBRACE stmtLst RBRACE;
+procedureDef: INLINE? P (IDENTIFIER DOT)? IDENTIFIER LPAREN paramLstDef? RPAREN LBRACE stmtLst RBRACE;
 extDecl: EXT (LESS dataType GREATER)? IDENTIFIER LPAREN typeLst? RPAREN DLL? SEMICOLON;
 structDef: TYPE IDENTIFIER STRUCT LBRACE field* RBRACE;
 globalVarDef: declSpecifiers? dataType IDENTIFIER (ASSIGN MINUS? value)? SEMICOLON;
@@ -99,6 +99,7 @@ PRINTF: 'printf';
 SIZEOF: 'sizeof';
 EXT: 'ext';
 DLL: 'dll';
+INLINE: 'inline';
 TRUE: 'true';
 FALSE: 'false';
 

--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -62,8 +62,16 @@ f<int> main() {
     makePi();
 }*/
 
-import "std/io/dir" as dir;
+/*import "std/io/dir" as dir;
 
 f<int> main() {
     dir.mkDir("./test", dir.MODE_ALL_RWX);
+}*/
+
+inline f<long> getInlinedValue() {
+    return 12l;
+}
+
+f<int> main() {
+    printf("Inlined value: %d\n", getInlinedValue());
 }


### PR DESCRIPTION
- Add support for explicit function/procedure inlining by using the new `inline` keyword
- When the `ìnline` keyword is provided, the linkage and visibility is always set to private automatically