### PR TITLE
Fix dev-setup script issues

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -6,7 +6,7 @@ set LLVM_DIR=".\llvm\build-release\lib\cmake\llvm"
 REM - Build
 mkdir bin 2> NUL
 pushd bin
-cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja -DCMAKE_CXX_FLAGS_RELEASE="-O2" ..
+cmake -DCMAKE_BUILD_TYPE=Release -GNinja -DCMAKE_CXX_FLAGS_RELEASE="-O2" ..
 cmake --build . --target spice
 move src\spice.exe spice.exe
 popd

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,7 @@
 #!/bin/sh
+set -eu
+
+# Create bin dir
 mkdir bin
 
 # Check for LLVM_DIR env var
@@ -7,7 +10,7 @@ export LLVM_DIR=./llvm/build-release/lib/cmake/llvm
 # Build
 (
   cd ./bin || exit
-  cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -GNinja -DCMAKE_CXX_FLAGS_RELEASE="-O2" ..
+  cmake -DCMAKE_BUILD_TYPE=Release -GNinja -DCMAKE_CXX_FLAGS_RELEASE="-O2" ..
   cmake --build . --target spice
   mv ./src/spice spice
 )

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 mkdir coverage
 gcovr --html --html-details -s -r . -o coverage/index.html

--- a/dev-setup.bat
+++ b/dev-setup.bat
@@ -9,6 +9,13 @@ if errorlevel 1 (
     goto end
 )
 
+REM - Check if lld is installed
+where lld > nul 2>&1
+if errorlevel 1 (
+    echo LLD linker was not found. Please install the latest version from https://winlibs.com
+    goto end
+)
+
 REM - Check if Ninja is installed
 where ninja > nul 2>&1
 if errorlevel 1 (
@@ -34,7 +41,7 @@ REM - Build LLVM
 echo [Step 3] Building LLVM (Could take a whole while, please be patient) ...
 mkdir .\llvm\build-release
 pushd .\llvm\build-release
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -fuse-ld=lld" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -fuse-ld=lld" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
 cmake --build .
 popd
 echo done.

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 colored_echo() {
     GREEN='\e[0;92m' # Green color
@@ -10,7 +11,7 @@ colored_echo() {
 colored_echo "[Step 1] Installing dependencies via Linux packages (Could take a while) ... "
 sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 sudo apt update
-sudo apt-get install -y cmake make ninja-build valgrind ccache uuid-dev pkg-config openjdk-11-jre-headless
+sudo apt-get install -y cmake make ninja-build valgrind ccache uuid-dev pkg-config openjdk-11-jre-headless clang lld
 colored_echo "done."
 
 # Clone LLVM
@@ -23,7 +24,7 @@ colored_echo "[Step 3] Building LLVM (Could take a whole while, please be patien
 mkdir ./llvm/build-release 2>/dev/null
 (
   cd ./llvm/build-release || exit
-  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -fuse-ld=lld" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -fuse-ld=lld" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
   cmake --build .
 )
 colored_echo "done."


### PR DESCRIPTION
- Make script fail when an error occurs in a subcommand
- Require the lld linker to use script
- Use default compiler for building LLVM