### PR TITLE
Fix LLVM pass printing

### DIFF
--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O2 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_LIB_DIR" value="D:/LLVM/build-release/lib" />
       <env name="LLVM_INCLUDE_DIR" value="D:/LLVM/llvm/include" />

--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O2 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O3 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_LIB_DIR" value="D:/LLVM/build-release/lib" />
       <env name="LLVM_INCLUDE_DIR" value="D:/LLVM/llvm/include" />

--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
+  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_CLASS="IRGeneratorTests" TEST_MODE="SUITE_TEST">
     <envs>
       <env name="RUN_TESTS" value="ON" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_CLASS="IRGeneratorTests" TEST_MODE="SUITE_TEST">
+  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
     <envs>
       <env name="RUN_TESTS" value="ON" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,29 +1,22 @@
-type ITest interface {
-    p test();
-}
-
-type InnerTest struct : ITest {
-    int a
-}
-
-p InnerTest.ctor() {
-    this.a = 0;
-}
-
-p InnerTest.test() {
-    printf("InnerTest.test()\n");
-}
-
-type Test struct {
-    ITest* test
+type Struct struct {
+    int _fieldA
+    bool _fieldB
+    string _fieldC
 }
 
 f<int> main() {
-    InnerTest innerTest;
-    Test test = Test{&innerTest};
-    ITest* test2 = &innerTest;
-    test2.test();
-    test.test.test();
+    printf("Alignment of double: %d\n", alignof(-19.34989));
+    printf("Alignment of int: %d\n", alignof(353));
+    printf("Alignment of short: %d\n", alignof(35s));
+    printf("Alignment of long: %d\n", alignof(9223372036854775807l));
+    printf("Alignment of byte: %d\n", alignof((byte) 13));
+    printf("Alignment of char: %d\n", alignof((char) 65));
+    printf("Alignment of string: %d\n", alignof("Hello Spice!"));
+    printf("Alignment of bool: %d\n", alignof(false));
+    printf("Alignment of int[]: %d\n", alignof([1, 2, 3, 4, 5, 6, 7]));
+    int intVariable = 123;
+    printf("Alignment of int*: %d\n", alignof(&intVariable));
+    printf("Alignment of struct instance: %d\n", alignof(type Struct));
 }
 
 /*import "bootstrap/util/block-allocator";

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -312,7 +312,7 @@ void SourceFile::runDefaultIROptimizer() {
   assert(!resourceManager.cliOptions.useLTO);
 
   // Skip if restored from cache or this stage has already been done
-  if (restoredFromCache || previousStage >= IR_OPTIMIZER)
+  if (restoredFromCache || (previousStage >= IR_OPTIMIZER && !resourceManager.cliOptions.testMode))
     return;
 
   // Skip this stage if optimization is disabled

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -297,7 +297,7 @@ void SourceFile::runIRGenerator() {
   irGenerator.visit(ast);
 
   // Save the ir string in the compiler output
-  compilerOutput.irString = irGenerator.getIRString();
+  compilerOutput.irString = IRGenerator::getIRString(llvmModule.get());
 
   // Dump unoptimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)
@@ -316,7 +316,7 @@ void SourceFile::runDefaultIROptimizer() {
     return;
 
   // Skip this stage if optimization is disabled
-  OptLevel optLevel = resourceManager.cliOptions.optLevel;
+  const OptLevel optLevel = resourceManager.cliOptions.optLevel;
   if (optLevel < OptLevel::O1 || optLevel > OptLevel::Oz)
     return;
 
@@ -329,7 +329,7 @@ void SourceFile::runDefaultIROptimizer() {
   irOptimizer.optimizeDefault();
 
   // Save the optimized ir string in the compiler output
-  compilerOutput.irOptString = irOptimizer.getOptimizedIRString();
+  compilerOutput.irOptString = IRGenerator::getIRString(llvmModule.get());
 
   // Dump optimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)
@@ -360,7 +360,7 @@ void SourceFile::runPreLinkIROptimizer() {
   irOptimizer.optimizePreLink();
 
   // Save the optimized ir string in the compiler output
-  compilerOutput.irOptString = irOptimizer.getOptimizedIRString();
+  compilerOutput.irOptString = IRGenerator::getIRString(llvmModule.get());
 
   // Dump optimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)
@@ -411,11 +411,11 @@ void SourceFile::runPostLinkIROptimizer() {
   // Optimize LTO module
   IROptimizer irOptimizer(resourceManager, this);
   irOptimizer.prepare();
-  irOptimizer.optimizePostLink(*resourceManager.ltoModule);
+  irOptimizer.optimizePostLink();
 
   // Save the optimized ir string in the compiler output
   llvm::Module *module = resourceManager.ltoModule.get();
-  compilerOutput.irOptString = irOptimizer.getOptimizedIRString(module);
+  compilerOutput.irOptString = IRGenerator::getIRString(module);
 
   // Dump optimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -546,11 +546,14 @@ void IRGenerator::materializeConstant(LLVMExprResult &exprResult) {
   exprResult.value = exprResult.constant;
 }
 
-std::string IRGenerator::getIRString() const {
+std::string IRGenerator::getIRString(llvm::Module *llvmModule) {
+  assert(llvmModule != nullptr); // Make sure the module hasn't been moved away
+
   std::string output;
   llvm::raw_string_ostream oss(output);
-  module->print(oss, nullptr);
-  return oss.str();
+  llvmModule->print(oss, nullptr);
+
+  return output;
 }
 
 /**

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -124,7 +124,7 @@ public:
   llvm::Value *resolveAddress(const ASTNode *node);
   llvm::Value *resolveAddress(LLVMExprResult &exprResult);
   [[nodiscard]] llvm::Constant *getDefaultValueForSymbolType(const SymbolType &symbolType);
-  [[nodiscard]] std::string getIRString() const;
+  [[nodiscard]] static std::string getIRString(llvm::Module *llvmModule);
 
 private:
   // Private methods

--- a/src/iroptimizer/IROptimizer.cpp
+++ b/src/iroptimizer/IROptimizer.cpp
@@ -11,7 +11,10 @@
 namespace spice::compiler {
 
 void IROptimizer::prepare() {
-  passBuilder = std::make_unique<llvm::PassBuilder>(resourceManager.targetMachine.get());
+  llvm::PipelineTuningOptions lto;
+  llvm::TargetMachine *targetMachine = resourceManager.targetMachine.get();
+  standardInstrumentations.registerCallbacks(passInstrumentationCallbacks);
+  passBuilder = std::make_unique<llvm::PassBuilder>(targetMachine, lto, std::nullopt, &passInstrumentationCallbacks);
 
   functionAnalysisMgr.registerPass([&] { return passBuilder->buildDefaultAAPipeline(); });
 

--- a/src/iroptimizer/IROptimizer.cpp
+++ b/src/iroptimizer/IROptimizer.cpp
@@ -12,7 +12,8 @@ namespace spice::compiler {
 
 void IROptimizer::prepare() {
   llvm::PipelineTuningOptions pto;
-  si.registerCallbacks(pic, &moduleAnalysisMgr);
+  if (!resourceManager.cliOptions.testMode)
+    si.registerCallbacks(pic, &moduleAnalysisMgr);
   passBuilder = std::make_unique<llvm::PassBuilder>(resourceManager.targetMachine.get(), pto, std::nullopt, &pic);
 
   functionAnalysisMgr.registerPass([&] { return passBuilder->buildDefaultAAPipeline(); });

--- a/src/iroptimizer/IROptimizer.cpp
+++ b/src/iroptimizer/IROptimizer.cpp
@@ -11,10 +11,9 @@
 namespace spice::compiler {
 
 void IROptimizer::prepare() {
-  llvm::PipelineTuningOptions lto;
-  llvm::TargetMachine *targetMachine = resourceManager.targetMachine.get();
-  standardInstrumentations.registerCallbacks(passInstrumentationCallbacks);
-  passBuilder = std::make_unique<llvm::PassBuilder>(targetMachine, lto, std::nullopt, &passInstrumentationCallbacks);
+  llvm::PipelineTuningOptions pto;
+  si.registerCallbacks(pic, &moduleAnalysisMgr);
+  passBuilder = std::make_unique<llvm::PassBuilder>(resourceManager.targetMachine.get(), pto, std::nullopt, &pic);
 
   functionAnalysisMgr.registerPass([&] { return passBuilder->buildDefaultAAPipeline(); });
 
@@ -30,10 +29,10 @@ void IROptimizer::optimizeDefault() {
     std::cout << "\nOptimizing on level " + std::to_string(cliOptions.optLevel) << " ...\n"; // GCOV_EXCL_LINE
 
   // Run passes
-  llvm::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
+  const llvm::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
   llvm::ModulePassManager modulePassMgr = passBuilder->buildPerModuleDefaultPipeline(llvmOptLevel);
   modulePassMgr.addPass(llvm::AlwaysInlinerPass());
-  modulePassMgr.run(*module, moduleAnalysisMgr);
+  modulePassMgr.run(*sourceFile->llvmModule, moduleAnalysisMgr);
 }
 
 void IROptimizer::optimizePreLink() {
@@ -41,19 +40,20 @@ void IROptimizer::optimizePreLink() {
     std::cout << "\nOptimizing on level " + std::to_string(cliOptions.optLevel) << " (pre-link) ...\n";      // GCOV_EXCL_LINE
 
   // Run passes
-  llvm::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
+  const llvm::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
   llvm::ModulePassManager modulePassMgr = passBuilder->buildLTOPreLinkDefaultPipeline(llvmOptLevel);
   modulePassMgr.addPass(llvm::AlwaysInlinerPass());
-  modulePassMgr.run(*module, moduleAnalysisMgr);
+  modulePassMgr.run(*sourceFile->llvmModule, moduleAnalysisMgr);
 
   // Generate module summary index
   llvm::ModuleSummaryIndexAnalysis moduleSummaryIndexAnalysis;
   moduleSummaryIndexAnalysis.run(*sourceFile->llvmModule, moduleAnalysisMgr);
 }
 
-void IROptimizer::optimizePostLink(llvm::Module &ltoModule) {
+void IROptimizer::optimizePostLink() {
   if (cliOptions.printDebugOutput && cliOptions.dumpSettings.dumpIR && !cliOptions.dumpSettings.dumpToFiles) // GCOV_EXCL_LINE
     std::cout << "\nOptimizing on level " + std::to_string(cliOptions.optLevel) << " (post-link) ...\n";     // GCOV_EXCL_LINE
+  llvm::Module &ltoModule = *resourceManager.ltoModule;
 
   // Compute module summary index
   llvm::ModuleSummaryIndexAnalysis moduleSummaryIndexAnalysis;
@@ -61,20 +61,10 @@ void IROptimizer::optimizePostLink(llvm::Module &ltoModule) {
   moduleSummaryIndex.setWithWholeProgramVisibility();
 
   // Run passes
-  llvm::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
+  const llvm::OptimizationLevel llvmOptLevel = getLLVMOptLevelFromSpiceOptLevel();
   llvm::ModulePassManager modulePassMgr = passBuilder->buildLTODefaultPipeline(llvmOptLevel, &moduleSummaryIndex);
   modulePassMgr.addPass(llvm::AlwaysInlinerPass());
   modulePassMgr.run(ltoModule, moduleAnalysisMgr);
-}
-
-std::string IROptimizer::getOptimizedIRString(llvm::Module *llvmModule) const {
-  if (!llvmModule)
-    llvmModule = module;
-  assert(llvmModule != nullptr); // Ensure that the module was not moved away
-  std::string output;
-  llvm::raw_string_ostream oss(output);
-  llvmModule->print(oss, nullptr);
-  return oss.str();
 }
 
 llvm::OptimizationLevel IROptimizer::getLLVMOptLevelFromSpiceOptLevel() const {

--- a/src/iroptimizer/IROptimizer.h
+++ b/src/iroptimizer/IROptimizer.h
@@ -12,6 +12,7 @@
 #include <CompilerPass.h>
 #include <SourceFile.h>
 #include <ast/ASTVisitor.h>
+#include <global/GlobalResourceManager.h>
 
 namespace spice::compiler {
 
@@ -19,15 +20,14 @@ class IROptimizer : private CompilerPass {
 public:
   // Constructors
   IROptimizer(GlobalResourceManager &resourceManager, SourceFile *sourceFile)
-      : CompilerPass(resourceManager, sourceFile), standardInstrumentations(sourceFile->llvmModule->getContext(), false),
-        module(sourceFile->llvmModule.get()) {}
+      : CompilerPass(resourceManager, sourceFile),
+        si(resourceManager.context, false, resourceManager.cliOptions.testMode, llvm::PrintPassOptions(false, true, false)) {}
 
   // Public methods
   void prepare();
   void optimizeDefault();
   void optimizePreLink();
-  void optimizePostLink(llvm::Module &ltoModule);
-  [[nodiscard]] std::string getOptimizedIRString(llvm::Module *llvmModule = nullptr) const;
+  void optimizePostLink();
 
 private:
   // Private members
@@ -35,10 +35,9 @@ private:
   llvm::FunctionAnalysisManager functionAnalysisMgr;
   llvm::CGSCCAnalysisManager cgsccAnalysisMgr;
   llvm::ModuleAnalysisManager moduleAnalysisMgr;
-  llvm::PassInstrumentationCallbacks passInstrumentationCallbacks;
-  llvm::StandardInstrumentations standardInstrumentations;
+  llvm::StandardInstrumentations si;
+  llvm::PassInstrumentationCallbacks pic;
   std::unique_ptr<llvm::PassBuilder> passBuilder;
-  llvm::Module *module;
 
   // Private methods
   [[nodiscard]] llvm::OptimizationLevel getLLVMOptLevelFromSpiceOptLevel() const;

--- a/src/iroptimizer/IROptimizer.h
+++ b/src/iroptimizer/IROptimizer.h
@@ -7,6 +7,7 @@
 #include <llvm/Analysis/LoopAnalysisManager.h>
 #include <llvm/Passes/OptimizationLevel.h>
 #include <llvm/Passes/PassBuilder.h>
+#include <llvm/Passes/StandardInstrumentations.h>
 
 #include <CompilerPass.h>
 #include <SourceFile.h>
@@ -18,7 +19,8 @@ class IROptimizer : private CompilerPass {
 public:
   // Constructors
   IROptimizer(GlobalResourceManager &resourceManager, SourceFile *sourceFile)
-      : CompilerPass(resourceManager, sourceFile), module(sourceFile->llvmModule.get()) {}
+      : CompilerPass(resourceManager, sourceFile), standardInstrumentations(sourceFile->llvmModule->getContext(), false),
+        module(sourceFile->llvmModule.get()) {}
 
   // Public methods
   void prepare();
@@ -33,6 +35,8 @@ private:
   llvm::FunctionAnalysisManager functionAnalysisMgr;
   llvm::CGSCCAnalysisManager cgsccAnalysisMgr;
   llvm::ModuleAnalysisManager moduleAnalysisMgr;
+  llvm::PassInstrumentationCallbacks passInstrumentationCallbacks;
+  llvm::StandardInstrumentations standardInstrumentations;
   std::unique_ptr<llvm::PassBuilder> passBuilder;
   llvm::Module *module;
 

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -146,6 +146,8 @@ void execTestCase(const TestCase &testCase) {
             } else {
               mainSourceFile->runDefaultIROptimizer();
             }
+
+            // mainSourceFile->previousStage = CompileStageType::IR_GENERATOR; // ToDo: Uncomment
             return mainSourceFile->compilerOutput.irOptString;
           },
           [&](std::string &expectedOutput, std::string &actualOutput) {

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -32,8 +32,8 @@ void execTestCase(const TestCase &testCase) {
     GTEST_SKIP();
 
   // Create fake cli options
-  std::filesystem::path sourceFilePath = testCase.testPath / REF_NAME_SOURCE;
-  llvm::Triple targetTriple(llvm::Triple::normalize(llvm::sys::getDefaultTargetTriple()));
+  const std::filesystem::path sourceFilePath = testCase.testPath / REF_NAME_SOURCE;
+  const llvm::Triple targetTriple(llvm::Triple::normalize(llvm::sys::getDefaultTargetTriple()));
   CliOptions cliOptions = {
       /* mainSourceFile= */ sourceFilePath,
       /* targetTriple= */ targetTriple.getTriple(),
@@ -147,7 +147,6 @@ void execTestCase(const TestCase &testCase) {
               mainSourceFile->runDefaultIROptimizer();
             }
 
-            // mainSourceFile->previousStage = CompileStageType::IR_GENERATOR; // ToDo: Uncomment
             return mainSourceFile->compilerOutput.irOptString;
           },
           [&](std::string &expectedOutput, std::string &actualOutput) {

--- a/test/test-files/benchmark/success-pidigits/assembly.asm
+++ b/test/test-files/benchmark/success-pidigits/assembly.asm
@@ -37,91 +37,89 @@ main:                                   # @main
 	.seh_setframe %rbp, 48
 	.seh_endprologue
 	callq	__main
-	xorl	%ebx, %ebx
-	movl	$1, %esi
-	movl	$3, %r11d
-	xorl	%r13d, %r13d
-	xorl	%r10d, %r10d
-	movl	$3, %r15d
+	xorl	%edi, %edi
+	movl	$1, %r14d
+	movl	$3, %r10d
+	xorl	%r12d, %r12d
+	xorl	%r11d, %r11d
+	movl	$3, %esi
 	movl	$1, %edx
-	movl	$1, %r12d
+	movl	$1, %ebx
 	jmp	.LBB0_1
 .LBB0_1:                                # %for.body.L19
                                         # =>This Inner Loop Header: Depth=1
-	movq	%rsi, %rax
+	movq	%r14, %rax
 	shlq	$2, %rax
-	movq	%r13, %rcx
-	subq	%r12, %rcx
-	addq	%rax, %rcx
-	movq	%r15, %rdi
-	imulq	%r12, %rdi
-	cmpq	%rdi, %rcx
+	subq	%rbx, %rax
+	addq	%r12, %rax
+	movq	%rbx, %r15
+	imulq	%rsi, %r15
+	cmpq	%r15, %rax
 	jge	.LBB0_5
 # %bb.2:                                # %if.then.L20
                                         #   in Loop: Header=BB0_1 Depth=1
 	movq	%rdx, (%rbp)                    # 8-byte Spill
-	movq	%r11, -8(%rbp)                  # 8-byte Spill
+	movq	%r10, -8(%rbp)                  # 8-byte Spill
 	leaq	.Lprintf.str.0(%rip), %rcx
-	movq	%r15, %rdx
-	movl	%r10d, %r14d
+	movq	%rsi, %rdx
+	movl	%r11d, %r13d
 	callq	printf
-	movl	%r14d, %r10d
-	cmpl	$0, %r10d
+	movl	%r13d, %r11d
+	cmpl	$0, %r11d
 	jne	.LBB0_4
 # %bb.3:                                # %if.then.L22
                                         #   in Loop: Header=BB0_1 Depth=1
 	movl	$46, %ecx
 	callq	putchar
-	movl	%r14d, %r10d
+	movl	%r13d, %r11d
 .LBB0_4:                                # %if.exit.L22
                                         #   in Loop: Header=BB0_1 Depth=1
-	addl	$1, %r10d
-	imulq	$10, %rsi, %rcx
-	movq	%r13, %rax
-	subq	%rdi, %rax
+	addl	$1, %r11d
+	imulq	$10, %r14, %rcx
+	movq	%r12, %rax
+	subq	%r15, %rax
 	imulq	$10, %rax, %r8
-	imulq	$3, %rsi, %rax
-	addq	%r13, %rax
-	imulq	$10, %rax, %rax
+	imulq	$3, %r14, %rax
+	addq	%rax, %r12
+	imulq	$10, %r12, %rax
 	cqto
-	idivq	%r12
-	imulq	$-10, %r15, %rdx
+	idivq	%rbx
+	imulq	$-10, %rsi, %rdx
 	addq	%rdx, %rax
-	movq	%r8, %r13
-	movq	%rax, %r15
-	movq	%rcx, %rsi
-	movq	-8(%rbp), %r11                  # 8-byte Reload
+	movq	%r8, %r12
+	movq	%rax, %rsi
+	movq	%rcx, %r14
+	movq	-8(%rbp), %r10                  # 8-byte Reload
 	movq	(%rbp), %rdx                    # 8-byte Reload
 	jmp	.LBB0_6
 .LBB0_5:                                # %if.else.L20
                                         #   in Loop: Header=BB0_1 Depth=1
-	movq	%rsi, %rcx
-	imulq	%rdx, %rcx
-	movq	%rsi, %r8
-	shlq	%r8
-	addq	%r13, %r8
-	imulq	%r11, %r8
-	imulq	%r11, %r12
+	movq	%rdx, %rcx
+	imulq	%r14, %rcx
+	movq	%r14, %rax
+	shlq	%rax
+	movq	%r12, %r8
+	addq	%rax, %r8
+	imulq	%r10, %r8
+	imulq	%r10, %rbx
 	movq	%rdx, %r9
 	addq	$1, %r9
 	imulq	$7, %rdx, %rax
 	addq	$2, %rax
-	imulq	%rax, %rsi
-	movq	%r11, %rax
-	imulq	%r13, %rax
-	addq	%rax, %rsi
-	movq	%rsi, %rax
+	imulq	%r14, %rax
+	imulq	%r10, %r12
+	addq	%r12, %rax
 	cqto
-	idivq	%r12
-	movq	%rax, %r15
-	addq	$2, %r11
-	movq	%r8, %r13
+	idivq	%rbx
+	movq	%rax, %rsi
+	addq	$2, %r10
+	movq	%r8, %r12
 	movq	%r9, %rdx
-	movq	%rcx, %rsi
+	movq	%rcx, %r14
 .LBB0_6:                                # %for.tail.L19
                                         #   in Loop: Header=BB0_1 Depth=1
-	addl	$1, %ebx
-	cmpl	$20, %ebx
+	addl	$1, %edi
+	cmpl	$20, %edi
 	jne	.LBB0_1
 # %bb.7:                                # %for.exit.L19
 	xorl	%eax, %eax

--- a/test/test-files/benchmark/success-pidigits/ir-code-O2.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O2.ll
@@ -19,9 +19,9 @@ for.body.L19:                                     ; preds = %0, %for.tail.L19
   %t.029 = phi i64 [ 1, %0 ], [ %t.1, %for.tail.L19 ]
   %r.028 = phi i64 [ 0, %0 ], [ %r.1, %for.tail.L19 ]
   %1 = shl nsw i64 %q.033, 2
-  %2 = sub i64 %r.028, %t.029
-  %3 = add i64 %2, %1
-  %4 = mul nsw i64 %m.031, %t.029
+  %2 = sub i64 %1, %t.029
+  %3 = add i64 %2, %r.028
+  %4 = mul nsw i64 %t.029, %m.031
   %5 = icmp slt i64 %3, %4
   br i1 %5, label %if.then.L20, label %if.else.L20
 
@@ -40,7 +40,7 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   %10 = sub nsw i64 %r.028, %4
   %11 = mul nsw i64 %10, 10
   %12 = mul nsw i64 %q.033, 3
-  %13 = add nsw i64 %12, %r.028
+  %13 = add nsw i64 %r.028, %12
   %14 = mul nsw i64 %13, 10
   %15 = sdiv i64 %14, %t.029
   %.neg = mul i64 %m.031, -10
@@ -48,16 +48,16 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   br label %for.tail.L19
 
 if.else.L20:                                      ; preds = %for.body.L19
-  %17 = mul nsw i64 %q.033, %k.030
+  %17 = mul nsw i64 %k.030, %q.033
   %18 = shl nsw i64 %q.033, 1
-  %19 = add nsw i64 %18, %r.028
+  %19 = add nsw i64 %r.028, %18
   %20 = mul nsw i64 %19, %x.032
-  %21 = mul nsw i64 %x.032, %t.029
+  %21 = mul nsw i64 %t.029, %x.032
   %22 = add nsw i64 %k.030, 1
   %23 = mul nsw i64 %k.030, 7
   %24 = add nsw i64 %23, 2
-  %25 = mul nsw i64 %q.033, %24
-  %26 = mul nsw i64 %x.032, %r.028
+  %25 = mul nsw i64 %24, %q.033
+  %26 = mul nsw i64 %r.028, %x.032
   %27 = add nsw i64 %25, %26
   %28 = sdiv i64 %27, %21
   %29 = add nsw i64 %x.032, 2

--- a/test/test-files/benchmark/success-pidigits/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O3.ll
@@ -19,9 +19,9 @@ for.body.L19:                                     ; preds = %0, %for.tail.L19
   %t.029 = phi i64 [ 1, %0 ], [ %t.1, %for.tail.L19 ]
   %r.028 = phi i64 [ 0, %0 ], [ %r.1, %for.tail.L19 ]
   %1 = shl nsw i64 %q.033, 2
-  %2 = sub i64 %r.028, %t.029
-  %3 = add i64 %2, %1
-  %4 = mul nsw i64 %m.031, %t.029
+  %2 = sub i64 %1, %t.029
+  %3 = add i64 %2, %r.028
+  %4 = mul nsw i64 %t.029, %m.031
   %5 = icmp slt i64 %3, %4
   br i1 %5, label %if.then.L20, label %if.else.L20
 
@@ -40,7 +40,7 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   %10 = sub nsw i64 %r.028, %4
   %11 = mul nsw i64 %10, 10
   %12 = mul nsw i64 %q.033, 3
-  %13 = add nsw i64 %12, %r.028
+  %13 = add nsw i64 %r.028, %12
   %14 = mul nsw i64 %13, 10
   %15 = sdiv i64 %14, %t.029
   %.neg = mul i64 %m.031, -10
@@ -48,16 +48,16 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   br label %for.tail.L19
 
 if.else.L20:                                      ; preds = %for.body.L19
-  %17 = mul nsw i64 %q.033, %k.030
+  %17 = mul nsw i64 %k.030, %q.033
   %18 = shl nsw i64 %q.033, 1
-  %19 = add nsw i64 %18, %r.028
+  %19 = add nsw i64 %r.028, %18
   %20 = mul nsw i64 %19, %x.032
-  %21 = mul nsw i64 %x.032, %t.029
+  %21 = mul nsw i64 %t.029, %x.032
   %22 = add nsw i64 %k.030, 1
   %23 = mul nsw i64 %k.030, 7
   %24 = add nsw i64 %23, 2
-  %25 = mul nsw i64 %q.033, %24
-  %26 = mul nsw i64 %x.032, %r.028
+  %25 = mul nsw i64 %24, %q.033
+  %26 = mul nsw i64 %r.028, %x.032
   %27 = add nsw i64 %25, %26
   %28 = sdiv i64 %27, %21
   %29 = add nsw i64 %x.032, 2

--- a/test/test-files/benchmark/success-pidigits/ir-code-Os.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-Os.ll
@@ -19,9 +19,9 @@ for.body.L19:                                     ; preds = %0, %for.tail.L19
   %t.029 = phi i64 [ 1, %0 ], [ %t.1, %for.tail.L19 ]
   %r.028 = phi i64 [ 0, %0 ], [ %r.1, %for.tail.L19 ]
   %1 = shl nsw i64 %q.033, 2
-  %2 = sub i64 %r.028, %t.029
-  %3 = add i64 %2, %1
-  %4 = mul nsw i64 %m.031, %t.029
+  %2 = sub i64 %1, %t.029
+  %3 = add i64 %2, %r.028
+  %4 = mul nsw i64 %t.029, %m.031
   %5 = icmp slt i64 %3, %4
   br i1 %5, label %if.then.L20, label %if.else.L20
 
@@ -40,7 +40,7 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   %10 = sub nsw i64 %r.028, %4
   %11 = mul nsw i64 %10, 10
   %12 = mul nsw i64 %q.033, 3
-  %13 = add nsw i64 %12, %r.028
+  %13 = add nsw i64 %r.028, %12
   %14 = mul nsw i64 %13, 10
   %15 = sdiv i64 %14, %t.029
   %.neg = mul i64 %m.031, -10
@@ -48,16 +48,16 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   br label %for.tail.L19
 
 if.else.L20:                                      ; preds = %for.body.L19
-  %17 = mul nsw i64 %q.033, %k.030
+  %17 = mul nsw i64 %k.030, %q.033
   %18 = shl nsw i64 %q.033, 1
-  %19 = add nsw i64 %18, %r.028
+  %19 = add nsw i64 %r.028, %18
   %20 = mul nsw i64 %19, %x.032
-  %21 = mul nsw i64 %x.032, %t.029
+  %21 = mul nsw i64 %t.029, %x.032
   %22 = add nsw i64 %k.030, 1
   %23 = mul nsw i64 %k.030, 7
   %24 = add nsw i64 %23, 2
-  %25 = mul nsw i64 %q.033, %24
-  %26 = mul nsw i64 %x.032, %r.028
+  %25 = mul nsw i64 %24, %q.033
+  %26 = mul nsw i64 %r.028, %x.032
   %27 = add nsw i64 %25, %26
   %28 = sdiv i64 %27, %21
   %29 = add nsw i64 %x.032, 2

--- a/test/test-files/benchmark/success-pidigits/ir-code-Oz.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-Oz.ll
@@ -19,9 +19,9 @@ for.body.L19:                                     ; preds = %0, %for.tail.L19
   %t.029 = phi i64 [ 1, %0 ], [ %t.1, %for.tail.L19 ]
   %r.028 = phi i64 [ 0, %0 ], [ %r.1, %for.tail.L19 ]
   %1 = shl nsw i64 %q.033, 2
-  %2 = sub i64 %r.028, %t.029
-  %3 = add i64 %2, %1
-  %4 = mul nsw i64 %m.031, %t.029
+  %2 = sub i64 %1, %t.029
+  %3 = add i64 %2, %r.028
+  %4 = mul nsw i64 %t.029, %m.031
   %5 = icmp slt i64 %3, %4
   br i1 %5, label %if.then.L20, label %if.else.L20
 
@@ -40,7 +40,7 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   %10 = sub nsw i64 %r.028, %4
   %11 = mul nsw i64 %10, 10
   %12 = mul nsw i64 %q.033, 3
-  %13 = add nsw i64 %12, %r.028
+  %13 = add nsw i64 %r.028, %12
   %14 = mul nsw i64 %13, 10
   %15 = sdiv i64 %14, %t.029
   %.neg = mul i64 %m.031, -10
@@ -48,16 +48,16 @@ if.exit.L22:                                      ; preds = %if.then.L22, %if.th
   br label %for.tail.L19
 
 if.else.L20:                                      ; preds = %for.body.L19
-  %17 = mul nsw i64 %q.033, %k.030
+  %17 = mul nsw i64 %k.030, %q.033
   %18 = shl nsw i64 %q.033, 1
-  %19 = add nsw i64 %18, %r.028
+  %19 = add nsw i64 %r.028, %18
   %20 = mul nsw i64 %19, %x.032
-  %21 = mul nsw i64 %x.032, %t.029
+  %21 = mul nsw i64 %t.029, %x.032
   %22 = add nsw i64 %k.030, 1
   %23 = mul nsw i64 %k.030, 7
   %24 = add nsw i64 %23, 2
-  %25 = mul nsw i64 %q.033, %24
-  %26 = mul nsw i64 %x.032, %r.028
+  %25 = mul nsw i64 %24, %q.033
+  %26 = mul nsw i64 %r.028, %x.032
   %27 = add nsw i64 %25, %26
   %28 = sdiv i64 %27, %21
   %29 = add nsw i64 %x.032, 2

--- a/test/util/TestUtil.cpp
+++ b/test/util/TestUtil.cpp
@@ -61,7 +61,8 @@ std::vector<TestCase> TestUtil::collectTestCases(const char *suiteName, bool use
  * Check if the expected output matches the actual output
  *
  * @param refPath Path to the reference file
- * @param callback Callback to execute the required steps to get the actual test output
+ * @param getActualOutput Callback to execute the required steps to get the actual test output
+ * @aaram modifyOutputFct Callback to modify the output before comparing it with the reference
  *
  * @return True, if the ref file was found
  */


### PR DESCRIPTION
- Fix `-llvm -print-before-all` and `-llvm -print-after-all` options, which were not working correctly with the new pass manager
- Fix bug in test runner that caused wrong refs for optimized IR
- Reduce code redundancy