### PR TITLE
Replace new with unique_ptr in GlobalResourceManager

### DIFF
--- a/src/global/GlobalResourceManager.cpp
+++ b/src/global/GlobalResourceManager.cpp
@@ -57,23 +57,16 @@ GlobalResourceManager::GlobalResourceManager(const CliOptions &cliOptions)
     ltoModule = std::make_unique<llvm::Module>(LTO_FILE_NAME, context);
 }
 
-GlobalResourceManager::~GlobalResourceManager() {
-  // Delete all source files
-  for (const std::pair<const std::string, SourceFile *> &sourceFile : sourceFiles)
-    delete sourceFile.second;
-}
-
 SourceFile *GlobalResourceManager::createSourceFile(SourceFile *parent, const std::string &dependencyName,
                                                     const std::filesystem::path &path, bool isStdFile) {
   // Check if the source file was already added (e.g. by another source file that imports it)
   const std::string filePathStr = path.string();
-  if (sourceFiles.contains(filePathStr))
-    return sourceFiles.at(filePathStr);
 
-  // Create the new source file
-  auto newSourceFile = new SourceFile(*this, parent, dependencyName, path, isStdFile);
-  sourceFiles.insert({filePathStr, newSourceFile});
-  return newSourceFile;
+  // Create the new source file if it does not exist yet
+  if (!sourceFiles.contains(filePathStr))
+    sourceFiles.insert({filePathStr, std::make_unique<SourceFile>(*this, parent, dependencyName, path, isStdFile)});
+
+  return sourceFiles.at(filePathStr).get();
 }
 
 } // namespace spice::compiler

--- a/src/global/GlobalResourceManager.h
+++ b/src/global/GlobalResourceManager.h
@@ -28,7 +28,7 @@ const char *const LTO_FILE_NAME = "lto-module";
 
 /**
  * The GlobalResourceManager is instantiated at startup of the compiler and serves as distribution point for globally used assets.
- * This component owns all SourceFile instances and is therefore the resource root of the compiler.
+ * This component owns all SourceFile instances and AST nodes and therefore is the resource root of the compiler.
  * Other components of the compiler can request the required global resources from the GlobalResourceManager.
  */
 class GlobalResourceManager {
@@ -36,23 +36,22 @@ public:
   // Constructors
   explicit GlobalResourceManager(const CliOptions &cliOptions);
   GlobalResourceManager(const GlobalResourceManager &) = delete;
-  ~GlobalResourceManager();
 
   // Public methods
   SourceFile *createSourceFile(SourceFile *parent, const std::string &dependencyName, const std::filesystem::path &path,
                                bool isStdFile);
 
   // Public members
-  std::unordered_map<std::string, SourceFile *> sourceFiles;
-  std::vector<std::unique_ptr<ASTNode>> astNodes; // The GlobalResourceManager owns all AST nodes
-  const CliOptions &cliOptions;
-  ExternalLinkerInterface linker;
-  CacheManager cacheManager;
-  RuntimeModuleManager runtimeModuleManager;
   llvm::LLVMContext context;
   llvm::IRBuilder<> builder = llvm::IRBuilder<>(context);
   std::unique_ptr<llvm::Module> ltoModule;
   std::unique_ptr<llvm::TargetMachine> targetMachine;
+  std::unordered_map<std::string, std::unique_ptr<SourceFile>> sourceFiles; // The GlobalResourceManager owns all source files
+  std::vector<std::unique_ptr<ASTNode>> astNodes;                           // The GlobalResourceManager owns all AST nodes
+  const CliOptions &cliOptions;
+  ExternalLinkerInterface linker;
+  CacheManager cacheManager;
+  RuntimeModuleManager runtimeModuleManager;
   Timer totalTimer;
   BS::thread_pool threadPool = BS::thread_pool(cliOptions.compileJobCount);
   BS::synced_stream tout;

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -94,6 +94,14 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
   return nullptr;
 }
 
+std::any IRGenerator::visitModAttr(const spice::compiler::ModAttrNode *node) {
+  return nullptr; // Noop
+}
+
+std::any IRGenerator::visitTopLevelDefinitionAttr(const spice::compiler::TopLevelDefinitionAttrNode *node) {
+  return nullptr; // Noop
+}
+
 std::any IRGenerator::visitSpecifierLst(const SpecifierLstNode *node) {
   return nullptr; // Noop
 }

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -64,6 +64,8 @@ public:
   std::any visitStmtLst(const StmtLstNode *node) override;
   std::any visitTypeAltsLst(const TypeAltsLstNode *node) override;
   std::any visitDeclStmt(const DeclStmtNode *node) override;
+  std::any visitModAttr(const ModAttrNode *node) override;
+  std::any visitTopLevelDefinitionAttr(const TopLevelDefinitionAttrNode *node) override;
   std::any visitSpecifierLst(const SpecifierLstNode *node) override;
   std::any visitReturnStmt(const ReturnStmtNode *node) override;
   std::any visitBreakStmt(const BreakStmtNode *node) override;

--- a/src/linker/BitcodeLinker.cpp
+++ b/src/linker/BitcodeLinker.cpp
@@ -6,7 +6,7 @@ namespace spice::compiler {
 
 void BitcodeLinker::link() {
   // Link all source file modules in
-  for (const std::pair<const std::string, SourceFile *> &sourceFile : resourceManager.sourceFiles)
+  for (const auto &sourceFile : resourceManager.sourceFiles)
     linker.linkInModule(std::move(sourceFile.second->llvmModule), llvm::Linker::None);
 }
 

--- a/src/linker/ExternalLinkerInterface.cpp
+++ b/src/linker/ExternalLinkerInterface.cpp
@@ -45,14 +45,15 @@ void ExternalLinkerInterface::link() const {
   // Build the linker command
   std::stringstream linkerCommandBuilder;
   linkerCommandBuilder << linkerCmd;
+  // linkerCommandBuilder << " -###"; // For debugging purposes
   // Append linker flags
   for (const std::string &linkerFlag : linkerFlags)
-    linkerCommandBuilder << " " + linkerFlag;
+    linkerCommandBuilder << " " << linkerFlag;
   // Append output path
-  linkerCommandBuilder << " -o " + outputPath.string();
+  linkerCommandBuilder << " -o " << outputPath.string();
   // Append object files
   for (const std::string &objectFilePath : objectFilePaths)
-    linkerCommandBuilder << " " + objectFilePath;
+    linkerCommandBuilder << " " << objectFilePath;
 
   // Print status message
   if (cliOptions.printDebugOutput)                                                 // GCOV_EXCL_LINE


### PR DESCRIPTION
- Replace new with unique_ptr in GlobalResourceManager
- Do not generate unnecessary IR for attribute values
- Minor code improvements