### PR TITLE
Fix array to ptr decay assignments

### DIFF
--- a/test/test-files/irgenerator/pointers/success-pointer-arithmetic/source.spice
+++ b/test/test-files/irgenerator/pointers/success-pointer-arithmetic/source.spice
@@ -1,6 +1,6 @@
 f<int> main() {
     int[3] a = [1, 2, 3];
-    int* aPtr = &a[0];
+    int* aPtr = a;
     assert *aPtr == 1;
     unsafe { aPtr++; }
     assert *aPtr == 2;


### PR DESCRIPTION
This fixes miscompilations when assigning arrays with known size to pointers by value. This corresponds to an array to pointer decay and can be performed with an inbounds GEP and behaves essentially the same as when assigning the address of the 0th array element to the pointer e.g. `int* intPtr = intArray` is equivalent to `int* intPtr = &intArray[0]`, but only the former was working. Now do both.