### PR TITLE
Improve std container types

### DIFF
--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d ../../media/test-project/os-test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="RUN_TESTS" value="OFF" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
+  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=true" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_CLASS="IRGeneratorTests" TEST_MODE="SUITE_TEST">
     <envs>
       <env name="RUN_TESTS" value="ON" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/src/irgenerator/GenBuiltinFunctions.cpp
+++ b/src/irgenerator/GenBuiltinFunctions.cpp
@@ -60,7 +60,7 @@ std::any IRGenerator::visitSizeofCall(const SizeofCallNode *node) {
   const unsigned int size = module->getDataLayout().getTypeSizeInBits(type);
 
   // Return size value
-  llvm::Value *sizeValue = builder.getInt32(size);
+  llvm::Value *sizeValue = builder.getInt64(size);
   return ExprResult{.value = sizeValue};
 }
 
@@ -68,7 +68,9 @@ std::any IRGenerator::visitLenCall(const LenCallNode *node) {
   // Check if the length is fixed and known via the symbol type
   const SymbolType assignExprSymbolType = node->assignExpr()->getEvaluatedSymbolType(manIdx);
   assert(assignExprSymbolType.isArray() && assignExprSymbolType.getArraySize() != ARRAY_SIZE_UNKNOWN);
-  llvm::Value *lengthValue = builder.getInt32(assignExprSymbolType.getArraySize());
+
+  // Return length value
+  llvm::Value *lengthValue = builder.getInt64(assignExprSymbolType.getArraySize());
   return ExprResult{.value = lengthValue};
 }
 

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -352,18 +352,6 @@ std::any TypeChecker::visitParamLst(ParamLstNode *node) {
   return namedParams;
 }
 
-std::any TypeChecker::visitField(FieldNode *node) {
-  // Visit field type
-  const auto fieldType = std::any_cast<SymbolType>(node->dataType());
-
-  // Update type of field entry
-  SymbolTableEntry *fieldEntry = currentScope->lookupStrict(node->fieldName);
-  assert(fieldEntry != nullptr);
-  fieldEntry->updateType(fieldType, false);
-
-  return fieldType;
-}
-
 std::any TypeChecker::visitSignature(SignatureNode *node) {
   // Visit return type
   SymbolType returnType(TY_DYN);
@@ -613,7 +601,7 @@ std::any TypeChecker::visitSizeofCall(SizeofCallNode *node) {
     visit(node->assignExpr());
   }
 
-  return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_INT), manIdx)};
+  return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_LONG), manIdx)};
 }
 
 std::any TypeChecker::visitLenCall(LenCallNode *node) {
@@ -624,16 +612,16 @@ std::any TypeChecker::visitLenCall(LenCallNode *node) {
   if (!argType.isArray())
     throw SemanticError(node->assignExpr(), EXPECTED_ARRAY_TYPE, "The len builtin can only work on arrays");
 
-  return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_INT), manIdx)};
+  return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_LONG), manIdx)};
 }
 
 std::any TypeChecker::visitTidCall(TidCallNode *node) {
   // Nothing to check here. Tid builtin has no arguments
-  return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_INT), manIdx)};
+  return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_LONG), manIdx)};
 }
 
 std::any TypeChecker::visitJoinCall(JoinCallNode *node) {
-  SymbolType bytePtr = SymbolType(TY_BYTE).toPointer(node);
+  const SymbolType bytePtr = SymbolType(TY_BYTE).toPointer(node);
 
   for (AssignExprNode *assignExpr : node->assignExpressions()) {
     // Visit assign expression

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -58,7 +58,7 @@ public:
   std::any visitEnumDefPrepare(EnumDefNode *node);
   std::any visitGenericTypeDef(GenericTypeDefNode *node) override;
   std::any visitGenericTypeDefPrepare(GenericTypeDefNode *node);
-  std::any visitAliasDef(AliasDefNode *node);
+  std::any visitAliasDef(AliasDefNode *node) override;
   std::any visitAliasDefPrepare(AliasDefNode *node);
   std::any visitGlobalVarDef(GlobalVarDefNode *node) override;
   std::any visitGlobalVarDefPrepare(GlobalVarDefNode *node);
@@ -75,11 +75,10 @@ public:
   std::any visitAnonymousBlockStmt(AnonymousBlockStmtNode *node) override;
   std::any visitStmtLst(StmtLstNode *node) override;
   std::any visitParamLst(ParamLstNode *node) override;
-  std::any visitField(FieldNode *node) override;
   std::any visitSignature(SignatureNode *node) override;
   std::any visitDeclStmt(DeclStmtNode *node) override;
   std::any visitImportStmt(ImportStmtNode *node) override;
-  static std::any visitImportStmtPrepare(ImportStmtNode *node);
+  std::any visitImportStmtPrepare(ImportStmtNode *node);
   std::any visitReturnStmt(ReturnStmtNode *node) override;
   std::any visitBreakStmt(BreakStmtNode *node) override;
   std::any visitContinueStmt(ContinueStmtNode *node) override;

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -34,7 +34,7 @@ bool TypeMatcher::matchRequestedToCandidateType(SymbolType candidateType, Symbol
 
     // Check if we know the concrete type for that generic type name already
     if (typeMapping.contains(genericTypeName)) {
-      SymbolType knownConcreteType = typeMapping.at(candidateType.getSubType());
+      SymbolType knownConcreteType = typeMapping.at(genericTypeName);
 
       // Remove reference wrapper of candidate type if required
       if (!requestedType.isRef())

--- a/std/data/queue.spice
+++ b/std/data/queue.spice
@@ -28,7 +28,6 @@ public type Queue<T> struct {
     unsigned long size      // Current number of items
     unsigned long idxFront  // Index for front access
     unsigned long idxBack   // Index for back access
-    unsigned int itemSize   // Size of a single item
 }
 
 public p Queue.ctor(unsigned long initAllocItems, const T& defaultValue) {
@@ -50,9 +49,9 @@ public p Queue.ctor(unsigned int initAllocItems) {
 
 public p Queue.ctor(unsigned long initAllocItems = INITIAL_ALLOC_COUNT) {
     // Allocate space for the initial number of elements
-    this.itemSize = sizeof(type T) / 8;
+    const long itemSize = sizeof(type T) / 8l;
     unsafe {
-        this.contents = (T*) malloc(this.itemSize * initAllocItems);
+        this.contents = (T*) malloc(itemSize * initAllocItems);
     }
     this.size = 0l;
     this.capacity = initAllocItems;
@@ -181,9 +180,10 @@ public p Queue.pack() {
  */
 p Queue.resize(unsigned long itemCount) {
     // Allocate the new memory
+    const long itemSize = sizeof(type T) / 8l;
     unsafe {
         byte* oldAddress = (byte*) this.contents;
-        int newSize = (int) (this.itemSize * itemCount);
+        int newSize = (int) (itemSize * itemCount);
         T* newMemory = (T*) realloc(oldAddress, newSize);
         this.contents = newMemory;
     }

--- a/std/data/stack.spice
+++ b/std/data/stack.spice
@@ -26,7 +26,6 @@ public type Stack<T> struct {
     T* contents             // Pointer to the first data element
     unsigned long capacity  // Allocated number of items
     unsigned long size      // Current number of items
-    unsigned int itemSize   // Size of a single item
 }
 
 public p Stack.ctor(unsigned long initAllocItems, const T &defaultValue) {
@@ -47,9 +46,9 @@ public p Stack.ctor(unsigned int initAllocItems) {
 
 public p Stack.ctor(unsigned long initAllocItems = INITIAL_ALLOC_COUNT) {
     // Allocate space for the initial number of elements
-    this.itemSize = sizeof(type T) / 8;
+    const long itemSize = sizeof(type T) / 8l;
     unsafe {
-        this.contents = (T*) malloc(this.itemSize * initAllocItems);
+        this.contents = (T*) malloc(itemSize * initAllocItems);
     }
     this.size = 0l;
     this.capacity = initAllocItems;
@@ -138,9 +137,10 @@ public p Stack.pack() {
  */
 p Stack.resize(unsigned long itemCount) {
     // Allocate the new memory
+    const long itemSize = sizeof(type T) / 8l;
     unsafe {
         byte* oldAddress = (byte*) this.contents;
-        int newSize = (int) (this.itemSize * itemCount);
+        int newSize = (int) (itemSize * itemCount);
         T* newMemory = (T*) realloc(oldAddress, newSize);
         this.contents = newMemory;
     }

--- a/std/data/vector.spice
+++ b/std/data/vector.spice
@@ -26,7 +26,6 @@ public type Vector<T> struct {
     T* contents             // Pointer to the first data element
     unsigned long capacity  // Allocated number of items
     unsigned long size      // Current number of items
-    unsigned int itemSize   // Size of a single item
 }
 
 public p Vector.ctor(unsigned int initAllocItems) {
@@ -35,9 +34,9 @@ public p Vector.ctor(unsigned int initAllocItems) {
 
 public p Vector.ctor(unsigned long initAllocItems = INITIAL_ALLOC_COUNT) {
     // Allocate space for the initial number of elements
-    this.itemSize = sizeof(type T) / 8;
+    const long itemSize = sizeof(type T) / 8l;
     unsafe {
-        this.contents = (T*) malloc(this.itemSize * initAllocItems);
+        this.contents = (T*) malloc(itemSize * initAllocItems);
     }
     this.size = 0l;
     this.capacity = initAllocItems;
@@ -174,9 +173,10 @@ public p Vector.pack() {
  */
 p Vector.resize(unsigned long itemCount) {
     // Allocate the new memory
+    const long itemSize = sizeof(type T) / 8l;
     unsafe {
         byte* oldAddress = (byte*) this.contents;
-        int newSize = (int) (this.itemSize * itemCount);
+        int newSize = (int) (itemSize * itemCount);
         T* newMemory = (T*) realloc(oldAddress, newSize);
         this.contents = newMemory;
     }

--- a/std/iterator/array-iterator.spice
+++ b/std/iterator/array-iterator.spice
@@ -12,7 +12,7 @@ public type ArrayIterator<I> struct : Iterable<I> {
     unsigned long cursor
 }
 
-public p ArrayIterator.ctor(I* array, unsigned long size) {
+public p ArrayIterator.ctor(I[] array, unsigned long size) {
     this.array = array;
     this.size = size;
     this.cursor = 0l;
@@ -24,7 +24,9 @@ public p ArrayIterator.ctor(I* array, unsigned long size) {
  * @return Reference to the current item
  */
 public inline f<I&> ArrayIterator.get() {
-    return this.array[this.cursor];
+    unsafe {
+        return this.array[this.cursor];
+    }
 }
 
 public inline f<Pair<unsigned long, I&>> ArrayIterator.getIdx() {

--- a/std/runtime/iterator_rt.spice
+++ b/std/runtime/iterator_rt.spice
@@ -7,7 +7,7 @@ type I dyn; // Item type
 /**
  * Convenience wrapper for creating a simple array iterator
  */
-/*public inline f<ArrayIterator<I>> array<I>(I* array, unsigned long size) {
+/*public inline f<ArrayIterator<I>> iterate<I>(I[] array, unsigned long size) {
     return ArrayIterator<I>(array, size);
 }*/
 

--- a/test/test-files/irgenerator/builtins/success-len/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-len/ir-code-O2.ll
@@ -7,7 +7,7 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %1 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i32 4)
+  %1 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i64 4)
   ret i32 0
 }
 

--- a/test/test-files/irgenerator/builtins/success-len/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-len/ir-code.ll
@@ -14,7 +14,7 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   call void @llvm.memcpy.p0.p0.i64(ptr %1, ptr @anon.array.0, i64 16, i1 false)
   store [4 x i32] [i32 1, i32 2, i32 3, i32 4], ptr %testIntArray, align 4
-  %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 4)
+  %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 4)
   %3 = load i32, ptr %result, align 4
   ret i32 %3
 }

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
@@ -17,17 +17,17 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %1 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i32 64)
-  %2 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.1, i32 32)
-  %3 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.2, i32 16)
-  %4 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.3, i32 64)
-  %5 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.4, i32 8)
-  %6 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.5, i32 8)
-  %7 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.6, i32 64)
-  %8 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.7, i32 1)
-  %9 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.8, i32 224)
-  %10 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.9, i32 64)
-  %11 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.10, i32 128)
+  %1 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i64 64)
+  %2 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.1, i64 32)
+  %3 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.2, i64 16)
+  %4 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.3, i64 64)
+  %5 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.4, i64 8)
+  %6 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.5, i64 8)
+  %7 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.6, i64 64)
+  %8 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.7, i64 1)
+  %9 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.8, i64 224)
+  %10 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.9, i64 64)
+  %11 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.10, i64 128)
   ret i32 0
 }
 

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
@@ -20,18 +20,18 @@ define dso_local i32 @main() #0 {
   %result = alloca i32, align 4
   %intVariable = alloca i32, align 4
   store i32 0, ptr %result, align 4
-  %1 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 64)
-  %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 32)
-  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 16)
-  %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 64)
-  %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.4, i32 8)
-  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.5, i32 8)
-  %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.6, i32 64)
-  %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.7, i32 1)
-  %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.8, i32 224)
+  %1 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 64)
+  %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i64 32)
+  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i64 16)
+  %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i64 64)
+  %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.4, i64 8)
+  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.5, i64 8)
+  %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.6, i64 64)
+  %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.7, i64 1)
+  %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.8, i64 224)
   store i32 123, ptr %intVariable, align 4
-  %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.9, i32 64)
-  %11 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.10, i32 128)
+  %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.9, i64 64)
+  %11 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.10, i64 128)
   %12 = load i32, ptr %result, align 4
   ret i32 %12
 }

--- a/test/test-files/irgenerator/debug-info/success-dgb-info-complex/ir-code-dbg.ll
+++ b/test/test-files/irgenerator/debug-info/success-dgb-info-complex/ir-code-dbg.ll
@@ -3,7 +3,7 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%__int__Vector__intptr_long_long_int = type { ptr, i64, i64, i32 }
+%__int__Vector__intptr_long_long = type { ptr, i64, i64 }
 %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" = type { ptr, i64 }
 %__long_intref__Pair__long_intref = type { i64, ptr }
 
@@ -23,6 +23,15 @@ target triple = "x86_64-w64-windows-gnu"
 @anon.string.13 = private unnamed_addr constant [66 x i8] c"Assertion failed: Condition 'it.get() == 123' evaluated to false.\00", align 1
 @anon.string.14 = private unnamed_addr constant [66 x i8] c"Assertion failed: Condition 'it.get() == -99' evaluated to false.\00", align 1
 @anon.string.15 = private unnamed_addr constant [64 x i8] c"Assertion failed: Condition '!it.isValid()' evaluated to false.\00", align 1
+@anon.string.16 = private unnamed_addr constant [67 x i8] c"Assertion failed: Condition 'vi.get(0) == 123' evaluated to false.\00", align 1
+@anon.string.17 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'vi.get(1) == 4321' evaluated to false.\00", align 1
+@anon.string.18 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'vi.get(2) == 9876' evaluated to false.\00", align 1
+@anon.string.19 = private unnamed_addr constant [67 x i8] c"Assertion failed: Condition 'vi.get(0) == 124' evaluated to false.\00", align 1
+@anon.string.20 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'vi.get(1) == 4322' evaluated to false.\00", align 1
+@anon.string.21 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'vi.get(2) == 9877' evaluated to false.\00", align 1
+@anon.string.22 = private unnamed_addr constant [67 x i8] c"Assertion failed: Condition 'vi.get(0) == 124' evaluated to false.\00", align 1
+@anon.string.23 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'vi.get(1) == 4323' evaluated to false.\00", align 1
+@anon.string.24 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'vi.get(2) == 9879' evaluated to false.\00", align 1
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 1
 
 ; Function Attrs: noinline nounwind optnone uwtable
@@ -30,7 +39,7 @@ define dso_local i32 @main(i32 %0, ptr %1) #0 !dbg !6 {
   %result = alloca i32, align 4
   %argc = alloca i32, align 4
   %argv = alloca ptr, align 8
-  %vi = alloca %__int__Vector__intptr_long_long_int, align 8
+  %vi = alloca %__int__Vector__intptr_long_long, align 8
   %3 = alloca i32, align 4
   %4 = alloca i32, align 4
   %5 = alloca i32, align 4
@@ -40,212 +49,398 @@ define dso_local i32 @main(i32 %0, ptr %1) #0 !dbg !6 {
   %7 = alloca i32, align 4
   %8 = alloca i32, align 4
   %9 = alloca i1, align 1
+  %10 = alloca %"__int__VectorIterator__std/data/vector::Vector<int>ref_long", align 8
+  %item = alloca i32, align 4
+  %11 = alloca %"__int__VectorIterator__std/data/vector::Vector<int>ref_long", align 8
+  %item1 = alloca ptr, align 8
+  %12 = alloca %"__int__VectorIterator__std/data/vector::Vector<int>ref_long", align 8
+  %idx = alloca i64, align 8
+  %item2 = alloca ptr, align 8
+  %pair_addr = alloca %__long_intref__Pair__long_intref, align 8
   call void @llvm.dbg.declare(metadata ptr %result, metadata !14, metadata !DIExpression()), !dbg !15
   store i32 0, ptr %result, align 4, !dbg !15
   call void @llvm.dbg.declare(metadata ptr %argc, metadata !16, metadata !DIExpression()), !dbg !15
   store i32 %0, ptr %argc, align 4, !dbg !15
   call void @llvm.dbg.declare(metadata ptr %argv, metadata !17, metadata !DIExpression()), !dbg !15
   store ptr %1, ptr %argv, align 8, !dbg !15
-  call void @llvm.dbg.declare(metadata ptr %vi, metadata !18, metadata !DIExpression()), !dbg !24
-  call void @_mp__Vector_int__void__ctor(ptr %vi), !dbg !24
-  store i32 123, ptr %3, align 4, !dbg !25
-  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %3), !dbg !25
-  store i32 4321, ptr %4, align 4, !dbg !26
-  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %4), !dbg !26
-  store i32 9876, ptr %5, align 4, !dbg !27
-  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %5), !dbg !27
-  %10 = call i64 @_mf__Vector_int__long__getSize(ptr %vi), !dbg !28
-  %11 = icmp eq i64 %10, 3, !dbg !29
-  br i1 %11, label %assert.exit.L9, label %assert.then.L9, !dbg !29, !prof !30
+  call void @llvm.dbg.declare(metadata ptr %vi, metadata !18, metadata !DIExpression()), !dbg !23
+  call void @_mp__Vector_int__void__ctor(ptr %vi), !dbg !23
+  store i32 123, ptr %3, align 4, !dbg !24
+  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %3), !dbg !24
+  store i32 4321, ptr %4, align 4, !dbg !25
+  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %4), !dbg !25
+  store i32 9876, ptr %5, align 4, !dbg !26
+  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %5), !dbg !26
+  %13 = call i64 @_mf__Vector_int__long__getSize(ptr %vi), !dbg !27
+  %14 = icmp eq i64 %13, 3, !dbg !28
+  br i1 %14, label %assert.exit.L9, label %assert.then.L9, !dbg !28, !prof !29
 
 assert.then.L9:                                   ; preds = %2
-  %12 = call i32 (ptr, ...) @printf(ptr @anon.string.0), !dbg !29
-  call void @exit(i32 1), !dbg !29
-  unreachable, !dbg !29
+  %15 = call i32 (ptr, ...) @printf(ptr @anon.string.0), !dbg !28
+  call void @exit(i32 1), !dbg !28
+  unreachable, !dbg !28
 
 assert.exit.L9:                                   ; preds = %2
-  %13 = call %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" @"_f__void__std/iterator/vector-iterator::VectorIterator<int>__iterate__std/iterator/vector-iterator::Vector<int>ref"(ptr %vi), !dbg !31
-  store %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" %13, ptr %it, align 8, !dbg !31
-  call void @llvm.dbg.declare(metadata ptr %it, metadata !32, metadata !DIExpression()), !dbg !31
-  store %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" %13, ptr %it, align 8, !dbg !31
-  %14 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !36
-  br i1 %14, label %assert.exit.L13, label %assert.then.L13, !dbg !36, !prof !30
+  %16 = call %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" @"_f__void__std/iterator/vector-iterator::VectorIterator<int>__iterate__std/iterator/vector-iterator::Vector<int>ref"(ptr %vi), !dbg !30
+  store %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" %16, ptr %it, align 8, !dbg !30
+  call void @llvm.dbg.declare(metadata ptr %it, metadata !31, metadata !DIExpression()), !dbg !30
+  store %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" %16, ptr %it, align 8, !dbg !30
+  %17 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !35
+  br i1 %17, label %assert.exit.L13, label %assert.then.L13, !dbg !35, !prof !29
 
 assert.then.L13:                                  ; preds = %assert.exit.L9
-  %15 = call i32 (ptr, ...) @printf(ptr @anon.string.1), !dbg !36
-  call void @exit(i32 1), !dbg !36
-  unreachable, !dbg !36
+  %18 = call i32 (ptr, ...) @printf(ptr @anon.string.1), !dbg !35
+  call void @exit(i32 1), !dbg !35
+  unreachable, !dbg !35
 
 assert.exit.L13:                                  ; preds = %assert.exit.L9
-  %16 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !37
-  %17 = load i32, ptr %16, align 4, !dbg !38
-  %18 = icmp eq i32 %17, 123, !dbg !38
-  br i1 %18, label %assert.exit.L14, label %assert.then.L14, !dbg !38, !prof !30
+  %19 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !36
+  %20 = load i32, ptr %19, align 4, !dbg !37
+  %21 = icmp eq i32 %20, 123, !dbg !37
+  br i1 %21, label %assert.exit.L14, label %assert.then.L14, !dbg !37, !prof !29
 
 assert.then.L14:                                  ; preds = %assert.exit.L13
-  %19 = call i32 (ptr, ...) @printf(ptr @anon.string.2), !dbg !38
-  call void @exit(i32 1), !dbg !38
-  unreachable, !dbg !38
+  %22 = call i32 (ptr, ...) @printf(ptr @anon.string.2), !dbg !37
+  call void @exit(i32 1), !dbg !37
+  unreachable, !dbg !37
 
 assert.exit.L14:                                  ; preds = %assert.exit.L13
-  %20 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !39
-  %21 = load i32, ptr %20, align 4, !dbg !40
-  %22 = icmp eq i32 %21, 123, !dbg !40
-  br i1 %22, label %assert.exit.L15, label %assert.then.L15, !dbg !40, !prof !30
+  %23 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !38
+  %24 = load i32, ptr %23, align 4, !dbg !39
+  %25 = icmp eq i32 %24, 123, !dbg !39
+  br i1 %25, label %assert.exit.L15, label %assert.then.L15, !dbg !39, !prof !29
 
 assert.then.L15:                                  ; preds = %assert.exit.L14
-  %23 = call i32 (ptr, ...) @printf(ptr @anon.string.3), !dbg !40
-  call void @exit(i32 1), !dbg !40
-  unreachable, !dbg !40
+  %26 = call i32 (ptr, ...) @printf(ptr @anon.string.3), !dbg !39
+  call void @exit(i32 1), !dbg !39
+  unreachable, !dbg !39
 
 assert.exit.L15:                                  ; preds = %assert.exit.L14
-  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !41
-  %24 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !42
-  %25 = load i32, ptr %24, align 4, !dbg !43
-  %26 = icmp eq i32 %25, 4321, !dbg !43
-  br i1 %26, label %assert.exit.L17, label %assert.then.L17, !dbg !43, !prof !30
+  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !40
+  %27 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !41
+  %28 = load i32, ptr %27, align 4, !dbg !42
+  %29 = icmp eq i32 %28, 4321, !dbg !42
+  br i1 %29, label %assert.exit.L17, label %assert.then.L17, !dbg !42, !prof !29
 
 assert.then.L17:                                  ; preds = %assert.exit.L15
-  %27 = call i32 (ptr, ...) @printf(ptr @anon.string.4), !dbg !43
+  %30 = call i32 (ptr, ...) @printf(ptr @anon.string.4), !dbg !42
+  call void @exit(i32 1), !dbg !42
+  unreachable, !dbg !42
+
+assert.exit.L17:                                  ; preds = %assert.exit.L15
+  %31 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !43
+  br i1 %31, label %assert.exit.L18, label %assert.then.L18, !dbg !43, !prof !29
+
+assert.then.L18:                                  ; preds = %assert.exit.L17
+  %32 = call i32 (ptr, ...) @printf(ptr @anon.string.5), !dbg !43
   call void @exit(i32 1), !dbg !43
   unreachable, !dbg !43
 
-assert.exit.L17:                                  ; preds = %assert.exit.L15
-  %28 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !44
-  br i1 %28, label %assert.exit.L18, label %assert.then.L18, !dbg !44, !prof !30
-
-assert.then.L18:                                  ; preds = %assert.exit.L17
-  %29 = call i32 (ptr, ...) @printf(ptr @anon.string.5), !dbg !44
-  call void @exit(i32 1), !dbg !44
-  unreachable, !dbg !44
-
 assert.exit.L18:                                  ; preds = %assert.exit.L17
-  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !45
-  %30 = call %__long_intref__Pair__long_intref @"_mf__VectorIterator_int__std/iterator/iterable::Pair<unsigned long,int&>__getIdx"(ptr %it), !dbg !46
-  store %__long_intref__Pair__long_intref %30, ptr %pair, align 8, !dbg !46
-  call void @llvm.dbg.declare(metadata ptr %pair, metadata !47, metadata !DIExpression()), !dbg !46
-  store %__long_intref__Pair__long_intref %30, ptr %pair, align 8, !dbg !46
-  %31 = call ptr @_mf__Pair_long_intref__longref__getFirst(ptr %pair), !dbg !50
-  %32 = load i64, ptr %31, align 8, !dbg !51
-  %33 = icmp eq i64 %32, 2, !dbg !51
-  br i1 %33, label %assert.exit.L21, label %assert.then.L21, !dbg !51, !prof !30
+  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !44
+  %33 = call %__long_intref__Pair__long_intref @"_mf__VectorIterator_int__std/iterator/iterable::Pair<unsigned long,int&>__getIdx"(ptr %it), !dbg !45
+  store %__long_intref__Pair__long_intref %33, ptr %pair, align 8, !dbg !45
+  call void @llvm.dbg.declare(metadata ptr %pair, metadata !46, metadata !DIExpression()), !dbg !45
+  store %__long_intref__Pair__long_intref %33, ptr %pair, align 8, !dbg !45
+  %34 = call ptr @_mf__Pair_long_intref__longref__getFirst(ptr %pair), !dbg !49
+  %35 = load i64, ptr %34, align 8, !dbg !50
+  %36 = icmp eq i64 %35, 2, !dbg !50
+  br i1 %36, label %assert.exit.L21, label %assert.then.L21, !dbg !50, !prof !29
 
 assert.then.L21:                                  ; preds = %assert.exit.L18
-  %34 = call i32 (ptr, ...) @printf(ptr @anon.string.6), !dbg !51
-  call void @exit(i32 1), !dbg !51
-  unreachable, !dbg !51
+  %37 = call i32 (ptr, ...) @printf(ptr @anon.string.6), !dbg !50
+  call void @exit(i32 1), !dbg !50
+  unreachable, !dbg !50
 
 assert.exit.L21:                                  ; preds = %assert.exit.L18
-  %35 = call ptr @_mf__Pair_long_intref__intref__getSecond(ptr %pair), !dbg !52
-  %36 = load i32, ptr %35, align 4, !dbg !53
-  %37 = icmp eq i32 %36, 9876, !dbg !53
-  br i1 %37, label %assert.exit.L22, label %assert.then.L22, !dbg !53, !prof !30
+  %38 = call ptr @_mf__Pair_long_intref__intref__getSecond(ptr %pair), !dbg !51
+  %39 = load i32, ptr %38, align 4, !dbg !52
+  %40 = icmp eq i32 %39, 9876, !dbg !52
+  br i1 %40, label %assert.exit.L22, label %assert.then.L22, !dbg !52, !prof !29
 
 assert.then.L22:                                  ; preds = %assert.exit.L21
-  %38 = call i32 (ptr, ...) @printf(ptr @anon.string.7), !dbg !53
-  call void @exit(i32 1), !dbg !53
-  unreachable, !dbg !53
+  %41 = call i32 (ptr, ...) @printf(ptr @anon.string.7), !dbg !52
+  call void @exit(i32 1), !dbg !52
+  unreachable, !dbg !52
 
 assert.exit.L22:                                  ; preds = %assert.exit.L21
-  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !54
-  %39 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !55
-  %40 = xor i1 %39, true, !dbg !55
-  store i1 %40, ptr %6, align 1, !dbg !55
-  br i1 %40, label %assert.exit.L24, label %assert.then.L24, !dbg !55, !prof !30
+  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !53
+  %42 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !54
+  %43 = xor i1 %42, true, !dbg !54
+  store i1 %43, ptr %6, align 1, !dbg !54
+  br i1 %43, label %assert.exit.L24, label %assert.then.L24, !dbg !54, !prof !29
 
 assert.then.L24:                                  ; preds = %assert.exit.L22
-  %41 = call i32 (ptr, ...) @printf(ptr @anon.string.8), !dbg !55
-  call void @exit(i32 1), !dbg !55
-  unreachable, !dbg !55
+  %44 = call i32 (ptr, ...) @printf(ptr @anon.string.8), !dbg !54
+  call void @exit(i32 1), !dbg !54
+  unreachable, !dbg !54
 
 assert.exit.L24:                                  ; preds = %assert.exit.L22
-  store i32 321, ptr %7, align 4, !dbg !56
-  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %7), !dbg !56
-  store i32 -99, ptr %8, align 4, !dbg !57
-  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %8), !dbg !57
-  %42 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !58
-  br i1 %42, label %assert.exit.L29, label %assert.then.L29, !dbg !58, !prof !30
+  store i32 321, ptr %7, align 4, !dbg !55
+  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %7), !dbg !55
+  store i32 -99, ptr %8, align 4, !dbg !56
+  call void @_mp__Vector_int__void__pushBack__intref(ptr %vi, ptr %8), !dbg !56
+  %45 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !57
+  br i1 %45, label %assert.exit.L29, label %assert.then.L29, !dbg !57, !prof !29
 
 assert.then.L29:                                  ; preds = %assert.exit.L24
-  %43 = call i32 (ptr, ...) @printf(ptr @anon.string.9), !dbg !58
-  call void @exit(i32 1), !dbg !58
-  unreachable, !dbg !58
+  %46 = call i32 (ptr, ...) @printf(ptr @anon.string.9), !dbg !57
+  call void @exit(i32 1), !dbg !57
+  unreachable, !dbg !57
 
 assert.exit.L29:                                  ; preds = %assert.exit.L24
-  call void @"_p__void__void__op.minusequal__VectorIterator<int>ref_int"(ptr %it, i32 3), !dbg !59
-  %44 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !60
-  %45 = load i32, ptr %44, align 4, !dbg !61
-  %46 = icmp eq i32 %45, 123, !dbg !61
-  br i1 %46, label %assert.exit.L33, label %assert.then.L33, !dbg !61, !prof !30
+  call void @"_p__void__void__op.minusequal__VectorIterator<int>ref_int"(ptr %it, i32 3), !dbg !58
+  %47 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !59
+  %48 = load i32, ptr %47, align 4, !dbg !60
+  %49 = icmp eq i32 %48, 123, !dbg !60
+  br i1 %49, label %assert.exit.L33, label %assert.then.L33, !dbg !60, !prof !29
 
 assert.then.L33:                                  ; preds = %assert.exit.L29
-  %47 = call i32 (ptr, ...) @printf(ptr @anon.string.10), !dbg !61
+  %50 = call i32 (ptr, ...) @printf(ptr @anon.string.10), !dbg !60
+  call void @exit(i32 1), !dbg !60
+  unreachable, !dbg !60
+
+assert.exit.L33:                                  ; preds = %assert.exit.L29
+  %51 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !61
+  br i1 %51, label %assert.exit.L34, label %assert.then.L34, !dbg !61, !prof !29
+
+assert.then.L34:                                  ; preds = %assert.exit.L33
+  %52 = call i32 (ptr, ...) @printf(ptr @anon.string.11), !dbg !61
   call void @exit(i32 1), !dbg !61
   unreachable, !dbg !61
 
-assert.exit.L33:                                  ; preds = %assert.exit.L29
-  %48 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !62
-  br i1 %48, label %assert.exit.L34, label %assert.then.L34, !dbg !62, !prof !30
-
-assert.then.L34:                                  ; preds = %assert.exit.L33
-  %49 = call i32 (ptr, ...) @printf(ptr @anon.string.11), !dbg !62
-  call void @exit(i32 1), !dbg !62
-  unreachable, !dbg !62
-
 assert.exit.L34:                                  ; preds = %assert.exit.L33
-  %50 = load %"__int__VectorIterator__std/data/vector::Vector<int>ref_long", ptr %it, align 8, !dbg !63
-  call void @"_p__void__void__op.plusplus.post__VectorIterator<int>ref"(ptr %it), !dbg !63
-  %51 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !64
-  %52 = load i32, ptr %51, align 4, !dbg !65
-  %53 = icmp eq i32 %52, 4321, !dbg !65
-  br i1 %53, label %assert.exit.L36, label %assert.then.L36, !dbg !65, !prof !30
+  %53 = load %"__int__VectorIterator__std/data/vector::Vector<int>ref_long", ptr %it, align 8, !dbg !62
+  call void @"_p__void__void__op.plusplus.post__VectorIterator<int>ref"(ptr %it), !dbg !62
+  %54 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !63
+  %55 = load i32, ptr %54, align 4, !dbg !64
+  %56 = icmp eq i32 %55, 4321, !dbg !64
+  br i1 %56, label %assert.exit.L36, label %assert.then.L36, !dbg !64, !prof !29
 
 assert.then.L36:                                  ; preds = %assert.exit.L34
-  %54 = call i32 (ptr, ...) @printf(ptr @anon.string.12), !dbg !65
-  call void @exit(i32 1), !dbg !65
-  unreachable, !dbg !65
+  %57 = call i32 (ptr, ...) @printf(ptr @anon.string.12), !dbg !64
+  call void @exit(i32 1), !dbg !64
+  unreachable, !dbg !64
 
 assert.exit.L36:                                  ; preds = %assert.exit.L34
-  %55 = load %"__int__VectorIterator__std/data/vector::Vector<int>ref_long", ptr %it, align 8, !dbg !66
-  call void @"_p__void__void__op.minusminus.post__VectorIterator<int>ref"(ptr %it), !dbg !66
-  %56 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !67
-  %57 = load i32, ptr %56, align 4, !dbg !68
-  %58 = icmp eq i32 %57, 123, !dbg !68
-  br i1 %58, label %assert.exit.L38, label %assert.then.L38, !dbg !68, !prof !30
+  %58 = load %"__int__VectorIterator__std/data/vector::Vector<int>ref_long", ptr %it, align 8, !dbg !65
+  call void @"_p__void__void__op.minusminus.post__VectorIterator<int>ref"(ptr %it), !dbg !65
+  %59 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !66
+  %60 = load i32, ptr %59, align 4, !dbg !67
+  %61 = icmp eq i32 %60, 123, !dbg !67
+  br i1 %61, label %assert.exit.L38, label %assert.then.L38, !dbg !67, !prof !29
 
 assert.then.L38:                                  ; preds = %assert.exit.L36
-  %59 = call i32 (ptr, ...) @printf(ptr @anon.string.13), !dbg !68
-  call void @exit(i32 1), !dbg !68
-  unreachable, !dbg !68
+  %62 = call i32 (ptr, ...) @printf(ptr @anon.string.13), !dbg !67
+  call void @exit(i32 1), !dbg !67
+  unreachable, !dbg !67
 
 assert.exit.L38:                                  ; preds = %assert.exit.L36
-  call void @"_p__void__void__op.plusequal__VectorIterator<int>ref_int"(ptr %it, i32 4), !dbg !69
-  %60 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !70
-  %61 = load i32, ptr %60, align 4, !dbg !71
-  %62 = icmp eq i32 %61, -99, !dbg !71
-  br i1 %62, label %assert.exit.L40, label %assert.then.L40, !dbg !71, !prof !30
+  call void @"_p__void__void__op.plusequal__VectorIterator<int>ref_int"(ptr %it, i32 4), !dbg !68
+  %63 = call ptr @_mf__VectorIterator_int__intref__get(ptr %it), !dbg !69
+  %64 = load i32, ptr %63, align 4, !dbg !70
+  %65 = icmp eq i32 %64, -99, !dbg !70
+  br i1 %65, label %assert.exit.L40, label %assert.then.L40, !dbg !70, !prof !29
 
 assert.then.L40:                                  ; preds = %assert.exit.L38
-  %63 = call i32 (ptr, ...) @printf(ptr @anon.string.14), !dbg !71
-  call void @exit(i32 1), !dbg !71
-  unreachable, !dbg !71
+  %66 = call i32 (ptr, ...) @printf(ptr @anon.string.14), !dbg !70
+  call void @exit(i32 1), !dbg !70
+  unreachable, !dbg !70
 
 assert.exit.L40:                                  ; preds = %assert.exit.L38
-  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !72
-  %64 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !73
-  %65 = xor i1 %64, true, !dbg !73
-  store i1 %65, ptr %9, align 1, !dbg !73
-  br i1 %65, label %assert.exit.L42, label %assert.then.L42, !dbg !73, !prof !30
+  call void @_mp__VectorIterator_int__void__next(ptr %it), !dbg !71
+  %67 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %it), !dbg !72
+  %68 = xor i1 %67, true, !dbg !72
+  store i1 %68, ptr %9, align 1, !dbg !72
+  br i1 %68, label %assert.exit.L42, label %assert.then.L42, !dbg !72, !prof !29
 
 assert.then.L42:                                  ; preds = %assert.exit.L40
-  %66 = call i32 (ptr, ...) @printf(ptr @anon.string.15), !dbg !73
-  call void @exit(i32 1), !dbg !73
-  unreachable, !dbg !73
+  %69 = call i32 (ptr, ...) @printf(ptr @anon.string.15), !dbg !72
+  call void @exit(i32 1), !dbg !72
+  unreachable, !dbg !72
 
 assert.exit.L42:                                  ; preds = %assert.exit.L40
-  %67 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !74
-  %68 = load i32, ptr %result, align 4, !dbg !74
-  ret i32 %68, !dbg !74
+  %70 = call %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" @"_f__void__std/iterator/vector-iterator::VectorIterator<int>__iterate__std/iterator/vector-iterator::Vector<int>ref"(ptr %vi), !dbg !73
+  call void @llvm.dbg.declare(metadata ptr %item, metadata !74, metadata !DIExpression()), !dbg !75
+  store %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" %70, ptr %10, align 8, !dbg !73
+  br label %foreach.head.L45, !dbg !75
+
+foreach.head.L45:                                 ; preds = %foreach.tail.L45, %assert.exit.L42
+  %71 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %10), !dbg !75
+  br i1 %71, label %foreach.body.L45, label %foreach.exit.L45, !dbg !75
+
+foreach.body.L45:                                 ; preds = %foreach.head.L45
+  %72 = call ptr @_mf__VectorIterator_int__intref__get(ptr %10), !dbg !75
+  %73 = load i32, ptr %72, align 4, !dbg !75
+  store i32 %73, ptr %item, align 4, !dbg !75
+  %74 = load i32, ptr %item, align 4, !dbg !76
+  %75 = add i32 %74, 1, !dbg !76
+  store i32 %75, ptr %item, align 4, !dbg !76
+  br label %foreach.tail.L45, !dbg !76
+
+foreach.tail.L45:                                 ; preds = %foreach.body.L45
+  call void @_mp__VectorIterator_int__void__next(ptr %10), !dbg !76
+  br label %foreach.head.L45, !dbg !76
+
+foreach.exit.L45:                                 ; preds = %foreach.head.L45
+  %76 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 0), !dbg !77
+  %77 = load i32, ptr %76, align 4, !dbg !78
+  %78 = icmp eq i32 %77, 123, !dbg !78
+  br i1 %78, label %assert.exit.L48, label %assert.then.L48, !dbg !78, !prof !29
+
+assert.then.L48:                                  ; preds = %foreach.exit.L45
+  %79 = call i32 (ptr, ...) @printf(ptr @anon.string.16), !dbg !78
+  call void @exit(i32 1), !dbg !78
+  unreachable, !dbg !78
+
+assert.exit.L48:                                  ; preds = %foreach.exit.L45
+  %80 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 1), !dbg !79
+  %81 = load i32, ptr %80, align 4, !dbg !80
+  %82 = icmp eq i32 %81, 4321, !dbg !80
+  br i1 %82, label %assert.exit.L49, label %assert.then.L49, !dbg !80, !prof !29
+
+assert.then.L49:                                  ; preds = %assert.exit.L48
+  %83 = call i32 (ptr, ...) @printf(ptr @anon.string.17), !dbg !80
+  call void @exit(i32 1), !dbg !80
+  unreachable, !dbg !80
+
+assert.exit.L49:                                  ; preds = %assert.exit.L48
+  %84 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 2), !dbg !81
+  %85 = load i32, ptr %84, align 4, !dbg !82
+  %86 = icmp eq i32 %85, 9876, !dbg !82
+  br i1 %86, label %assert.exit.L50, label %assert.then.L50, !dbg !82, !prof !29
+
+assert.then.L50:                                  ; preds = %assert.exit.L49
+  %87 = call i32 (ptr, ...) @printf(ptr @anon.string.18), !dbg !82
+  call void @exit(i32 1), !dbg !82
+  unreachable, !dbg !82
+
+assert.exit.L50:                                  ; preds = %assert.exit.L49
+  %88 = call %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" @"_f__void__std/iterator/vector-iterator::VectorIterator<int>__iterate__std/iterator/vector-iterator::Vector<int>ref"(ptr %vi), !dbg !83
+  call void @llvm.dbg.declare(metadata ptr %item1, metadata !84, metadata !DIExpression()), !dbg !85
+  store %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" %88, ptr %11, align 8, !dbg !83
+  br label %foreach.head.L53, !dbg !85
+
+foreach.head.L53:                                 ; preds = %foreach.tail.L53, %assert.exit.L50
+  %89 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %11), !dbg !85
+  br i1 %89, label %foreach.body.L53, label %foreach.exit.L53, !dbg !85
+
+foreach.body.L53:                                 ; preds = %foreach.head.L53
+  %90 = call ptr @_mf__VectorIterator_int__intref__get(ptr %11), !dbg !85
+  store ptr %90, ptr %item1, align 8, !dbg !85
+  %91 = load ptr, ptr %item1, align 8, !dbg !86
+  %92 = load i32, ptr %91, align 4, !dbg !86
+  %93 = add i32 %92, 1, !dbg !86
+  store i32 %93, ptr %91, align 4, !dbg !86
+  br label %foreach.tail.L53, !dbg !86
+
+foreach.tail.L53:                                 ; preds = %foreach.body.L53
+  call void @_mp__VectorIterator_int__void__next(ptr %11), !dbg !86
+  br label %foreach.head.L53, !dbg !86
+
+foreach.exit.L53:                                 ; preds = %foreach.head.L53
+  %94 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 0), !dbg !87
+  %95 = load i32, ptr %94, align 4, !dbg !88
+  %96 = icmp eq i32 %95, 124, !dbg !88
+  br i1 %96, label %assert.exit.L56, label %assert.then.L56, !dbg !88, !prof !29
+
+assert.then.L56:                                  ; preds = %foreach.exit.L53
+  %97 = call i32 (ptr, ...) @printf(ptr @anon.string.19), !dbg !88
+  call void @exit(i32 1), !dbg !88
+  unreachable, !dbg !88
+
+assert.exit.L56:                                  ; preds = %foreach.exit.L53
+  %98 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 1), !dbg !89
+  %99 = load i32, ptr %98, align 4, !dbg !90
+  %100 = icmp eq i32 %99, 4322, !dbg !90
+  br i1 %100, label %assert.exit.L57, label %assert.then.L57, !dbg !90, !prof !29
+
+assert.then.L57:                                  ; preds = %assert.exit.L56
+  %101 = call i32 (ptr, ...) @printf(ptr @anon.string.20), !dbg !90
+  call void @exit(i32 1), !dbg !90
+  unreachable, !dbg !90
+
+assert.exit.L57:                                  ; preds = %assert.exit.L56
+  %102 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 2), !dbg !91
+  %103 = load i32, ptr %102, align 4, !dbg !92
+  %104 = icmp eq i32 %103, 9877, !dbg !92
+  br i1 %104, label %assert.exit.L58, label %assert.then.L58, !dbg !92, !prof !29
+
+assert.then.L58:                                  ; preds = %assert.exit.L57
+  %105 = call i32 (ptr, ...) @printf(ptr @anon.string.21), !dbg !92
+  call void @exit(i32 1), !dbg !92
+  unreachable, !dbg !92
+
+assert.exit.L58:                                  ; preds = %assert.exit.L57
+  %106 = call %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" @"_f__void__std/iterator/vector-iterator::VectorIterator<int>__iterate__std/iterator/vector-iterator::Vector<int>ref"(ptr %vi), !dbg !93
+  store %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" %106, ptr %12, align 8, !dbg !93
+  call void @llvm.dbg.declare(metadata ptr %idx, metadata !94, metadata !DIExpression()), !dbg !96
+  call void @llvm.dbg.declare(metadata ptr %item2, metadata !97, metadata !DIExpression()), !dbg !98
+  store i64 0, ptr %idx, align 8, !dbg !96
+  br label %foreach.head.L60, !dbg !98
+
+foreach.head.L60:                                 ; preds = %foreach.tail.L60, %assert.exit.L58
+  %107 = call i1 @_mf__VectorIterator_int__bool__isValid(ptr %12), !dbg !98
+  br i1 %107, label %foreach.body.L60, label %foreach.exit.L60, !dbg !98
+
+foreach.body.L60:                                 ; preds = %foreach.head.L60
+  %pair3 = call %__long_intref__Pair__long_intref @"_mf__VectorIterator_int__std/iterator/iterable::Pair<unsigned long,int&>__getIdx"(ptr %12), !dbg !98
+  store %__long_intref__Pair__long_intref %pair3, ptr %pair_addr, align 8, !dbg !98
+  %idx_addr = getelementptr inbounds %__long_intref__Pair__long_intref, ptr %pair_addr, i32 0, i32 0, !dbg !98
+  %108 = load i64, ptr %idx_addr, align 8, !dbg !98
+  store i64 %108, ptr %idx, align 8, !dbg !98
+  %item_addr = getelementptr inbounds %__long_intref__Pair__long_intref, ptr %pair_addr, i32 0, i32 1, !dbg !98
+  %109 = load ptr, ptr %item_addr, align 8, !dbg !98
+  store ptr %109, ptr %item2, align 8, !dbg !98
+  %110 = load i64, ptr %idx, align 8, !dbg !99
+  %111 = trunc i64 %110 to i32, !dbg !99
+  %112 = load ptr, ptr %item2, align 8, !dbg !99
+  %113 = load i32, ptr %112, align 4, !dbg !99
+  %114 = add i32 %113, %111, !dbg !99
+  store i32 %114, ptr %112, align 4, !dbg !99
+  br label %foreach.tail.L60, !dbg !99
+
+foreach.tail.L60:                                 ; preds = %foreach.body.L60
+  call void @_mp__VectorIterator_int__void__next(ptr %12), !dbg !99
+  br label %foreach.head.L60, !dbg !99
+
+foreach.exit.L60:                                 ; preds = %foreach.head.L60
+  %115 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 0), !dbg !100
+  %116 = load i32, ptr %115, align 4, !dbg !101
+  %117 = icmp eq i32 %116, 124, !dbg !101
+  br i1 %117, label %assert.exit.L63, label %assert.then.L63, !dbg !101, !prof !29
+
+assert.then.L63:                                  ; preds = %foreach.exit.L60
+  %118 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !101
+  call void @exit(i32 1), !dbg !101
+  unreachable, !dbg !101
+
+assert.exit.L63:                                  ; preds = %foreach.exit.L60
+  %119 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 1), !dbg !102
+  %120 = load i32, ptr %119, align 4, !dbg !103
+  %121 = icmp eq i32 %120, 4323, !dbg !103
+  br i1 %121, label %assert.exit.L64, label %assert.then.L64, !dbg !103, !prof !29
+
+assert.then.L64:                                  ; preds = %assert.exit.L63
+  %122 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !103
+  call void @exit(i32 1), !dbg !103
+  unreachable, !dbg !103
+
+assert.exit.L64:                                  ; preds = %assert.exit.L63
+  %123 = call ptr @_mf__Vector_int__intref__get__int(ptr %vi, i32 2), !dbg !104
+  %124 = load i32, ptr %123, align 4, !dbg !105
+  %125 = icmp eq i32 %124, 9879, !dbg !105
+  br i1 %125, label %assert.exit.L65, label %assert.then.L65, !dbg !105, !prof !29
+
+assert.then.L65:                                  ; preds = %assert.exit.L64
+  %126 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !105
+  call void @exit(i32 1), !dbg !105
+  unreachable, !dbg !105
+
+assert.exit.L65:                                  ; preds = %assert.exit.L64
+  %127 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !106
+  %128 = load i32, ptr %result, align 4, !dbg !106
+  ret i32 %128, !dbg !106
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind speculatable willreturn memory(none)
@@ -283,6 +478,8 @@ declare void @"_p__void__void__op.minusminus.post__VectorIterator<int>ref"(ptr)
 
 declare void @"_p__void__void__op.plusequal__VectorIterator<int>ref_int"(ptr, i32)
 
+declare ptr @_mf__Vector_int__intref__get__int(ptr, i32)
+
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
@@ -310,58 +507,90 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !17 = !DILocalVariable(name: "argv", arg: 2, scope: !6, file: !7, line: 3, type: !11)
 !18 = !DILocalVariable(name: "vi", scope: !6, file: !7, line: 5, type: !19)
 !19 = !DICompositeType(tag: DW_TAG_structure_type, name: "Vector", scope: !7, file: !7, line: 25, align: 8, flags: DIFlagTypePassByValue, elements: !20)
-!20 = !{!21, !22, !22, !23}
+!20 = !{!21, !22, !22}
 !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !10, size: 64)
 !22 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
-!23 = !DIBasicType(name: "unsigned int", size: 32, encoding: DW_ATE_unsigned)
-!24 = !DILocation(line: 5, column: 22, scope: !6)
-!25 = !DILocation(line: 6, column: 17, scope: !6)
-!26 = !DILocation(line: 7, column: 17, scope: !6)
-!27 = !DILocation(line: 8, column: 17, scope: !6)
-!28 = !DILocation(line: 9, column: 12, scope: !6)
-!29 = !DILocation(line: 9, column: 28, scope: !6)
-!30 = !{!"branch_weights", i32 2000, i32 1}
-!31 = !DILocation(line: 12, column: 22, scope: !6)
-!32 = !DILocalVariable(name: "it", scope: !6, file: !7, line: 12, type: !33)
-!33 = !DICompositeType(tag: DW_TAG_structure_type, name: "VectorIterator", scope: !7, file: !7, line: 11, align: 8, flags: DIFlagTypePassByValue, elements: !34)
-!34 = !{!35, !22}
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
-!36 = !DILocation(line: 13, column: 12, scope: !6)
-!37 = !DILocation(line: 14, column: 12, scope: !6)
-!38 = !DILocation(line: 14, column: 24, scope: !6)
-!39 = !DILocation(line: 15, column: 12, scope: !6)
-!40 = !DILocation(line: 15, column: 24, scope: !6)
-!41 = !DILocation(line: 16, column: 5, scope: !6)
-!42 = !DILocation(line: 17, column: 12, scope: !6)
-!43 = !DILocation(line: 17, column: 24, scope: !6)
-!44 = !DILocation(line: 18, column: 12, scope: !6)
-!45 = !DILocation(line: 19, column: 5, scope: !6)
-!46 = !DILocation(line: 20, column: 16, scope: !6)
-!47 = !DILocalVariable(name: "pair", scope: !6, file: !7, line: 20, type: !48)
-!48 = !DICompositeType(tag: DW_TAG_structure_type, name: "Pair", scope: !7, file: !7, line: 8, align: 8, flags: DIFlagTypePassByValue, elements: !49)
-!49 = !{!22, !21}
-!50 = !DILocation(line: 21, column: 12, scope: !6)
-!51 = !DILocation(line: 21, column: 31, scope: !6)
-!52 = !DILocation(line: 22, column: 12, scope: !6)
-!53 = !DILocation(line: 22, column: 32, scope: !6)
-!54 = !DILocation(line: 23, column: 5, scope: !6)
-!55 = !DILocation(line: 24, column: 13, scope: !6)
-!56 = !DILocation(line: 27, column: 17, scope: !6)
-!57 = !DILocation(line: 28, column: 17, scope: !6)
-!58 = !DILocation(line: 29, column: 12, scope: !6)
-!59 = !DILocation(line: 32, column: 5, scope: !6)
-!60 = !DILocation(line: 33, column: 12, scope: !6)
-!61 = !DILocation(line: 33, column: 24, scope: !6)
-!62 = !DILocation(line: 34, column: 12, scope: !6)
-!63 = !DILocation(line: 35, column: 5, scope: !6)
-!64 = !DILocation(line: 36, column: 12, scope: !6)
-!65 = !DILocation(line: 36, column: 24, scope: !6)
-!66 = !DILocation(line: 37, column: 5, scope: !6)
-!67 = !DILocation(line: 38, column: 12, scope: !6)
-!68 = !DILocation(line: 38, column: 24, scope: !6)
-!69 = !DILocation(line: 39, column: 5, scope: !6)
-!70 = !DILocation(line: 40, column: 12, scope: !6)
-!71 = !DILocation(line: 40, column: 24, scope: !6)
-!72 = !DILocation(line: 41, column: 5, scope: !6)
-!73 = !DILocation(line: 42, column: 13, scope: !6)
-!74 = !DILocation(line: 44, column: 5, scope: !6)
+!23 = !DILocation(line: 5, column: 22, scope: !6)
+!24 = !DILocation(line: 6, column: 17, scope: !6)
+!25 = !DILocation(line: 7, column: 17, scope: !6)
+!26 = !DILocation(line: 8, column: 17, scope: !6)
+!27 = !DILocation(line: 9, column: 12, scope: !6)
+!28 = !DILocation(line: 9, column: 28, scope: !6)
+!29 = !{!"branch_weights", i32 2000, i32 1}
+!30 = !DILocation(line: 12, column: 22, scope: !6)
+!31 = !DILocalVariable(name: "it", scope: !6, file: !7, line: 12, type: !32)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, name: "VectorIterator", scope: !7, file: !7, line: 11, align: 8, flags: DIFlagTypePassByValue, elements: !33)
+!33 = !{!34, !22}
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!35 = !DILocation(line: 13, column: 12, scope: !6)
+!36 = !DILocation(line: 14, column: 12, scope: !6)
+!37 = !DILocation(line: 14, column: 24, scope: !6)
+!38 = !DILocation(line: 15, column: 12, scope: !6)
+!39 = !DILocation(line: 15, column: 24, scope: !6)
+!40 = !DILocation(line: 16, column: 5, scope: !6)
+!41 = !DILocation(line: 17, column: 12, scope: !6)
+!42 = !DILocation(line: 17, column: 24, scope: !6)
+!43 = !DILocation(line: 18, column: 12, scope: !6)
+!44 = !DILocation(line: 19, column: 5, scope: !6)
+!45 = !DILocation(line: 20, column: 16, scope: !6)
+!46 = !DILocalVariable(name: "pair", scope: !6, file: !7, line: 20, type: !47)
+!47 = !DICompositeType(tag: DW_TAG_structure_type, name: "Pair", scope: !7, file: !7, line: 8, align: 8, flags: DIFlagTypePassByValue, elements: !48)
+!48 = !{!22, !21}
+!49 = !DILocation(line: 21, column: 12, scope: !6)
+!50 = !DILocation(line: 21, column: 31, scope: !6)
+!51 = !DILocation(line: 22, column: 12, scope: !6)
+!52 = !DILocation(line: 22, column: 32, scope: !6)
+!53 = !DILocation(line: 23, column: 5, scope: !6)
+!54 = !DILocation(line: 24, column: 13, scope: !6)
+!55 = !DILocation(line: 27, column: 17, scope: !6)
+!56 = !DILocation(line: 28, column: 17, scope: !6)
+!57 = !DILocation(line: 29, column: 12, scope: !6)
+!58 = !DILocation(line: 32, column: 5, scope: !6)
+!59 = !DILocation(line: 33, column: 12, scope: !6)
+!60 = !DILocation(line: 33, column: 24, scope: !6)
+!61 = !DILocation(line: 34, column: 12, scope: !6)
+!62 = !DILocation(line: 35, column: 5, scope: !6)
+!63 = !DILocation(line: 36, column: 12, scope: !6)
+!64 = !DILocation(line: 36, column: 24, scope: !6)
+!65 = !DILocation(line: 37, column: 5, scope: !6)
+!66 = !DILocation(line: 38, column: 12, scope: !6)
+!67 = !DILocation(line: 38, column: 24, scope: !6)
+!68 = !DILocation(line: 39, column: 5, scope: !6)
+!69 = !DILocation(line: 40, column: 12, scope: !6)
+!70 = !DILocation(line: 40, column: 24, scope: !6)
+!71 = !DILocation(line: 41, column: 5, scope: !6)
+!72 = !DILocation(line: 42, column: 13, scope: !6)
+!73 = !DILocation(line: 45, column: 32, scope: !6)
+!74 = !DILocalVariable(name: "item", scope: !6, file: !7, line: 45, type: !10)
+!75 = !DILocation(line: 45, column: 13, scope: !6)
+!76 = !DILocation(line: 46, column: 9, scope: !6)
+!77 = !DILocation(line: 48, column: 19, scope: !6)
+!78 = !DILocation(line: 48, column: 25, scope: !6)
+!79 = !DILocation(line: 49, column: 19, scope: !6)
+!80 = !DILocation(line: 49, column: 25, scope: !6)
+!81 = !DILocation(line: 50, column: 19, scope: !6)
+!82 = !DILocation(line: 50, column: 25, scope: !6)
+!83 = !DILocation(line: 53, column: 33, scope: !6)
+!84 = !DILocalVariable(name: "item", scope: !6, file: !7, line: 53, type: !21)
+!85 = !DILocation(line: 53, column: 13, scope: !6)
+!86 = !DILocation(line: 54, column: 9, scope: !6)
+!87 = !DILocation(line: 56, column: 19, scope: !6)
+!88 = !DILocation(line: 56, column: 25, scope: !6)
+!89 = !DILocation(line: 57, column: 19, scope: !6)
+!90 = !DILocation(line: 57, column: 25, scope: !6)
+!91 = !DILocation(line: 58, column: 19, scope: !6)
+!92 = !DILocation(line: 58, column: 25, scope: !6)
+!93 = !DILocation(line: 60, column: 43, scope: !6)
+!94 = !DILocalVariable(name: "idx", scope: !6, file: !7, line: 60, type: !95)
+!95 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!96 = !DILocation(line: 60, column: 13, scope: !6)
+!97 = !DILocalVariable(name: "item", scope: !6, file: !7, line: 60, type: !21)
+!98 = !DILocation(line: 60, column: 23, scope: !6)
+!99 = !DILocation(line: 61, column: 9, scope: !6)
+!100 = !DILocation(line: 63, column: 19, scope: !6)
+!101 = !DILocation(line: 63, column: 25, scope: !6)
+!102 = !DILocation(line: 64, column: 19, scope: !6)
+!103 = !DILocation(line: 64, column: 25, scope: !6)
+!104 = !DILocation(line: 65, column: 19, scope: !6)
+!105 = !DILocation(line: 65, column: 25, scope: !6)
+!106 = !DILocation(line: 67, column: 5, scope: !6)

--- a/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
@@ -8,27 +8,27 @@ target triple = "x86_64-w64-windows-gnu"
 @anon.array.1 = private unnamed_addr constant [4 x i64] [i64 10, i64 12, i64 14, i64 16]
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Results: %d, %d\0A\00", align 1
 
-define private i32 @_f__void__int__sumNumbers__shortarray_int(ptr %0, i32 %1) {
+define private i32 @_f__void__int__sumNumbers__shortarray_long(ptr %0, i64 %1) {
   %result = alloca i32, align 4
   %numberArray = alloca ptr, align 8
-  %arrayLength = alloca i32, align 4
-  %i = alloca i32, align 4
+  %arrayLength = alloca i64, align 8
+  %i = alloca i64, align 8
   store ptr %0, ptr %numberArray, align 8
-  store i32 %1, ptr %arrayLength, align 4
+  store i64 %1, ptr %arrayLength, align 8
   store i32 0, ptr %result, align 4
-  store i32 0, ptr %i, align 4
+  store i64 0, ptr %i, align 8
   br label %for.head.L6
 
 for.head.L6:                                      ; preds = %for.tail.L6, %2
-  %3 = load i32, ptr %arrayLength, align 4
-  %4 = load i32, ptr %i, align 4
-  %5 = icmp slt i32 %4, %3
+  %3 = load i64, ptr %arrayLength, align 8
+  %4 = load i64, ptr %i, align 8
+  %5 = icmp slt i64 %4, %3
   br i1 %5, label %for.body.L6, label %for.exit.L6
 
 for.body.L6:                                      ; preds = %for.head.L6
-  %6 = load i32, ptr %i, align 4
+  %6 = load i64, ptr %i, align 8
   %7 = load ptr, ptr %numberArray, align 8
-  %8 = getelementptr inbounds i16, ptr %7, i32 %6
+  %8 = getelementptr inbounds i16, ptr %7, i64 %6
   %9 = load i16, ptr %8, align 2
   %10 = sext i16 %9 to i32
   %11 = load i32, ptr %result, align 4
@@ -37,9 +37,9 @@ for.body.L6:                                      ; preds = %for.head.L6
   br label %for.tail.L6
 
 for.tail.L6:                                      ; preds = %for.body.L6
-  %13 = load i32, ptr %i, align 4
-  %14 = add i32 %13, 1
-  store i32 %14, ptr %i, align 4
+  %13 = load i64, ptr %i, align 8
+  %14 = add i64 %13, 1
+  store i64 %14, ptr %i, align 8
   br label %for.head.L6
 
 for.exit.L6:                                      ; preds = %for.head.L6
@@ -47,27 +47,27 @@ for.exit.L6:                                      ; preds = %for.head.L6
   ret i32 %15
 }
 
-define private i32 @_f__void__int__sumNumbers__longarray_int(ptr %0, i32 %1) {
+define private i32 @_f__void__int__sumNumbers__longarray_long(ptr %0, i64 %1) {
   %result = alloca i32, align 4
   %numberArray = alloca ptr, align 8
-  %arrayLength = alloca i32, align 4
-  %i = alloca i32, align 4
+  %arrayLength = alloca i64, align 8
+  %i = alloca i64, align 8
   store ptr %0, ptr %numberArray, align 8
-  store i32 %1, ptr %arrayLength, align 4
+  store i64 %1, ptr %arrayLength, align 8
   store i32 0, ptr %result, align 4
-  store i32 0, ptr %i, align 4
+  store i64 0, ptr %i, align 8
   br label %for.head.L6
 
 for.head.L6:                                      ; preds = %for.tail.L6, %2
-  %3 = load i32, ptr %arrayLength, align 4
-  %4 = load i32, ptr %i, align 4
-  %5 = icmp slt i32 %4, %3
+  %3 = load i64, ptr %arrayLength, align 8
+  %4 = load i64, ptr %i, align 8
+  %5 = icmp slt i64 %4, %3
   br i1 %5, label %for.body.L6, label %for.exit.L6
 
 for.body.L6:                                      ; preds = %for.head.L6
-  %6 = load i32, ptr %i, align 4
+  %6 = load i64, ptr %i, align 8
   %7 = load ptr, ptr %numberArray, align 8
-  %8 = getelementptr inbounds i64, ptr %7, i32 %6
+  %8 = getelementptr inbounds i64, ptr %7, i64 %6
   %9 = load i64, ptr %8, align 8
   %10 = trunc i64 %9 to i32
   %11 = load i32, ptr %result, align 4
@@ -76,9 +76,9 @@ for.body.L6:                                      ; preds = %for.head.L6
   br label %for.tail.L6
 
 for.tail.L6:                                      ; preds = %for.body.L6
-  %13 = load i32, ptr %i, align 4
-  %14 = add i32 %13, 1
-  store i32 %14, ptr %i, align 4
+  %13 = load i64, ptr %i, align 8
+  %14 = add i64 %13, 1
+  store i64 %14, ptr %i, align 8
   br label %for.head.L6
 
 for.exit.L6:                                      ; preds = %for.head.L6
@@ -86,32 +86,32 @@ for.exit.L6:                                      ; preds = %for.head.L6
   ret i32 %15
 }
 
-define private void @_p__void__void__printData__int_intarray(i32 %0, [2 x i32] %1) {
-  %arrayLength = alloca i32, align 4
+define private void @_p__void__void__printData__long_intarray(i64 %0, [2 x i32] %1) {
+  %arrayLength = alloca i64, align 8
   %list = alloca [2 x i32], align 4
-  %i = alloca i32, align 4
-  store i32 %0, ptr %arrayLength, align 4
+  %i = alloca i64, align 8
+  store i64 %0, ptr %arrayLength, align 8
   store [2 x i32] %1, ptr %list, align 4
-  store i32 0, ptr %i, align 4
+  store i64 0, ptr %i, align 8
   br label %for.head.L12
 
 for.head.L12:                                     ; preds = %for.tail.L12, %2
-  %3 = load i32, ptr %arrayLength, align 4
-  %4 = load i32, ptr %i, align 4
-  %5 = icmp slt i32 %4, %3
+  %3 = load i64, ptr %arrayLength, align 8
+  %4 = load i64, ptr %i, align 8
+  %5 = icmp slt i64 %4, %3
   br i1 %5, label %for.body.L12, label %for.exit.L12
 
 for.body.L12:                                     ; preds = %for.head.L12
-  %6 = load i32, ptr %i, align 4
-  %7 = getelementptr inbounds [2 x i32], ptr %list, i32 0, i32 %6
+  %6 = load i64, ptr %i, align 8
+  %7 = getelementptr inbounds [2 x i32], ptr %list, i32 0, i64 %6
   %8 = load i32, ptr %7, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %8)
   br label %for.tail.L12
 
 for.tail.L12:                                     ; preds = %for.body.L12
-  %10 = load i32, ptr %i, align 4
-  %11 = add i32 %10, 1
-  store i32 %11, ptr %i, align 4
+  %10 = load i64, ptr %i, align 8
+  %11 = add i64 %10, 1
+  store i64 %11, ptr %i, align 8
   br label %for.head.L12
 
 for.exit.L12:                                     ; preds = %for.head.L12
@@ -135,12 +135,12 @@ define dso_local i32 @main() #0 {
   call void @llvm.memcpy.p0.p0.i64(ptr %1, ptr @anon.array.0, i64 14, i1 false)
   store [7 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6, i16 7], ptr %numberList1, align 2
   %4 = getelementptr inbounds [7 x i16], ptr %numberList1, i32 0, i32 0
-  %5 = call i32 @_f__void__int__sumNumbers__shortarray_int(ptr %4, i32 7)
+  %5 = call i32 @_f__void__int__sumNumbers__shortarray_long(ptr %4, i64 7)
   store i32 %5, ptr %result1, align 4
   call void @llvm.memcpy.p0.p0.i64(ptr %2, ptr @anon.array.1, i64 32, i1 false)
   store [4 x i64] [i64 10, i64 12, i64 14, i64 16], ptr %numberList2, align 8
   %6 = getelementptr inbounds [4 x i64], ptr %numberList2, i32 0, i32 0
-  %7 = call i32 @_f__void__int__sumNumbers__longarray_int(ptr %6, i32 4)
+  %7 = call i32 @_f__void__int__sumNumbers__longarray_long(ptr %6, i64 4)
   store i32 %7, ptr %result2, align 4
   %8 = getelementptr inbounds [2 x i32], ptr %3, i32 0
   %9 = load i32, ptr %result1, align 4
@@ -151,7 +151,7 @@ define dso_local i32 @main() #0 {
   %12 = load [2 x i32], ptr %3, align 4
   store [2 x i32] %12, ptr %resultList, align 4
   %13 = load [2 x i32], ptr %resultList, align 4
-  call void @_p__void__void__printData__int_intarray(i32 2, [2 x i32] %13)
+  call void @_p__void__void__printData__long_intarray(i64 2, [2 x i32] %13)
   %14 = load i32, ptr %result1, align 4
   %15 = load i32, ptr %result2, align 4
   %16 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %14, i32 %15)

--- a/test/test-files/irgenerator/generics/success-generic-functions2/source.spice
+++ b/test/test-files/irgenerator/generics/success-generic-functions2/source.spice
@@ -1,15 +1,15 @@
 type T int|double|short|long;
 type U bool[]|int[];
 
-f<int> sumNumbers<T>(T[] numberArray, int arrayLength) {
+f<int> sumNumbers<T>(T[] numberArray, long arrayLength) {
     result = 0;
-    for int i = 0; i < arrayLength; i++ {
+    for long i = 0l; i < arrayLength; i++ {
         result += numberArray[i];
     }
 }
 
-p printData<U>(int arrayLength, U list) {
-    for int i = 0; i < arrayLength; i++ {
+p printData<U>(long arrayLength, U list) {
+    for long i = 0l; i < arrayLength; i++ {
         printf("Data: %d\n", list[i]);
     }
 }

--- a/test/test-files/std/data/combined-test-1-fq/ir-code-O2.ll
+++ b/test/test-files/std/data/combined-test-1-fq/ir-code-O2.ll
@@ -3,7 +3,7 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%"__pair::Pair<int,string>__Vector__pair::Pair<int,string>ptr_long_long_int" = type { ptr, i64, i64, i32 }
+%"__pair::Pair<int,string>__Vector__pair::Pair<int,string>ptr_long_long" = type { ptr, i64, i64 }
 %__int_string__Pair__int_string = type { i32, ptr }
 
 @anon.string.0 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
@@ -12,7 +12,7 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %pairVector = alloca %"__pair::Pair<int,string>__Vector__pair::Pair<int,string>ptr_long_long_int", align 8
+  %pairVector = alloca %"__pair::Pair<int,string>__Vector__pair::Pair<int,string>ptr_long_long", align 8
   %1 = alloca %__int_string__Pair__int_string, align 8
   %2 = alloca i32, align 4
   %3 = alloca ptr, align 8

--- a/test/test-files/std/data/combined-test-1/ir-code-O2.ll
+++ b/test/test-files/std/data/combined-test-1/ir-code-O2.ll
@@ -3,7 +3,7 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%"__std/data/pair::Pair<int,string>__Vector__std/data/pair::Pair<int,string>ptr_long_long_int" = type { ptr, i64, i64, i32 }
+%"__std/data/pair::Pair<int,string>__Vector__std/data/pair::Pair<int,string>ptr_long_long" = type { ptr, i64, i64 }
 %__int_string__Pair__int_string = type { i32, ptr }
 
 @anon.string.0 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
@@ -12,7 +12,7 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %pairVector = alloca %"__std/data/pair::Pair<int,string>__Vector__std/data/pair::Pair<int,string>ptr_long_long_int", align 8
+  %pairVector = alloca %"__std/data/pair::Pair<int,string>__Vector__std/data/pair::Pair<int,string>ptr_long_long", align 8
   %1 = alloca %__int_string__Pair__int_string, align 8
   %2 = alloca i32, align 4
   %3 = alloca ptr, align 8

--- a/test/test-files/std/data/optional-normal-usecase/ir-code-O2.ll
+++ b/test/test-files/std/data/optional-normal-usecase/ir-code-O2.ll
@@ -3,8 +3,8 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%__double__Stack__doubleptr_long_long_int = type { ptr, i64, i64, i32 }
-%"__std/data/stack::Stack<double>__Optional__std/data/stack::Stack<double>_bool" = type { %__double__Stack__doubleptr_long_long_int, i1 }
+%__double__Stack__doubleptr_long_long = type { ptr, i64, i64 }
+%"__std/data/stack::Stack<double>__Optional__std/data/stack::Stack<double>_bool" = type { %__double__Stack__doubleptr_long_long, i1 }
 %"____rt_string::String__Optional____rt_string::String_bool" = type { %__String__charptr_long_long, i1 }
 %__String__charptr_long_long = type { ptr, i64, i64 }
 
@@ -14,7 +14,7 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %doubleStack = alloca %__double__Stack__doubleptr_long_long_int, align 8
+  %doubleStack = alloca %__double__Stack__doubleptr_long_long, align 8
   %1 = alloca double, align 8
   %oi = alloca %"__std/data/stack::Stack<double>__Optional__std/data/stack::Stack<double>_bool", align 8
   %oi2 = alloca %"____rt_string::String__Optional____rt_string::String_bool", align 8

--- a/test/test-files/std/data/queue-normal-usecase/ir-code-O2.ll
+++ b/test/test-files/std/data/queue-normal-usecase/ir-code-O2.ll
@@ -3,13 +3,13 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%__char__Queue__charptr_long_long_long_long_int = type { ptr, i64, i64, i64, i64, i32 }
+%__char__Queue__charptr_long_long_long_long = type { ptr, i64, i64, i64, i64 }
 
 @printf.str.0 = private unnamed_addr constant [24 x i8] c"Size: %d, Capacity: %d\0A\00", align 1
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %q1 = alloca %__char__Queue__charptr_long_long_long_long_int, align 8
+  %q1 = alloca %__char__Queue__charptr_long_long_long_long, align 8
   %1 = alloca i8, align 1
   %2 = alloca i8, align 1
   %3 = alloca i8, align 1

--- a/test/test-files/std/data/stack-normal-usecase/ir-code-O2.ll
+++ b/test/test-files/std/data/stack-normal-usecase/ir-code-O2.ll
@@ -3,7 +3,7 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%__int__Stack__intptr_long_long_int = type { ptr, i64, i64, i32 }
+%__int__Stack__intptr_long_long = type { ptr, i64, i64 }
 
 @printf.str.0 = private unnamed_addr constant [16 x i8] c"Stack size: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [20 x i8] c"Stack capacity: %d\0A\00", align 1
@@ -13,11 +13,11 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %s1 = alloca %__int__Stack__intptr_long_long_int, align 8
+  %s1 = alloca %__int__Stack__intptr_long_long, align 8
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4
-  call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(28) %s1, i8 0, i64 28, i1 false)
+  call void @llvm.memset.p0.i64(ptr noundef nonnull align 8 dereferenceable(24) %s1, i8 0, i64 24, i1 false)
   call void @_mp__Stack_int__void__ctor(ptr nonnull %s1) #3
   store i32 123, ptr %1, align 4
   call void @_mp__Stack_int__void__push__intref(ptr nonnull %s1, ptr nonnull %1) #3

--- a/test/test-files/std/data/vector-normal-usecase/ir-code-O2.ll
+++ b/test/test-files/std/data/vector-normal-usecase/ir-code-O2.ll
@@ -3,7 +3,7 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%__double__Vector__doubleptr_long_long_int = type { ptr, i64, i64, i32 }
+%__double__Vector__doubleptr_long_long = type { ptr, i64, i64 }
 
 @printf.str.0 = private unnamed_addr constant [17 x i8] c"Vector size: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [21 x i8] c"Vector capacity: %d\0A\00", align 1
@@ -11,7 +11,7 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %v1 = alloca %__double__Vector__doubleptr_long_long_int, align 8
+  %v1 = alloca %__double__Vector__doubleptr_long_long, align 8
   %1 = alloca double, align 8
   %2 = alloca double, align 8
   %3 = alloca double, align 8

--- a/test/test-files/std/iterators/array-iterators/cout.out
+++ b/test/test-files/std/iterators/array-iterators/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/iterators/array-iterators/source.spice
+++ b/test/test-files/std/iterators/array-iterators/source.spice
@@ -1,15 +1,11 @@
 import "std/runtime/iterator_rt";
 
-f<int> main(int argc, string[] argv) {
-    // Create test vector to iterate over
-    Vector<int> vi = Vector<int>();
-    vi.pushBack(123);
-    vi.pushBack(4321);
-    vi.pushBack(9876);
-    assert vi.getSize() == 3;
+f<int> main() {
+    // Create test array to iterate over
+    int[5] a = { 123, 4321, 9876, 321, -99 };
 
     // Test base functionality
-    dyn it = iterate(vi);
+    dyn it = iterate(a, len(a));
     assert it.isValid();
     assert it.get() == 123;
     assert it.get() == 123;
@@ -21,12 +17,6 @@ f<int> main(int argc, string[] argv) {
     assert pair.getFirst() == 2;
     assert pair.getSecond() == 9876;
     it.next();
-    assert !it.isValid();
-
-    // Add new items to the vector
-    vi.pushBack(321);
-    vi.pushBack(-99);
-    assert it.isValid();
 
     // Test overloaded operators
     it -= 3;
@@ -42,27 +32,27 @@ f<int> main(int argc, string[] argv) {
     assert !it.isValid();
 
     // Test foreach value
-    foreach int item : iterate(vi) {
+    foreach int item : iterate(a, len(a)) {
         item++;
     }
-    assert vi.get(0) == 123;
-    assert vi.get(1) == 4321;
-    assert vi.get(2) == 9876;
+    assert a[0] == 123;
+    assert a[1] == 4321;
+    assert a[2] == 9876;
 
     // Test foreach ref
-    foreach int& item : iterate(vi) {
+    foreach int& item : iterate(a, len(a)) {
         item++;
     }
-    assert vi.get(0) == 124;
-    assert vi.get(1) == 4322;
-    assert vi.get(2) == 9877;
+    assert a[0] == 124;
+    assert a[1] == 4322;
+    assert a[2] == 9877;
 
-    foreach long idx, int& item : iterate(vi) {
+    foreach long idx, int& item : iterate(a, len(a)) {
         item += idx;
     }
-    assert vi.get(0) == 124;
-    assert vi.get(1) == 4323;
-    assert vi.get(2) == 9879;
+    assert a[0] == 124;
+    assert a[1] == 4323;
+    assert a[2] == 9879;
 
     printf("All assertions passed!");
 }

--- a/test/test-files/std/iterators/vector-iterators/ir-code-O2.ll
+++ b/test/test-files/std/iterators/vector-iterators/ir-code-O2.ll
@@ -3,7 +3,7 @@ source_filename = "source.spice"
 target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "x86_64-w64-windows-gnu"
 
-%__int__Vector__intptr_long_long_int = type { ptr, i64, i64, i32 }
+%__int__Vector__intptr_long_long = type { ptr, i64, i64 }
 %"__int__VectorIterator__std/data/vector::Vector<int>ref_long" = type { ptr, i64 }
 %__long_intref__Pair__long_intref = type { i64, ptr }
 
@@ -27,7 +27,7 @@ target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %vi = alloca %__int__Vector__intptr_long_long_int, align 8
+  %vi = alloca %__int__Vector__intptr_long_long, align 8
   %1 = alloca i32, align 4
   %2 = alloca i32, align 4
   %3 = alloca i32, align 4


### PR DESCRIPTION
- Improve std container types
- Fix bug regarding type matching
- Fix coverage leaks
- Use i64 instead of i32 for return type of `len` and `sizeof` builtins