### PR TITLE
Extend iterator std

### DIFF
--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -1,6 +1,6 @@
-import "std/data/optional";
+import "std/iterators/ranges";
 
 f<int> main() {
-    Optional<int> iO = Optional<int>(12);
-    printf("%d", iO.get());
+    dyn it = range(1, 10);
+    assert it.hasNext();
 }

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -22,14 +22,14 @@ SymbolType OpRuleManager::getAssignResultType(const ASTNode *node, SymbolType lh
     return resultType;
   }
   // Allow pointers and arrays of the same type straight away
-  if (lhs.isOneOf({TY_PTR, TY_ARRAY, TY_STRUCT}) && lhs == rhs)
-    return rhs;
-  // Allow struct of the same type straight away
-  if (lhs.is(TY_STRUCT) && lhs.equals(rhs, false, true))
+  if (lhs.is(TY_PTR) && lhs == rhs)
     return rhs;
   // Allow type to ref type of the same contained type straight away
   if (lhs.is(TY_REF) && lhs.getContainedTy() == rhs)
     return lhs;
+  // Allow struct of the same type straight away
+  if (lhs.isOneOf({TY_ARRAY, TY_STRUCT}) && lhs.equals(rhs, false, true))
+    return rhs;
   // Allow array to pointer
   if (lhs.is(TY_PTR) && rhs.is(TY_ARRAY) && lhs.getContainedTy() == rhs.getContainedTy())
     return lhs;

--- a/std/iterators/iterator.spice
+++ b/std/iterators/iterator.spice
@@ -1,6 +1,5 @@
 // Add generic type definitions
 type T dyn;
-type U int|short|long;
 
 /**
  * The Iterable interface must be implemented in order to be handled as an iterator by Spice. For instance, all elements,
@@ -8,6 +7,6 @@ type U int|short|long;
  */
 public type Iterable<T> interface {
     f<bool> hasNext();
-    f<T> next();
+    f<T&> next();
     f<T&> get();
 }

--- a/std/iterators/number-iterator.spice
+++ b/std/iterators/number-iterator.spice
@@ -1,28 +1,47 @@
+import "std/iterators/iterator";
+
+// Generic type definitions
+type T int|long|short;
+
 /**
- * A NumberIterator in Spice can be used to iterate over
+ * A NumberIterator in Spice can be used to iterate over a range of numbers
  */
-public type NumberIterator<U> struct : Iterable<U> {
-    U lowerBound
-    U upperBound
-    unsigned long index
+public type NumberIterator<T> struct : Iterable<T> {
+    T lowerBound // Inclusive
+    T upperBound // Inclusive
+    unsigned long cursor
 }
 
-public p NumberIterator.ctor(U lowerBound, U upperBound) {
+public p NumberIterator.ctor(T lowerBound, T upperBound) {
     this.lowerBound = lowerBound;
     this.upperBound = upperBound;
-    this.index = 0;
+    this.cursor = 0;
 }
 
+/**
+ * Check if the number range has another number
+ *
+ * @return true or false
+ */
 public inline const f<bool> NumberIterator.hasNext() {
-    return this.lowerBound + this.index <= this.upperBound;
+    return this.lowerBound + this.cursor <= this.upperBound;
 }
 
-public inline f<U*> NumberIterator.next() {
+/**
+ * Returns the current number of the number range and moves the cursor to the next item
+ *
+ * @return current item
+ */
+public inline f<T&> NumberIterator.next() {
     assert this.hasNext();
-    this.index++;
-    return this.data;
+    U& currentItem = this.get();
+    this.cursor++;
+    return currentItem;
 }
 
-public inline f<U&> NumberIterator.get() {
-    return this.lowerBound + this.index;
+/**
+ * Returns the current number of the number range
+ */
+public inline f<T&> NumberIterator.get() {
+    return this.lowerBound + this.cursor;
 }

--- a/std/iterators/ranges.spice
+++ b/std/iterators/ranges.spice
@@ -1,0 +1,11 @@
+import "std/iterators/number-iterator";
+
+// Generic type definitions
+type Numeric int|long|short;
+
+/**
+ * Convenience wrapper for creating a simple number iterator
+ */
+public inline f<NumberIterator> range<Numeric>(Numeric begin, Numeric end) {
+    return NumberIterator(begin, end);
+}

--- a/std/runtime/string_rt.spice
+++ b/std/runtime/string_rt.spice
@@ -252,8 +252,8 @@ public f<bool> operator!=(const String& a, const String& b) {
  *
  * @return Raw immutable string
  */
-public inline f<char*> String.getRaw() {
-    return this.contents;
+public inline f<string> String.getRaw() {
+    return (string) this.contents;
 }
 
 /**

--- a/test/test-files/std/runtime/string-basic-operations/ir-code-O2.ll
+++ b/test/test-files/std/runtime/string-basic-operations/ir-code-O2.ll
@@ -19,42 +19,42 @@ define dso_local i32 @main() local_unnamed_addr #0 {
   %s = alloca %__String__charptr_long_long, align 8
   %1 = alloca %__String__charptr_long_long, align 8
   call void @_mp__String__void__ctor__string(ptr nonnull %s, ptr nonnull @anon.string.0) #3
-  %2 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #3
+  %2 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #3
   %3 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.15, ptr %2)
   %4 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #3
   %5 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.16, i64 %4)
   %6 = call i64 @_mf__String__long__getCapacity(ptr nonnull %s) #3
   %7 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.17, i64 %6)
   call void @_mp__String__void__append__string(ptr nonnull %s, ptr nonnull @anon.string.1) #3
-  %8 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #3
+  %8 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #3
   %9 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.15, ptr %8)
   %10 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #3
   %11 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.16, i64 %10)
   %12 = call i64 @_mf__String__long__getCapacity(ptr nonnull %s) #3
   %13 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.17, i64 %12)
   call void @_mp__String__void__append__char(ptr nonnull %s, i8 63) #3
-  %14 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #3
+  %14 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #3
   %15 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.15, ptr %14)
   %16 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #3
   %17 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.16, i64 %16)
   %18 = call i64 @_mf__String__long__getCapacity(ptr nonnull %s) #3
   %19 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.17, i64 %18)
   call void @_mp__String__void__append__char(ptr nonnull %s, i8 33) #3
-  %20 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #3
+  %20 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #3
   %21 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.15, ptr %20)
   %22 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #3
   %23 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.16, i64 %22)
   %24 = call i64 @_mf__String__long__getCapacity(ptr nonnull %s) #3
   %25 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.17, i64 %24)
   call void @_mp__String__void__clear(ptr nonnull %s) #3
-  %26 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #3
+  %26 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #3
   %27 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.15, ptr %26)
   %28 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #3
   %29 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.16, i64 %28)
   %30 = call i64 @_mf__String__long__getCapacity(ptr nonnull %s) #3
   %31 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.17, i64 %30)
   call void @_mp__String__void__reserve__long(ptr nonnull %s, i64 100) #3
-  %32 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #3
+  %32 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #3
   %33 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.15, ptr %32)
   %34 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #3
   %35 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.16, i64 %34)
@@ -77,7 +77,7 @@ declare void @_mp__String__void__ctor__string(ptr, ptr) local_unnamed_addr
 ; Function Attrs: nofree nounwind
 declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_addr #1
 
-declare ptr @_mf__String__charptr__getRaw(ptr) local_unnamed_addr
+declare ptr @_mf__String__string__getRaw(ptr) local_unnamed_addr
 
 declare i64 @_mf__String__long__getLength(ptr) local_unnamed_addr
 

--- a/test/test-files/std/runtime/string-ctor-char/ir-code-O2.ll
+++ b/test/test-files/std/runtime/string-ctor-char/ir-code-O2.ll
@@ -15,14 +15,14 @@ target triple = "x86_64-w64-windows-gnu"
 define dso_local i32 @main() local_unnamed_addr #0 {
   %s = alloca %__String__charptr_long_long, align 8
   call void @_mp__String__void__ctor__char(ptr nonnull %s, i8 72) #2
-  %1 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #2
+  %1 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #2
   %2 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.3, ptr %1)
   %3 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #2
   %4 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.4, i64 %3)
   %5 = call i64 @_mf__String__long__getCapacity(ptr nonnull %s) #2
   %6 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.2, i64 %5)
   call void @_mp__String__void__append__string(ptr nonnull %s, ptr nonnull @anon.string.0) #2
-  %7 = call ptr @_mf__String__charptr__getRaw(ptr nonnull %s) #2
+  %7 = call ptr @_mf__String__string__getRaw(ptr nonnull %s) #2
   %8 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.3, ptr %7)
   %9 = call i64 @_mf__String__long__getLength(ptr nonnull %s) #2
   %10 = call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.4, i64 %9)
@@ -36,7 +36,7 @@ declare void @_mp__String__void__ctor__char(ptr, i8) local_unnamed_addr
 ; Function Attrs: nofree nounwind
 declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_addr #1
 
-declare ptr @_mf__String__charptr__getRaw(ptr) local_unnamed_addr
+declare ptr @_mf__String__string__getRaw(ptr) local_unnamed_addr
 
 declare i64 @_mf__String__long__getLength(ptr) local_unnamed_addr
 


### PR DESCRIPTION
- Extend iterator std
- Fix bug with const array variables
- Return `string` instead of `char*` for String.getRaw() to prevent redundant casting