### PR TITLE
Improve LLVM type retrieval

### DIFF
--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -10,18 +10,10 @@ f<int> main() {
     printf("Hello %s!", p1.getSecond());
 }*/
 
-p testProc(int[]*** nums) {
-    int[]* nums1 = **nums;
-    int[] nums2 = *nums1;
-    nums2[2] = 10;
-    printf("1: %d\n", nums2[0]);
-    printf("2: %d\n", nums2[1]);
-    printf("3: %d\n", nums2[2]);
-    printf("4: %d\n", nums2[3]);
-}
-
 f<int> main() {
-    int[4] intArray = { 1, 2, 3, 4 };
-    printf("1: %d\n", intArray[1]);
-    testProc(&&&intArray);
+    int value0 = 2;
+    int[5] intArray = { value0, 7, 4 };
+    intArray[2] *= 11;
+    intArray[0] = 3;
+    printf("Item 0: %d, item 2: %d", intArray[0], intArray[2]);
 }

--- a/src/generator/GeneratorVisitor.h
+++ b/src/generator/GeneratorVisitor.h
@@ -166,7 +166,6 @@ private:
   llvm::Function *retrieveExitFct();
   llvm::Function *retrieveStackSaveFct();
   llvm::Function *retrieveStackRestoreFct();
-  llvm::Type *getTypeForSymbolType(SymbolType symbolType, SymbolTable *accessScope);
   llvm::Constant *getDefaultValueForType(llvm::Type *type, const std::string &subTypeName);
   SymbolTableEntry *initExtGlobal(const std::string &globalName, const std::string &fqGlobalName);
   bool compareLLVMTypes(llvm::Type *lhs, llvm::Type *rhs);

--- a/src/symbol/SymbolType.h
+++ b/src/symbol/SymbolType.h
@@ -6,10 +6,13 @@
 #include <string>
 #include <vector>
 
+#include <llvm/IR/DerivedTypes.h>
+#include <llvm/IR/Type.h>
 #include <llvm/IR/Value.h>
 
 // Forward declarations
 class ErrorFactory;
+class SymbolTable;
 struct CodeLoc;
 
 enum SymbolSuperType {
@@ -66,6 +69,7 @@ public:
   [[nodiscard]] SymbolType getContainedTy() const;
   [[nodiscard]] SymbolType replaceBaseSubType(const std::string &newSubType) const;
   [[nodiscard]] SymbolType replaceBaseType(const SymbolType &newBaseType) const;
+  [[nodiscard]] llvm::Type *toLLVMType(llvm::LLVMContext &context, SymbolTable *accessScope) const;
   [[nodiscard]] bool isPointer() const;
   [[nodiscard]] bool isPointerOf(SymbolSuperType superType) const;
   [[nodiscard]] bool isArray() const;


### PR DESCRIPTION
Introduce `SymbolType.toLLVMType()` to replace `getTypeFromSymbolType()`