### PR TITLE
Fix destructing order

### DIFF
--- a/.run/spice.run.xml
+++ b/.run/spice.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O2 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O2 ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_BUILD_INCLUDE_DIR" value="D:/LLVM/build-release/include" />
       <env name="LLVM_INCLUDE_DIR" value="D:/LLVM/llvm/include" />

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -275,7 +275,11 @@ void TypeChecker::implicitlyCallStructDtor(SymbolTableEntry *entry, StmtLstNode 
 void TypeChecker::doScopeCleanup(StmtLstNode *node) {
   // Get all variables, that are approved for deallocation
   std::vector<SymbolTableEntry *> vars = currentScope->getVarsGoingOutOfScope();
-  for (SymbolTableEntry *var : std::ranges::reverse_view(vars)) {
+  // Sort by reverse declaration order
+  auto lambda = [](const SymbolTableEntry *a, const SymbolTableEntry *b) { return a->declNode->codeLoc > b->declNode->codeLoc; };
+  std::ranges::sort(vars, lambda);
+  // Call dtor for each variable. We call the dtor in reverse declaration order
+  for (SymbolTableEntry *var : vars) {
     // Only generate dtor call for structs and if not omitted
     if (!var->getType().is(TY_STRUCT) || var->omitDtorCall)
       continue;


### PR DESCRIPTION
We want to destruct objects automatically at the end of the scope. This should happen automatically in the correct order, which is the reversed declaration order. Previously, this worked in most cases, but we had no explicit sorting in place. This is now fixed.