### PR TITLE
Make compiler query based

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.20
 
       - name: Restore Go modules cache
         uses: actions/cache@v3
@@ -220,7 +220,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.15.0
+          version: v1.15.1
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -220,7 +220,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
-          version: v1.14.1
+          version: v1.15.0
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O2 -ir -asm ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O2 -ir ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="RUN_TESTS" value="OFF" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O2 -ir ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O2 -ir -asm ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="RUN_TESTS" value="OFF" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=true" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
+  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
     <envs>
       <env name="RUN_TESTS" value="ON" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -1,20 +1,20 @@
-//import "std/data/red-black-tree";
-
-type T int|double;
-
-type Node<T> struct {
-    T data
-}
-
-f<int> test<T>(Node<T, Node<T>> test) {
-    return 1;
-}
+import "std/io/dir" as dir;
 
 f<int> main() {
-    dyn node = Node<Node<int>>{ Node<int>{ 12 } };
-    test(node);
-    /*RedBlackTree<int> tree = RedBlackTree<int>();
+    printf("Existing before create: %d\n", dirExists("./test"));
+    dyn mkReturnCode = mkDir("./test", dir::MODE_ALL_RWX);
+    printf("mkDir return code: %d\n", mkReturnCode);
+    printf("Existing after create: %d\n", dirExists("./test"));
+    dyn rmReturnCode = rmDir("./test");
+    printf("rmDir return code: %d\n", rmReturnCode);
+    printf("Existing after delete: %d\n", dirExists("./test"));
+}
+
+/*import "std/data/red-black-tree";
+
+f<int> main() {
+    RedBlackTree<int> tree = RedBlackTree<int>();
     tree.insert(12);
     tree.insert(5);
-    tree.insert(7);*/
-}
+    tree.insert(7);
+}*/

--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -1,3 +1,20 @@
+//import "std/data/red-black-tree";
+
+type T int|double;
+
+type Node<T> struct {
+    T data
+}
+
+f<int> test<T>(Node<T, Node<T>> test) {
+    return 1;
+}
+
 f<int> main() {
-    printf("Result: %d", sizeof(type int));
+    dyn node = Node<Node<int>>{ Node<int>{ 12 } };
+    test(node);
+    /*RedBlackTree<int> tree = RedBlackTree<int>();
+    tree.insert(12);
+    tree.insert(5);
+    tree.insert(7);*/
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -70,6 +70,8 @@ set(SOURCES
         typechecker/FunctionManager.h
         typechecker/StructManager.cpp
         typechecker/StructManager.h
+        typechecker/TypeMatcher.cpp
+        typechecker/TypeMatcher.h
         # Borrow checker
         borrowchecker/BorrowChecker.cpp
         borrowchecker/BorrowChecker.h

--- a/src/ast/ASTBuilder.cpp
+++ b/src/ast/ASTBuilder.cpp
@@ -91,9 +91,10 @@ std::any ASTBuilder::visitFunctionDef(SpiceParser::FunctionDefContext *ctx) {
     ParserRuleContext *rule;
     if (rule = dynamic_cast<SpiceParser::SpecifierLstContext *>(subTree); rule != nullptr) // DeclSpecifiers
       currentNode = fctDefNode->createChild<SpecifierLstNode>(CodeLoc(rule->start, filePath));
-    else if (rule = dynamic_cast<SpiceParser::DataTypeContext *>(subTree); rule != nullptr) // DataType
+    else if (rule = dynamic_cast<SpiceParser::DataTypeContext *>(subTree); rule != nullptr) { // DataType
       currentNode = fctDefNode->createChild<DataTypeNode>(CodeLoc(rule->start, filePath));
-    else if (rule = dynamic_cast<SpiceParser::FctNameContext *>(subTree); rule != nullptr) // FctName
+      isReturnType = true;
+    } else if (rule = dynamic_cast<SpiceParser::FctNameContext *>(subTree); rule != nullptr) // FctName
       currentNode = fctDefNode->createChild<FctNameNode>(CodeLoc(rule->start, filePath));
     else if (rule = dynamic_cast<SpiceParser::TypeLstContext *>(subTree); rule != nullptr) { // TypeLst
       currentNode = fctDefNode->createChild<TypeLstNode>(CodeLoc(rule->start, filePath));
@@ -111,6 +112,7 @@ std::any ASTBuilder::visitFunctionDef(SpiceParser::FunctionDefContext *ctx) {
       visit(rule);
       currentNode = fctDefNode;
       isParam = false;
+      isReturnType = false;
     }
   }
 
@@ -1792,6 +1794,7 @@ std::any ASTBuilder::visitCustomDataType(SpiceParser::CustomDataTypeContext *ctx
 
   customDataTypeNode->isParamType = isParam;
   customDataTypeNode->isFieldType = isField;
+  customDataTypeNode->isReturnType = isReturnType;
 
   for (ParserRuleContext::ParseTree *subTree : ctx->children) {
     ParserRuleContext *rule;

--- a/src/ast/ASTBuilder.h
+++ b/src/ast/ASTBuilder.h
@@ -110,6 +110,8 @@ private:
   ASTNode *currentNode;
   const std::string &filePath;
   antlr4::ANTLRInputStream *inputStream;
+  bool isParam = false;
+  bool isField = false;
 
   // Private methods
   int32_t parseInt(ConstantNode *constantNode, TerminalNode *terminal);

--- a/src/ast/ASTBuilder.h
+++ b/src/ast/ASTBuilder.h
@@ -112,6 +112,7 @@ private:
   antlr4::ANTLRInputStream *inputStream;
   bool isParam = false;
   bool isField = false;
+  bool isReturnType = false;
 
   // Private methods
   int32_t parseInt(ConstantNode *constantNode, TerminalNode *terminal);

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -1691,6 +1691,7 @@ public:
   std::vector<SymbolTableEntry *> customTypes;
   bool isParamType = false;
   bool isFieldType = false;
+  bool isReturnType = false;
 };
 
 } // namespace spice::compiler

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -904,13 +904,13 @@ public:
   [[nodiscard]] AssignExprNode *assignExpr() const { return getChild<AssignExprNode>(); }
 
   // Util methods
-  [[nodiscard]] bool isParam() const { return dynamic_cast<ParamLstNode *>(parent); }
   void customItemsInitialization(size_t manifestationCount) override { entries.resize(manifestationCount, nullptr); }
 
   // Public members
   std::string varName;
   bool hasAssignment = false;
   std::vector<SymbolTableEntry *> entries;
+  bool isParam = false;
 };
 
 // ======================================================= SpecifierLstNode ======================================================
@@ -1689,6 +1689,8 @@ public:
   std::string fqTypeName;
   std::vector<std::string> typeNameFragments;
   std::vector<SymbolTableEntry *> customTypes;
+  bool isParamType = false;
+  bool isFieldType = false;
 };
 
 } // namespace spice::compiler

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -470,7 +470,7 @@ std::any IRGenerator::visitStructDef(const StructDefNode *node) {
       fieldTypes.reserve(node->fields().size());
       for (const FieldNode *field : node->fields()) {
         SymbolTableEntry *fieldEntry = currentScope->lookupStrict(field->fieldName);
-        assert(fieldEntry && !fieldEntry->getType().is(TY_GENERIC));
+        assert(fieldEntry && !fieldEntry->getType().hasAnyGenericParts());
         fieldTypes.push_back(fieldEntry->getType().toLLVMType(context, currentScope));
       }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,4 @@ int main(int argc, char **argv) {
     std::cout << e.what() << "\n";
     return EXIT_FAILURE;
   }
-
-  return EXIT_SUCCESS;
 }

--- a/src/model/Function.cpp
+++ b/src/model/Function.cpp
@@ -181,9 +181,9 @@ bool Function::hasSubstantiatedParams() const {
  */
 bool Function::hasSubstantiatedGenerics() const {
   for (const SymbolType &templateType : thisType.getTemplateTypes())
-    if (templateType.isBaseType(TY_GENERIC))
+    if (templateType.hasAnyGenericParts())
       return false;
-  return templateTypes.empty() && !thisType.isBaseType(TY_GENERIC) && !returnType.isBaseType(TY_GENERIC);
+  return templateTypes.empty() && !thisType.hasAnyGenericParts() && !returnType.hasAnyGenericParts();
 }
 
 /**

--- a/src/model/GenericType.cpp
+++ b/src/model/GenericType.cpp
@@ -32,6 +32,9 @@ bool GenericType::checkConditionsOf(const SymbolType &symbolType, bool ignoreArr
  * @return True or false
  */
 bool GenericType::checkTypeConditionOf(const SymbolType &symbolType, bool ignoreArraySize) const {
+  // Succeed if no type conditions are set
+  if (typeConditions.empty())
+    return true;
   // Check type conditions
   return std::ranges::any_of(typeConditions, [&](const SymbolType &typeCondition) {
     if (ignoreArraySize)

--- a/src/model/GenericType.h
+++ b/src/model/GenericType.h
@@ -11,6 +11,9 @@
 
 namespace spice::compiler {
 
+// Typedefs
+using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/SymbolType>;
+
 class GenericType : public SymbolType {
 public:
   // Constructors

--- a/src/model/Struct.cpp
+++ b/src/model/Struct.cpp
@@ -109,43 +109,4 @@ std::vector<SymbolType> Struct::getTemplateTypes() const {
   return templateSymbolTypes;
 }
 
-/**
- * Checks if the current struct is of infinite size.
- *
- * This can happen for structs with at least a:
- * 1) direct dependency (e.g. the struct A has a field with type A)
- * 2) indirect dependency (e.g. the struct A has a field with type B and struct B has a field with type A)
- *
- * @return Infinite size or not
- */
-/*bool Struct::hasInfiniteSize(Scope *anchorScope) const { // NOLINT(misc-no-recursion)
-  // Cancel recursion if we have reached the anchor again
-  if (structScope == anchorScope)
-    return true;
-
-  // Set the recursion anchor scope
-  if (!anchorScope)
-    anchorScope = structScope;
-
-  // Loop through all fields
-  for (const SymbolType &fieldType : fieldTypes) {
-    // Skip non-struct fields
-    if (!fieldType.is(TY_STRUCT))
-      continue;
-    // Check for 1)
-    if (fieldType.getStructBodyScope() == structScope)
-      return true;
-    // Check for 2)
-    const std::string &structName = fieldType.getSubType();
-    Scope *structParentScope = fieldType.getStructBodyScope()->parent;
-    SymbolTableEntry *structEntry = structParentScope->lookupStrict(structName);
-    StructManifestationList *structs = StructManager::getManifestationList(structParentScope, structEntry->getDeclCodeLoc());
-    for (auto &[mangledName, spiceStruct] : *structs) {
-      if (spiceStruct.hasInfiniteSize(anchorScope))
-        return true;
-    }
-  }
-  return false;
-}*/
-
 } // namespace spice::compiler

--- a/src/model/Struct.cpp
+++ b/src/model/Struct.cpp
@@ -86,7 +86,7 @@ std::string Struct::getSignature(const std::string &name, const std::vector<Symb
  */
 bool Struct::hasSubstantiatedGenerics() const {
   return std::none_of(templateTypes.begin(), templateTypes.end(),
-                      [](const GenericType &genericType) { return genericType.isBaseType(TY_GENERIC); });
+                      [](const GenericType &genericType) { return genericType.hasAnyGenericParts(); });
 }
 
 /**

--- a/src/model/Struct.h
+++ b/src/model/Struct.h
@@ -48,6 +48,7 @@ public:
   Scope *structScope = nullptr;
   ASTNode *declNode;
   bool genericSubstantiation = false;
+  bool alreadyTypeChecked = false;
   bool used = false;
 
   // Json serializer/deserializer

--- a/src/model/Struct.h
+++ b/src/model/Struct.h
@@ -36,7 +36,6 @@ public:
   [[nodiscard]] bool hasSubstantiatedGenerics() const;
   [[nodiscard]] bool isFullySubstantiated() const;
   [[nodiscard]] std::vector<SymbolType> getTemplateTypes() const;
-  // bool hasInfiniteSize(Scope *anchorScope = nullptr) const;
 
   // Public members
   std::string name;

--- a/src/model/Struct.h
+++ b/src/model/Struct.h
@@ -46,6 +46,7 @@ public:
   SymbolTableEntry *entry = nullptr;
   Scope *structScope = nullptr;
   ASTNode *declNode;
+  size_t manifestationIndex = 0;
   bool genericSubstantiation = false;
   bool alreadyTypeChecked = false;
   bool used = false;

--- a/src/symboltablebuilder/SymbolType.h
+++ b/src/symboltablebuilder/SymbolType.h
@@ -20,6 +20,7 @@ namespace spice::compiler {
 class SymbolTable;
 class ASTNode;
 class Scope;
+class GenericType;
 
 // Constants
 const char *const STROBJ_NAME = "String";
@@ -161,26 +162,27 @@ public:
     return typeChainCopy;
   }
   [[nodiscard]] inline SymbolType removeReferenceWrappers() const { return SymbolType(getTypeChainWithoutReferences()); }
-  [[nodiscard]] SymbolType getBaseType() const { return SymbolType({typeChain.front()}); }
+  [[nodiscard]] SymbolType getBaseType() const {
+    assert(!typeChain.empty());
+    return SymbolType({typeChain.front()});
+  }
+  [[nodiscard]] bool hasAnyGenericParts() const;
   void setTemplateTypes(const std::vector<SymbolType> &templateTypes);
   void setBaseTemplateTypes(const std::vector<SymbolType> &templateTypes);
   [[nodiscard]] inline const std::vector<SymbolType> &getTemplateTypes() const { return typeChain.back().templateTypes; }
+  [[nodiscard]] bool isCoveredByGenericTypeList(const std::vector<GenericType> &genericTypeList) const;
   [[nodiscard]] std::string getName(bool withSize = false, bool mangledName = false) const;
-  [[nodiscard]] long getArraySize() const;
+  [[nodiscard]] size_t getArraySize() const;
   void setSigned(bool value = true);
   [[nodiscard]] bool isSigned() const;
   void setStructBodyScope(Scope *bodyScope);
   [[nodiscard]] Scope *getStructBodyScope() const;
   friend bool operator==(const SymbolType &lhs, const SymbolType &rhs);
   friend bool operator!=(const SymbolType &lhs, const SymbolType &rhs);
-  bool equalsIgnoreArraySize(const SymbolType &otherType) const;
+  [[nodiscard]] bool equalsIgnoreArraySize(const SymbolType &otherType) const;
 
   // Public members
   TypeChain typeChain;
-
-protected:
-  // Protected methods
-  void setSubType(const std::string &newSubType);
 
 private:
   // Private methods

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -344,7 +344,7 @@ bool FunctionManager::matchArgTypes(Function &candidate, const std::vector<Symbo
  */
 const GenericType *FunctionManager::getGenericTypeOfCandidateByName(const Function &candidate,
                                                                     const std::string &templateTypeName) {
-  for (const auto &templateType : candidate.templateTypes) {
+  for (const GenericType &templateType : candidate.templateTypes) {
     if (templateType.getSubType() == templateTypeName)
       return &templateType;
   }

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -6,6 +6,7 @@
 #include <symboltablebuilder/Scope.h>
 #include <symboltablebuilder/SymbolTableBuilder.h>
 #include <typechecker/TypeChecker.h>
+#include <typechecker/TypeMatcher.h>
 
 namespace spice::compiler {
 
@@ -138,6 +139,8 @@ Function *FunctionManager::insertSubstantiation(Scope *insertScope, const Functi
  */
 Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &requestedName, const SymbolType &requestedThisType,
                                          const std::vector<SymbolType> &requestedParamTypes, const ASTNode *callNode) {
+  assert(requestedThisType.isOneOf({TY_DYN, TY_STRUCT}));
+
   // Copy the registry to prevent iterating over items, that are created within the loop
   FunctionRegistry functionRegistry = matchScope->functions;
   // Loop over function registry to find functions, that match the requirements of the call
@@ -171,6 +174,10 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
       if (!matchArgTypes(candidate, requestedParamTypes, candidate.typeMapping))
         continue; // Leave this manifestation and try the next one
 
+      // We found a match! -> Set the actual candidate and its entry to used
+      candidate.used = true;
+      candidate.entry->used = true;
+
       const SymbolType &thisType = candidate.thisType;
       if (!thisType.is(TY_DYN)) {
         // Update struct scope of 'this' type to the substantiated struct scope
@@ -183,10 +190,6 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
         matchScope = substantiatedStructBodyScope;
       }
 
-      // We found a match! -> Set the actual candidate and its entry to used
-      candidate.used = true;
-      candidate.entry->used = true;
-
       // Check if the function is generic needs to be substantiated
       if (presetFunction.templateTypes.empty()) {
         assert(matchScope->functions.contains(defCodeLocStr) && matchScope->functions.at(defCodeLocStr).contains(mangledName));
@@ -198,12 +201,9 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
       // Clear template types of candidate, since they are not needed anymore
       candidate.templateTypes.clear();
 
-      // Replace return type with concrete type
-      if (candidate.returnType.isBaseType(TY_GENERIC)) {
-        const std::string genericReturnTypeName = candidate.returnType.getBaseType().getSubType();
-        assert(candidate.typeMapping.contains(genericReturnTypeName));
-        candidate.returnType = candidate.returnType.replaceBaseType(candidate.typeMapping.at(genericReturnTypeName));
-      }
+      // Substantiate return type
+      if (candidate.returnType.hasAnyGenericParts())
+        TypeMatcher::substantiateTypeWithTypeMapping(candidate.returnType, candidate.typeMapping);
 
       // Check if we already have this manifestation and can simply re-use it
       if (matchScope->functions.at(defCodeLocStr).contains(candidate.getMangledName())) {
@@ -233,15 +233,16 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
       for (const auto &[typeName, concreteType] : substantiatedFunction->typeMapping)
         childScope->insertGenericType(typeName, GenericType(concreteType));
 
-      // Substantiate the 'this' symbol table entry in the new function scope
+      // Substantiate the 'this' entry in the new function scope
       if (presetFunction.isMethod() && !presetFunction.templateTypes.empty()) {
         SymbolTableEntry *thisEntry = childScope->lookupStrict(THIS_VARIABLE_NAME);
         assert(thisEntry != nullptr);
-        thisEntry->updateType(requestedThisType.toPointer(callNode), /*overwriteExistingType=*/true);
+        thisEntry->updateType(candidate.thisType.toPointer(callNode), /*overwriteExistingType=*/true);
       }
 
       // Add to matched functions
       matches.push_back(substantiatedFunction);
+
       break; // Leave the whole manifestation list to not double-match the manifestation
     }
   }
@@ -278,47 +279,20 @@ bool FunctionManager::matchName(const Function &candidate, const std::string &re
  * @return Fulfilled or not
  */
 bool FunctionManager::matchThisType(Function &candidate, const SymbolType &requestedThisType, TypeMapping &typeMapping) {
-  const SymbolType &candidateThisType = candidate.thisType;
-  const SymbolType &requestedThisBaseType = requestedThisType.getBaseType();
+  SymbolType &candidateThisType = candidate.thisType;
 
-  // If the candidate 'this' type is non-generic, we can simpy check for equality of the types
-  if (candidateThisType.getTemplateTypes().empty())
-    return candidateThisType == requestedThisBaseType;
+  // Give the type matcher a way to retrieve instances of GenericType by their name
+  std::function<const GenericType *(const std::string &)> genericTypeResolver = [=](const std::string &genericTypeName) {
+    return getGenericTypeOfCandidateByName(candidate, genericTypeName);
+  };
 
-  assert(candidateThisType.is(TY_STRUCT) && requestedThisBaseType.is(TY_STRUCT)); // The 'this' type must always be a struct
-
-  // Compare this type template type list sizes
-  const std::vector<SymbolType> &candidateTemplateTypeList = candidateThisType.getTemplateTypes();
-  if (requestedThisBaseType.getTemplateTypes().size() != candidateTemplateTypeList.size())
+  // Check if the requested 'this' type matches the candidate 'this' type. The type mapping may be extended
+  if (!TypeMatcher::matchRequestedToCandidateType(candidateThisType, requestedThisType, typeMapping, genericTypeResolver))
     return false;
 
-  // Substantiate 'this' type
-  std::vector<SymbolType> concreteTemplateTypes;
-  concreteTemplateTypes.reserve(candidateThisType.getTemplateTypes().size());
-  for (size_t i = 0; i < requestedThisBaseType.getTemplateTypes().size(); i++) {
-    const SymbolType &templateType = candidateTemplateTypeList.at(i);
-    const SymbolType &concreteTemplateType = requestedThisBaseType.getTemplateTypes().at(i);
-
-    // If the template type is non-generic, check it directly
-    if (!templateType.is(TY_GENERIC)) {
-      if (templateType != concreteTemplateType)
-        return false;
-      concreteTemplateTypes.push_back(templateType);
-      continue;
-    }
-
-    // Append to concrete template types mapping
-    if (!typeMapping.contains(templateType.getSubType()))
-      typeMapping.insert({templateType.getSubType(), concreteTemplateType});
-    else if (typeMapping.at(templateType.getSubType()) != concreteTemplateType)
-      return false;
-
-    // Add to the list of concrete template types
-    concreteTemplateTypes.push_back(concreteTemplateType);
-  }
-
-  // Mount the new concrete template type list to the 'this' type
-  candidate.thisType.setBaseTemplateTypes(concreteTemplateTypes);
+  // Substantiate the candidate param type, based on the type mapping
+  if (candidateThisType.hasAnyGenericParts())
+    TypeMatcher::substantiateTypeWithTypeMapping(candidateThisType, typeMapping);
 
   return true;
 }
@@ -340,53 +314,22 @@ bool FunctionManager::matchArgTypes(Function &candidate, const std::vector<Symbo
   // Loop over all parameters
   for (size_t i = 0; i < requestedParamTypes.size(); i++) {
     // Retrieve actual and requested types
-    SymbolType requestedParamType = requestedParamTypes.at(i);
-    SymbolType originalParamType = candidate.paramList.at(i).type;
-    SymbolType paramType = originalParamType;
+    const SymbolType &requestedParamType = requestedParamTypes.at(i);
+    assert(!candidate.paramList.at(i).isOptional);
+    SymbolType &candidateParamType = candidate.paramList.at(i).type;
 
-    // If this is a non-generic type, we can do the type check straight away and move to the next param
-    if (!paramType.isBaseType(TY_GENERIC)) {
-      if (paramType.equalsIgnoreArraySize(requestedParamType))
-        continue;
-      return false;
-    }
+    // Give the type matcher a way to retrieve instances of GenericType by their name
+    std::function<const GenericType *(const std::string &)> genericTypeResolver = [=](const std::string &genericTypeName) {
+      return getGenericTypeOfCandidateByName(candidate, genericTypeName);
+    };
 
-    // Unwrap both types
-    while (paramType.isSameContainerTypeAs(requestedParamType)) {
-      requestedParamType = requestedParamType.getContainedTy();
-      paramType = paramType.getContainedTy();
-    }
-
-    // Check if all wrappers around the generic type are removed now
-    if (!paramType.is(TY_GENERIC))
+    // Check if the requested param type matches the candidate param type. The type mapping may be extended
+    if (!TypeMatcher::matchRequestedToCandidateType(candidateParamType, requestedParamType, typeMapping, genericTypeResolver))
       return false;
 
-    // Check if we have an information mismatch
-    const std::string &genericTypeName = paramType.getSubType();
-    if (typeMapping.contains(genericTypeName)) { // Known type name
-      const SymbolType &knownConcreteType = typeMapping.at(paramType.getSubType());
-
-      // Check if the concrete type matches the requested type
-      if (knownConcreteType != requestedParamType)
-        return false;
-
-      // If the already known and the given type match, accept the type straight away and move to the next param
-      SymbolType newParamType = originalParamType.replaceBaseType(knownConcreteType);
-      candidate.paramList.at(i) = Param{newParamType, false};
-      continue;
-    }
-
-    // Check if the given type matches all conditions of the generic type
-    const GenericType *genericType = getGenericTypeOfCandidateByName(candidate, genericTypeName);
-    if (!genericType->checkConditionsOf(requestedParamType, true))
-      return false;
-
-    // Add new type mapping entry
-    typeMapping.insert({genericTypeName, requestedParamType});
-
-    // Substantiate generic type with the requested type
-    const SymbolType &newParamType = originalParamType.replaceBaseType(requestedParamType);
-    candidate.paramList.at(i) = Param{newParamType, false};
+    // Substantiate the candidate param type, based on the type mapping
+    if (candidateParamType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(candidateParamType, typeMapping);
   }
 
   return true;

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -6,6 +6,8 @@
 #include <unordered_map>
 #include <vector>
 
+#include <model/GenericType.h>
+
 namespace spice::compiler {
 
 // Forward declarations
@@ -17,9 +19,9 @@ class ASTNode;
 class GenericType;
 struct CodeLoc;
 
+// Typedefs
 using FunctionManifestationList = std::unordered_map</*mangledName=*/std::string, /*structObject=*/Function>;
 using FunctionRegistry = std::unordered_map</*codeLoc=*/std::string, /*manifestations=*/FunctionManifestationList>;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/SymbolType>;
 
 class FunctionManager {
 public:
@@ -40,7 +42,7 @@ private:
                                                       const ASTNode *declNode);
   [[nodiscard]] static bool matchName(const Function &candidate, const std::string &requestedName);
   [[nodiscard]] static bool matchThisType(Function &candidate, const SymbolType &requestedThisType, TypeMapping &typeMapping);
-  [[nodiscard]] static bool matchArgTypes(Function &candidate, const std::vector<SymbolType> &requestedParamTypes,
+  [[nodiscard]] static bool matchArgTypes(Function &genericTypeName, const std::vector<SymbolType> &requestedParamTypes,
                                           TypeMapping &typeMapping);
   [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Function &candidate,
                                                                           const std::string &templateTypeName);

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -6,6 +6,7 @@
 #include <exception/SemanticError.h>
 #include <symboltablebuilder/Scope.h>
 #include <symboltablebuilder/SymbolTableBuilder.h>
+#include <typechecker/TypeMatcher.h>
 
 namespace spice::compiler {
 
@@ -178,44 +179,23 @@ bool StructManager::matchTemplateTypes(Struct &candidate, const std::vector<Symb
   if (typeCount != candidate.templateTypes.size())
     return false;
 
-  // Loop over all candidate template types and collect the concrete fill-ins
-  std::vector<GenericType> concreteTemplateTypes;
-  concreteTemplateTypes.reserve(typeCount);
+  // Loop over all template types
   for (size_t i = 0; i < typeCount; i++) {
     const SymbolType &requestedType = requestedTemplateTypes.at(i);
-    const GenericType &candidateType = candidate.templateTypes.at(i);
+    SymbolType &candidateType = candidate.templateTypes.at(i);
 
-    if (candidateType.is(TY_GENERIC)) { // Type is generic
-      const std::string candidateTypeName = candidateType.getSubType();
+    // Give the type matcher a way to retrieve instances of GenericType by their name
+    std::function<const GenericType *(const std::string &)> genericTypeResolver = [=](const std::string &genericTypeName) {
+      return getGenericTypeOfCandidateByName(candidate, genericTypeName);
+    };
 
-      // Check if the name is already assigned to a type
-      if (typeMapping.contains(candidateTypeName) && typeMapping.at(candidateTypeName) != requestedType)
-        return false; // Contradictory information
+    // Check if the requested param type matches the candidate template type. The type mapping may be extended
+    if (!TypeMatcher::matchRequestedToCandidateType(candidateType, requestedType, typeMapping, genericTypeResolver))
+      return false;
 
-      // Check if the proposal matches the candidates conditions
-      if (!candidateType.checkConditionsOf(requestedType))
-        return false;
-
-      // Add to the type mapping
-      typeMapping.insert({candidateTypeName, requestedType});
-    } else { // Type is non-generic
-      // Check if the types match
-      if (requestedType != candidateType)
-        return false;
-    }
-    // Insert the requested type to the concrete types list
-    concreteTemplateTypes.emplace_back(requestedType);
-  }
-
-  // Set the concrete type list to the candidate
-  candidate.templateTypes = concreteTemplateTypes;
-
-  // Substantiate field types
-  for (SymbolType &fieldType : candidate.fieldTypes) {
-    if (!fieldType.is(TY_GENERIC))
-      continue;
-    const std::string genericTypeName = fieldType.getSubType();
-    fieldType = fieldType.replaceBaseType(typeMapping.at(genericTypeName));
+    // Substantiate the candidate param type, based on the type mapping
+    if (candidateType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(candidateType, typeMapping);
   }
 
   return true;
@@ -223,15 +203,26 @@ bool StructManager::matchTemplateTypes(Struct &candidate, const std::vector<Symb
 
 void StructManager::substantiateFieldTypes(Struct &candidate, TypeMapping &typeMapping) {
   // Loop over all field types and substantiate the generic ones
-  for (SymbolType &fieldType : candidate.fieldTypes) {
-    // Skip non-generic types
-    if (!fieldType.isBaseType(TY_GENERIC))
+  for (SymbolType &fieldType : candidate.fieldTypes)
+    if (fieldType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping);
+}
+
+/**
+ * Searches the candidate template types for a generic type object with a certain name and return it
+ *
+ * @param candidate Matching candidate struct
+ * @param templateTypeName Template type name
+ * @return Generic type object
+ */
+const GenericType *StructManager::getGenericTypeOfCandidateByName(const Struct &candidate, const std::string &templateTypeName) {
+  for (const GenericType &templateType : candidate.templateTypes) {
+    if (!templateType.is(TY_GENERIC))
       continue;
-    // Substantiate generic types
-    const std::string genericTypeName = fieldType.getBaseType().getSubType();
-    assert(typeMapping.contains(genericTypeName));
-    fieldType = fieldType.replaceBaseType(typeMapping.at(genericTypeName));
+    if (templateType.getSubType() == templateTypeName)
+      return &templateType;
   }
+  return nullptr;
 }
 
 } // namespace spice::compiler

--- a/src/typechecker/StructManager.h
+++ b/src/typechecker/StructManager.h
@@ -24,14 +24,14 @@ using StructRegistry = std::unordered_map</*codeLoc=*/std::string, /*manifestati
 class StructManager {
 public:
   // Public methods
-  [[nodiscard]] static Struct *insertStruct(Scope *insertScope, const Struct &spiceStruct, std::vector<Struct *> *nodeStructList);
+  [[nodiscard]] static Struct *insertStruct(Scope *insertScope, Struct &spiceStruct, std::vector<Struct *> *nodeStructList);
   [[nodiscard]] static StructManifestationList *getManifestationList(Scope *lookupScope, const CodeLoc &defCodeLoc);
   [[nodiscard]] static Struct *matchStruct(Scope *matchScope, const std::string &requestedName,
                                            const std::vector<SymbolType> &requestedTemplateTypes, const ASTNode *node);
 
 private:
   // Private methods
-  [[nodiscard]] static Struct *insertSubstantiation(Scope *insertScope, const Struct &newManifestation, const ASTNode *declNode);
+  [[nodiscard]] static Struct *insertSubstantiation(Scope *insertScope, Struct &newManifestation, const ASTNode *declNode);
   [[nodiscard]] static bool matchName(const Struct &candidate, const std::string &requestedName);
   [[nodiscard]] static bool matchTemplateTypes(Struct &candidate, const std::vector<SymbolType> &requestedTemplateTypes,
                                                TypeMapping &typeMapping);

--- a/src/typechecker/StructManager.h
+++ b/src/typechecker/StructManager.h
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include <typechecker/FunctionManager.h>
+#include <model/GenericType.h>
 
 namespace spice::compiler {
 
@@ -15,7 +15,9 @@ class Struct;
 class Scope;
 class SymbolType;
 class ASTNode;
+struct CodeLoc;
 
+// Typedefs
 using StructManifestationList = std::unordered_map</*mangledName=*/std::string, /*structObject=*/Struct>;
 using StructRegistry = std::unordered_map</*codeLoc=*/std::string, /*manifestations=*/StructManifestationList>;
 

--- a/src/typechecker/StructManager.h
+++ b/src/typechecker/StructManager.h
@@ -36,6 +36,8 @@ private:
   [[nodiscard]] static bool matchTemplateTypes(Struct &candidate, const std::vector<SymbolType> &requestedTemplateTypes,
                                                TypeMapping &typeMapping);
   static void substantiateFieldTypes(Struct &candidate, TypeMapping &typeMapping);
+  [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Struct &candidate,
+                                                                          const std::string &templateTypeName);
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -1757,7 +1757,7 @@ std::any TypeChecker::visitCustomDataType(CustomDataTypeNode *node) {
       entryType.setTemplateTypes(templateTypes);
     }
 
-    if (!isParamOrFieldType) { // Only do the next step, if we have concrete template types
+    if (!node->templateTypeLst() || !isParamOrFieldType) { // Only do the next step, if we have concrete template types
       // Set the struct instance to used, if found
       // Here, it is allowed to accept, that the struct cannot be found, because there are self-referencing structs
       const std::string structName = node->typeNameFragments.back();

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -1741,7 +1741,7 @@ std::any TypeChecker::visitCustomDataType(CustomDataTypeNode *node) {
     if (entry->declNode->codeLoc.sourceFilePath == node->codeLoc.sourceFilePath && entry->declNode->codeLoc > node->codeLoc)
       throw SemanticError(node, REFERENCED_UNDEFINED_STRUCT, "Structs must be defined before usage");
 
-    const bool isParamOrFieldType = node->isParamType || node->isFieldType;
+    const bool isParamOrFieldOrReturnType = node->isParamType || node->isFieldType || node->isReturnType;
 
     // Collect the concrete template types
     std::vector<SymbolType> templateTypes;
@@ -1750,14 +1750,14 @@ std::any TypeChecker::visitCustomDataType(CustomDataTypeNode *node) {
       for (DataTypeNode *dataType : node->templateTypeLst()->dataTypes()) {
         auto templateType = std::any_cast<SymbolType>(visit(dataType));
         // Generic types are only allowed for parameters and fields at this point
-        if (templateType.is(TY_GENERIC) && !isParamOrFieldType)
+        if (templateType.is(TY_GENERIC) && !isParamOrFieldOrReturnType)
           throw SemanticError(dataType, EXPECTED_NON_GENERIC_TYPE, "Only concrete template types are allowed here");
         templateTypes.push_back(templateType);
       }
       entryType.setTemplateTypes(templateTypes);
     }
 
-    if (!node->templateTypeLst() || !isParamOrFieldType) { // Only do the next step, if we have concrete template types
+    if (!node->templateTypeLst() || !isParamOrFieldOrReturnType) { // Only do the next step, if we have concrete template types
       // Set the struct instance to used, if found
       // Here, it is allowed to accept, that the struct cannot be found, because there are self-referencing structs
       const std::string structName = node->typeNameFragments.back();

--- a/src/typechecker/TypeCheckerCheck.cpp
+++ b/src/typechecker/TypeCheckerCheck.cpp
@@ -141,7 +141,7 @@ std::any TypeChecker::visitProcDefCheck(ProcDefNode *node) {
 }
 
 std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
-  // Change to struct scope
+  // Change to generic struct scope
   currentScope = currentScope->getChildScope(STRUCT_SCOPE_PREFIX + node->structName);
   assert(currentScope != nullptr && currentScope->type == SCOPE_STRUCT);
 

--- a/src/typechecker/TypeCheckerPrepare.cpp
+++ b/src/typechecker/TypeCheckerPrepare.cpp
@@ -301,9 +301,13 @@ std::any TypeChecker::visitStructDefPrepare(StructDefNode *node) {
     // Add to field types
     fieldTypes.push_back(fieldType);
 
+    // Update type of field entry
+    SymbolTableEntry *fieldEntry = currentScope->lookupStrict(field->fieldName);
+    assert(fieldEntry != nullptr);
+    fieldEntry->updateType(fieldType, false);
+
     // Check if the template type list contains this type
-    if (fieldType.hasAnyGenericParts() && std::none_of(usedTemplateTypesGeneric.begin(), usedTemplateTypesGeneric.end(),
-                                                       [&](const GenericType &t) { return t == fieldType.getBaseType(); }))
+    if (!fieldType.isCoveredByGenericTypeList(usedTemplateTypesGeneric))
       throw SemanticError(field->dataType(), GENERIC_TYPE_NOT_IN_TEMPLATE, "Generic field type not included in struct template");
   }
 

--- a/src/typechecker/TypeCheckerPrepare.cpp
+++ b/src/typechecker/TypeCheckerPrepare.cpp
@@ -74,10 +74,10 @@ std::any TypeChecker::visitFctDefPrepare(FctDefNode *node) {
     assert(structEntry != nullptr);
     // Set struct to used
     structEntry->used = true;
-    auto manifestations = StructManager::getManifestationList(structParentScope, structEntry->getDeclCodeLoc());
+    /*auto manifestations = StructManager::getManifestationList(structParentScope, structEntry->getDeclCodeLoc());
     if (manifestations)
       for (auto &manifestation : *manifestations)
-        manifestation.second.used = true;
+        manifestation.second.used = true;*/
     // Get type and ptr type
     thisType = structEntry->getType();
     thisPtrType = thisType.toPointer(node);
@@ -178,10 +178,10 @@ std::any TypeChecker::visitProcDefPrepare(ProcDefNode *node) {
     assert(structEntry != nullptr);
     // Set struct to used
     structEntry->used = true;
-    auto manifestations = StructManager::getManifestationList(structParentScope, structEntry->getDeclCodeLoc());
+    /*auto manifestations = StructManager::getManifestationList(structParentScope, structEntry->getDeclCodeLoc());
     if (manifestations)
       for (auto &manifestation : *manifestations)
-        manifestation.second.used = true;
+        manifestation.second.used = true;*/
     // Get type and ptr type
     thisType = structEntry->getType();
     thisPtrType = thisType.toPointer(node);

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -24,7 +24,7 @@ bool TypeMatcher::matchRequestedToCandidateType(SymbolType candidateType, Symbol
     if (typeMapping.contains(genericTypeName)) {
       const SymbolType &knownConcreteType = typeMapping.at(candidateType.getSubType());
       // Check if the known concrete type matches the requested type
-      return knownConcreteType != requestedType;
+      return knownConcreteType == requestedType;
     } else {
       // Retrieve generic candidate type by its name
       const GenericType *genericCandidateType = resolveGenericType(genericTypeName);

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2021-2023 ChilliBits. All rights reserved.
+
+#include "TypeMatcher.h"
+
+namespace spice::compiler {
+
+bool TypeMatcher::matchRequestedToCandidateType(SymbolType candidateType, SymbolType requestedType, TypeMapping &typeMapping,
+                                                std::function<const GenericType *(const std::string &)> &resolveGenericType) {
+  // Unwrap both types as far as possible
+  while (candidateType.isSameContainerTypeAs(requestedType)) {
+    requestedType = requestedType.getContainedTy();
+    candidateType = candidateType.getContainedTy();
+  }
+
+  // If the candidate does not contain any generic parts, we can simply check for type equality
+  if (!candidateType.hasAnyGenericParts())
+    return requestedType.equalsIgnoreArraySize(candidateType);
+
+  // Check if the candidate type itself is generic
+  if (candidateType.isBaseType(TY_GENERIC)) { // The candidate type itself is generic
+    const std::string &genericTypeName = candidateType.getSubType();
+
+    // Check if we know the concrete type for that generic type name already
+    if (typeMapping.contains(genericTypeName)) {
+      const SymbolType &knownConcreteType = typeMapping.at(candidateType.getSubType());
+      // Check if the known concrete type matches the requested type
+      return knownConcreteType != requestedType;
+    } else {
+      // Retrieve generic candidate type by its name
+      const GenericType *genericCandidateType = resolveGenericType(genericTypeName);
+      assert(genericCandidateType != nullptr);
+
+      // Check if the requested type fulfills all conditions of the generic candidate type
+      if (!genericCandidateType->checkConditionsOf(requestedType, true))
+        return false;
+
+      // Add to type mapping
+      typeMapping.insert({genericTypeName, requestedType});
+
+      return true; // The type was successfully matched, by enriching the type mapping
+    }
+  } else { // The candidate type itself is non-generic, but one or several template types are
+    const std::vector<SymbolType> &requestedTypeTemplateTypes = requestedType.getTemplateTypes();
+    const std::vector<SymbolType> &candidateTypeTemplateTypes = candidateType.getTemplateTypes();
+
+    // Check if the size of template type matches
+    if (requestedTypeTemplateTypes.size() != candidateTypeTemplateTypes.size())
+      return false;
+
+    // Loop through both lists at the same time and match each pair of template types individually
+    for (size_t i = 0; i < candidateTypeTemplateTypes.size(); i++) {
+      const SymbolType &requestedTypeTemplateType = requestedTypeTemplateTypes.at(i);
+      const SymbolType &candidateTypeTemplateType = candidateTypeTemplateTypes.at(i);
+
+      // Match the pair of template types
+      if (!matchRequestedToCandidateType(candidateTypeTemplateType, requestedTypeTemplateType, typeMapping, resolveGenericType))
+        return false;
+    }
+
+    return true; // All requested template types match to their respective candidate template type -> successfully matched
+  }
+}
+
+void TypeMatcher::substantiateTypeWithTypeMapping(SymbolType &symbolType, const TypeMapping &typeMapping) {
+  assert(symbolType.hasAnyGenericParts());
+
+  // Check if the type itself is generic
+  if (symbolType.isBaseType(TY_GENERIC)) { // The symbol type itself is generic
+    const std::string genericTypeName = symbolType.getBaseType().getSubType();
+    assert(typeMapping.contains(genericTypeName));
+    symbolType = symbolType.replaceBaseType(typeMapping.at(genericTypeName));
+  } else { // The symbol type itself is non-generic, but one or several template types are
+    std::vector<SymbolType> templateTypes = symbolType.getBaseType().getTemplateTypes();
+    // Substantiate every template type
+    for (SymbolType &templateType : templateTypes)
+      substantiateTypeWithTypeMapping(templateType, typeMapping);
+    // Attach the list of concrete template types to the symbol type
+    symbolType.setBaseTemplateTypes(templateTypes);
+  }
+}
+
+} // namespace spice::compiler

--- a/src/typechecker/TypeMatcher.h
+++ b/src/typechecker/TypeMatcher.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2021-2023 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <model/GenericType.h>
+
+namespace spice::compiler {
+
+// Forward declarations
+class SymbolType;
+
+/**
+ * Helper class for FunctionManager and StructManager to match generic types.
+ * This is a tricky task, because the types can be indirect or/and nested.
+ */
+class TypeMatcher {
+public:
+  static bool matchRequestedToCandidateType(SymbolType candidateType, SymbolType requestedType, TypeMapping &typeMapping,
+                                            std::function<const GenericType *(const std::string &)> &resolveGenericType);
+  static void substantiateTypeWithTypeMapping(SymbolType &symbolType, const TypeMapping &typeMapping);
+};
+
+} // namespace spice::compiler

--- a/src/util/CommonUtil.cpp
+++ b/src/util/CommonUtil.cpp
@@ -31,14 +31,4 @@ std::string CommonUtil::getLastFragment(const std::string &haystack, const std::
   return index == std::string::npos ? haystack : haystack.substr(index + needle.length());
 }
 
-/**
- * Get scope prefix from scope name
- *
- * @param haystack Scope name
- * @return Scope prefix
- */
-std::string CommonUtil::getPrefix(const std::string &haystack, const std::string &needle) {
-  return haystack.substr(0, haystack.find(needle) + needle.length());
-}
-
 } // namespace spice::compiler

--- a/src/util/CommonUtil.h
+++ b/src/util/CommonUtil.h
@@ -16,7 +16,6 @@ class CommonUtil {
 public:
   static void replaceAll(std::string &haystack, const std::string &needle, const std::string &replacement);
   static std::string getLastFragment(const std::string &haystack, const std::string &needle);
-  static std::string getPrefix(const std::string &haystack, const std::string &needle);
 };
 
 } // namespace spice::compiler

--- a/std/data/hash-table.spice
+++ b/std/data/hash-table.spice
@@ -1,0 +1,49 @@
+import "std/data/vector";
+import "std/data/doubly-linked-list";
+import "std/data/pair";
+
+type Size alias long;
+
+// Generic types for key and value
+type K dyn;
+type V dyn;
+
+public type HashTable<K, V> struct {
+    Vector<DoublyLinkedList<Pair<K, V>>> table
+    Size bucketCount
+}
+
+public p HashTable.ctor(Size bucketCount = 1000l) {
+    this.bucketCount = bucketCount;
+}
+
+public p HashTable.insert(const K& key, const V& value) {
+    Size index = hash(key);
+    this.table.at(index).pushBack(Pair(key, value));
+}
+
+public p HashTable.delete(const K& key) {
+    Size index = hash(key);
+    const DoublyLinkedList<Pair<K, V>>& bucket = this.table.at(index);
+
+    for Size i = 0l; i < bucket.getSize(); i++ {
+        Pair<K, V>& candidate = bucket.at(i);
+        if candidate.first() == key {
+            bucket.remove(i);
+            return;
+        }
+    }
+}
+
+public f<V*> HashTable.search(const K& key) {
+    Size index = hash(key);
+    const DoublyLinkedList<Pair<K, V>>& bucket = this.table.at(index);
+
+    for Size i = 0l; i < bucket.getSize(); i++ {
+        Pair<K, V>& candidate = bucket.at(i);
+        if candidate.first() == key {
+            return &candidate.second();
+        }
+    }
+    return nil<V*>;
+}

--- a/std/data/hash-table.spice
+++ b/std/data/hash-table.spice
@@ -28,7 +28,7 @@ public p HashTable.delete(const K& key) {
 
     for Size i = 0l; i < bucket.getSize(); i++ {
         Pair<K, V>& candidate = bucket.at(i);
-        if candidate.first() == key {
+        if candidate.getFirst() == key {
             bucket.remove(i);
             return;
         }
@@ -41,8 +41,8 @@ public f<V*> HashTable.search(const K& key) {
 
     for Size i = 0l; i < bucket.getSize(); i++ {
         Pair<K, V>& candidate = bucket.at(i);
-        if candidate.first() == key {
-            return &candidate.second();
+        if candidate.getFirst() == key {
+            return &candidate.getSecond();
         }
     }
     return nil<V*>;

--- a/std/data/red-black-tree.spice
+++ b/std/data/red-black-tree.spice
@@ -1,0 +1,60 @@
+// Link external functions
+ext<byte*> malloc(long);
+ext free(byte*);
+
+// Add generic type definitions
+type T dyn;
+
+// Enums
+type NodeColor enum { RED, BLACK }
+
+/**
+ * Node of a Red-Black Tree
+ */
+type Node<T> struct {
+    T data
+    Node<T>* childLeft
+    Node<T>* childRight
+    NodeColor color
+}
+
+f<Node<T>*> createNode<T>(T data) {
+    Node<T>* newNode = malloc(sizeof(type Node<T>) / 8);
+    newNode.data = data;
+    newNode.childLeft = nil<Node<T>*>;
+    newNode.childRight = nil<Node<T>*>;
+    newNode.color = NodeColor::RED;
+    return newNode;
+}
+
+inline f<bool> Node.isRoot() {
+    return this.parent == nil<Node<T>*>;
+}
+
+/**
+ * A Red-Black Tree is a self-balancing search tree, which is used e.g. in the implementation of maps.
+ *
+ * Insertion time: O(log n)
+ * Lookup time: O(log n)
+ * Deletion time: O(log n)
+ */
+public type RedBlackTree<T> struct {
+    Node<T>* rootNode
+}
+
+public p RedBlackTree.ctor() {
+    this.rootNode = nil<Node<T>*>;
+}
+
+public p RedBlackTree.insert(T newItem) {
+    this.insertAdd(newItem);
+    this.insertRebalance(newItem);
+}
+
+p RedBlackTree.insertAdd(T newItem) {
+
+}
+
+p RedBlackTree.insertRebalance(T newItem) {
+
+}

--- a/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
@@ -1,0 +1,43 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
+
+@printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
+
+; Function Attrs: nofree nosync nounwind memory(none)
+define private fastcc i32 @_f__void__int__fibo__int(i32 %0) unnamed_addr #0 {
+  %2 = icmp slt i32 %0, 2
+  br i1 %2, label %common.ret, label %if.exit.L2
+
+common.ret:                                       ; preds = %if.exit.L2, %1
+  %accumulator.tr.lcssa = phi i32 [ 0, %1 ], [ %6, %if.exit.L2 ]
+  %.tr.lcssa = phi i32 [ %0, %1 ], [ %5, %if.exit.L2 ]
+  %accumulator.ret.tr = add i32 %.tr.lcssa, %accumulator.tr.lcssa
+  ret i32 %accumulator.ret.tr
+
+if.exit.L2:                                       ; preds = %1, %if.exit.L2
+  %.tr5 = phi i32 [ %5, %if.exit.L2 ], [ %0, %1 ]
+  %accumulator.tr4 = phi i32 [ %6, %if.exit.L2 ], [ 0, %1 ]
+  %3 = add nsw i32 %.tr5, -1
+  %4 = tail call fastcc i32 @_f__void__int__fibo__int(i32 %3)
+  %5 = add nsw i32 %.tr5, -2
+  %6 = add i32 %4, %accumulator.tr4
+  %7 = icmp ult i32 %.tr5, 4
+  br i1 %7, label %common.ret, label %if.exit.L2
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() local_unnamed_addr #1 {
+  %1 = tail call fastcc i32 @_f__void__int__fibo__int(i32 30) #3
+  %2 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i32 %1)
+  ret i32 0
+}
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_addr #2
+
+attributes #0 = { nofree nosync nounwind memory(none) }
+attributes #1 = { noinline nounwind optnone uwtable }
+attributes #2 = { nofree nounwind }
+attributes #3 = { nounwind }

--- a/test/test-files/benchmark/success-fibonacci/ir-code.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code.ll
@@ -1,0 +1,43 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
+
+@printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
+
+define private i32 @_f__void__int__fibo__int(i32 %0) {
+  %result = alloca i32, align 4
+  %n = alloca i32, align 4
+  store i32 %0, ptr %n, align 4
+  %2 = load i32, ptr %n, align 4
+  %3 = icmp sle i32 %2, 1
+  br i1 %3, label %if.then.L2, label %if.exit.L2
+
+if.then.L2:                                       ; preds = %1
+  %4 = load i32, ptr %n, align 4
+  ret i32 %4
+
+if.exit.L2:                                       ; preds = %1
+  %5 = load i32, ptr %n, align 4
+  %6 = sub i32 %5, 1
+  %7 = call i32 @_f__void__int__fibo__int(i32 %6)
+  %8 = load i32, ptr %n, align 4
+  %9 = sub i32 %8, 2
+  %10 = call i32 @_f__void__int__fibo__int(i32 %9)
+  %11 = add i32 %7, %10
+  ret i32 %11
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  %result = alloca i32, align 4
+  store i32 0, ptr %result, align 4
+  %1 = call i32 @_f__void__int__fibo__int(i32 30)
+  %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
+  %3 = load i32, ptr %result, align 4
+  ret i32 %3
+}
+
+declare i32 @printf(ptr noundef, ...)
+
+attributes #0 = { noinline nounwind optnone uwtable }

--- a/test/test-files/irgenerator/generics/success-nested-generic-structs/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-nested-generic-structs/ir-code.ll
@@ -1,0 +1,19 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
+target triple = "x86_64-w64-windows-gnu"
+
+%"__Node<Node<Node<Node<string,double>,int>,double>,int>_double__Node__Node<Node<Node<Node<string,double>,int>,double>,int>ptr_double" = type { ptr, double }
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  %result = alloca i32, align 4
+  %1 = alloca %"__Node<Node<Node<Node<string,double>,int>,double>,int>_double__Node__Node<Node<Node<Node<string,double>,int>,double>,int>ptr_double", align 8
+  %node = alloca %"__Node<Node<Node<Node<string,double>,int>,double>,int>_double__Node__Node<Node<Node<Node<string,double>,int>,double>,int>ptr_double", align 8
+  store i32 0, ptr %result, align 4
+  store %"__Node<Node<Node<Node<string,double>,int>,double>,int>_double__Node__Node<Node<Node<Node<string,double>,int>,double>,int>ptr_double" zeroinitializer, ptr %node, align 8
+  %2 = load i32, ptr %result, align 4
+  ret i32 %2
+}
+
+attributes #0 = { noinline nounwind optnone uwtable }

--- a/test/test-files/irgenerator/generics/success-nested-generic-structs/source.spice
+++ b/test/test-files/irgenerator/generics/success-nested-generic-structs/source.spice
@@ -7,6 +7,5 @@ type Node<T, U> struct {
 }
 
 f<int> main() {
-    dyn node = Node<Node<Node<string, double>, int>, double>{};
-    printf("%f", node.data2);
+    dyn node = Node<Node<Node<Node<Node<string, double>, int>, double>, int>, double>{};
 }

--- a/test/test-files/typechecker/generics/error-not-in-template1/exception.out
+++ b/test/test-files/typechecker/generics/error-not-in-template1/exception.out
@@ -1,5 +1,5 @@
 [Error|Semantic] ./test-files/typechecker/generics/error-not-in-template1/source.spice:4:16:
-Generic type not contained in template: Generic argument type not included in function template types
+Generic type not contained in template: Generic param type not included in the template type list of the function
 
 4  f<T> getDyn<T>(T a1, U a2) {
                   ^^^^^^^^^^

--- a/test/test-files/typechecker/generics/error-not-in-template2/exception.out
+++ b/test/test-files/typechecker/generics/error-not-in-template2/exception.out
@@ -1,5 +1,5 @@
 [Error|Semantic] ./test-files/typechecker/generics/error-not-in-template2/source.spice:4:15:
-Generic type not contained in template: Generic argument type not included in procedure template types
+Generic type not contained in template: Generic param type not included in the template type list of the procedure
 
 4  p printDyn<T>(T a1, U a2) {
                  ^^^^^^^^^^

--- a/test/test-files/typechecker/generics/error-not-in-template4/exception.out
+++ b/test/test-files/typechecker/generics/error-not-in-template4/exception.out
@@ -1,0 +1,5 @@
+[Error|Semantic] ./test-files/typechecker/generics/error-not-in-template4/source.spice:7:13:
+Generic type not contained in template: Generic param type not included in the template type list of the function
+
+7  f<int> test(Node<T>* test) {
+               ^^^^^^^^^^^^^

--- a/test/test-files/typechecker/generics/error-not-in-template4/source.spice
+++ b/test/test-files/typechecker/generics/error-not-in-template4/source.spice
@@ -1,0 +1,14 @@
+type T dyn;
+
+type Node<T> struct {
+    T data
+}
+
+f<int> test(Node<T>* test) {
+    return 1;
+}
+
+f<int> main() {
+    dyn node = Node<int>{ 12 };
+    test(&node);
+}


### PR DESCRIPTION
- Instead of visiting function/procedure/struct definitions staight away, the compile steps for those must be requested by other components. e.g. the main function calls a function `test`, it request the type-checking and later the IR generation for this function.
- Fix a bug, that prevented nesting of template types for field types, param types and return types.
- Add tests