### PR TITLE
Improve linker and linker invoker lookup

### DIFF
--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -d -O2 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_LIB_DIR" value="D:/LLVM/build-release/lib" />
       <env name="LLVM_INCLUDE_DIR" value="D:/LLVM/llvm/include" />

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -719,8 +719,8 @@ void SourceFile::visualizerOutput(std::string outputName, const std::string &out
   if (resourceManager.cliOptions.dumpSettings.dumpToFiles) {
     // Check if graphviz is installed
     // GCOV_EXCL_START
-    if (FileUtil::isCommandAvailable("dot"))
-      throw CompilerError(IO_ERROR, "Please check if you have installed 'Graphviz Dot' and added it to the PATH variable");
+    if (!FileUtil::isGraphvizInstalled())
+      throw CompilerError(IO_ERROR, "Please check if you have installed Graphviz and added it to the PATH variable");
     // GCOV_EXCL_STOP
 
     // Write to dot file

--- a/src/exception/CompilerError.cpp
+++ b/src/exception/CompilerError.cpp
@@ -6,12 +6,12 @@
 
 namespace spice::compiler {
 
-CompilerError::CompilerError(const CompilerErrorType &type, const std::string &message) : type(type) {
+CompilerError::CompilerError(const CompilerErrorType &type, const std::string &message) {
   errorMessage = "[Error|Compiler]:\n";
   errorMessage += getMessagePrefix(type) + ": " + message;
 }
 
-CompilerError::CompilerError(const CodeLoc &codeLoc, const CompilerErrorType &type, const std::string &message) : type(type) {
+CompilerError::CompilerError(const CodeLoc &codeLoc, const CompilerErrorType &type, const std::string &message) {
   errorMessage = "[Error|Compiler] " + codeLoc.toPrettyString() + ":\n";
   errorMessage += getMessagePrefix(type) + ": " + message;
 }
@@ -61,8 +61,6 @@ std::string CompilerError::getMessagePrefix(CompilerErrorType type) {
     return "Printf has null type";
   case OOM:
     return "An out of memory error occurred";
-  case ABORTED_BY_DUMP:
-    return "Aborted by dump";
   case INVALID_FUNCTION:
     return "Invalid function";
   case INVALID_MODULE:

--- a/src/exception/CompilerError.h
+++ b/src/exception/CompilerError.h
@@ -28,7 +28,6 @@ enum CompilerErrorType : uint8_t {
   REFERENCED_UNDEFINED_FUNCTION_IR,
   PRINTF_NULL_TYPE,
   OOM,
-  ABORTED_BY_DUMP,
   INVALID_FUNCTION,
   INVALID_MODULE
 };
@@ -47,7 +46,6 @@ public:
   [[nodiscard]] static std::string getMessagePrefix(CompilerErrorType errorType);
 
   // Public members
-  CompilerErrorType type;
   std::string errorMessage;
 };
 

--- a/src/linker/ExternalLinkerInterface.cpp
+++ b/src/linker/ExternalLinkerInterface.cpp
@@ -10,8 +10,6 @@
 
 namespace spice::compiler {
 
-const char *const LINKER_EXECUTABLE_NAME = "clang";
-
 void ExternalLinkerInterface::prepare() {
   // Set target to linker
   addLinkerFlag("--target=" + cliOptions.targetTriple);
@@ -36,20 +34,12 @@ void ExternalLinkerInterface::prepare() {
  * Start the linking process
  */
 void ExternalLinkerInterface::link() const {
-  std::string linkerCmd(LINKER_EXECUTABLE_NAME);
-  // LCOV_EXCL_START
-  if (FileUtil::isCommandAvailable(linkerCmd))
-    throw LinkerError(LINKER_NOT_FOUND, "Please check if you have installed " + linkerCmd + " and added it to the PATH variable");
-  // LCOV_EXCL_STOP
-
-  // Check if the output path was set
-  if (outputPath.empty())                                                    // GCOV_EXCL_LINE
-    throw CompilerError(IO_ERROR, "Output path for the linker was not set"); // GCOV_EXCL_LINE
+  assert(!outputPath.empty());
 
   // Build the linker command
   std::stringstream linkerCommandBuilder;
-  linkerCommandBuilder << linkerCmd;
-  // linkerCommandBuilder << " -###"; // For debugging purposes
+  linkerCommandBuilder << FileUtil::findLinkerInvoker();
+  linkerCommandBuilder << " -fuse-ld=" << FileUtil::findLinker(); // Select linker
   // Append linker flags
   for (const std::string &linkerFlag : linkerFlags)
     linkerCommandBuilder << " " << linkerFlag;

--- a/src/linker/ExternalLinkerInterface.h
+++ b/src/linker/ExternalLinkerInterface.h
@@ -30,8 +30,7 @@ private:
   const CliOptions &cliOptions;
   std::vector<std::string> objectFilePaths;
   std::vector<std::string> linkerFlags = {
-      "-fuse-ld=lld", // Use LLD linker
-      "-flto",        // Enable LTO
+      "-flto", // Enable LTO
   };
 };
 

--- a/src/util/FileUtil.cpp
+++ b/src/util/FileUtil.cpp
@@ -1,12 +1,13 @@
 // Copyright (c) 2021-2024 ChilliBits. All rights reserved.
 
 #include "FileUtil.h"
-#include "exception/CompilerError.h"
 
 #include <array>
 #include <filesystem>
 #include <iostream>
 
+#include <exception/CompilerError.h>
+#include <exception/LinkerError.h>
 #include <util/CommonUtil.h>
 
 namespace spice::compiler {
@@ -86,7 +87,54 @@ bool FileUtil::isCommandAvailable(const std::string &cmd) {
 #else
 #error "Unsupported platform"
 #endif
-  return std::system(checkCmd.c_str()) != 0;
+  return std::system(checkCmd.c_str()) == 0;
+}
+
+/**
+ * Checks if Graphviz is installed on the system
+ *
+ * @return Present or not
+ */
+bool FileUtil::isGraphvizInstalled() { return std::system("dot -V") == 0; }
+
+/**
+ * Search for a supported linker invoker on the system and return the executable name or path.
+ * This function may throw a LinkerError if no linker invoker is found.
+ *
+ * @return Name of path to the linker invoker executable
+ */
+std::string FileUtil::findLinkerInvoker() {
+#ifdef OS_UNIX
+  for (const char *linkerInvokerName : {"clang", "gcc"})
+    for (const char *path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
+      if (std::filesystem::exists(path + linkerInvokerName))
+        return path + linkerInvokerName;
+#elif OS_WINDOWS
+  for (const char *linkerInvokerName : {"clang", "gcc"})
+    if (isCommandAvailable(std::string(linkerInvokerName) + " -v"))
+      return linkerInvokerName;
+#endif
+  throw LinkerError(LINKER_NOT_FOUND, "No supported linker invoker was found on the system. Supported are: clang and gcc");
+}
+
+/**
+ * Search for a supported linker on the system and return the executable name or path.
+ * This function may throw a LinkerError if no linker is found.
+ *
+ * @return Name of path to the linker executable
+ */
+std::string FileUtil::findLinker() {
+#ifdef OS_UNIX
+  for (const char *linkerName : {"mold", "lld", "gold", "ld"})
+    for (const char *path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
+      if (std::filesystem::exists(path + linkerName))
+        return path + linkerName;
+#elif OS_WINDOWS
+  for (const char *linkerName : {"lld", "ld"})
+    if (isCommandAvailable(std::string(linkerName) + " -v"))
+      return linkerName;
+#endif
+  throw LinkerError(LINKER_NOT_FOUND, "No supported linker was found on the system. Supported are: mold, lld, gold and ld");
 }
 
 /**

--- a/src/util/FileUtil.cpp
+++ b/src/util/FileUtil.cpp
@@ -105,13 +105,13 @@ bool FileUtil::isGraphvizInstalled() { return std::system("dot -V") == 0; }
  */
 std::string FileUtil::findLinkerInvoker() {
 #ifdef OS_UNIX
-  for (const char *linkerInvokerName : {"clang", "gcc"})
-    for (const char *path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
+  for (const std::string linkerInvokerName : {"clang", "gcc"})
+    for (const std::string path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
       if (std::filesystem::exists(path + linkerInvokerName))
         return path + linkerInvokerName;
 #elif OS_WINDOWS
-  for (const char *linkerInvokerName : {"clang", "gcc"})
-    if (isCommandAvailable(std::string(linkerInvokerName) + " -v"))
+  for (const std::string linkerInvokerName : {"clang", "gcc"})
+    if (isCommandAvailable(linkerInvokerName + " -v"))
       return linkerInvokerName;
 #endif
   throw LinkerError(LINKER_NOT_FOUND, "No supported linker invoker was found on the system. Supported are: clang and gcc");
@@ -125,13 +125,13 @@ std::string FileUtil::findLinkerInvoker() {
  */
 std::string FileUtil::findLinker() {
 #ifdef OS_UNIX
-  for (const char *linkerName : {"mold", "lld", "gold", "ld"})
-    for (const char *path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
+  for (const std::string linkerName : {"mold", "lld", "gold", "ld"})
+    for (const std::string path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
       if (std::filesystem::exists(path + linkerName))
         return path + linkerName;
 #elif OS_WINDOWS
-  for (const char *linkerName : {"lld", "ld"})
-    if (isCommandAvailable(std::string(linkerName) + " -v"))
+  for (const std::string linkerName : {"lld", "ld"})
+    if (isCommandAvailable(linkerName + " -v"))
       return linkerName;
 #endif
   throw LinkerError(LINKER_NOT_FOUND, "No supported linker was found on the system. Supported are: mold, lld, gold and ld");
@@ -149,7 +149,7 @@ std::filesystem::path FileUtil::getStdDir() {
     return std::filesystem::path("/usr/lib/spice/std/");
 #endif
   if (std::getenv("SPICE_STD_DIR")) {
-    std::filesystem::path stdPath(std::getenv("SPICE_STD_DIR"));
+    const std::filesystem::path stdPath(std::getenv("SPICE_STD_DIR"));
     if (std::filesystem::exists(stdPath))
       return stdPath;
   }
@@ -164,7 +164,7 @@ std::filesystem::path FileUtil::getStdDir() {
  */
 std::filesystem::path FileUtil::getBootstrapDir() {
   if (std::getenv("SPICE_BOOTSTRAP_DIR")) {
-    std::filesystem::path stdPath(std::getenv("SPICE_BOOTSTRAP_DIR"));
+    const std::filesystem::path stdPath(std::getenv("SPICE_BOOTSTRAP_DIR"));
     if (std::filesystem::exists(stdPath))
       return stdPath;
   }

--- a/src/util/FileUtil.h
+++ b/src/util/FileUtil.h
@@ -21,6 +21,9 @@ public:
   static std::string getFileContent(const std::filesystem::path &filePath);
   static ExecResult exec(const std::string &command);
   static bool isCommandAvailable(const std::string &cmd);
+  static bool isGraphvizInstalled();
+  static std::string findLinkerInvoker();
+  static std::string findLinker();
   static std::filesystem::path getStdDir();
   static std::filesystem::path getBootstrapDir();
   static std::filesystem::path getSpiceBinDir();


### PR DESCRIPTION
- Check for linker invokers in this order: `clang`, `gcc`
- Check for linker to pass via the `-fuse-ld=<value>` to the linker invoker in this order: `mold`, `lld`, `gold`, `ld`