### PR TITLE
Fix bug where the ctor for structs with VTable was not enforced

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,18 +1,38 @@
+type Visitor struct {}
+
+type SymbolTable struct {}
+
+type Visitable interface {
+    f<bool> accept(Visitor*);
+}
+
+type AstNode struct : Visitable {}
+
+type AstEntryNode struct : Visitable {
+    AstNode astNode
+    SymbolTable* extFunctionScope
+    bool takesArgs
+}
+
 f<int> main() {
-    int[3] a = [1, 2, 3];
-    int* aPtr = a;
-    printf("%d\n", *aPtr);
-    unsafe {
-        aPtr++;
-    }
-    printf("%d\n", *aPtr);
+    AstEntryNode entryNode;
+    printf("%d", entryNode.takesArgs);
 }
 
 /*import "bootstrap/util/block-allocator";
 import "bootstrap/util/memory";
 
+type ASTNode struct {
+    int value
+}
+
+p ASTNode.dtor() {
+    printf("Dtor called!");
+}
+
 f<int> main() {
     DefaultMemoryManager defaultMemoryManager;
     IMemoryManager* memoryManager = &defaultMemoryManager;
-    BlockAllocator<int> allocator = BlockAllocator<int>(memoryManager, 10l);
+    memoryManager.allocate(10l);
+    //BlockAllocator<ASTNode> allocator = BlockAllocator<ASTNode>(memoryManager, 10l);
 }*/

--- a/src-bootstrap/util/block-allocator.spice
+++ b/src-bootstrap/util/block-allocator.spice
@@ -1,6 +1,5 @@
 // Std imports
 import "std/data/vector";
-import "std/type/long";
 import "std/os/system";
 
 // Own imports
@@ -10,7 +9,7 @@ type Base dyn;
 
 public type BlockAllocator<Base> struct {
     IMemoryManager* memoryManager
-    Vector<heap byte*> memoryBlocks
+    Vector<byte*> memoryBlocks
     Vector<Base*> allocatedObjects
     unsigned long blockSize
     unsigned long offsetInBlock = 0l

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -325,6 +325,25 @@ std::vector<Function *> Scope::getVirtualMethods() {
 }
 
 /**
+ * Retrieve all struct manifestations in this scope in the order of their declaration
+ *
+ * @return All struct manifestations in declaration order
+ */
+std::vector<const Struct *> Scope::getAllStructManifestationsInDeclarationOrder() const {
+  // Retrieve all struct manifestations in this scope
+  std::vector<const Struct *> manifestations;
+  manifestations.reserve(structs.size()); // Reserve at least the size of individual generic structs
+  for (const auto &[structId, structManifestations] : structs)
+    for (const auto &[_, manifestation] : structManifestations)
+      manifestations.push_back(&manifestation);
+
+  // Sort manifestations by declaration code location
+  auto sortLambda = [](const Struct *lhs, const Struct *rhs) { return lhs->getDeclCodeLoc() < rhs->getDeclCodeLoc(); };
+  std::ranges::sort(manifestations, sortLambda);
+  return manifestations;
+}
+
+/**
  * Check if this struct has any reference fields
  *
  * @return Has reference fields or not

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -80,6 +80,7 @@ public:
   void ensureSuccessfulTypeInference() const;
   [[nodiscard]] size_t getFieldCount() const;
   [[nodiscard]] std::vector<Function *> getVirtualMethods();
+  [[nodiscard]] std::vector<const Struct *> getAllStructManifestationsInDeclarationOrder() const;
   [[nodiscard]] bool hasRefFields();
   [[nodiscard]] unsigned int getLoopNestingDepth() const;
   [[nodiscard]] bool isInCaseBranch() const;

--- a/test/test-files/typechecker/structs/error-missing-no-args-ctor-ref-fields/exception.out
+++ b/test/test-files/typechecker/structs/error-missing-no-args-ctor-ref-fields/exception.out
@@ -1,0 +1,8 @@
+[Error|Compiler]:
+Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
+
+[Error|Semantic] ./source.spice:7:5:
+No matching ctor found: Struct 'TypeWithVTable' misses a no-args constructor
+
+7  TypeWithVTable v;
+   ^^^^^^^^^^^^^^^^

--- a/test/test-files/typechecker/structs/error-missing-no-args-ctor-ref-fields/source.spice
+++ b/test/test-files/typechecker/structs/error-missing-no-args-ctor-ref-fields/source.spice
@@ -1,0 +1,8 @@
+type TypeWithVTable struct {
+    int& refField
+}
+
+f<int> main() {
+    // Types containing reference fields can't have a default constructor, thus this should fail
+    TypeWithVTable v;
+}

--- a/test/test-files/typechecker/structs/error-missing-no-args-ctor-vtable/exception.out
+++ b/test/test-files/typechecker/structs/error-missing-no-args-ctor-vtable/exception.out
@@ -1,0 +1,8 @@
+[Error|Compiler]:
+Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
+
+[Error|Semantic] ./source.spice:13:5:
+No matching ctor found: Struct 'TypeWithVTable' misses a no-args constructor
+
+13  TypeWithVTable v;
+    ^^^^^^^^^^^^^^^^

--- a/test/test-files/typechecker/structs/error-missing-no-args-ctor-vtable/source.spice
+++ b/test/test-files/typechecker/structs/error-missing-no-args-ctor-vtable/source.spice
@@ -1,0 +1,14 @@
+type TypeContainingRefField struct {
+    int& refField
+}
+
+#[core.compiler.alwaysEmitVTable]
+type TypeWithVTable struct {
+    TypeContainingRefField refFieldStruct
+}
+
+f<int> main() {
+    // Can't call default ctor, because it can't be generated due to the reference field
+    // But we need to call it to trigger the generation of the vtable.
+    TypeWithVTable v;
+}


### PR DESCRIPTION
- Fix bug where the ctor for structs with VTable was not enforced
- Fix bug where the default ctor/copy ctor was not generated although the struct has a VTable, that needs to be initialized
- Fix bug where default ctor/copy ctor/dtor was not generated in the correct order, which is declaration order
- Add tests