### PR TITLE
Strip target dependent info from IR refs

### DIFF
--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -298,7 +298,7 @@ void SourceFile::runIRGenerator() {
   irGenerator.visit(ast);
 
   // Save the ir string in the compiler output
-  compilerOutput.irString = IRGenerator::getIRString(llvmModule.get());
+  compilerOutput.irString = IRGenerator::getIRString(llvmModule.get(), resourceManager.cliOptions.testMode);
 
   // Dump unoptimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)
@@ -330,7 +330,7 @@ void SourceFile::runDefaultIROptimizer() {
   irOptimizer.optimizeDefault();
 
   // Save the optimized ir string in the compiler output
-  compilerOutput.irOptString = IRGenerator::getIRString(llvmModule.get());
+  compilerOutput.irOptString = IRGenerator::getIRString(llvmModule.get(), resourceManager.cliOptions.testMode);
 
   // Dump optimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)
@@ -361,7 +361,7 @@ void SourceFile::runPreLinkIROptimizer() {
   irOptimizer.optimizePreLink();
 
   // Save the optimized ir string in the compiler output
-  compilerOutput.irOptString = IRGenerator::getIRString(llvmModule.get());
+  compilerOutput.irOptString = IRGenerator::getIRString(llvmModule.get(), resourceManager.cliOptions.testMode);
 
   // Dump optimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)
@@ -416,7 +416,7 @@ void SourceFile::runPostLinkIROptimizer() {
 
   // Save the optimized ir string in the compiler output
   llvm::Module *module = resourceManager.ltoModule.get();
-  compilerOutput.irOptString = IRGenerator::getIRString(module);
+  compilerOutput.irOptString = IRGenerator::getIRString(module, resourceManager.cliOptions.testMode);
 
   // Dump optimized IR code
   if (resourceManager.cliOptions.dumpSettings.dumpIR)

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -546,12 +546,28 @@ void IRGenerator::materializeConstant(LLVMExprResult &exprResult) {
   exprResult.value = exprResult.constant;
 }
 
-std::string IRGenerator::getIRString(llvm::Module *llvmModule) {
+std::string IRGenerator::getIRString(llvm::Module *llvmModule, bool withoutTargetData) {
   assert(llvmModule != nullptr); // Make sure the module hasn't been moved away
 
+  // Backup target triple and data layout
+  const std::string targetTriple = llvmModule->getTargetTriple();
+  const std::string targetDataLayout = llvmModule->getDataLayoutStr();
+  // Remove target triple and data layout
+  if (withoutTargetData) {
+    llvmModule->setTargetTriple("");
+    llvmModule->setDataLayout("");
+  }
+
+  // Get IR string
   std::string output;
   llvm::raw_string_ostream oss(output);
   llvmModule->print(oss, nullptr);
+
+  // Restore target triple and data layout
+  if (withoutTargetData) {
+    llvmModule->setTargetTriple(targetTriple);
+    llvmModule->setDataLayout(targetDataLayout);
+  }
 
   return output;
 }

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -124,7 +124,7 @@ public:
   llvm::Value *resolveAddress(const ASTNode *node);
   llvm::Value *resolveAddress(LLVMExprResult &exprResult);
   [[nodiscard]] llvm::Constant *getDefaultValueForSymbolType(const SymbolType &symbolType);
-  [[nodiscard]] static std::string getIRString(llvm::Module *llvmModule);
+  [[nodiscard]] static std::string getIRString(llvm::Module *llvmModule, bool withoutTargetInfo);
 
 private:
   // Private methods

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -123,9 +123,6 @@ void execTestCase(const TestCase &testCase) {
     TestUtil::checkRefMatch(
         testCase.testPath / REF_NAME_IR, [&]() { return mainSourceFile->compilerOutput.irString; },
         [&](std::string &expectedOutput, std::string &actualOutput) {
-          // Cut of first few lines to be target independent
-          TestUtil::eraseIRModuleHeader(expectedOutput);
-          TestUtil::eraseIRModuleHeader(actualOutput);
           if (cliOptions.generateDebugInfo) {
             // Remove the lines, containing paths on the local file system
             TestUtil::eraseLinesBySubstring(expectedOutput, " = !DIFile(filename:");
@@ -135,26 +132,19 @@ void execTestCase(const TestCase &testCase) {
 
     // Check optimized IR code
     for (uint8_t i = 1; i <= 5; i++) {
-      TestUtil::checkRefMatch(
-          testCase.testPath / REF_NAME_OPT_IR[i - 1],
-          [&]() {
-            cliOptions.optLevel = static_cast<OptLevel>(i);
+      TestUtil::checkRefMatch(testCase.testPath / REF_NAME_OPT_IR[i - 1], [&]() {
+        cliOptions.optLevel = static_cast<OptLevel>(i);
 
-            if (cliOptions.useLTO) {
-              mainSourceFile->runPreLinkIROptimizer();
-              mainSourceFile->runBitcodeLinker();
-              mainSourceFile->runPostLinkIROptimizer();
-            } else {
-              mainSourceFile->runDefaultIROptimizer();
-            }
+        if (cliOptions.useLTO) {
+          mainSourceFile->runPreLinkIROptimizer();
+          mainSourceFile->runBitcodeLinker();
+          mainSourceFile->runPostLinkIROptimizer();
+        } else {
+          mainSourceFile->runDefaultIROptimizer();
+        }
 
-            return mainSourceFile->compilerOutput.irOptString;
-          },
-          [&](std::string &expectedOutput, std::string &actualOutput) {
-            // Cut of first n lines to be target independent
-            TestUtil::eraseIRModuleHeader(expectedOutput);
-            TestUtil::eraseIRModuleHeader(actualOutput);
-          });
+        return mainSourceFile->compilerOutput.irOptString;
+      });
     }
 
     // Link the bitcode if not happened yet

--- a/test/test-files/benchmark/success-ackermann/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-ackermann/ir-code-O3.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [36 x i8] c"Ackermann of base m=%d and n=%d: %d\00", align 1
 

--- a/test/test-files/benchmark/success-ackermann/ir-code.ll
+++ b/test/test-files/benchmark/success-ackermann/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [36 x i8] c"Ackermann of base m=%d and n=%d: %d\00", align 1
 

--- a/test/test-files/benchmark/success-faculty/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-faculty/ir-code-O3.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [21 x i8] c"Faculty of %d is: %d\00", align 1
 

--- a/test/test-files/benchmark/success-faculty/ir-code.ll
+++ b/test/test-files/benchmark/success-faculty/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [21 x i8] c"Faculty of %d is: %d\00", align 1
 

--- a/test/test-files/benchmark/success-fibonacci-threaded/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-fibonacci-threaded/ir-code-O3.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Thread = type { { ptr, ptr }, i64 }
 

--- a/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
 

--- a/test/test-files/benchmark/success-fibonacci/ir-code.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
 

--- a/test/test-files/benchmark/success-hello-world/ir-code-O2.ll
+++ b/test/test-files/benchmark/success-hello-world/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Hello World!\00", align 1
 

--- a/test/test-files/benchmark/success-hello-world2/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-hello-world2/ir-code-O3.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {

--- a/test/test-files/benchmark/success-pidigits/ir-code-O1.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O1.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 

--- a/test/test-files/benchmark/success-pidigits/ir-code-O2.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 

--- a/test/test-files/benchmark/success-pidigits/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O3.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 

--- a/test/test-files/benchmark/success-pidigits/ir-code-Os.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-Os.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 

--- a/test/test-files/benchmark/success-pidigits/ir-code-Oz.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-Oz.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 

--- a/test/test-files/benchmark/success-pidigits/ir-code.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 @printf.str.1 = private unnamed_addr constant [2 x i8] c".\00", align 1

--- a/test/test-files/irgenerator/anonymous-blocks/success-anonymous-block/ir-code.ll
+++ b/test/test-files/irgenerator/anonymous-blocks/success-anonymous-block/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [14 x i8] c"Test var: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/anonymous-blocks/success-nested-anonymous-blocks/ir-code.ll
+++ b/test/test-files/irgenerator/anonymous-blocks/success-nested-anonymous-blocks/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Param: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/arrays/success-arrays-multidimensional/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays-multidimensional/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Cell [1,3]: %d\00", align 1
 

--- a/test/test-files/irgenerator/arrays/success-arrays/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"Item 0: %d, item 2: %d\00", align 1
 

--- a/test/test-files/irgenerator/arrays/success-arrays2/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays2/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.array.0 = private unnamed_addr constant [10 x i32] [i32 1, i32 2, i32 4, i32 8, i32 16, i32 32, i32 64, i32 128, i32 256, i32 512]
 @printf.str.0 = private unnamed_addr constant [17 x i8] c"intArray[3]: %d\0A\00", align 1

--- a/test/test-files/irgenerator/arrays/success-arrays3/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays3/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.array.0 = private unnamed_addr constant [2 x i32] [i32 1, i32 2]
 @printf.str.0 = private unnamed_addr constant [17 x i8] c"intArray[1]: %d\0A\00", align 1

--- a/test/test-files/irgenerator/arrays/success-string-char-access/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-string-char-access/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [5 x i8] c"test\00", align 1
 @printf.str.0 = private unnamed_addr constant [10 x i8] c"Char: %c\0A\00", align 1

--- a/test/test-files/irgenerator/assertions/success-basic-assertion/ir-code.ll
+++ b/test/test-files/irgenerator/assertions/success-basic-assertion/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [55 x i8] c"Assertion failed: Condition 'true' evaluated to false.\00", align 1
 @printf.str.0 = private unnamed_addr constant [26 x i8] c"First assertion was true\0A\00", align 1

--- a/test/test-files/irgenerator/builtins/success-alignof/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-alignof/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [25 x i8] c"Alignment of double: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [22 x i8] c"Alignment of int: %d\0A\00", align 1

--- a/test/test-files/irgenerator/builtins/success-alignof/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-alignof/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [25 x i8] c"Alignment of double: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [22 x i8] c"Alignment of int: %d\0A\00", align 1

--- a/test/test-files/irgenerator/builtins/success-len/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-len/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [18 x i8] c"Array length: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/builtins/success-len/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-len/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.array.0 = private unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4]
 @printf.str.0 = private unnamed_addr constant [18 x i8] c"Array length: %d\0A\00", align 1

--- a/test/test-files/irgenerator/builtins/success-printf/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-printf/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Hello World!\00", align 1
 

--- a/test/test-files/irgenerator/builtins/success-printf/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-printf/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Hello World!\00", align 1
 

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [20 x i8] c"Size of double: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [20 x i8] c"Size of double: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Size of int: %d\0A\00", align 1

--- a/test/test-files/irgenerator/cli-args/success-cli-args/ir-code.ll
+++ b/test/test-files/irgenerator/cli-args/success-cli-args/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [10 x i8] c"Argc: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [16 x i8] c"Argv no. 0: %s\0A\00", align 1

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Vector = type { %interface.IIterable, ptr, i64, i64 }
 %interface.IIterable = type { ptr }

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.TestStruct = type { i64, %struct.String, i32 }
 %struct.String = type { ptr, i64, i64 }

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop/ir-code.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [17 x i8] c"i is now at: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/enums/success-enums/ir-code.ll
+++ b/test/test-files/irgenerator/enums/success-enums/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1

--- a/test/test-files/irgenerator/ext-decl/success-ext-decl-force-substantiate/ir-code.ll
+++ b/test/test-files/irgenerator/ext-decl/success-ext-decl-force-substantiate/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [21 x i8] c"Hello from thread 1\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [21 x i8] c"Hello from thread 2\0A\00", align 1

--- a/test/test-files/irgenerator/ext-decl/success-ext-decl/ir-code.ll
+++ b/test/test-files/irgenerator/ext-decl/success-ext-decl/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 declare ptr @malloc(i64 noundef)
 

--- a/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Loop run %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [19 x i8] c"Inner loop run %d\0A\00", align 1

--- a/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Loop run %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [19 x i8] c"Inner loop run %d\0A\00", align 1

--- a/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Loop run %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [19 x i8] c"Inner loop run %d\0A\00", align 1

--- a/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Loop run %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [19 x i8] c"Inner loop run %d\0A\00", align 1

--- a/test/test-files/irgenerator/for-loops/success-for-loop/ir-code.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [9 x i8] c"Step %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.NumberIterator = type { %interface.IIterator, i16, i16, i16 }
 %interface.IIterator = type { ptr }

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.NumberIterator = type { %interface.IIterator, i16, i16, i16 }
 %interface.IIterator = type { ptr }

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.NumberIterator = type { %interface.IIterator, i16, i16, i16 }
 %interface.IIterator = type { ptr }

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.NumberIterator = type { %interface.IIterator, i16, i16, i16 }
 %interface.IIterator = type { ptr }

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.ArrayIterator = type { %interface.IIterator, ptr, i64, i64 }
 %interface.IIterator = type { ptr }

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-normal/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-normal/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.ArrayIterator = type { %interface.IIterator, ptr, i64, i64 }
 %interface.IIterator = type { ptr }

--- a/test/test-files/irgenerator/function-pointers/success-basic/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-basic/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1
 

--- a/test/test-files/irgenerator/function-pointers/success-indirect/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-indirect/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [7 x i8] c"string\00", align 1
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 1

--- a/test/test-files/irgenerator/function-pointers/success-pass-by-non-value/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-pass-by-non-value/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [7 x i8] c"string\00", align 1
 @anon.string.1 = private unnamed_addr constant [7 x i8] c"string\00", align 1

--- a/test/test-files/irgenerator/functions/success-default-arg-value-expressions/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-default-arg-value-expressions/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [10 x i8] c"Test: %f\0A\00", align 1
 

--- a/test/test-files/irgenerator/functions/success-default-arg-values/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-default-arg-values/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [5 x i8] c"Test\00", align 1
 @printf.str.0 = private unnamed_addr constant [12 x i8] c"Result: %s\0A\00", align 1

--- a/test/test-files/irgenerator/functions/success-down-call/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-down-call/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
 

--- a/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code-O2.ll
+++ b/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [19 x i8] c"Inlined value: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [19 x i8] c"Inlined value: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/functions/success-external-function/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-external-function/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"IsTrue: %d\00", align 1
 

--- a/test/test-files/irgenerator/functions/success-overloading/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-overloading/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Test func 1\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Test func 2: %s\0A\00", align 1

--- a/test/test-files/irgenerator/functions/success-result-variable/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-result-variable/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"The age is: %d\00", align 1
 

--- a/test/test-files/irgenerator/generics/success-external-generic-functions/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-external-generic-functions/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [6 x i8] c"Hello\00", align 1
 @anon.string.1 = private unnamed_addr constant [6 x i8] c"World\00", align 1

--- a/test/test-files/irgenerator/generics/success-generic-functions/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [4 x i8] c"%f\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [4 x i8] c"%f\0A\00", align 1

--- a/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [10 x i8] c"Data: %d\0A\00", align 1
 @anon.array.0 = private unnamed_addr constant [7 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6, i16 7]

--- a/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Vector = type { ptr, i32 }
 

--- a/test/test-files/irgenerator/generics/success-nested-generic-structs/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-nested-generic-structs/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Node = type { ptr, double }
 

--- a/test/test-files/irgenerator/generics/success-type-hints/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-type-hints/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 1
 

--- a/test/test-files/irgenerator/if-stmts/success-if-else-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/if-stmts/success-if-else-stmt/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [10 x i8] c"If branch\00", align 1
 @printf.str.1 = private unnamed_addr constant [10 x i8] c"Else if 1\00", align 1

--- a/test/test-files/irgenerator/if-stmts/success-if-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/if-stmts/success-if-stmt/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [16 x i8] c"Condition true\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Condition false\0A\00", align 1

--- a/test/test-files/irgenerator/imports/success-modules-std/ir-code.ll
+++ b/test/test-files/irgenerator/imports/success-modules-std/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [12 x i8] c"Result: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/imports/success-modules/ir-code.ll
+++ b/test/test-files/irgenerator/imports/success-modules/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
 

--- a/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Car = type { %interface.Driveable, i1 }
 %interface.Driveable = type { ptr }

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Car = type { %interface.Driveable, i1 }
 %interface.Driveable = type { ptr }

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Car = type { %interface.Driveable, i1 }
 %interface.Driveable = type { ptr }

--- a/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Person = type { %interface.Compareable, ptr, ptr, i32 }
 %interface.Compareable = type { ptr }

--- a/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.InnerTest = type { %interface.ITest, i32 }
 %interface.ITest = type { ptr }

--- a/test/test-files/irgenerator/lambdas/success-captures/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-captures/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [57 x i8] c"Assertion failed: Condition 'x == 6' evaluated to false.\00", align 1
 @anon.string.1 = private unnamed_addr constant [58 x i8] c"Assertion failed: Condition 'foo2(x)' evaluated to false.\00", align 1

--- a/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"Hello from inside: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [23 x i8] c"Hello from inside: %d\0A\00", align 1

--- a/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.array.0 = private unnamed_addr constant [10 x i32] [i32 10, i32 9, i32 8, i32 7, i32 6, i32 5, i32 4, i32 3, i32 2, i32 1]
 @printf.str.0 = private unnamed_addr constant [4 x i8] c"%d \00", align 1

--- a/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [57 x i8] c"Assertion failed: Condition 'x == 6' evaluated to false.\00", align 1
 @anon.string.1 = private unnamed_addr constant [56 x i8] c"Assertion failed: Condition 'l2(x)' evaluated to false.\00", align 1

--- a/test/test-files/irgenerator/lambdas/success-function-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-function-lambda/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.String = type { ptr, i64, i64 }
 

--- a/test/test-files/irgenerator/lambdas/success-multiple-visits/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-multiple-visits/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [8 x i8] c"%d, %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [8 x i8] c"%d, %d\0A\00", align 1

--- a/test/test-files/irgenerator/lambdas/success-procedure-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-procedure-lambda/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.String = type { ptr, i64, i64 }
 

--- a/test/test-files/irgenerator/lto/success-lto-simple/ir-code-O2.ll
+++ b/test/test-files/irgenerator/lto/success-lto-simple/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'lto-module'
 source_filename = "lto-module"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [81 x i8] c"Assertion failed: Condition '(functionInModuleB(1, 2) == 3)' evaluated to false.\00", align 1
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 1

--- a/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Stamp = type { double, i1 }
 %struct.Letter = type { ptr, %struct.Stamp }

--- a/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.TestStruct = type { i8, i32 }
 

--- a/test/test-files/irgenerator/methods/success-methods/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-methods/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Letter = type { ptr }
 

--- a/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Counter = type { i64 }
 

--- a/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.TestStruct = type { i64 }
 

--- a/test/test-files/irgenerator/operators/success-operators/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operators/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [59 x i8] c"Assertion failed: Condition 'val == 9' evaluated to false.\00", align 1
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 1

--- a/test/test-files/irgenerator/operators/success-operators2/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operators2/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [57 x i8] c"Assertion failed: Condition 'i == 1' evaluated to false.\00", align 1
 @anon.string.1 = private unnamed_addr constant [57 x i8] c"Assertion failed: Condition 'i == 1' evaluated to false.\00", align 1

--- a/test/test-files/irgenerator/operators/success-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-short-circuiting/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Function True\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [16 x i8] c"Function False\0A\00", align 1

--- a/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [7 x i8] c"1: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [7 x i8] c"2: %d\0A\00", align 1

--- a/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Person = type { ptr, ptr, i32 }
 

--- a/test/test-files/irgenerator/pointers/success-pointer/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [6 x i8] c"Pizza\00", align 1
 @printf.str.0 = private unnamed_addr constant [32 x i8] c"Pointer address: %p, value: %s\0A\00", align 1

--- a/test/test-files/irgenerator/procedures/success-early-return/ir-code.ll
+++ b/test/test-files/irgenerator/procedures/success-early-return/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [16 x i8] c"Input was false\00", align 1
 

--- a/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code-O2.ll
+++ b/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [21 x i8] c"This is a value: %d\0A\00", align 1
 @str = private unnamed_addr constant [13 x i8] c"Before value\00", align 1

--- a/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code.ll
+++ b/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [21 x i8] c"This is a value: %d\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [14 x i8] c"Before value\0A\00", align 1

--- a/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Struct = type { ptr }
 

--- a/test/test-files/irgenerator/references/success-ref-assign/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-assign/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition '&test == &testRef' evaluated to false.\00", align 1
 @anon.string.1 = private unnamed_addr constant [62 x i8] c"Assertion failed: Condition 'test == 135' evaluated to false.\00", align 1

--- a/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Struct = type { ptr, i1 }
 

--- a/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.TestStruct = type { i1, ptr }
 

--- a/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.D = type { %struct.A, %struct.C, i32 }
 %struct.A = type { i32 }

--- a/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Vector = type { i1, ptr }
 

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Inner = type { i16 }
 %struct.Middle = type { %struct.Inner }

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.StructToCopy = type { i32, i1 }
 

--- a/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Inner = type { ptr }
 %struct.Middle = type { %struct.Inner }

--- a/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.TestStruct = type { i32, ptr, double, i1 }
 

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Inner = type { ptr, ptr }
 %struct.Middle = type { %struct.Inner }

--- a/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.StructWithHeapFields = type { ptr }
 %struct.Result = type { ptr, %struct.Error }

--- a/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Test = type { i32, ptr }
 

--- a/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Test = type { i32, ptr }
 

--- a/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Test = type { i32, ptr }
 

--- a/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Test = type { i32, ptr }
 

--- a/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Vector = type { i1, ptr }
 

--- a/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Vector = type { i1, ptr }
 

--- a/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Socket = type { i32, i16, %struct.NestedSocket }
 %struct.NestedSocket = type { ptr, i64 }

--- a/test/test-files/irgenerator/structs/success-external-structs/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-external-structs/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Vec = type { i32, i1 }
 

--- a/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Test = type { i32, i1, i1, i32, i16, i64, i1, i1, i1, i1, i1, i1, i32, i64, i8, i32, i32, i32, i32, i32 }
 

--- a/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Test = type { i32, i64 }
 %struct.TestPacked = type <{ i32, i64 }>

--- a/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Person = type { ptr, ptr, i32 }
 

--- a/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.ShoppingItem = type { ptr, double, ptr }
 %struct.ShoppingCart = type { ptr, [3 x %struct.ShoppingItem] }

--- a/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.TreeNode = type { ptr, i32 }
 

--- a/test/test-files/irgenerator/structs/success-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Nested = type { ptr, ptr }
 %struct.TestStruct = type { ptr, double, ptr }

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [6 x i8] c"Apple\00", align 1
 @anon.string.1 = private unnamed_addr constant [7 x i8] c"Banana\00", align 1

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-with-fallthrough/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-with-fallthrough/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Input is at least 5.\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [22 x i8] c"Input is at least 4.\0A\00", align 1

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [5 x i8] c"Zero\00", align 1
 @anon.string.1 = private unnamed_addr constant [4 x i8] c"One\00", align 1

--- a/test/test-files/irgenerator/ternary/success-shortened-ternary/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-shortened-ternary/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [12 x i8] c"F1 called.\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [12 x i8] c"F2 called.\0A\00", align 1

--- a/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
 

--- a/test/test-files/irgenerator/ternary/success-ternary-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-stmt/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 1
 

--- a/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code.ll
+++ b/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [65 x i8] c"Assertion failed: Condition 'add(1, 2) == 3' evaluated to false.\00", align 1
 @anon.string.1 = private unnamed_addr constant [65 x i8] c"Assertion failed: Condition 'add(2, 2) == 4' evaluated to false.\00", align 1

--- a/test/test-files/irgenerator/testing/success-testing/ir-code.ll
+++ b/test/test-files/irgenerator/testing/success-testing/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @anon.string.0 = private unnamed_addr constant [65 x i8] c"Assertion failed: Condition 'add(1, 2) == 3' evaluated to false.\00", align 1
 @anon.string.1 = private unnamed_addr constant [65 x i8] c"Assertion failed: Condition 'add(2, 2) == 4' evaluated to false.\00", align 1

--- a/test/test-files/irgenerator/unsafe/success-pointer-cast/ir-code.ll
+++ b/test/test-files/irgenerator/unsafe/success-pointer-cast/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [9 x i8] c"Int: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.NestedStruct = type { i32, ptr }
 

--- a/test/test-files/irgenerator/variables/success-external-global-var/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-external-global-var/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [16 x i8] c"Global var: %s\0A\00", align 1
 @GLOBAL = external global ptr

--- a/test/test-files/irgenerator/variables/success-global-variables/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-global-variables/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @TEST1 = private global i32 10
 @TEST2 = private global ptr @anon.string.0

--- a/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [22 x i8] c"Outer: %f, inner: %d\0A\00", align 1
 

--- a/test/test-files/irgenerator/while-loops/success-while-loop/ir-code.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop/ir-code.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 @printf.str.0 = private unnamed_addr constant [17 x i8] c"i is now at: %d\0A\00", align 1
 

--- a/test/test-files/std/time/high-res-timer/ir-code-O2.ll
+++ b/test/test-files/std/time/high-res-timer/ir-code-O2.ll
@@ -1,7 +1,5 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
-target datalayout = "e-m:w-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128"
-target triple = "x86_64-w64-windows-gnu"
 
 %struct.Timer = type { i64, i64, i32, ptr }
 

--- a/test/util/TestUtil.cpp
+++ b/test/util/TestUtil.cpp
@@ -172,16 +172,6 @@ bool TestUtil::isDisabled(const TestCase &testCase, bool isGHActions) {
 }
 
 /**
- * Removes the first n lines of the IR code to not compare target dependent code
- *
- * @param irCode IR code to modify
- */
-void TestUtil::eraseIRModuleHeader(std::string &irCode) {
-  for (unsigned int i = 0; i < IR_FILE_SKIP_LINES; i++)
-    irCode.erase(0, irCode.find('\n') + 1);
-}
-
-/**
  * Removes the first n lines of the GDB output to not compare target dependent code
  *
  * @param gdbOutput GDB output to modify

--- a/test/util/TestUtil.h
+++ b/test/util/TestUtil.h
@@ -16,7 +16,6 @@ namespace spice::testing {
 
 const char *const PATH_TEST_FILES = "./test-files/";
 const unsigned int EXPECTED_NUMBER_OF_TESTS = 250;
-const unsigned int IR_FILE_SKIP_LINES = 5; // Skip the first couple of lines, because they contain target dependent information
 const char *const GDB_READING_SYMBOLS_MESSAGE = "Reading symbols from ";
 const char *const GDB_INFERIOR_MESSAGE = "[Inferior";
 extern bool updateRefs;
@@ -84,7 +83,6 @@ public:
 #endif
   }
   static bool isDisabled(const TestCase &testCase, bool isGHActions);
-  static void eraseIRModuleHeader(std::string &irCode);
   static void eraseGDBHeader(std::string &gdbOutput);
   static void eraseLinesBySubstring(std::string &irCode, const char *needle);
 };


### PR DESCRIPTION
Strip target dependent info from IR refs while printing instead of cutting off the first five lines in the TestRunner.