### PR TITLE
Improve file scope for CI workflow

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -3,11 +3,19 @@ name: C++ CI
 
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - 'media/**'
+      - '**.md'
   pull_request:
     branches:
       - main
       - dev
       - feature/**
+    paths:
+      - 'docs/**'
+      - 'media/**'
+      - '**.md'
 
 jobs:
   build-linux:


### PR DESCRIPTION
Do not run CI workflow when only documentation files are touched