### PR TITLE
Fix segfault on linker error by explicitly catching it

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -46,6 +46,8 @@ bool compileProject(CliOptions &cliOptions) {
     std::cout << e.what() << "\n";
   } catch (CompilerError &e) {
     std::cout << e.what() << "\n";
+  } catch (LinkerError &e) {
+    std::cout << e.what() << "\n";
   }
   return false;
 }


### PR DESCRIPTION
Fix segfault on linker error by explicitly catching it