### PR TITLE
Improve cli flags for debug output

### DIFF
--- a/.run/Spice_run.run.xml
+++ b/.run/Spice_run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="Spice_run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O2 ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="Spice_run" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="Spice_run">
+  <configuration default="false" name="Spice_run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -ir -O2 ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="Spice_run" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="Spice_run">
     <envs>
       <env name="RUN_TESTS" value="OFF" />
     </envs>

--- a/src/cli/CliInterface.cpp
+++ b/src/cli/CliInterface.cpp
@@ -112,6 +112,11 @@ void CliInterface::enrich() {
     cliOptions.targetVendor = triple.getVendorName();
     cliOptions.targetOs = triple.getOSName();
   }
+  // Dump IR as well as symbol table if all debug output is enabled
+  if (cliOptions.printDebugOutput) {
+    cliOptions.dumpIR = true;
+    cliOptions.dumpSymbolTables = true;
+  }
 }
 
 /**
@@ -129,6 +134,10 @@ void CliInterface::addBuildSubcommand() {
 
   // --debug-output
   subCmd->add_flag<bool>("--debug-output,-d", cliOptions.printDebugOutput, "Enable debug output");
+  // --dump-ir
+  subCmd->add_flag<bool>("--dump-ir,-ir", cliOptions.dumpIR, "Dump LLVM-IR");
+  // --dump-symtab
+  subCmd->add_flag<bool>("--dump-symtab,-symtab", cliOptions.dumpSymbolTables, "Dump serialized symbol tables");
 
   // --target-triple
   subCmd->add_option<std::string>("--target,-t,--target-triple", cliOptions.targetTriple,
@@ -182,6 +191,10 @@ void CliInterface::addRunSubcommand() {
 
   // --debug-output
   subCmd->add_flag<bool>("--debug-output,-d", cliOptions.printDebugOutput, "Enable debug output");
+  // --dump-ir
+  subCmd->add_flag<bool>("--dump-ir,-ir", cliOptions.dumpIR, "Dump LLVM-IR");
+  // --dump-symtab
+  subCmd->add_flag<bool>("--dump-symtab,-symtab", cliOptions.dumpSymbolTables, "Dump serialized symbol tables");
 
   // --output
   subCmd->add_option<std::string>("--output,-o", cliOptions.outputPath, "Set the output file path");
@@ -221,6 +234,10 @@ void CliInterface::addInstallSubcommand() {
 
   // --debug-output
   subCmd->add_flag<bool>("--debug-output,-d", cliOptions.printDebugOutput, "Enable debug output");
+  // --dump-ir
+  subCmd->add_flag<bool>("--dump-ir,-ir", cliOptions.dumpIR, "Dump LLVM-IR");
+  // --dump-symtab
+  subCmd->add_flag<bool>("--dump-symtab,-symtab", cliOptions.dumpSymbolTables, "Dump serialized symbol tables");
 
   // --output
   subCmd->add_option<std::string>("--output,-o", cliOptions.outputPath, "Set the output file path");

--- a/src/cli/CliInterface.h
+++ b/src/cli/CliInterface.h
@@ -26,6 +26,8 @@ struct CliOptions {
   std::string outputDir;  // Where the object files go. Should always be a temp directory
   std::string outputPath; // Where the output binary goes.
   bool printDebugOutput = false;
+  bool dumpIR = false;
+  bool dumpSymbolTables = false;
   short optLevel = 2; // -O0 = 0, -O1 = 1, -O2 = 2, -O3 = 3, -Os = 4, -Oz = 5
 };
 

--- a/src/dependency/SourceFile.cpp
+++ b/src/dependency/SourceFile.cpp
@@ -92,7 +92,7 @@ void SourceFile::reAnalyze(const std::shared_ptr<llvm::LLVMContext> &context, co
   compilerOutput.symbolTableString = symbolTable->toJSON().dump(2);
 
   // Dump symbol table
-  if (options->printDebugOutput) { // GCOV_EXCL_START
+  if (options->dumpSymbolTables) { // GCOV_EXCL_START
     std::cout << "\nSymbol table of file " << filePath << ":\n\n";
     std::cout << compilerOutput.symbolTableString << "\n";
   } // GCOV_EXCL_STOP
@@ -112,8 +112,8 @@ void SourceFile::generate(const std::shared_ptr<llvm::LLVMContext> &context, con
   compilerOutput.irString = generator->getIRString();
 
   // Dump unoptimized IR code
-  if (options->printDebugOutput) { // GCOV_EXCL_START
-    std::cout << "\nIR code:\n";
+  if (options->dumpIR) { // GCOV_EXCL_START
+    std::cout << "\nUnoptimized IR code:\n";
     generator->dumpIR();
   } // GCOV_EXCL_STOP
 
@@ -125,7 +125,7 @@ void SourceFile::generate(const std::shared_ptr<llvm::LLVMContext> &context, con
     compilerOutput.irOptString = generator->getIRString();
 
     // Dump optimized IR code
-    if (options->printDebugOutput) { // GCOV_EXCL_START
+    if (options->dumpIR) { // GCOV_EXCL_START
       std::cout << "\nOptimized IR code:\n";
       generator->dumpIR();
     } // GCOV_EXCL_STOP

--- a/test/AnalyzerTest.cpp
+++ b/test/AnalyzerTest.cpp
@@ -94,7 +94,7 @@ void executeTest(const AnalyzerTestCase &testCase) {
     ThreadFactory threadFactory = ThreadFactory();
 
     // Create instance of cli options
-    CliOptions options = {sourceFile, "", "", "", "", ".", ".", false, 0};
+    CliOptions options = {sourceFile, "", "", "", "", ".", ".", false, false, false, 0};
     CliInterface cli(options);
     cli.validate();
     cli.enrich();

--- a/test/GeneratorTest.cpp
+++ b/test/GeneratorTest.cpp
@@ -101,7 +101,7 @@ void executeTest(const GeneratorTestCase &testCase) {
     ThreadFactory threadFactory = ThreadFactory();
 
     // Create instance of cli options
-    CliOptions options = {sourceFile, "", "", "", "", ".", ".", false, 0};
+    CliOptions options = {sourceFile, "", "", "", "", ".", ".", false, false, false, 0};
     CliInterface cli(options);
     cli.validate();
     cli.enrich();
@@ -190,17 +190,17 @@ void executeTest(const GeneratorTestCase &testCase) {
 
     // Check if the optimized ir code matches the expected output
     if (options.optLevel > 0) {
-      std::string actualOptimizedIR = mainSourceFile.compilerOutput.irOptString;
+      std::string actualOptIR = mainSourceFile.compilerOutput.irOptString;
       if (TestUtil::isUpdateRefsEnabled()) {
         // Update ref
-        TestUtil::setFileContent(irCodeOptFileName, actualOptimizedIR);
+        TestUtil::setFileContent(irCodeOptFileName, actualOptIR);
       } else {
         // Cut of first n lines to have a target independent
         for (int i = 0; i < IR_FILE_SKIP_LINES; i++) {
           expectedOptIR.erase(0, expectedOptIR.find('\n') + 1);
-          actualOptimizedIR.erase(0, actualOptimizedIR.find('\n') + 1);
+          actualOptIR.erase(0, actualOptIR.find('\n') + 1);
         }
-        EXPECT_EQ(expectedOptIR, actualOptimizedIR);
+        EXPECT_EQ(expectedOptIR, actualOptIR);
       }
     }
 

--- a/test/StdTest.cpp
+++ b/test/StdTest.cpp
@@ -101,7 +101,7 @@ void executeTest(const StdTestCase &testCase) {
     ThreadFactory threadFactory = ThreadFactory();
 
     // Create instance of cli options
-    CliOptions options = {sourceFile, "", "", "", "", ".", ".", false, 0};
+    CliOptions options = {sourceFile, "", "", "", "", ".", ".", false, false, false, 0};
     CliInterface cli(options);
     cli.validate();
     cli.enrich();


### PR DESCRIPTION
- Introduce cli flags `--dump-ir,-ir` and `--dump-symtab,-symtab` to control debug output more granular
- The existing flag `--debug-output,-d` enables all debug output, including IR and symbol tables
- Improve debug output
- Code improvements