### PR TITLE
Upgrade CLI11 to version 2.4.1-spice

### DIFF
--- a/setup-libs.bat
+++ b/setup-libs.bat
@@ -23,6 +23,6 @@ curl -SsL "https://raw.githubusercontent.com/bshoshany/thread-pool/v4.0.1/includ
 
 :: Download CLI11
 mkdir cli11
-curl -SsL "https://github.com/spicelang/CLI11/releases/download/v2.4.0-spice/CLI11.hpp" --output cli11/CLI11.hpp
+curl -SsL "https://github.com/spicelang/CLI11/releases/download/v2.4.1-spice/CLI11.hpp" --output cli11/CLI11.hpp
 
 popd

--- a/setup-libs.sh
+++ b/setup-libs.sh
@@ -22,6 +22,6 @@ curl -SsL "https://raw.githubusercontent.com/bshoshany/thread-pool/v4.0.1/includ
 
 # Download CLI11
 mkdir cli11
-curl -SsL "https://github.com/spicelang/CLI11/releases/download/v2.4.0-spice/CLI11.hpp" --output cli11/CLI11.hpp
+curl -SsL "https://github.com/spicelang/CLI11/releases/download/v2.4.1-spice/CLI11.hpp" --output cli11/CLI11.hpp
 
 cd ..


### PR DESCRIPTION
Upgrade CLI11 to version 2.4.1-spice. This contains a hotfix from CLI11 side and a hotfix from Spice side, undefining macros that lead to conflicts with the lexer