### PR TITLE
Not store IR names when not dumping IR

### DIFF
--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O1 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O3 -d ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />
     </envs>

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,24 +1,29 @@
-import "test2";
+import "std/io/cli-parser";
 
-type Car struct : Driveable {
-    bool driving
+type CliOptions struct {
+    bool sayHi = false
 }
 
-p Car.ctor() {
-    this.driving = false;
+p callback(bool& value) {
+    printf("Callback called with value %d\n", value);
 }
 
-public p Car.drive(int param) {
-    this.driving = true;
-}
+f<int> main(int argc, string[] argv) {
+    CliParser parser = CliParser("Test Program", "This is a simple test program");
+    parser.setVersion("v0.1.0");
+    parser.setFooter("Copyright (c) Marc Auberer 2021-2023");
 
-public f<bool> Car.isDriving() {
-    return this.driving;
-}
+    CliOptions options;
+    parser.addFlag("--hi", options.sayHi, "Say hi to the user");
+    parser.addFlag("--callback", callback, "Call a callback function");
+    parser.addFlag("-cb", p(bool& value) {
+        printf("CB called with value %d\n", value);
+    }, "Call a callback function");
 
-f<int> main() {
-    Car car = Car();
-    Driveable* driveable = &car;
-    driveable.drive(12);
-    printf("Is driving: %d", driveable.isDriving());
+    parser.parse(argc, argv);
+
+    // Print hi if requested
+    if options.sayHi {
+        printf("Hi!\n");
+    }
 }

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -251,7 +251,7 @@ void SourceFile::runTypeCheckerPre() { // NOLINT(misc-no-recursion)
   timer.start();
 
   // Then type-check the current file
-  TypeChecker typeChecker(resourceManager, this, TC_MODE_PREPARE);
+  TypeChecker typeChecker(resourceManager, this, TC_MODE_PRE);
   typeChecker.visit(ast);
 
   previousStage = TYPE_CHECKER_PRE;
@@ -268,7 +268,7 @@ void SourceFile::runTypeCheckerPost() { // NOLINT(misc-no-recursion)
   timer.start();
 
   // Start type-checking loop. The type-checker can request a re-execution. The max number of type-checker runs is limited
-  TypeChecker typeChecker(resourceManager, this, TC_MODE_CHECK);
+  TypeChecker typeChecker(resourceManager, this, TC_MODE_POST);
   unsigned short typeCheckerRuns = 0;
   do {
     typeCheckerRuns++;
@@ -293,7 +293,7 @@ void SourceFile::runTypeCheckerPost() { // NOLINT(misc-no-recursion)
   checkForSoftErrors();
 
   // Check if all dyn variables were type-inferred successfully
-  globalScope->checkSuccessfulTypeInference();
+  globalScope->ensureSuccessfulTypeInference();
 
   previousStage = TYPE_CHECKER_POST;
   timer.stop();
@@ -637,13 +637,9 @@ void SourceFile::collectAndPrintWarnings() { // NOLINT(misc-no-recursion)
     warning.print();
 }
 
-bool SourceFile::isStringRT() const {
-  return globalScope->lookupStrict(STROBJ_NAME) != nullptr;
-}
+bool SourceFile::isStringRT() const { return globalScope->lookupStrict(STROBJ_NAME) != nullptr; }
 
-bool SourceFile::isRttiRT() const {
-  return globalScope->lookupStrict(TIOBJ_NAME) != nullptr;
-}
+bool SourceFile::isRttiRT() const { return globalScope->lookupStrict(TIOBJ_NAME) != nullptr; }
 
 bool SourceFile::haveAllDependantsBeenTypeChecked() const {
   return std::ranges::all_of(dependants, [](const SourceFile *dependant) { return dependant->totalTypeCheckerRuns >= 1; });

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -132,6 +132,10 @@ void Driver::enrich() {
     cliOptions.targetOs = triple.getOSName();
     cliOptions.isNativeTarget = triple == defaultTriple;
   }
+
+  // Always preserve IR value names when dumping IR
+  if (cliOptions.dumpSettings.dumpIR)
+    cliOptions.namesForIRValues = true;
 }
 
 /**

--- a/src/driver/Driver.h
+++ b/src/driver/Driver.h
@@ -59,6 +59,7 @@ struct CliOptions {
     bool dumpToFiles = false;
   } dumpSettings;
   bool enableAstOpt = false;
+  bool namesForIRValues = false;
   OptLevel optLevel = OptLevel::O0; // Default optimization level for debug build mode is O0
   bool useLTO = false;
   bool noEntryFct = false;

--- a/src/irgenerator/GenBuiltinFunctions.cpp
+++ b/src/irgenerator/GenBuiltinFunctions.cpp
@@ -26,12 +26,12 @@ std::any IRGenerator::visitPrintfCall(const PrintfCallNode *node) {
     if (argSymbolType.isArray()) {
       llvm::Value *argValPtr = resolveAddress(arg);
       llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(0)};
-      argVal = builder.CreateInBoundsGEP(argType, argValPtr, indices);
+      argVal = insertInBoundsGEP(argType, argValPtr, indices);
     } else if (argSymbolType.getBaseType().isStringObj()) {
       llvm::Value *argValPtr = resolveAddress(arg);
       llvm::Type *argBaseType = argSymbolType.getBaseType().toLLVMType(context, currentScope);
       argValPtr = builder.CreateStructGEP(argBaseType, argValPtr, 0);
-      argVal = builder.CreateLoad(builder.getPtrTy(), argValPtr);
+      argVal = insertLoad(builder.getPtrTy(), argValPtr);
     } else {
       argVal = resolveValue(arg);
     }

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -674,7 +674,7 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
 
       // Calculate address of array item
       llvm::Value *indices[2] = {builder.getInt32(0), indexValue};
-      lhs.ptr = builder.CreateInBoundsGEP(lhsTy, lhs.ptr, indices);
+      lhs.ptr = insertInBoundsGEP(lhsTy, lhs.ptr, indices);
     } else { // Pointer
       // Make sure the value is present
       resolveValue(lhsNode, lhs);
@@ -685,7 +685,7 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
 
       lhsTy = lhsSTy.getContainedTy().toLLVMType(context, currentScope);
       // Calculate address of pointer item
-      lhs.ptr = builder.CreateInBoundsGEP(lhsTy, lhs.ptr, indexValue);
+      lhs.ptr = insertInBoundsGEP(lhsTy, lhs.ptr, indexValue);
     }
 
     // Reset value and entry
@@ -716,15 +716,15 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
     std::vector<llvm::Value *> indices = {builder.getInt32(0)};
     for (size_t index : indexPath)
       indices.push_back(builder.getInt32(index));
-    llvm::Value *memberAddress = builder.CreateInBoundsGEP(lhsSTy.toLLVMType(context, structScope->parent), lhs.ptr, indices);
-    memberAddress->setName(fieldName + "_addr");
+    const std::string name = fieldName + "_addr";
+    llvm::Value *memberAddr = insertInBoundsGEP(lhsSTy.toLLVMType(context, structScope->parent), lhs.ptr, indices, name);
 
     // Set as ptr or refPtr, depending on the type
     if (fieldSymbolType.isRef()) {
       lhs.ptr = nullptr;
-      lhs.refPtr = memberAddress;
+      lhs.refPtr = memberAddr;
     } else {
-      lhs.ptr = memberAddress;
+      lhs.ptr = memberAddr;
       lhs.refPtr = nullptr;
     }
 

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -112,7 +112,7 @@ std::any IRGenerator::visitReturnStmt(const ReturnStmtNode *node) {
     if (resultEntry != nullptr) {
       llvm::Type *resultSTy = resultEntry->getType().toLLVMType(context, currentScope);
       llvm::Value *returnValueAddr = resultEntry->getAddress();
-      returnValue = builder.CreateLoad(resultSTy, returnValueAddr);
+      returnValue = insertLoad(resultSTy, returnValueAddr);
     }
   }
 

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -108,7 +108,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
 
   // Create return statement if the block is not terminated yet
   if (!blockAlreadyTerminated) {
-    llvm::Value *result = builder.CreateLoad(fct->getReturnType(), resultEntry->getAddress());
+    llvm::Value *result = insertLoad(fct->getReturnType(), resultEntry->getAddress());
     builder.CreateRet(result);
   }
 
@@ -269,7 +269,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
 
     // Create return statement if the block is not terminated yet
     if (!blockAlreadyTerminated) {
-      llvm::Value *result = builder.CreateLoad(returnType, resultEntry->getAddress());
+      llvm::Value *result = insertLoad(returnType, resultEntry->getAddress());
       builder.CreateRet(result);
     }
 

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -42,7 +42,7 @@ std::any IRGenerator::visitEntry(const EntryNode *node) {
 }
 
 llvm::Value *IRGenerator::insertAlloca(llvm::Type *llvmType, std::string varName) {
-  if (!cliOptions.dumpSettings.dumpIR)
+  if (!cliOptions.namesForIRValues)
     varName = "";
 
   if (allocaInsertInst != nullptr) { // If there is already an alloca inst, insert right after that
@@ -68,7 +68,7 @@ llvm::Value *IRGenerator::insertAlloca(llvm::Type *llvmType, std::string varName
 llvm::Value *IRGenerator::insertLoad(llvm::Type *llvmType, llvm::Value *ptr, std::string varName) const {
   assert(ptr->getType()->isPointerTy());
 
-  if (!cliOptions.dumpSettings.dumpIR)
+  if (!cliOptions.namesForIRValues)
     varName = "";
 
   // Insert load
@@ -80,7 +80,7 @@ llvm::Value *IRGenerator::insertInBoundsGEP(llvm::Type *llvmType, llvm::Value *b
   assert(basePtr->getType()->isPointerTy());
   assert(!indices.empty());
 
-  if (!cliOptions.dumpSettings.dumpIR)
+  if (!cliOptions.namesForIRValues)
     varName = "";
 
   // Insert GEP

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -103,7 +103,10 @@ public:
   std::any visitDataType(const DataTypeNode *node) override;
 
   // Public methods
-  llvm::Value *insertAlloca(llvm::Type *llvmType, const std::string &varName = "");
+  llvm::Value *insertAlloca(llvm::Type *llvmType, std::string varName = "");
+  llvm::Value *insertLoad(llvm::Type *llvmType, llvm::Value *ptr, std::string varName = "") const;
+  llvm::Value *insertInBoundsGEP(llvm::Type *llvmType, llvm::Value *basePtr, llvm::ArrayRef<llvm::Value *> indices,
+                                 std::string varName = "") const;
   llvm::Value *resolveValue(const ASTNode *node, Scope *accessScope = nullptr);
   llvm::Value *resolveValue(const ASTNode *node, LLVMExprResult &exprResult, Scope *accessScope = nullptr);
   llvm::Value *resolveValue(const SymbolType &symbolType, LLVMExprResult &exprResult, Scope *accessScope = nullptr);

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -351,7 +351,7 @@ void Scope::collectWarnings(std::vector<CompilerWarning> &warnings) const { // N
  * Checks if all variables of this and all child scopes are of an explicit type.
  * This is executed after type inference to check that all variables could be inferred correctly.
  */
-void Scope::checkSuccessfulTypeInference() const {
+void Scope::ensureSuccessfulTypeInference() const {
   // Check symbols in this scope
   for (auto &[name, entry] : symbolTable.symbols)
     if (entry.getType().is(TY_DYN))
@@ -359,7 +359,7 @@ void Scope::checkSuccessfulTypeInference() const {
 
   // Check child scopes
   for (auto &[_, scope] : children)
-    scope->checkSuccessfulTypeInference();
+    scope->ensureSuccessfulTypeInference();
 }
 
 /**

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -75,7 +75,7 @@ public:
 
   // Util
   void collectWarnings(std::vector<CompilerWarning> &warnings) const;
-  void checkSuccessfulTypeInference() const;
+  void ensureSuccessfulTypeInference() const;
   [[nodiscard]] size_t getFieldCount() const;
   [[nodiscard]] std::vector<Function *> getVirtualMethods();
   [[nodiscard]] size_t getVirtualMethodCount() const;

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -19,7 +19,7 @@ std::any TypeChecker::visitEntry(EntryNode *node) {
   reVisitRequested = false;
 
   // Initialize AST nodes with size of 1
-  const bool isPrepare = typeCheckerMode == TC_MODE_PREPARE;
+  const bool isPrepare = typeCheckerMode == TC_MODE_PRE;
   if (isPrepare)
     node->resizeToNumberOfManifestations(1);
 
@@ -41,65 +41,65 @@ std::any TypeChecker::visitEntry(EntryNode *node) {
 }
 
 std::any TypeChecker::visitMainFctDef(MainFctDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitMainFctDefPrepare(node);
   else
     return visitMainFctDefCheck(node);
 }
 
 std::any TypeChecker::visitFctDef(FctDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitFctDefPrepare(node);
   else
     return visitFctDefCheck(node);
 }
 
 std::any TypeChecker::visitProcDef(ProcDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitProcDefPrepare(node);
   else
     return visitProcDefCheck(node);
 }
 
 std::any TypeChecker::visitStructDef(StructDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitStructDefPrepare(node);
   else
     return visitStructDefCheck(node);
 }
 
 std::any TypeChecker::visitInterfaceDef(InterfaceDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitInterfaceDefPrepare(node);
   return nullptr;
 }
 
 std::any TypeChecker::visitEnumDef(EnumDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitEnumDefPrepare(node);
   return nullptr;
 }
 
 std::any TypeChecker::visitGenericTypeDef(GenericTypeDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitGenericTypeDefPrepare(node);
   return nullptr;
 }
 
 std::any TypeChecker::visitAliasDef(AliasDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitAliasDefPrepare(node);
   return nullptr;
 }
 
 std::any TypeChecker::visitGlobalVarDef(GlobalVarDefNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitGlobalVarDefPrepare(node);
   return nullptr;
 }
 
 std::any TypeChecker::visitExtDecl(ExtDeclNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitExtDeclPrepare(node);
   return nullptr;
 }
@@ -525,7 +525,7 @@ std::any TypeChecker::visitDeclStmt(DeclStmtNode *node) {
 }
 
 std::any TypeChecker::visitImportStmt(ImportStmtNode *node) {
-  if (typeCheckerMode == TC_MODE_PREPARE)
+  if (typeCheckerMode == TC_MODE_PRE)
     return visitImportStmtPrepare(node);
   return nullptr;
 }

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -15,7 +15,10 @@
 
 namespace spice::compiler {
 
-enum TypeCheckerMode { TC_MODE_PREPARE, TC_MODE_CHECK };
+enum TypeCheckerMode {
+  TC_MODE_PRE,
+  TC_MODE_POST,
+};
 
 /**
  * Jobs:

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -59,6 +59,7 @@ void execTestCase(const TestCase &testCase) {
           /* dumpToFiles= */ false,
       },
       /* disableAstOpt= */ false,
+      /* namesForIRValues= */ true,
       /* optLevel= */ OptLevel::O0,
       /* useLTO= */ std::filesystem::exists(testCase.testPath / CTL_LTO),
       /* noEntryFct= */ false,


### PR DESCRIPTION
- Optimized compile time and memory footprint by not storing IR value names in most cases
- Smaller code improvements