### PR TITLE
Introduce way to abort the compilation after the first dumped resource

### DIFF
--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O3 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_LIB_DIR" value="D:/LLVM/build-release/lib" />
       <env name="LLVM_INCLUDE_DIR" value="D:/LLVM/llvm/include" />

--- a/docs/docs/cli/build.md
+++ b/docs/docs/cli/build.md
@@ -29,6 +29,7 @@ You can apply following options to the `build` subcommand:
 | `-s`, `-asm` | `--dump-assembly`    | Dump Assembly code                                                                                              |
 | `-b`, `-obj` | `--dump-object-file` | Dump object files                                                                                               |
 | -            | `--dump-to-files`    | Redirect all dumps to files instead of printing them to the screen                                              |
+| -            | `--abort-after-dump` | Abort the compilation process after dumping the first requested resource                                        |
 | `-j <n>`     | `--jobs <n>`         | Set number of jobs to parallelize compilation (default is auto)                                                 |
 | `-t`         | `--target`           | Target triple for the emitted executable (for cross-compiling). <br> Format: `<arch><sub>-<vendor>-<sys>-<abi>` |
 | `-o`         | `--output`           | Set path for executable output.                                                                                 |

--- a/docs/docs/cli/install.md
+++ b/docs/docs/cli/install.md
@@ -28,7 +28,6 @@ You can apply following options to the `install` subcommand:
 | `-ir`        | `--dump-ir`          | Dump LLVM-IR                                                                         |
 | `-s`, `-asm` | `--dump-assembly`    | Dump Assembly code                                                                   |
 | `-b`, `-obj` | `--dump-object-file` | Dump object files                                                                    |
-| -            | `--dump-to-files`    | Redirect all dumps to files instead of printing them to the screen                   |
 | `-d`         | `--debug-output`     | Print compiler output for debugging.                                                 |
 | `-j <n>`     | `--jobs <n>`         | Set number of jobs to parallelize compilation (Default is auto)                      |
 | `-o`         | `--output`           | Set path for executable output.                                                      |

--- a/docs/docs/cli/run.md
+++ b/docs/docs/cli/run.md
@@ -28,7 +28,6 @@ You can apply following options to the `run` subcommand:
 | `-ir`        | `--dump-ir`          | Dump LLVM-IR                                                                                |
 | `-s`, `-asm` | `--dump-assembly`    | Dump Assembly code                                                                          |
 | `-b`, `-obj` | `--dump-object-file` | Dump object files                                                                           |
-| -            | `--dump-to-files`    | Redirect all dumps to files instead of printing them to the screen                          |
 | `-j <n>`     | `--jobs <n>`         | Set number of jobs to parallelize compilation (default is auto)                             |
 | `-o`         | `--output`           | Set path for executable output.                                                             |
 | `-O<x>`      | -                    | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz`        |

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -205,6 +205,11 @@ void Driver::addBuildSubcommand() {
   subCmd->add_flag<bool>("--no-entry", cliOptions.noEntryFct, "Do not generate main function");
   // --static
   subCmd->add_flag<bool>("--static", cliOptions.staticLinking, "Link statically");
+  // --dump-to-files
+  subCmd->add_flag<bool>("--dump-to-files", cliOptions.dumpSettings.dumpToFiles, "Redirect dumps to files instead of printing");
+  // --abort-after-dump
+  subCmd->add_flag<bool>("--abort-after-dump", cliOptions.dumpSettings.abortAfterDump,
+                         "Abort the compilation process after dumping the first requested resource");
 }
 
 /**
@@ -343,8 +348,6 @@ void Driver::addCompileSubcommandOptions(CLI::App *subCmd) {
   subCmd->add_flag<bool>("--dump-assembly,-asm,-s", cliOptions.dumpSettings.dumpAssembly, "Dump Assembly code");
   // --dump-object-file
   subCmd->add_flag<bool>("--dump-object-file,-obj", cliOptions.dumpSettings.dumpObjectFile, "Dump object file");
-  // --dump-to-files
-  subCmd->add_flag<bool>("--dump-to-files", cliOptions.dumpSettings.dumpToFiles, "Redirect dumps to files instead of printing");
 
   // Source file
   subCmd->add_option<std::filesystem::path>("<main-source-file>", cliOptions.mainSourceFile, "Main source file")

--- a/src/driver/Driver.h
+++ b/src/driver/Driver.h
@@ -59,6 +59,7 @@ struct CliOptions {
     bool dumpAssembly = false;
     bool dumpObjectFile = false;
     bool dumpToFiles = false;
+    bool abortAfterDump = false;
   } dumpSettings;
   bool namesForIRValues = false;
   OptLevel optLevel = OptLevel::O0; // Default optimization level for debug build mode is O0

--- a/src/exception/CompilerError.cpp
+++ b/src/exception/CompilerError.cpp
@@ -6,12 +6,12 @@
 
 namespace spice::compiler {
 
-CompilerError::CompilerError(const CompilerErrorType &type, const std::string &message) {
+CompilerError::CompilerError(const CompilerErrorType &type, const std::string &message) : type(type) {
   errorMessage = "[Error|Compiler]:\n";
   errorMessage += getMessagePrefix(type) + ": " + message;
 }
 
-CompilerError::CompilerError(const CodeLoc &codeLoc, const CompilerErrorType &type, const std::string &message) {
+CompilerError::CompilerError(const CodeLoc &codeLoc, const CompilerErrorType &type, const std::string &message) : type(type) {
   errorMessage = "[Error|Compiler] " + codeLoc.toPrettyString() + ":\n";
   errorMessage += getMessagePrefix(type) + ": " + message;
 }
@@ -61,6 +61,8 @@ std::string CompilerError::getMessagePrefix(CompilerErrorType type) {
     return "Printf has null type";
   case OOM:
     return "An out of memory error occurred";
+  case ABORTED_BY_DUMP:
+    return "Aborted by dump";
   case INVALID_FUNCTION:
     return "Invalid function";
   case INVALID_MODULE:

--- a/src/exception/CompilerError.h
+++ b/src/exception/CompilerError.h
@@ -28,6 +28,7 @@ enum CompilerErrorType : uint8_t {
   REFERENCED_UNDEFINED_FUNCTION_IR,
   PRINTF_NULL_TYPE,
   OOM,
+  ABORTED_BY_DUMP,
   INVALID_FUNCTION,
   INVALID_MODULE
 };
@@ -46,6 +47,7 @@ public:
   [[nodiscard]] static std::string getMessagePrefix(CompilerErrorType errorType);
 
   // Public members
+  CompilerErrorType type;
   std::string errorMessage;
 };
 

--- a/src/global/GlobalResourceManager.h
+++ b/src/global/GlobalResourceManager.h
@@ -62,6 +62,7 @@ public:
   BS::thread_pool threadPool = BS::thread_pool(cliOptions.compileJobCount);
   BS::synced_stream tout;
   ErrorManager errorManager;
+  bool abortCompilation = false;
 
 private:
   // Private members

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,7 @@
 #include <exception/ParserError.h>
 #include <exception/SemanticError.h>
 #include <global/GlobalResourceManager.h>
+#include <typechecker/MacroDefs.h>
 #include <util/FileUtil.h>
 
 using namespace spice::compiler;
@@ -27,8 +28,11 @@ bool compileProject(CliOptions &cliOptions) {
 
     // Run compile pipeline for main source file. All dependent source files are triggered by their parents
     mainSourceFile->runFrontEnd();
+    CHECK_ABORT_FLAG_B()
     mainSourceFile->runMiddleEnd();
+    CHECK_ABORT_FLAG_B()
     mainSourceFile->runBackEnd();
+    CHECK_ABORT_FLAG_B()
 
     // Link the target executable (link object files to executable)
     resourceManager.linker.prepare();

--- a/src/typechecker/MacroDefs.h
+++ b/src/typechecker/MacroDefs.h
@@ -46,4 +46,11 @@
       return nullptr;                                                                                                            \
   }
 
+#define CHECK_ABORT_FLAG_V()                                                                                                     \
+  if (resourceManager.abortCompilation)                                                                                          \
+    return;
+
+#define CHECK_ABORT_FLAG_B()                                                                                                     \
+  if (resourceManager.abortCompilation)                                                                                          \
+    return true;
 #pragma warning(default : 4129)

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -59,6 +59,7 @@ void execTestCase(const TestCase &testCase) {
           /* dumpAssembly= */ false,
           /* dumpObjectFile= */ false,
           /* dumpToFiles= */ false,
+          /* abortWhenAllDumped */ false,
       },
       /* namesForIRValues= */ true,
       /* optLevel= */ OptLevel::O0,

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -59,7 +59,7 @@ void execTestCase(const TestCase &testCase) {
           /* dumpAssembly= */ false,
           /* dumpObjectFile= */ false,
           /* dumpToFiles= */ false,
-          /* abortWhenAllDumped */ false,
+          /* abortAfterDump */ false,
       },
       /* namesForIRValues= */ true,
       /* optLevel= */ OptLevel::O0,


### PR DESCRIPTION
Introduce `--abort-after-dump` option for build subcommand. This can be used to abort the compilation after the first resource like `-ir`, `-asm`, `-ast`, `-cst`, ... is dumped.