### PR TITLE
Improve circular import error message

### DIFF
--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -140,7 +140,7 @@ public:
   // Public methods
   void addDependency(SourceFile *sourceFile, const ASTNode *declNode, const std::string &dependencyName, const std::string &path);
   [[nodiscard]] bool imports(const SourceFile *sourceFile) const;
-  [[nodiscard]] bool isAlreadyImported(const std::string &filePathSearch) const;
+  [[nodiscard]] bool isAlreadyImported(const std::string &filePathSearch, std::vector<const SourceFile *> &circle) const;
   SourceFile *requestRuntimeModule(RuntimeModule runtimeModule);
   bool isRuntimeModuleAvailable(RuntimeModule runtimeModule) const;
   void addNameRegistryEntry(const std::string &symbolName, uint64_t typeId, SymbolTableEntry *entry, Scope *scope,

--- a/src/typechecker/InterfaceManager.cpp
+++ b/src/typechecker/InterfaceManager.cpp
@@ -26,7 +26,7 @@ Interface *InterfaceManager::insertSubstantiation(Scope *insertScope, Interface 
   const std::string signature = newManifestation.getSignature();
 
   // Make sure that the manifestation does not exist already
-  for (const auto &manifestations : insertScope->interfaces)
+  for ([[maybe_unused]] const auto &manifestations : insertScope->interfaces)
     assert(!manifestations.second.contains(newManifestation.getSignature()));
 
   // Retrieve the matching manifestation list of the scope

--- a/src/util/CommonUtil.cpp
+++ b/src/util/CommonUtil.cpp
@@ -4,6 +4,8 @@
 
 #include <cxxabi.h>
 
+#include <SourceFile.h>
+
 #ifdef OS_WINDOWS
 #include <windows.h>
 #elif OS_UNIX
@@ -99,6 +101,26 @@ bool CommonUtil::isValidMangledName(const std::string &mangledName) {
   char *demangled = abi::__cxa_demangle(mangledName.c_str(), nullptr, nullptr, &status);
   free(demangled);
   return status == 0;
+}
+
+/**
+ * Generate a circular import message from the given source files
+ *
+ * @param sourceFiles Source files building the circular dependency chain
+ * @return Error message
+ */
+std::string CommonUtil::getCircularImportMessage(const std::vector<const SourceFile *> &sourceFiles) {
+  std::stringstream message;
+  message << "*-----*\n";
+  message << "|     |\n";
+  for (size_t i = 0; i < sourceFiles.size(); i++) {
+    if (i != 0)
+      message << "|     |\n";
+    message << "|  " << sourceFiles.at(i)->fileName.c_str() << "\n";
+  }
+  message << "|     |\n";
+  message << "*-----*";
+  return message.str();
 }
 
 /**

--- a/src/util/CommonUtil.h
+++ b/src/util/CommonUtil.h
@@ -8,6 +8,9 @@
 
 namespace spice::compiler {
 
+// Forward declarations
+class SourceFile;
+
 /**
  * Util for general simplification of tasks
  */
@@ -19,6 +22,7 @@ public:
   static std::vector<std::string> split(const std::string &input);
   static size_t getSystemPageSize();
   static bool isValidMangledName(const std::string &mangledName);
+  static std::string getCircularImportMessage(const std::vector<const SourceFile *> &sourceFiles);
   static std::string getVersionInfo();
 };
 

--- a/test/test-files/typechecker/imports/error-circular-import/exception.out
+++ b/test/test-files/typechecker/imports/error-circular-import/exception.out
@@ -1,5 +1,15 @@
 [Error|Semantic] ../source2.spice:1:1:
-Circular import detected: Circular import detected while importing 'source.spice'
+Circular import detected: Circular import detected while importing 'source.spice':
+
+*-----*
+|     |
+|  source2.spice
+|     |
+|  source1.spice
+|     |
+|  source.spice
+|     |
+*-----*
 
 1  import "source" as s;
    ^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Improve circular import error message
Those error messages look like this:

```
[Error|Semantic] ../source2.spice:1:1:
Circular import detected: Circular import detected while importing 'source.spice':

*-----*
|     |
|  source2.spice
|     |
|  source1.spice
|     |
|  source.spice
|     |
*-----*

1  import "source" as s;
   ^^^^^^^^^^^^^^^^^^^^^
```