### PR TITLE
Fix wrong unreachable code warning

### DIFF
--- a/src/ast/ASTNodes.cpp
+++ b/src/ast/ASTNodes.cpp
@@ -108,7 +108,7 @@ bool SwitchStmtNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable
   const bool allCaseBranchesReturn = std::ranges::all_of(
       caseNodes, [=](CaseBranchNode *node) { return node->returnsOnAllControlPaths(doSetPredecessorsUnreachable); });
   const bool defaultBranchReturns =
-      !defaultBranchNode || defaultBranchNode->returnsOnAllControlPaths(doSetPredecessorsUnreachable);
+      defaultBranchNode && defaultBranchNode->returnsOnAllControlPaths(doSetPredecessorsUnreachable);
 
   return allCaseBranchesReturn && defaultBranchReturns;
 }

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
@@ -4,6 +4,7 @@ source_filename = "source.spice"
 @anon.string.0 = private unnamed_addr constant [6 x i8] c"Apple\00", align 1
 @anon.string.1 = private unnamed_addr constant [7 x i8] c"Banana\00", align 1
 @anon.string.2 = private unnamed_addr constant [7 x i8] c"Orange\00", align 1
+@anon.string.3 = private unnamed_addr constant [1 x i8] zeroinitializer, align 1
 @printf.str.0 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
 @printf.str.1 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
 @printf.str.2 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 1
@@ -29,8 +30,7 @@ switch.case.L11:                                  ; preds = %1
   ret ptr @anon.string.2
 
 switch.exit.L8:                                   ; preds = %1
-  %3 = load ptr, ptr %result, align 8
-  ret ptr %3
+  ret ptr @anon.string.3
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/source.spice
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/source.spice
@@ -10,6 +10,7 @@ f<string> getName(Fruit input) {
         case Fruit::Banana: { return "Banana"; }
         case Fruit::Orange: { return "Orange"; }
     }
+    return "";
 }
 
 f<int> main() {


### PR DESCRIPTION
Fix the following warning:

```spice
public f<string> getOptLevelNameFromOptLevel(OptimizationLevel optLevel) {
    switch optLevel {
        case OptimizationLevel::O0: { return "O0"; }
        case OptimizationLevel::O1: { return "O1"; }
        case OptimizationLevel::O2: { return "O2"; }
        case OptimizationLevel::O3: { return "O3"; }
        case OptimizationLevel::Os: { return "Os"; }
        case OptimizationLevel::Oz: { return "Oz"; }
    }
    return "Invalid optimization level"; // <- This was marked unreachable, although it is not
}
```