### PR TITLE
Fix missing runtime modules

### DIFF
--- a/media/specs/iterators.md
+++ b/media/specs/iterators.md
@@ -1,9 +1,10 @@
 # Technical Specification for Iterators in Spice
 
 ## Implementation steps:
-- [ ] 1. Implement iterators in std
+- [x] 1. Implement simple NumberIterator in std
 - [ ] 2. Adjust foreach loop to work with iterators
-- [ ] 3. Offer iterator modifiers
+- [ ] 3. Implement VectorIterator in std
+- [ ] 4. Offer iterator modifiers
 
 ## Usage
 

--- a/media/test-project/os-test.spice
+++ b/media/test-project/os-test.spice
@@ -1,7 +1,32 @@
-f<bool> fn(int& ref) {
+/*import "std/data/vector";
+import "std/text/print";
+import "std/io/file" as io;
+
+f<int> main() {
+  dyn v = Vector<String>();
+  v.pushBack(String("Hello"));
+  v.pushBack(String("World!"));
+  createFile("output.txt");
+  const File file = openFile("output.txt", io::MODE_WRITE);
+
+  for int i = 0; i < v.getSize(); i++ {
+    String str = v.get(i);
+    file.writeString((string) str.getRaw());
+  }
+
+  file.close();
+}*/
+
+import "std/io/file";
+
+f<int> main() {
+    String test = String("test");
+}
+
+/*f<bool> fn(int& ref) {
     return false;
 }
 
 f<int> main() {
     fn(123);
-}
+}*/

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -538,8 +538,12 @@ void SourceFile::collectAllSourceFiles(std::vector<SourceFile *> &sourceFiles) {
     dependency.second.first->collectAllSourceFiles(sourceFiles);
 }
 
-void SourceFile::requestRuntimeModule(const RuntimeModuleName &moduleName) {
-  resourceManager.runtimeModuleManager.requestModule(this, moduleName);
+void SourceFile::requestRuntimeModule(RuntimeModule runtimeModule) {
+  // Check if the module was already imported
+  if (importedRuntimeModules & runtimeModule)
+    return;
+
+  resourceManager.runtimeModuleManager.requestModule(this, runtimeModule);
 }
 
 void SourceFile::addNameRegistryEntry(const std::string &name, SymbolTableEntry *entry, Scope *scope,

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -132,7 +132,7 @@ public:
   [[nodiscard]] bool isAlreadyImported(const std::string &filePathSearch) const;
   void collectAndPrintWarnings();
   void collectAllSourceFiles(std::vector<SourceFile *> &sourceFiles);
-  void requestRuntimeModule(const RuntimeModuleName &moduleName);
+  void requestRuntimeModule(RuntimeModule runtimeModule);
   void addNameRegistryEntry(const std::string &name, SymbolTableEntry *entry, Scope *scope, bool keepNewOnCollision = true,
                             SymbolTableEntry *importEntry = nullptr, const std::string &predecessorName = "");
   [[nodiscard]] const NameRegistryEntry *getNameRegistryEntry(std::string symbolName) const;
@@ -160,6 +160,7 @@ private:
   // Private fields
   GlobalResourceManager &resourceManager;
   BS::synced_stream &tout;
+  uint8_t importedRuntimeModules = 0;
 
   // Private methods
   void mergeNameRegistries(const SourceFile &importedSourceFile, const std::string &importName);

--- a/src/global/RuntimeModuleManager.h
+++ b/src/global/RuntimeModuleManager.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <unordered_map>
 
 namespace spice::compiler {
@@ -13,7 +14,15 @@ class Scope;
 const char *const STRING_RT_IMPORT_NAME = "__rt_string";
 const char *const THREAD_RT_IMPORT_NAME = "__rt_thread";
 
-enum RuntimeModuleName { STRING_RT, THREAD_RT };
+enum RuntimeModule : uint8_t {
+  STRING_RT = 1 << 0,
+  THREAD_RT = 1 << 1,
+};
+
+struct ModuleNamePair {
+  const char *const importName;
+  const char *const fileName;
+};
 
 class RuntimeModuleManager {
 public:
@@ -22,16 +31,16 @@ public:
   RuntimeModuleManager(const RuntimeModuleManager &) = delete;
 
   // Public methods
-  SourceFile *requestModule(SourceFile *sourceFile, const RuntimeModuleName &moduleName);
-  [[nodiscard]] Scope *getModuleScope(const RuntimeModuleName &moduleName) const;
-  [[nodiscard]] bool isModuleAvailable(const RuntimeModuleName &moduleName) const;
+  SourceFile *requestModule(SourceFile *sourceFile, RuntimeModule requestedModule);
+  [[nodiscard]] bool isModuleAvailable(RuntimeModule requestedModule) const;
 
 private:
   // Private methods
-  bool addModule(SourceFile *parentSourceFile, const RuntimeModuleName &moduleName);
+  bool addModule(SourceFile *parentSourceFile, RuntimeModule requestedModule);
+  static ModuleNamePair resolveNamePair(RuntimeModule requestedModule);
 
   // Private fields
-  std::unordered_map<RuntimeModuleName, SourceFile *> modules;
+  std::unordered_map<RuntimeModule, SourceFile *> modules;
 };
 
 } // namespace spice::compiler


### PR DESCRIPTION
Fix missing runtime modules in some cases. This bug occurred e.g. when importing a source file, that imports the String runtime implicitly. When we then try to use the String runtime in the main source file, the compiler will refuse to merge the name registries.