### PR TITLE
Rename SymbolType to Type

### DIFF
--- a/src-bootstrap/ast/ast-nodes.spice
+++ b/src-bootstrap/ast/ast-nodes.spice
@@ -32,7 +32,7 @@ public type ASTNode struct /*: IVisitable*/ {
     Vector<ASTNode*> children
     CodeLoc codeLoc
     string errorMessage
-    //Vector<SymbolType> symbolTypes
+    //Vector<Type> symbolTypes
     bool unreachable = false
     //Vector<Vector<const Function*>> opFct // Operator overloading functions
 }

--- a/src-bootstrap/model/function.spice
+++ b/src-bootstrap/model/function.spice
@@ -4,13 +4,13 @@ import "std/data/map";
 
 // Helper structs
 public type Param struct {
-    SymbolType sType
+    Type sType
     bool isOptional
 }
 
 public type NamedParam struct {
     String name
-    SymbolType sType
+    Type sType
     bool isOptional
 }
 
@@ -20,11 +20,11 @@ type NamedParamList alias Vector<NamedParam>;
 
 public type Function struct {
     String name
-    SymbolType thisType
-    SymbolType returnType
+    Type thisType
+    Type returnType
     ParamLits paramList
     Vector<GenericType> templateTypes
-    Map<String, SymbolType> typeMapping
+    Map<String, Type> typeMapping
     SymbolTableEntry* entry
     ASTNode* declNode
     bool genericSubstantiation

--- a/src-bootstrap/symboltablebuilder/symbol-table.spice
+++ b/src-bootstrap/symboltablebuilder/symbol-table.spice
@@ -75,7 +75,7 @@ public p SymbolTable.ctor(
  */
 public p SymbolTable.insert(
     const string name,
-    const SymbolType symbolType,
+    const Type symbolType,
     const TypeSpecifiers specifiers,
     const SymbolState state,
     const AstNode* declNode
@@ -93,7 +93,7 @@ public p SymbolTable.insert(
  * @param symbolType Type of the symbol
  * @param declNode AST node where the symbol is declared
  */
-public p SymbolTable.insertAnonymous(const SymbolType symbolType, const AstNode* declNode) {
+public p SymbolTable.insertAnonymous(const Type symbolType, const AstNode* declNode) {
     string name = "anon." + declNode.codeLoc.toString();
     this.insert(name, symbolType, TypeSpecifiers(symbolType), SymbolState.DECLARED, declNode);
     this.lookupAnonymous(declNode.codeLoc).used = true;
@@ -385,8 +385,8 @@ public f<Function*> SymbolTable.insertFunction(const Function *function) {
 public f<Function*> SymbolTable.matchFunction(
     SymbolTable* currentScope,
     const string callFunctionName,
-    const SymbolType callThisType,
-    const Vector<SymbolType>* callArgTypes,
+    const Type callThisType,
+    const Vector<Type>* callArgTypes,
     const AstNode* node
 ) {
     Vector<Function*> matches;
@@ -486,7 +486,7 @@ public f<Struct*> SymbolTable.insertStruct(const Struct *spiceStruct) {
 public f<Struct*> SymbolTable.matchStruct(
     SymbolTable* currentScope,
     const string structName,
-    const Vector<SymbolType>* templateTypes,
+    const Vector<Type>* templateTypes,
     const AstNode* node
 ) {
     Vector<Struct*> matches;
@@ -562,7 +562,7 @@ public p SymbolTable.insertInterface(const Interface* i) {
     assert !this.interfaces.contains(i.name);
     this.interfaces.insert(i.name, i);
     // Add symbol table entry for the interface
-    this.insert(i.name, SymbolType(TY_INTERFACE), i.specifiers, INITIALIZED, i.declNode);
+    this.insert(i.name, Type(TY_INTERFACE), i.specifiers, INITIALIZED, i.declNode);
 }
 
 /**

--- a/src-bootstrap/symboltablebuilder/symbol-type.spice
+++ b/src-bootstrap/symboltablebuilder/symbol-type.spice
@@ -5,7 +5,7 @@ import "std/data/vector";
 import "../util/common-util";
 import "../symboltablebuilder/scope";
 
-public type SymbolSuperType enum {
+public type SuperType enum {
     TY_INVALID,
     TY_UNRESOLVED,
     TY_DOUBLE,
@@ -37,11 +37,11 @@ type TypeChainElementData struct {
 }
 
 type TypeChainElement struct {
-    SymbolSuperType superType = SymbolSuperType::TY_DYN
+    SuperType superType = SuperType::TY_DYN
     String subType
     TypeChainElementData data
-    Vector<SymbolType> templateTypes
-    Vector<SymbolType> paramTypes // First type is the return type
+    Vector<Type> templateTypes
+    Vector<Type> paramTypes // First type is the return type
 }
 
 f<bool> operator==(const TypeChainElement& lhs, const TypeChainElement& rhs) {
@@ -74,11 +74,11 @@ f<bool> operator==(const TypeChainElement& lhs, const TypeChainElement& rhs) {
 
 type TypeChain alias Vector<TypeChainElement>;
 
-public type SymbolType struct {
+public type Type struct {
     Vector<TypeChainElement> typeChain
     bool isBaseTypeSigned
 }
 
-p SymbolType.ctor() {
+p Type.ctor() {
     this.isBaseTypeSigned = true;
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,8 +50,8 @@ set(SOURCES
         symboltablebuilder/SymbolTableEntry.h
         symboltablebuilder/Capture.cpp
         symboltablebuilder/Capture.h
-        symboltablebuilder/SymbolType.cpp
-        symboltablebuilder/SymbolType.h
+        symboltablebuilder/Type.cpp
+        symboltablebuilder/Type.h
         symboltablebuilder/TypeChain.cpp
         symboltablebuilder/TypeSpecifiers.cpp
         symboltablebuilder/TypeSpecifiers.h

--- a/src/ast/ASTBuilder.cpp
+++ b/src/ast/ASTBuilder.cpp
@@ -884,9 +884,9 @@ std::any ASTBuilder::visitAdditiveExpr(SpiceParser::AdditiveExprContext *ctx) {
 
   for (ParserRuleContext::ParseTree *subTree : ctx->children) {
     if (auto t1 = dynamic_cast<TerminalNode *>(subTree); t1 != nullptr && t1->getSymbol()->getType() == SpiceParser::PLUS)
-      additiveExprNode->opQueue.emplace(AdditiveExprNode::OP_PLUS, SymbolType(TY_INVALID));
+      additiveExprNode->opQueue.emplace(AdditiveExprNode::OP_PLUS, Type(TY_INVALID));
     else if (auto t2 = dynamic_cast<TerminalNode *>(subTree); t2 != nullptr && t2->getSymbol()->getType() == SpiceParser::MINUS)
-      additiveExprNode->opQueue.emplace(AdditiveExprNode::OP_MINUS, SymbolType(TY_INVALID));
+      additiveExprNode->opQueue.emplace(AdditiveExprNode::OP_MINUS, Type(TY_INVALID));
   }
 
   return concludeNode(additiveExprNode);
@@ -900,11 +900,11 @@ std::any ASTBuilder::visitMultiplicativeExpr(SpiceParser::MultiplicativeExprCont
 
   for (ParserRuleContext::ParseTree *subTree : ctx->children) {
     if (auto t1 = dynamic_cast<TerminalNode *>(subTree); t1 != nullptr && t1->getSymbol()->getType() == SpiceParser::MUL)
-      multiplicativeExprNode->opQueue.emplace(MultiplicativeExprNode::OP_MUL, SymbolType(TY_INVALID));
+      multiplicativeExprNode->opQueue.emplace(MultiplicativeExprNode::OP_MUL, Type(TY_INVALID));
     else if (auto t2 = dynamic_cast<TerminalNode *>(subTree); t2 != nullptr && t2->getSymbol()->getType() == SpiceParser::DIV)
-      multiplicativeExprNode->opQueue.emplace(MultiplicativeExprNode::OP_DIV, SymbolType(TY_INVALID));
+      multiplicativeExprNode->opQueue.emplace(MultiplicativeExprNode::OP_DIV, Type(TY_INVALID));
     else if (auto t3 = dynamic_cast<TerminalNode *>(subTree); t3 != nullptr && t3->getSymbol()->getType() == SpiceParser::REM)
-      multiplicativeExprNode->opQueue.emplace(MultiplicativeExprNode::OP_REM, SymbolType(TY_INVALID));
+      multiplicativeExprNode->opQueue.emplace(MultiplicativeExprNode::OP_REM, Type(TY_INVALID));
   }
 
   return concludeNode(multiplicativeExprNode);

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -83,7 +83,7 @@ public:
       child->resizeToNumberOfManifestations(manifestationCount);
     }
     // Reserve this node
-    symbolTypes.resize(manifestationCount, SymbolType(TY_INVALID));
+    symbolTypes.resize(manifestationCount, Type(TY_INVALID));
     // Do custom work
     customItemsInitialization(manifestationCount);
   }
@@ -99,13 +99,13 @@ public:
 
   virtual void customItemsInitialization(size_t) {} // Noop
 
-  SymbolType setEvaluatedSymbolType(const SymbolType &symbolType, const size_t idx) {
+  Type setEvaluatedSymbolType(const Type &symbolType, const size_t idx) {
     assert(symbolTypes.size() > idx);
     symbolTypes.at(idx) = symbolType;
     return symbolType;
   }
 
-  [[nodiscard]] const SymbolType &getEvaluatedSymbolType(const size_t idx) const { // NOLINT(misc-no-recursion)
+  [[nodiscard]] const Type &getEvaluatedSymbolType(const size_t idx) const { // NOLINT(misc-no-recursion)
     if (!symbolTypes.empty() && !symbolTypes.at(idx).is(TY_INVALID))
       return symbolTypes.at(idx);
     if (children.size() != 1)
@@ -159,7 +159,7 @@ public:
   ASTNode *parent = nullptr;
   std::vector<ASTNode *> children;
   const CodeLoc codeLoc;
-  std::vector<SymbolType> symbolTypes;
+  std::vector<Type> symbolTypes;
   bool unreachable = false;
 };
 
@@ -1638,7 +1638,7 @@ public:
   };
 
   // Typedefs
-  typedef std::queue<std::pair<AdditiveOp, SymbolType>> OpQueue;
+  typedef std::queue<std::pair<AdditiveOp, Type>> OpQueue;
 
   // Constructors
   using ExprNode::ExprNode;
@@ -1674,7 +1674,7 @@ public:
   };
 
   // Typedefs
-  typedef std::queue<std::pair<MultiplicativeOp, SymbolType>> OpQueue;
+  typedef std::queue<std::pair<MultiplicativeOp, Type>> OpQueue;
 
   // Constructors
   using ExprNode::ExprNode;
@@ -1908,7 +1908,7 @@ public:
     // Members
     FctCallType callType = TYPE_ORDINARY;
     bool isImported = false;
-    SymbolType thisType = SymbolType(TY_DYN); // Is filled if method or ctor call
+    Type thisType = Type(TY_DYN); // Is filled if method or ctor call
     std::vector<ExprResult> argResults;
     Function *callee = nullptr;
     Scope *calleeParentScope = nullptr;

--- a/src/global/RuntimeModuleManager.h
+++ b/src/global/RuntimeModuleManager.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <unordered_map>
 
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 
 namespace spice::compiler {
 

--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -120,7 +120,7 @@ void DebugInfoGenerator::generateFunctionDebugInfo(llvm::Function *llvmFunction,
     llvm::DIType *captureStructPtr = diBuilder->createPointerType(captureStructType, pointerWidth);
     argTypes.push_back(captureStructPtr); // Add this type
   }
-  for (const SymbolType &argType : spiceFunc->getParamTypes()) // Add arg types
+  for (const Type &argType : spiceFunc->getParamTypes()) // Add arg types
     argTypes.push_back(getDITypeForSymbolType(node, argType));
 
   // Create function type
@@ -176,9 +176,9 @@ llvm::DICompositeType *DebugInfoGenerator::generateCaptureStructDebugInfo(const 
   // Get LLVM type for struct
   std::vector<llvm::Type *> fieldTypes;
   std::vector<SymbolTableEntry *> fieldEntries;
-  std::vector<SymbolType> fieldSymbolTypes;
+  std::vector<Type> fieldSymbolTypes;
   for (const auto &[_, capture] : captures) {
-    SymbolType captureType = capture.capturedEntry->getType();
+    Type captureType = capture.capturedEntry->getType();
 
     // Capture by reference
     if (capture.getMode() == BY_REFERENCE)
@@ -275,7 +275,7 @@ void DebugInfoGenerator::finalize() {
     diBuilder->finalize();
 }
 
-llvm::DIType *DebugInfoGenerator::getDITypeForSymbolType(const ASTNode *node, const SymbolType &symbolType) const {
+llvm::DIType *DebugInfoGenerator::getDITypeForSymbolType(const ASTNode *node, const Type &symbolType) const {
   // Pointer type
   if (symbolType.isPtr()) {
     llvm::DIType *pointeeTy = getDITypeForSymbolType(node, symbolType.getContainedTy());
@@ -357,7 +357,7 @@ llvm::DIType *DebugInfoGenerator::getDITypeForSymbolType(const ASTNode *node, co
       if (fieldEntry->isImplicitField)
         continue;
 
-      const SymbolType fieldType = fieldEntry->getType();
+      const Type fieldType = fieldEntry->getType();
       const size_t fieldLineNo = fieldEntry->declNode->codeLoc.line;
       const size_t offsetInBits = structLayout->getElementOffsetInBits(i);
 

--- a/src/irgenerator/DebugInfoGenerator.h
+++ b/src/irgenerator/DebugInfoGenerator.h
@@ -12,7 +12,7 @@ namespace spice::compiler {
 // Forward declarations
 class IRGenerator;
 class SymbolTableEntry;
-class SymbolType;
+class Type;
 class Function;
 class Struct;
 class ASTNode;
@@ -62,7 +62,7 @@ private:
   llvm::DICompositeType *fatPtrTy = nullptr;
 
   // Private methods
-  [[nodiscard]] llvm::DIType *getDITypeForSymbolType(const ASTNode *node, const SymbolType &symbolType) const;
+  [[nodiscard]] llvm::DIType *getDITypeForSymbolType(const ASTNode *node, const Type &symbolType) const;
 };
 
 } // namespace spice::compiler

--- a/src/irgenerator/GenBuiltinFunctions.cpp
+++ b/src/irgenerator/GenBuiltinFunctions.cpp
@@ -18,7 +18,7 @@ std::any IRGenerator::visitPrintfCall(const PrintfCallNode *node) {
   // Collect replacement arguments
   for (AssignExprNode *arg : node->args()) {
     // Retrieve type of argument
-    const SymbolType argSymbolType = arg->getEvaluatedSymbolType(manIdx);
+    const Type argSymbolType = arg->getEvaluatedSymbolType(manIdx);
     llvm::Type *argType = argSymbolType.toLLVMType(context, currentScope);
 
     // Re-map some values
@@ -89,7 +89,7 @@ std::any IRGenerator::visitAlignofCall(const AlignofCallNode *node) {
 
 std::any IRGenerator::visitLenCall(const LenCallNode *node) {
   // Check if the length is fixed and known via the symbol type
-  SymbolType symbolType = node->assignExpr()->getEvaluatedSymbolType(manIdx);
+  Type symbolType = node->assignExpr()->getEvaluatedSymbolType(manIdx);
   symbolType = symbolType.removeReferenceWrapper();
 
   llvm::Value *lengthValue;

--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -95,8 +95,8 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
 
   // Resolve iterator
   AssignExprNode *iteratorAssignNode = node->iteratorAssign();
-  SymbolType iteratorOrIterableType = iteratorAssignNode->getEvaluatedSymbolType(manIdx).removeReferenceWrapper();
-  SymbolType iteratorType = iteratorOrIterableType;
+  Type iteratorOrIterableType = iteratorAssignNode->getEvaluatedSymbolType(manIdx).removeReferenceWrapper();
+  Type iteratorType = iteratorOrIterableType;
   llvm::Value *iteratorPtr;
   if (node->getIteratorFct != nullptr) { // The iteratorAssignExpr is of type Iterable
     iteratorType = node->getIteratorFct->returnType;
@@ -127,8 +127,8 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
     iteratorPtr = resolveAddress(iteratorAssignNode);
   }
 
-  const SymbolType itemSTy = iteratorType.getTemplateTypes().front();
-  const SymbolType itemRefSTy = itemSTy.toReference(node);
+  const Type itemSTy = iteratorType.getTemplateTypes().front();
+  const Type itemRefSTy = itemSTy.toReference(node);
   assert(!node->getFct || itemRefSTy == node->getFct->returnType);
   assert(!node->getIdxFct || itemRefSTy == node->getIdxFct->returnType.getTemplateTypes().back());
 
@@ -182,7 +182,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
     llvm::Value *idxAddrInPair = insertStructGEP(pairTy, pairPtr, 0, "idx_addr");
     LLVMExprResult idxResult = {.ptr = idxAddrInPair};
     assert(idxAddress != nullptr && idxEntry != nullptr);
-    doAssignment(idxAddress, idxEntry, idxResult, SymbolType(TY_LONG), true);
+    doAssignment(idxAddress, idxEntry, idxResult, Type(TY_LONG), true);
     // Store item to item var
     llvm::Value *itemAddrInPair = insertStructGEP(pairTy, pairPtr, 1, "item_addr");
     LLVMExprResult itemResult = {.refPtr = itemAddrInPair};

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -22,8 +22,8 @@ std::any IRGenerator::visitAssignExpr(const AssignExprNode *node) {
       return doAssignment(lhsNode, rhsNode);
     } else { // Compound assignment
       // Get symbol types of left and right side
-      const SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
-      const SymbolType rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
+      const Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+      const Type rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
 
       // Retrieve rhs
       auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
@@ -226,14 +226,14 @@ std::any IRGenerator::visitBitwiseOrExpr(const BitwiseOrExprNode *node) {
   // It is a bitwise or expression
   // Evaluate first operand
   BitwiseXorExprNode *lhsNode = node->operands().front();
-  const SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  const Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto result = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   // Evaluate all additional operands
   for (size_t i = 1; i < node->operands().size(); i++) {
     // Evaluate the operand
     BitwiseXorExprNode *rhsNode = node->operands()[i];
-    const SymbolType rhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+    const Type rhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
     auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
     result = conversionManager.getBitwiseOrInst(node, result, lhsSTy, rhs, rhsSTy, currentScope, i - 1);
   }
@@ -252,14 +252,14 @@ std::any IRGenerator::visitBitwiseXorExpr(const BitwiseXorExprNode *node) {
   // It is a bitwise xor expression
   // Evaluate first operand
   BitwiseAndExprNode *lhsNode = node->operands().front();
-  const SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  const Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto result = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   // Evaluate all additional operands
   for (size_t i = 1; i < node->operands().size(); i++) {
     // Evaluate the operand
     BitwiseAndExprNode *rhsNode = node->operands()[i];
-    const SymbolType rhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+    const Type rhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
     auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
     result = conversionManager.getBitwiseXorInst(node, result, lhsSTy, rhs, rhsSTy, currentScope);
   }
@@ -278,14 +278,14 @@ std::any IRGenerator::visitBitwiseAndExpr(const BitwiseAndExprNode *node) {
   // It is a bitwise and expression
   // Evaluate first operand
   EqualityExprNode *lhsNode = node->operands().front();
-  const SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  const Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto result = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   // Evaluate all additional operands
   for (size_t i = 1; i < node->operands().size(); i++) {
     // Evaluate the operand
     EqualityExprNode *rhsNode = node->operands()[i];
-    const SymbolType rhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+    const Type rhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
     auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
     result = conversionManager.getBitwiseAndInst(rhsNode, result, lhsSTy, rhs, rhsSTy, currentScope, i - 1);
   }
@@ -304,12 +304,12 @@ std::any IRGenerator::visitEqualityExpr(const EqualityExprNode *node) {
   // It is an equality expression
   // Evaluate lhs
   RelationalExprNode *lhsNode = node->operands()[0];
-  const SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  const Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto result = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   // Evaluate rhs
   RelationalExprNode *rhsNode = node->operands()[1];
-  const SymbolType rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
+  const Type rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
   auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
 
   // Retrieve the result value, based on the exact operator
@@ -338,12 +338,12 @@ std::any IRGenerator::visitRelationalExpr(const RelationalExprNode *node) {
   // It is a relational expression
   // Evaluate lhs
   ShiftExprNode *lhsNode = node->operands()[0];
-  const SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  const Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto result = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   // Evaluate rhs
   ShiftExprNode *rhsNode = node->operands()[1];
-  const SymbolType rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
+  const Type rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
   auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
 
   // Retrieve the result value, based on the exact operator
@@ -378,12 +378,12 @@ std::any IRGenerator::visitShiftExpr(const ShiftExprNode *node) {
   // It is a shift expression
   // Evaluate lhs
   AdditiveExprNode *lhsNode = node->operands()[0];
-  const SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  const Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto result = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   // Evaluate rhs
   AdditiveExprNode *rhsNode = node->operands()[1];
-  const SymbolType rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
+  const Type rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
   auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
 
   // Retrieve the result value, based on the exact operator
@@ -412,7 +412,7 @@ std::any IRGenerator::visitAdditiveExpr(const AdditiveExprNode *node) {
   // It is an additive expression
   // Evaluate first operand
   MultiplicativeExprNode *lhsNode = node->operands()[0];
-  SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto lhs = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   auto opQueue = node->opQueue;
@@ -422,7 +422,7 @@ std::any IRGenerator::visitAdditiveExpr(const AdditiveExprNode *node) {
     // Evaluate next operand
     MultiplicativeExprNode *rhsNode = node->operands()[operandIndex++];
     assert(rhsNode != nullptr);
-    const SymbolType rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
+    const Type rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
     auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
 
     // Retrieve the result, based on the exact operator
@@ -457,7 +457,7 @@ std::any IRGenerator::visitMultiplicativeExpr(const MultiplicativeExprNode *node
   // It is an additive expression
   // Evaluate first operand
   CastExprNode *lhsNode = node->operands()[0];
-  SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto result = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   auto opQueue = node->opQueue;
@@ -467,7 +467,7 @@ std::any IRGenerator::visitMultiplicativeExpr(const MultiplicativeExprNode *node
     // Evaluate next operand
     CastExprNode *rhsNode = node->operands()[operandIndex++];
     assert(rhsNode != nullptr);
-    const SymbolType rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
+    const Type rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
     auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
 
     // Retrieve the result, based on the exact operator
@@ -503,11 +503,11 @@ std::any IRGenerator::visitCastExpr(const CastExprNode *node) {
 
   // It is a cast expression
   // Retrieve target symbol type
-  const SymbolType targetSTy = node->getEvaluatedSymbolType(manIdx);
+  const Type targetSTy = node->getEvaluatedSymbolType(manIdx);
 
   // Evaluate rhs
   PrefixUnaryExprNode *rhsNode = node->prefixUnaryExpr();
-  const SymbolType rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
+  const Type rhsSTy = rhsNode->getEvaluatedSymbolType(manIdx);
   auto rhs = std::any_cast<LLVMExprResult>(visit(rhsNode));
 
   // Retrieve the result value
@@ -526,7 +526,7 @@ std::any IRGenerator::visitPrefixUnaryExpr(const PrefixUnaryExprNode *node) {
 
   // Evaluate lhs
   PrefixUnaryExprNode *lhsNode = node->prefixUnary();
-  SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto lhs = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   switch (node->op) {
@@ -652,7 +652,7 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
 
   // Evaluate lhs
   PostfixUnaryExprNode *lhsNode = node->postfixUnaryExpr();
-  SymbolType lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
+  Type lhsSTy = lhsNode->getEvaluatedSymbolType(manIdx);
   auto lhs = std::any_cast<LLVMExprResult>(visit(lhsNode));
 
   switch (node->op) {
@@ -708,7 +708,7 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
     std::vector<size_t> indexPath;
     lhs.entry = structScope->symbolTable.lookupInComposedFields(fieldName, indexPath);
     assert(lhs.entry != nullptr);
-    SymbolType fieldSymbolType = lhs.entry->getType();
+    Type fieldSymbolType = lhs.entry->getType();
 
     // Get address of the field in the struct instance
     std::vector<llvm::Value *> indices = {builder.getInt32(0)};
@@ -821,7 +821,7 @@ std::any IRGenerator::visitAtomicExpr(const AtomicExprNode *node) {
   assert(varEntry != nullptr);
   Scope *accessScope = data.accessScope;
   assert(accessScope != nullptr);
-  SymbolType varSymbolType = varEntry->getType();
+  Type varSymbolType = varEntry->getType();
   llvm::Type *varType = varSymbolType.toLLVMType(context, accessScope);
 
   // Check if external global variable

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -20,7 +20,7 @@ static const char *const TEST_CASE_SUCCESS_MSG = "\033[1m\033[32m[ PASSED   ]\03
 static const char *const TEST_CASE_FAILED_MSG = "\033[1m\033[31m[ FAILED   ]\033[0m\033[22m %s\n";
 static const char *const TEST_CASE_SKIPPED_MSG = "\033[1m\033[33m[ SKIPPED  ]\033[0m\033[22m %s\n";
 
-llvm::Value *IRGenerator::doImplicitCast(llvm::Value *src, SymbolType dstSTy, SymbolType srcSTy) {
+llvm::Value *IRGenerator::doImplicitCast(llvm::Value *src, Type dstSTy, Type srcSTy) {
   assert(srcSTy != dstSTy); // We only need to cast implicitly, if the types do not match exactly
 
   // Unpack the pointers until a pointer of another type is met
@@ -313,7 +313,7 @@ void IRGenerator::generateCtorBodyPreamble(Scope *bodyScope) {
   llvm::Value *thisAddress = thisEntry->getAddress();
   assert(thisAddress != nullptr);
   llvm::Value *thisAddressLoaded = nullptr;
-  SymbolType structSymbolType = thisEntry->getType().getBaseType();
+  Type structSymbolType = thisEntry->getType().getBaseType();
   llvm::Type *structType = structSymbolType.toLLVMType(context, structScope);
 
   // Store VTable to first struct field if required
@@ -336,7 +336,7 @@ void IRGenerator::generateCtorBodyPreamble(Scope *bodyScope) {
       continue;
 
     // Call ctor for struct fields
-    const SymbolType &fieldType = fieldSymbol->getType();
+    const Type &fieldType = fieldSymbol->getType();
     auto fieldNode = spice_pointer_cast<FieldNode *>(fieldSymbol->declNode);
     if (fieldType.is(TY_STRUCT)) {
       // Lookup ctor function and call if available
@@ -400,7 +400,7 @@ void IRGenerator::generateCopyCtorBodyPreamble(const Function *copyCtorFunction)
       continue;
 
     // Call copy ctor for struct fields
-    const SymbolType &fieldType = fieldSymbol->getType();
+    const Type &fieldType = fieldSymbol->getType();
     if (fieldType.is(TY_STRUCT)) {
       // Lookup copy ctor function and call if available
       Scope *matchScope = fieldType.getBodyScope();
@@ -445,7 +445,7 @@ void IRGenerator::generateDtorBodyPreamble(const Function *dtorFunction) {
       continue;
 
     // Call dtor for struct fields
-    const SymbolType &fieldType = fieldSymbol->getType();
+    const Type &fieldType = fieldSymbol->getType();
     if (fieldType.is(TY_STRUCT)) {
       // Lookup dtor function and generate call if found
       const Function *dtorFct = FunctionManager::lookupFunction(fieldType.getBodyScope(), DTOR_FUNCTION_NAME, fieldType, {}, false);
@@ -494,13 +494,13 @@ void IRGenerator::generateTestMain() {
   llvm::Constant *skippedMsg = createGlobalStringConst("skippedMsg", TEST_CASE_SKIPPED_MSG, *rootScope->codeLoc);
 
   // Prepare entry for test main
-  SymbolType functionType(TY_FUNCTION);
+  Type functionType(TY_FUNCTION);
   functionType.specifiers = TypeSpecifiers::of(TY_FUNCTION);
   functionType.specifiers.isPublic = true;
   SymbolTableEntry entry(MAIN_FUNCTION_NAME, functionType, rootScope, nullptr, 0, false);
 
   // Prepare test main function
-  Function testMain(MAIN_FUNCTION_NAME, &entry, SymbolType(TY_DYN), SymbolType(TY_INT), {}, {}, nullptr);
+  Function testMain(MAIN_FUNCTION_NAME, &entry, Type(TY_DYN), Type(TY_INT), {}, {}, nullptr);
   testMain.used = true; // Mark as used to prevent removal
   testMain.implicitDefault = true;
   testMain.mangleFunctionName = false;

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -36,7 +36,7 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
   // Get variable entry
   SymbolTableEntry *varEntry = node->entries.at(manIdx);
   assert(varEntry != nullptr);
-  const SymbolType varSymbolType = varEntry->getType();
+  const Type varSymbolType = varEntry->getType();
 
   // Get LLVM type of variable
   Scope *accessScope = currentScope;

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -25,7 +25,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
 
   // Visit parameters
   std::vector<std::pair<std::string, SymbolTableEntry *>> paramInfoList;
-  std::vector<SymbolType> paramSymbolTypes;
+  std::vector<Type> paramSymbolTypes;
   std::vector<llvm::Type *> paramTypes;
   if (node->takesArgs) {
     const size_t numOfParams = node->paramLst()->params().size();
@@ -141,7 +141,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
 
     // Change to struct scope
     if (manifestation->isMethod()) {
-      const SymbolType &thisType = manifestation->thisType;
+      const Type &thisType = manifestation->thisType;
       const std::string signature = Struct::getSignature(thisType.getSubType(), thisType.getTemplateTypes());
       currentScope = currentScope->getChildScope(STRUCT_SCOPE_PREFIX + signature);
       assert(currentScope != nullptr);
@@ -173,10 +173,10 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
         // Get symbol table entry of param
         SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
         assert(paramSymbol != nullptr);
-        const SymbolType paramSymbolType = manifestation->getParamTypes().at(argIdx);
+        const Type paramSymbolType = manifestation->getParamTypes().at(argIdx);
         // Pass the information if captures are taken for function/procedure types
         if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures()) {
-          SymbolType paramSymbolSymbolType = paramSymbol->getType();
+          Type paramSymbolSymbolType = paramSymbol->getType();
           paramSymbolSymbolType.setHasLambdaCaptures(true);
           paramSymbol->updateType(paramSymbolSymbolType, true);
         }
@@ -313,7 +313,7 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
 
     // Change to struct scope
     if (manifestation->isMethod()) {
-      const SymbolType &thisType = manifestation->thisType;
+      const Type &thisType = manifestation->thisType;
       const std::string signature = Struct::getSignature(thisType.getSubType(), thisType.getTemplateTypes());
       currentScope = currentScope->getChildScope(STRUCT_SCOPE_PREFIX + signature);
       assert(currentScope != nullptr);
@@ -345,10 +345,10 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
         // Get symbol table entry of param
         SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
         assert(paramSymbol != nullptr);
-        const SymbolType paramSymbolType = manifestation->getParamTypes().at(argIdx);
+        const Type paramSymbolType = manifestation->getParamTypes().at(argIdx);
         // Pass the information if captures are taken for function/procedure types
         if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures()) {
-          SymbolType paramSymbolSymbolType = paramSymbol->getType();
+          Type paramSymbolSymbolType = paramSymbol->getType();
           paramSymbolSymbolType.setHasLambdaCaptures(true);
           paramSymbol->updateType(paramSymbolSymbolType, true);
         }
@@ -492,7 +492,7 @@ std::any IRGenerator::visitStructDef(const StructDefNode *node) {
     }
 
     // Generate default ctor if required
-    const SymbolType &thisType = structEntry->getType();
+    const Type &thisType = structEntry->getType();
     const Function *ctorFunc = FunctionManager::lookupFunction(currentScope, CTOR_FUNCTION_NAME, thisType, {}, true);
     if (ctorFunc != nullptr && ctorFunc->implicitDefault)
       generateDefaultCtor(ctorFunc);
@@ -556,7 +556,7 @@ std::any IRGenerator::visitAliasDef(const AliasDefNode *node) {
 std::any IRGenerator::visitGlobalVarDef(const GlobalVarDefNode *node) {
   // Retrieve some information about the variable
   assert(node->entry != nullptr);
-  const SymbolType &entryType = node->entry->getType();
+  const Type &entryType = node->entry->getType();
   const bool isPublic = entryType.isPublic();
   const bool isConst = entryType.isConst();
 
@@ -599,7 +599,7 @@ std::any IRGenerator::visitExtDecl(const ExtDeclNode *node) {
   // Get arg types
   std::vector<llvm::Type *> argTypes;
   argTypes.reserve(spiceFunc->paramList.size());
-  for (const SymbolType &paramType : spiceFunc->getParamTypes())
+  for (const Type &paramType : spiceFunc->getParamTypes())
     argTypes.push_back(paramType.toLLVMType(context, currentScope));
 
   // Declare function

--- a/src/irgenerator/GenVTable.cpp
+++ b/src/irgenerator/GenVTable.cpp
@@ -33,7 +33,7 @@ llvm::Constant *IRGenerator::generateTypeInfo(StructBase *spiceStruct) {
   const std::string mangledName = NameMangling::mangleTypeInfo(spiceStruct);
   llvm::PointerType *ptrTy = builder.getPtrTy();
 
-  std::vector<SymbolType> interfaceTypes;
+  std::vector<Type> interfaceTypes;
   if (spiceStruct->entry->getType().is(TY_STRUCT)) {
     auto spiceStructEnsured = reinterpret_cast<Struct *>(spiceStruct);
     interfaceTypes = spiceStructEnsured->interfaceTypes;
@@ -57,7 +57,7 @@ llvm::Constant *IRGenerator::generateTypeInfo(StructBase *spiceStruct) {
   std::vector<llvm::Constant *> fieldValues;
   fieldValues.push_back(typeInfoVTable);
   fieldValues.push_back(typeInfoName);
-  for (const SymbolType &interfaceType : interfaceTypes) {
+  for (const Type &interfaceType : interfaceTypes) {
     Interface *interface = interfaceType.getInterface(nullptr);
     assert(interface != nullptr && interface->vTableData.typeInfo != nullptr);
     const std::string interfaceMangledName = NameMangling::mangleTypeInfo(interface);

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -120,15 +120,15 @@ public:
   llvm::Value *insertStructGEP(llvm::Type *type, llvm::Value *basePtr, unsigned index, std::string varName = "") const;
   llvm::Value *resolveValue(const ASTNode *node, Scope *accessScope = nullptr);
   llvm::Value *resolveValue(const ASTNode *node, LLVMExprResult &exprResult, Scope *accessScope = nullptr);
-  llvm::Value *resolveValue(const SymbolType &symbolType, LLVMExprResult &exprResult, Scope *accessScope = nullptr);
+  llvm::Value *resolveValue(const Type &symbolType, LLVMExprResult &exprResult, Scope *accessScope = nullptr);
   llvm::Value *resolveAddress(const ASTNode *node);
   llvm::Value *resolveAddress(LLVMExprResult &exprResult);
-  [[nodiscard]] llvm::Constant *getDefaultValueForSymbolType(const SymbolType &symbolType);
+  [[nodiscard]] llvm::Constant *getDefaultValueForSymbolType(const Type &symbolType);
   [[nodiscard]] static std::string getIRString(llvm::Module *llvmModule, bool withoutTargetInfo);
 
 private:
   // Private methods
-  llvm::Constant *getConst(const CompileTimeValue &compileTimeValue, const SymbolType &type, const ASTNode *node);
+  llvm::Constant *getConst(const CompileTimeValue &compileTimeValue, const Type &type, const ASTNode *node);
   llvm::BasicBlock *createBlock(const std::string &blockName = "");
   void switchToBlock(llvm::BasicBlock *block, llvm::Function *parentFct = nullptr);
   void insertJump(llvm::BasicBlock *targetBlock);
@@ -139,10 +139,10 @@ private:
   LLVMExprResult doAssignment(const ASTNode *lhsNode, const ASTNode *rhsNode);
   LLVMExprResult doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, const ASTNode *rhsNode, bool isDecl = false);
   LLVMExprResult doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, LLVMExprResult &rhs,
-                              const SymbolType &rhsSType, bool isDecl);
+                              const Type &rhsSType, bool isDecl);
   llvm::Value *createShallowCopy(llvm::Value *oldAddress, llvm::Type *varType, llvm::Value *targetAddress,
                                  const std::string &name = "", bool isVolatile = false);
-  void autoDeReferencePtr(llvm::Value *&ptr, SymbolType &symbolType, Scope *accessScope) const;
+  void autoDeReferencePtr(llvm::Value *&ptr, Type &symbolType, Scope *accessScope) const;
   llvm::GlobalVariable *createGlobalConst(const std::string &baseName, llvm::Constant *constant);
   llvm::Constant *createGlobalStringConst(const std::string &baseName, const std::string &value, const CodeLoc &codeLoc);
   [[nodiscard]] std::string getUnusedGlobalName(const std::string &baseName) const;
@@ -153,7 +153,7 @@ private:
   void unpackCapturesToLocalVariables(const CaptureMap &captures, llvm::Value *val, llvm::Type *structType);
 
   // Generate implicit
-  llvm::Value *doImplicitCast(llvm::Value *src, SymbolType dstSTy, SymbolType srcSTy);
+  llvm::Value *doImplicitCast(llvm::Value *src, Type dstSTy, Type srcSTy);
   void generateScopeCleanup(const StmtLstNode *node) const;
   void generateCtorOrDtorCall(SymbolTableEntry *entry, const Function *ctorOrDtor, const std::vector<llvm::Value *> &args) const;
   void generateDeallocCall(llvm::Value *variableAddress) const;

--- a/src/irgenerator/NameMangling.cpp
+++ b/src/irgenerator/NameMangling.cpp
@@ -50,7 +50,7 @@ std::string NameMangling::mangleFunction(const Function &spiceFunc) {
     // Template types themselves
     for (const GenericType &genericTemplateType : spiceFunc.templateTypes) {
       assert(spiceFunc.typeMapping.contains(genericTemplateType.getSubType()));
-      const SymbolType &actualType = spiceFunc.typeMapping.at(genericTemplateType.getSubType());
+      const Type &actualType = spiceFunc.typeMapping.at(genericTemplateType.getSubType());
       mangleType(mangledName, actualType, spiceFunc.typeMapping);
     }
     mangledName << "E";
@@ -78,7 +78,7 @@ std::string NameMangling::mangleFunction(const Function &spiceFunc) {
     mangledName << "v";
 
 #ifndef NDEBUG
-  const std::unordered_map<std::string, SymbolType> &typeMapping = spiceFunc.typeMapping;
+  const std::unordered_map<std::string, Type> &typeMapping = spiceFunc.typeMapping;
   const bool returnTypeIsFctOrProc = spiceFunc.returnType.getBaseType().isOneOf({TY_FUNCTION, TY_PROCEDURE});
   const auto paramPredicate = [](const Param &p) { return p.type.getBaseType().isOneOf({TY_FUNCTION, TY_PROCEDURE}); };
   const bool paramTypeIsFctOrProc = std::ranges::any_of(spiceFunc.paramList, paramPredicate);
@@ -153,7 +153,7 @@ void NameMangling::mangleName(std::stringstream &out, const std::string &name, b
  * @param type Input symbol type
  * @return Mangled name
  */
-void NameMangling::mangleType(std::stringstream &out, SymbolType type, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
+void NameMangling::mangleType(std::stringstream &out, Type type, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
   // Replace generic type with concrete type
   if (type.hasAnyGenericParts() && !typeMapping.empty())
     TypeMatcher::substantiateTypeWithTypeMapping(type, typeMapping);
@@ -223,7 +223,7 @@ void NameMangling::mangleTypeChainElement(std::stringstream &out, const TypeChai
     mangleName(out, chainElement.subType, nestedType);
     if (!chainElement.templateTypes.empty()) {
       out << "I";
-      for (const SymbolType &templateType : chainElement.templateTypes)
+      for (const Type &templateType : chainElement.templateTypes)
         mangleType(out, templateType, typeMapping);
       out << "E";
     }
@@ -240,7 +240,7 @@ void NameMangling::mangleTypeChainElement(std::stringstream &out, const TypeChai
   }
   case TY_FUNCTION: {
     out << (chainElement.data.hasCaptures ? "PFC" : "PF");
-    for (const SymbolType &paramType : chainElement.paramTypes)
+    for (const Type &paramType : chainElement.paramTypes)
       mangleType(out, paramType, typeMapping);
     out << "E";
     break;

--- a/src/irgenerator/NameMangling.h
+++ b/src/irgenerator/NameMangling.h
@@ -5,7 +5,7 @@
 #include <string>
 
 #include <model/GenericType.h>
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 
 namespace spice::compiler {
 
@@ -57,11 +57,11 @@ public:
 
 private:
   // Typedefs
-  using TypeChainElement = SymbolType::TypeChainElement;
+  using TypeChainElement = Type::TypeChainElement;
 
   // Private methods
   static void mangleName(std::stringstream &out, const std::string &name, bool &nestedType);
-  static void mangleType(std::stringstream &out, SymbolType type, const TypeMapping &typeMapping);
+  static void mangleType(std::stringstream &out, Type type, const TypeMapping &typeMapping);
   static void mangleTypeChainElement(std::stringstream &out, const TypeChainElement &chainElement, const TypeMapping &typeMapping,
                                      bool signedness);
 };

--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -14,8 +14,8 @@ OpRuleConversionManager::OpRuleConversionManager(GlobalResourceManager &resource
     : context(resourceManager.context), builder(resourceManager.builder), irGenerator(irGenerator),
       stdFunctionManager(irGenerator->stdFunctionManager) {}
 
-LLVMExprResult OpRuleConversionManager::getPlusEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                         LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getPlusEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                         LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                          size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -70,8 +70,8 @@ LLVMExprResult OpRuleConversionManager::getPlusEqualInst(const ASTNode *node, LL
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getMinusEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                          LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getMinusEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                          LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                           size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -127,8 +127,8 @@ LLVMExprResult OpRuleConversionManager::getMinusEqualInst(const ASTNode *node, L
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getMulEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getMulEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                         size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -175,8 +175,8 @@ LLVMExprResult OpRuleConversionManager::getMulEqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getDivEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getDivEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                         size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -223,8 +223,8 @@ LLVMExprResult OpRuleConversionManager::getDivEqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getRemEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getRemEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -264,8 +264,8 @@ LLVMExprResult OpRuleConversionManager::getRemEqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getSHLEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getSHLEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -297,8 +297,8 @@ LLVMExprResult OpRuleConversionManager::getSHLEqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getSHREqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getSHREqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -330,8 +330,8 @@ LLVMExprResult OpRuleConversionManager::getSHREqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getAndEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getAndEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -363,8 +363,9 @@ LLVMExprResult OpRuleConversionManager::getAndEqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getOrEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                       LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getOrEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                       LLVMExprResult &rhs,
+                                                       Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -396,8 +397,8 @@ LLVMExprResult OpRuleConversionManager::getOrEqualInst(const ASTNode *node, LLVM
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getXorEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getXorEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -430,8 +431,8 @@ LLVMExprResult OpRuleConversionManager::getXorEqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getBitwiseOrInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                         LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getBitwiseOrInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                         LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                          size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -450,8 +451,8 @@ LLVMExprResult OpRuleConversionManager::getBitwiseOrInst(const ASTNode *node, LL
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getBitwiseXorInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                          LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getBitwiseXorInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                          LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -469,8 +470,8 @@ LLVMExprResult OpRuleConversionManager::getBitwiseXorInst(const ASTNode *node, L
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getBitwiseAndInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                          LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getBitwiseAndInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                          LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                           size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -489,8 +490,9 @@ LLVMExprResult OpRuleConversionManager::getBitwiseAndInst(const ASTNode *node, L
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                     LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope, size_t opIdx) {
+LLVMExprResult OpRuleConversionManager::getEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                     LLVMExprResult &rhs,
+                                                     Type rhsSTy, Scope *accessScope, size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
@@ -623,8 +625,8 @@ LLVMExprResult OpRuleConversionManager::getEqualInst(const ASTNode *node, LLVMEx
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getNotEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                        LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getNotEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                        LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                         size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -759,8 +761,9 @@ LLVMExprResult OpRuleConversionManager::getNotEqualInst(const ASTNode *node, LLV
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getLessInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                    LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getLessInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                    LLVMExprResult &rhs,
+                                                    Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -823,8 +826,9 @@ LLVMExprResult OpRuleConversionManager::getLessInst(const ASTNode *node, LLVMExp
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getGreaterInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                       LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getGreaterInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                       LLVMExprResult &rhs,
+                                                       Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -887,8 +891,8 @@ LLVMExprResult OpRuleConversionManager::getGreaterInst(const ASTNode *node, LLVM
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getLessEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                         LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getLessEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                         LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -951,8 +955,8 @@ LLVMExprResult OpRuleConversionManager::getLessEqualInst(const ASTNode *node, LL
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getGreaterEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                            LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getGreaterEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                            LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -1015,8 +1019,8 @@ LLVMExprResult OpRuleConversionManager::getGreaterEqualInst(const ASTNode *node,
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getShiftLeftInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                         LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getShiftLeftInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                         LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                          size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -1062,8 +1066,8 @@ LLVMExprResult OpRuleConversionManager::getShiftLeftInst(const ASTNode *node, LL
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getShiftRightInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                          LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope,
+LLVMExprResult OpRuleConversionManager::getShiftRightInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                          LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope,
                                                           size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
@@ -1109,8 +1113,9 @@ LLVMExprResult OpRuleConversionManager::getShiftRightInst(const ASTNode *node, L
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                    LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope, size_t opIdx) {
+LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                    LLVMExprResult &rhs,
+                                                    Type rhsSTy, Scope *accessScope, size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
@@ -1190,8 +1195,9 @@ LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExp
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                     LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope, size_t opIdx) {
+LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                     LLVMExprResult &rhs,
+                                                     Type rhsSTy, Scope *accessScope, size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
@@ -1271,8 +1277,9 @@ LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMEx
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getMulInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                   LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope, size_t opIdx) {
+LLVMExprResult OpRuleConversionManager::getMulInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                   LLVMExprResult &rhs,
+                                                   Type rhsSTy, Scope *accessScope, size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
@@ -1340,8 +1347,9 @@ LLVMExprResult OpRuleConversionManager::getMulInst(const ASTNode *node, LLVMExpr
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getDivInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                   LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope, size_t opIdx) {
+LLVMExprResult OpRuleConversionManager::getDivInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                   LLVMExprResult &rhs,
+                                                   Type rhsSTy, Scope *accessScope, size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
@@ -1410,8 +1418,9 @@ LLVMExprResult OpRuleConversionManager::getDivInst(const ASTNode *node, LLVMExpr
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getRemInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
-                                                   LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getRemInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
+                                                   LLVMExprResult &rhs,
+                                                   Type rhsSTy, Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -1454,7 +1463,7 @@ LLVMExprResult OpRuleConversionManager::getRemInst(const ASTNode *node, LLVMExpr
   }
 }
 
-LLVMExprResult OpRuleConversionManager::getPrefixMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
+LLVMExprResult OpRuleConversionManager::getPrefixMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
                                                            Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -1472,7 +1481,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixMinusInst(const ASTNode *node, 
   throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: -"); // GCOV_EXCL_LINE
 }
 
-LLVMExprResult OpRuleConversionManager::getPrefixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
+LLVMExprResult OpRuleConversionManager::getPrefixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
                                                               Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -1494,7 +1503,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixPlusPlusInst(const ASTNode *nod
   throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: ++ (prefix)"); // GCOV_EXCL_LINE
 }
 
-LLVMExprResult OpRuleConversionManager::getPrefixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
+LLVMExprResult OpRuleConversionManager::getPrefixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
                                                                 Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -1516,7 +1525,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixMinusMinusInst(const ASTNode *n
   throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: -- (prefix)"); // GCOV_EXCL_LINE
 }
 
-LLVMExprResult OpRuleConversionManager::getPrefixNotInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
+LLVMExprResult OpRuleConversionManager::getPrefixNotInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
                                                          Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -1530,7 +1539,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixNotInst(const ASTNode *node, LL
   throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: !"); // GCOV_EXCL_LINE
 }
 
-LLVMExprResult OpRuleConversionManager::getPrefixBitwiseNotInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
+LLVMExprResult OpRuleConversionManager::getPrefixBitwiseNotInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
                                                                 Scope *accessScope) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
@@ -1546,7 +1555,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixBitwiseNotInst(const ASTNode *n
   throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: ~"); // GCOV_EXCL_LINE
 }
 
-LLVMExprResult OpRuleConversionManager::getPostfixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
+LLVMExprResult OpRuleConversionManager::getPostfixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
                                                                Scope *accessScope, size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
@@ -1573,7 +1582,7 @@ LLVMExprResult OpRuleConversionManager::getPostfixPlusPlusInst(const ASTNode *no
   throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: ++ (postfix)"); // GCOV_EXCL_LINE
 }
 
-LLVMExprResult OpRuleConversionManager::getPostfixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy,
+LLVMExprResult OpRuleConversionManager::getPostfixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy,
                                                                  Scope *accessScope, size_t opIdx) {
   ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs, accessScope); };
   ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
@@ -1600,8 +1609,7 @@ LLVMExprResult OpRuleConversionManager::getPostfixMinusMinusInst(const ASTNode *
   throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: -- (postfix)"); // GCOV_EXCL_LINE
 }
 
-LLVMExprResult OpRuleConversionManager::getCastInst(const ASTNode *node, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                                    SymbolType rhsSTy, Scope *accessScope) {
+LLVMExprResult OpRuleConversionManager::getCastInst(const ASTNode *node, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope) {
   ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs, accessScope); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
@@ -1687,7 +1695,7 @@ LLVMExprResult OpRuleConversionManager::callOperatorOverloadFct(const ASTNode *n
   assert(accessScope != nullptr);
 
   // Get arg values
-  const std::vector<SymbolType> &paramTypes = opFct->getParamTypes();
+  const std::vector<Type> &paramTypes = opFct->getParamTypes();
   assert(paramTypes.size() == N);
   llvm::Value *argValues[N];
   argValues[0] = paramTypes[0].isRef() ? opV[1]() : opV[0]();
@@ -1703,7 +1711,7 @@ LLVMExprResult OpRuleConversionManager::callOperatorOverloadFct(const ASTNode *n
 
     // Get arg types
     std::vector<llvm::Type *> argTypes;
-    for (const SymbolType &paramType : opFct->getParamTypes())
+    for (const Type &paramType : opFct->getParamTypes())
       argTypes.push_back(paramType.toLLVMType(context, accessScope));
 
     llvm::FunctionType *fctType = llvm::FunctionType::get(returnType, argTypes, false);
@@ -1741,14 +1749,14 @@ LLVMExprResult OpRuleConversionManager::callOperatorOverloadFct(const ASTNode *n
   return {.value = result, .ptr = resultPtr, .entry = anonymousSymbol};
 }
 
-llvm::Value *OpRuleConversionManager::generateIToFp(const SymbolType &srcSTy, llvm::Value *srcV, llvm::Type *tgtT) const {
+llvm::Value *OpRuleConversionManager::generateIToFp(const Type &srcSTy, llvm::Value *srcV, llvm::Type *tgtT) const {
   if (srcSTy.isSigned())
     return builder.CreateSIToFP(srcV, tgtT);
   else
     return builder.CreateUIToFP(srcV, tgtT);
 }
 
-llvm::Value *OpRuleConversionManager::generateSHR(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+llvm::Value *OpRuleConversionManager::generateSHR(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                                   llvm::Value *rhsV) const {
   if (lhsSTy.isSigned())
     return builder.CreateAShr(lhsV, rhsV);
@@ -1756,7 +1764,7 @@ llvm::Value *OpRuleConversionManager::generateSHR(const SymbolType &lhsSTy, cons
     return builder.CreateLShr(lhsV, rhsV);
 }
 
-llvm::Value *OpRuleConversionManager::generateLT(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+llvm::Value *OpRuleConversionManager::generateLT(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                                  llvm::Value *rhsV) const {
   if (lhsSTy.isSigned() && rhsSTy.isSigned())
     return builder.CreateICmpSLT(lhsV, rhsV);
@@ -1764,7 +1772,7 @@ llvm::Value *OpRuleConversionManager::generateLT(const SymbolType &lhsSTy, const
     return builder.CreateICmpULT(lhsV, rhsV);
 }
 
-llvm::Value *OpRuleConversionManager::generateLE(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+llvm::Value *OpRuleConversionManager::generateLE(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                                  llvm::Value *rhsV) const {
   if (lhsSTy.isSigned() && rhsSTy.isSigned())
     return builder.CreateICmpSLE(lhsV, rhsV);
@@ -1772,7 +1780,7 @@ llvm::Value *OpRuleConversionManager::generateLE(const SymbolType &lhsSTy, const
     return builder.CreateICmpULE(lhsV, rhsV);
 }
 
-llvm::Value *OpRuleConversionManager::generateGT(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+llvm::Value *OpRuleConversionManager::generateGT(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                                  llvm::Value *rhsV) const {
   if (lhsSTy.isSigned() && rhsSTy.isSigned())
     return builder.CreateICmpSGT(lhsV, rhsV);
@@ -1780,7 +1788,7 @@ llvm::Value *OpRuleConversionManager::generateGT(const SymbolType &lhsSTy, const
     return builder.CreateICmpUGT(lhsV, rhsV);
 }
 
-llvm::Value *OpRuleConversionManager::generateGE(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+llvm::Value *OpRuleConversionManager::generateGE(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                                  llvm::Value *rhsV) const {
   if (lhsSTy.isSigned() && rhsSTy.isSigned())
     return builder.CreateICmpSGE(lhsV, rhsV);
@@ -1788,7 +1796,7 @@ llvm::Value *OpRuleConversionManager::generateGE(const SymbolType &lhsSTy, const
     return builder.CreateICmpUGE(lhsV, rhsV);
 }
 
-llvm::Value *OpRuleConversionManager::generateDiv(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+llvm::Value *OpRuleConversionManager::generateDiv(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                                   llvm::Value *rhsV) const {
   if (lhsSTy.isSigned() && rhsSTy.isSigned())
     return builder.CreateSDiv(lhsV, rhsV);
@@ -1796,7 +1804,7 @@ llvm::Value *OpRuleConversionManager::generateDiv(const SymbolType &lhsSTy, cons
     return builder.CreateUDiv(lhsV, rhsV);
 }
 
-llvm::Value *OpRuleConversionManager::generateRem(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+llvm::Value *OpRuleConversionManager::generateRem(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                                   llvm::Value *rhsV) const {
   if (lhsSTy.isSigned() && rhsSTy.isSigned())
     return builder.CreateSRem(lhsV, rhsV);

--- a/src/irgenerator/OpRuleConversionManager.h
+++ b/src/irgenerator/OpRuleConversionManager.h
@@ -6,7 +6,7 @@
 
 #include <global/GlobalResourceManager.h>
 #include <irgenerator/LLVMExprResult.h>
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Value.h>
@@ -33,68 +33,49 @@ public:
   OpRuleConversionManager(GlobalResourceManager &resourceManager, IRGenerator *irGenerator);
 
   // Public methods
-  LLVMExprResult getPlusEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                  SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getMinusEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                   SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getMulEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getDivEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getRemEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getSHLEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getSHREqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getAndEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getOrEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getXorEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getBitwiseOrInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                  SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getBitwiseXorInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                   SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getBitwiseAndInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                   SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy,
+  LLVMExprResult getPlusEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getMinusEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getMulEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getDivEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getRemEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getSHLEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getSHREqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getAndEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getOrEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getXorEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getBitwiseOrInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getBitwiseXorInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getBitwiseAndInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy,
                               Scope *accessScope, size_t opIdx);
-  LLVMExprResult getNotEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                 SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getLessInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy,
+  LLVMExprResult getNotEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getLessInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy,
                              Scope *accessScope);
-  LLVMExprResult getGreaterInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getLessEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                  SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getGreaterEqualInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                     SymbolType rhsSTy, Scope *accessScope);
-  LLVMExprResult getShiftLeftInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                  SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getShiftRightInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs,
-                                   SymbolType rhsSTy, Scope *accessScope, size_t opIdx);
-  LLVMExprResult getPlusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy,
+  LLVMExprResult getGreaterInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getLessEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getGreaterEqualInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
+  LLVMExprResult getShiftLeftInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getShiftRightInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope, size_t opIdx);
+  LLVMExprResult getPlusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy,
                              Scope *accessScope, size_t opIdx);
-  LLVMExprResult getMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy,
+  LLVMExprResult getMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy,
                               Scope *accessScope, size_t opIdx);
-  LLVMExprResult getMulInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy,
+  LLVMExprResult getMulInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy,
                             Scope *accessScope, size_t opIdx);
-  LLVMExprResult getDivInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy,
+  LLVMExprResult getDivInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy,
                             Scope *accessScope, size_t opIdx);
-  LLVMExprResult getRemInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy,
+  LLVMExprResult getRemInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy,
                             Scope *accessScope);
-  LLVMExprResult getPrefixMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, Scope *accessScope);
-  LLVMExprResult getPrefixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, Scope *accessScope);
-  LLVMExprResult getPrefixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, Scope *accessScope);
-  LLVMExprResult getPrefixNotInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, Scope *accessScope);
-  LLVMExprResult getPrefixBitwiseNotInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, Scope *accessScope);
-  LLVMExprResult getPostfixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, Scope *accessScope,
+  LLVMExprResult getPrefixMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, Scope *accessScope);
+  LLVMExprResult getPrefixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, Scope *accessScope);
+  LLVMExprResult getPrefixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, Scope *accessScope);
+  LLVMExprResult getPrefixNotInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, Scope *accessScope);
+  LLVMExprResult getPrefixBitwiseNotInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, Scope *accessScope);
+  LLVMExprResult getPostfixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, Scope *accessScope,
                                         size_t opIdx);
-  LLVMExprResult getPostfixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, SymbolType lhsSTy, Scope *accessScope,
+  LLVMExprResult getPostfixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, Type lhsSTy, Scope *accessScope,
                                           size_t opIdx);
-  LLVMExprResult getCastInst(const ASTNode *node, SymbolType lhsSTy, LLVMExprResult &rhs, SymbolType rhsSTy, Scope *accessScope);
+  LLVMExprResult getCastInst(const ASTNode *node, Type lhsSTy, LLVMExprResult &rhs, Type rhsSTy, Scope *accessScope);
 
   // Util methods
   bool callsOverloadedOpFct(const ASTNode *node, size_t opIdx) const;
@@ -109,22 +90,22 @@ private:
   // Private methods
   template <size_t N>
   LLVMExprResult callOperatorOverloadFct(const ASTNode *node, const std::array<ResolverFct, N * 2> &opV, size_t opIdx);
-  [[nodiscard]] llvm::Value *generateIToFp(const SymbolType &srcSTy, llvm::Value *srcV, llvm::Type *tgtT) const;
-  [[nodiscard]] llvm::Value *generateSHR(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+  [[nodiscard]] llvm::Value *generateIToFp(const Type &srcSTy, llvm::Value *srcV, llvm::Type *tgtT) const;
+  [[nodiscard]] llvm::Value *generateSHR(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                          llvm::Value *rhsV) const;
-  [[nodiscard]] llvm::Value *generateLT(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+  [[nodiscard]] llvm::Value *generateLT(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                         llvm::Value *rhsV) const;
-  [[nodiscard]] llvm::Value *generateGT(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+  [[nodiscard]] llvm::Value *generateGT(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                         llvm::Value *rhsV) const;
-  [[nodiscard]] llvm::Value *generateLE(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+  [[nodiscard]] llvm::Value *generateLE(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                         llvm::Value *rhsV) const;
-  [[nodiscard]] llvm::Value *generateGE(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+  [[nodiscard]] llvm::Value *generateGE(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                         llvm::Value *rhsV) const;
-  [[nodiscard]] llvm::Value *generateDiv(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+  [[nodiscard]] llvm::Value *generateDiv(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                          llvm::Value *rhsV) const;
-  [[nodiscard]] llvm::Value *generateRem(const SymbolType &lhsSTy, const SymbolType &rhsSTy, llvm::Value *lhsV,
+  [[nodiscard]] llvm::Value *generateRem(const Type &lhsSTy, const Type &rhsSTy, llvm::Value *lhsV,
                                          llvm::Value *rhsV) const;
-  [[nodiscard]] static inline uint32_t getTypeCombination(const SymbolType &lhsTy, const SymbolType &rhsTy) {
+  [[nodiscard]] static inline uint32_t getTypeCombination(const Type &lhsTy, const Type &rhsTy) {
     return COMB(lhsTy.getSuperType(), rhsTy.getSuperType());
   }
 };

--- a/src/irgenerator/StdFunctionManager.cpp
+++ b/src/irgenerator/StdFunctionManager.cpp
@@ -58,22 +58,22 @@ llvm::Function *StdFunctionManager::getMemcpyIntrinsic() const {
 }
 
 llvm::Function *StdFunctionManager::getStringGetRawLengthStringFct() const {
-  const ParamList paramLst = {{SymbolType(TY_STRING), false}};
-  const Function function("getRawLength", nullptr, SymbolType(TY_DYN), SymbolType(TY_LONG), paramLst, {}, nullptr);
+  const ParamList paramLst = {{Type(TY_STRING), false}};
+  const Function function("getRawLength", nullptr, Type(TY_DYN), Type(TY_LONG), paramLst, {}, nullptr);
   const std::string mangledName = NameMangling::mangleFunction(function);
   return getFunction(mangledName.c_str(), builder.getInt64Ty(), {builder.getPtrTy()});
 }
 
 llvm::Function *StdFunctionManager::getStringIsRawEqualStringStringFct() const {
-  const ParamList paramLst = {{SymbolType(TY_STRING), false}, {SymbolType(TY_STRING), false}};
-  const Function function("isRawEqual", nullptr, SymbolType(TY_DYN), SymbolType(TY_BOOL), paramLst, {}, nullptr);
+  const ParamList paramLst = {{Type(TY_STRING), false}, {Type(TY_STRING), false}};
+  const Function function("isRawEqual", nullptr, Type(TY_DYN), Type(TY_BOOL), paramLst, {}, nullptr);
   const std::string mangledName = NameMangling::mangleFunction(function);
   return getFunction(mangledName.c_str(), builder.getInt1Ty(), {builder.getPtrTy(), builder.getPtrTy()});
 }
 
 llvm::Function *StdFunctionManager::getDeallocBytePtrRefFct() const {
-  const ParamList paramLst = {{SymbolType(TY_BYTE).toPointer(nullptr).toReference(nullptr), false}};
-  const Function function("sDealloc", nullptr, SymbolType(TY_DYN), SymbolType(TY_DYN), paramLst, {}, nullptr);
+  const ParamList paramLst = {{Type(TY_BYTE).toPointer(nullptr).toReference(nullptr), false}};
+  const Function function("sDealloc", nullptr, Type(TY_DYN), Type(TY_DYN), paramLst, {}, nullptr);
   const std::string mangledName = NameMangling::mangleFunction(function);
   return getProcedure(mangledName.c_str(), {builder.getPtrTy()});
 }

--- a/src/irgenerator/StdFunctionManager.h
+++ b/src/irgenerator/StdFunctionManager.h
@@ -10,7 +10,7 @@
 namespace spice::compiler {
 
 // Forward declarations
-class SymbolType;
+class Type;
 class Function;
 
 class StdFunctionManager {

--- a/src/model/Function.cpp
+++ b/src/model/Function.cpp
@@ -13,8 +13,8 @@ namespace spice::compiler {
  *
  * @return Vector of parameter types
  */
-std::vector<SymbolType> Function::getParamTypes() const {
-  std::vector<SymbolType> newParamTypes;
+std::vector<Type> Function::getParamTypes() const {
+  std::vector<Type> newParamTypes;
   for (const Param &param : paramList)
     newParamTypes.push_back(param.type);
   return newParamTypes;
@@ -31,7 +31,7 @@ std::vector<SymbolType> Function::getParamTypes() const {
  * @return String representation as function signature
  */
 std::string Function::getSignature(bool withThisType /*=true*/, bool ignorePublic /*=false*/) const {
-  std::vector<SymbolType> templateSymbolTypes;
+  std::vector<Type> templateSymbolTypes;
   templateSymbolTypes.reserve(templateTypes.size());
   for (const GenericType &genericType : templateTypes) {
     if (genericType.is(TY_GENERIC) && !typeMapping.empty()) {
@@ -57,14 +57,14 @@ std::string Function::getSignature(bool withThisType /*=true*/, bool ignorePubli
  * @param ignorePublic Not include public modifiers in signature
  * @return Function signature
  */
-std::string Function::getSignature(const std::string &name, const SymbolType &thisType, const SymbolType &returnType,
-                                   const ParamList &paramList, const std::vector<SymbolType> &concreteTemplateTypes,
+std::string Function::getSignature(const std::string &name, const Type &thisType, const Type &returnType,
+                                   const ParamList &paramList, const std::vector<Type> &concreteTemplateTypes,
                                    bool withThisType /*=true*/, bool ignorePublic /*=false*/) {
   // Build this type string
   std::stringstream thisTyStr;
   if (withThisType && !thisType.is(TY_DYN)) {
     thisTyStr << thisType.getBaseType().getSubType();
-    const std::vector<SymbolType> &thisTemplateTypes = thisType.getTemplateTypes();
+    const std::vector<Type> &thisTemplateTypes = thisType.getTemplateTypes();
     if (!thisTemplateTypes.empty()) {
       thisTyStr << "<";
       for (size_t i = 0; i < thisTemplateTypes.size(); i++) {

--- a/src/model/Function.h
+++ b/src/model/Function.h
@@ -5,7 +5,7 @@
 #include <utility>
 
 #include <model/GenericType.h>
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 #include <symboltablebuilder/TypeSpecifiers.h>
 
 #include <llvm/IR/Function.h>
@@ -18,14 +18,14 @@ struct CodeLoc;
 class SymbolTableEntry;
 
 struct Param {
-  SymbolType type;
+  Type type;
   bool isOptional = false;
 
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Param, type, isOptional)
 };
 struct NamedParam {
   std::string name;
-  SymbolType type;
+  Type type;
   bool isOptional = false;
 
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(NamedParam, name, type, isOptional)
@@ -36,17 +36,17 @@ using NamedParamList = std::vector<NamedParam>;
 class Function {
 public:
   // Constructors
-  Function(std::string name, SymbolTableEntry *entry, SymbolType thisType, SymbolType returnType, ParamList paramList,
+  Function(std::string name, SymbolTableEntry *entry, Type thisType, Type returnType, ParamList paramList,
            std::vector<GenericType> templateTypes, ASTNode *declNode)
       : name(std::move(name)), thisType(std::move(thisType)), returnType(std::move(returnType)), paramList(std::move(paramList)),
         templateTypes(std::move(templateTypes)), entry(entry), declNode(declNode) {}
   Function() = default;
 
   // Public methods
-  [[nodiscard]] std::vector<SymbolType> getParamTypes() const;
+  [[nodiscard]] std::vector<Type> getParamTypes() const;
   [[nodiscard]] std::string getSignature(bool withThisType = true, bool ignorePublic = true) const;
-  [[nodiscard]] static std::string getSignature(const std::string &name, const SymbolType &thisType, const SymbolType &returnType,
-                                                const ParamList &paramList, const std::vector<SymbolType> &concreteTemplateTypes,
+  [[nodiscard]] static std::string getSignature(const std::string &name, const Type &thisType, const Type &returnType,
+                                                const ParamList &paramList, const std::vector<Type> &concreteTemplateTypes,
                                                 bool withThisType = true, bool ignorePublic = true);
   [[nodiscard]] std::string getMangledName() const;
   [[nodiscard]] static std::string getSymbolTableEntryName(const std::string &functionName, const CodeLoc &codeLoc);
@@ -65,11 +65,11 @@ public:
 
   // Public members
   std::string name;
-  SymbolType thisType = SymbolType(TY_DYN);
-  SymbolType returnType = SymbolType(TY_DYN);
+  Type thisType = Type(TY_DYN);
+  Type returnType = Type(TY_DYN);
   ParamList paramList;
   std::vector<GenericType> templateTypes;
-  std::unordered_map<std::string, SymbolType> typeMapping;
+  std::unordered_map<std::string, Type> typeMapping;
   SymbolTableEntry *entry = nullptr;
   ASTNode *declNode = nullptr;
   Scope *bodyScope = nullptr;

--- a/src/model/GenericType.cpp
+++ b/src/model/GenericType.cpp
@@ -12,7 +12,7 @@ namespace spice::compiler {
  * @param ignoreSpecifiers Ignore the type specifiers for type comparison
  * @return True or false
  */
-bool GenericType::checkConditionsOf(const SymbolType &symbolType, bool ignoreArraySize /*=false*/,
+bool GenericType::checkConditionsOf(const Type &symbolType, bool ignoreArraySize /*=false*/,
                                     bool ignoreSpecifiers /*=false*/) const {
   return checkTypeConditionOf(symbolType, ignoreArraySize, ignoreSpecifiers);
 }
@@ -25,12 +25,12 @@ bool GenericType::checkConditionsOf(const SymbolType &symbolType, bool ignoreArr
  * @param ignoreSpecifiers Ignore the type specifiers for type comparison
  * @return True or false
  */
-bool GenericType::checkTypeConditionOf(const SymbolType &symbolType, bool ignoreArraySize, bool ignoreSpecifiers) const {
+bool GenericType::checkTypeConditionOf(const Type &symbolType, bool ignoreArraySize, bool ignoreSpecifiers) const {
   // Succeed if no type conditions are set
   if (typeConditions.empty())
     return true;
   // Check type conditions
-  return std::ranges::any_of(typeConditions, [&](const SymbolType &typeCondition) {
+  return std::ranges::any_of(typeConditions, [&](const Type &typeCondition) {
     return typeCondition.is(TY_DYN) || typeCondition.matches(symbolType, ignoreArraySize, ignoreSpecifiers, ignoreSpecifiers);
   });
 }

--- a/src/model/GenericType.h
+++ b/src/model/GenericType.h
@@ -5,26 +5,26 @@
 #include <string>
 #include <utility>
 
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 
 #include "../../lib/json/json.hpp"
 
 namespace spice::compiler {
 
 // Typedefs
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/SymbolType>;
+using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/Type>;
 
-class GenericType : public SymbolType {
+class GenericType : public Type {
 public:
   // Constructors
-  explicit GenericType(const SymbolType &type) : SymbolType(type){};
-  explicit GenericType(const std::string &name) : SymbolType(TY_GENERIC, name) {}
-  GenericType(const std::string &name, const std::vector<SymbolType> &typeConditions)
-      : SymbolType(TY_GENERIC, name), typeConditions(typeConditions) {}
+  explicit GenericType(const Type &type) : Type(type){};
+  explicit GenericType(const std::string &name) : Type(TY_GENERIC, name) {}
+  GenericType(const std::string &name, const std::vector<Type> &typeConditions)
+      : Type(TY_GENERIC, name), typeConditions(typeConditions) {}
   GenericType() = default;
 
   // Public methods
-  [[nodiscard]] bool checkConditionsOf(const SymbolType &symbolType, bool ignoreArraySize = false,
+  [[nodiscard]] bool checkConditionsOf(const Type &symbolType, bool ignoreArraySize = false,
                                        bool ignoreSpecifiers = false) const;
 
   // Public members
@@ -35,10 +35,10 @@ public:
 
 private:
   // Members
-  std::vector<SymbolType> typeConditions = {SymbolType(TY_DYN)};
+  std::vector<Type> typeConditions = {Type(TY_DYN)};
 
   // Private methods
-  [[nodiscard]] bool checkTypeConditionOf(const SymbolType &symbolType, bool ignoreArraySize, bool ignoreSpecifiers) const;
+  [[nodiscard]] bool checkTypeConditionOf(const Type &symbolType, bool ignoreArraySize, bool ignoreSpecifiers) const;
 };
 
 } // namespace spice::compiler

--- a/src/model/Struct.cpp
+++ b/src/model/Struct.cpp
@@ -13,7 +13,7 @@ namespace spice::compiler {
  * @return Has reference as field type or not
  */
 bool Struct::hasReferenceFields() const {
-  return std::ranges::any_of(fieldTypes, [](const SymbolType &fieldType) { return fieldType.isRef(); });
+  return std::ranges::any_of(fieldTypes, [](const Type &fieldType) { return fieldType.isRef(); });
 }
 
 } // namespace spice::compiler

--- a/src/model/Struct.h
+++ b/src/model/Struct.h
@@ -16,8 +16,8 @@ namespace spice::compiler {
 class Struct : public StructBase {
 public:
   // Constructors
-  Struct(std::string name, SymbolTableEntry *entry, Scope *scope, std::vector<SymbolType> fieldTypes,
-         std::vector<GenericType> templateTypes, std::vector<SymbolType> interfaceTypes, ASTNode *declNode)
+  Struct(std::string name, SymbolTableEntry *entry, Scope *scope, std::vector<Type> fieldTypes,
+         std::vector<GenericType> templateTypes, std::vector<Type> interfaceTypes, ASTNode *declNode)
       : StructBase(std::move(name), entry, scope, std::move(templateTypes), declNode), fieldTypes(std::move(fieldTypes)),
         interfaceTypes(std::move(interfaceTypes)) {}
 
@@ -25,8 +25,8 @@ public:
   [[nodiscard]] bool hasReferenceFields() const;
 
   // Public members
-  std::vector<SymbolType> fieldTypes;
-  std::vector<SymbolType> interfaceTypes;
+  std::vector<Type> fieldTypes;
+  std::vector<Type> interfaceTypes;
 
   // Json serializer/deserializer
   NLOHMANN_DEFINE_TYPE_INTRUSIVE(Struct, name, fieldTypes, templateTypes, interfaceTypes, genericSubstantiation, used)

--- a/src/model/StructBase.cpp
+++ b/src/model/StructBase.cpp
@@ -15,7 +15,7 @@ namespace spice::compiler {
  * @return String representation as struct signature
  */
 std::string StructBase::getSignature() const {
-  std::vector<SymbolType> templateSymbolTypes;
+  std::vector<Type> templateSymbolTypes;
   templateSymbolTypes.reserve(templateTypes.size());
   for (const GenericType &genericType : templateTypes) {
     if (genericType.is(TY_GENERIC) && !typeMapping.empty()) {
@@ -39,7 +39,7 @@ std::string StructBase::getSignature() const {
  * @param concreteTemplateTypes Concrete template types
  * @return Signature
  */
-std::string StructBase::getSignature(const std::string &name, const std::vector<SymbolType> &concreteTemplateTypes) {
+std::string StructBase::getSignature(const std::string &name, const std::vector<Type> &concreteTemplateTypes) {
   // Build template type string
   std::stringstream templateTyStr;
   if (!concreteTemplateTypes.empty()) {
@@ -78,8 +78,8 @@ bool StructBase::isFullySubstantiated() const { return hasSubstantiatedGenerics(
  *
  * @return Template types as vector of symbol types
  */
-std::vector<SymbolType> StructBase::getTemplateTypes() const {
-  std::vector<SymbolType> templateSymbolTypes;
+std::vector<Type> StructBase::getTemplateTypes() const {
+  std::vector<Type> templateSymbolTypes;
   for (const GenericType &genericTemplateType : templateTypes)
     templateSymbolTypes.push_back(genericTemplateType);
   return templateSymbolTypes;

--- a/src/model/StructBase.h
+++ b/src/model/StructBase.h
@@ -13,7 +13,7 @@
 namespace spice::compiler {
 
 // Forward declarations
-class SymbolType;
+class Type;
 class SymbolTableEntry;
 class Scope;
 class ASTNode;
@@ -27,16 +27,16 @@ public:
 
   // Public methods
   [[nodiscard]] std::string getSignature() const;
-  static std::string getSignature(const std::string &name, const std::vector<SymbolType> &concreteTemplateTypes);
+  static std::string getSignature(const std::string &name, const std::vector<Type> &concreteTemplateTypes);
   [[nodiscard]] bool hasSubstantiatedGenerics() const;
   [[nodiscard]] bool isFullySubstantiated() const;
-  [[nodiscard]] std::vector<SymbolType> getTemplateTypes() const;
+  [[nodiscard]] std::vector<Type> getTemplateTypes() const;
   [[nodiscard]] const CodeLoc &getDeclCodeLoc() const;
 
   // Public members
   std::string name;
   std::vector<GenericType> templateTypes;
-  std::unordered_map<std::string, SymbolType> typeMapping;
+  std::unordered_map<std::string, Type> typeMapping;
   SymbolTableEntry *entry = nullptr;
   Scope *scope = nullptr;
   ASTNode *declNode;

--- a/src/symboltablebuilder/Capture.cpp
+++ b/src/symboltablebuilder/Capture.cpp
@@ -7,7 +7,7 @@ namespace spice::compiler {
 Capture::Capture(SymbolTableEntry *entry) : capturedEntry(entry) {
   // Set the capture mode depending on the symbol type
   // All types with guaranteed size <= 64 bit are captured by value, all others by reference.
-  const SymbolType &type = entry->getType();
+  const Type &type = entry->getType();
   captureMode = type.isOneOf({TY_STRUCT, TY_INTERFACE}) ? BY_REFERENCE : BY_VALUE;
 }
 

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -290,7 +290,7 @@ size_t Scope::getFieldCount() const {
   assert(type == ScopeType::STRUCT);
   size_t fieldCount = 0;
   for (const auto &symbol : symbolTable.symbols) {
-    const SymbolType &symbolType = symbol.second.getType();
+    const Type &symbolType = symbol.second.getType();
     if (symbolType.is(TY_IMPORT))
       continue;
     const ASTNode *declNode = symbol.second.declNode;

--- a/src/symboltablebuilder/SymbolTable.cpp
+++ b/src/symboltablebuilder/SymbolTable.cpp
@@ -22,7 +22,7 @@ SymbolTableEntry *SymbolTable::insert(const std::string &name, ASTNode *declNode
   bool isGlobal = parent == nullptr;
   size_t orderIndex = symbols.size();
   // Insert into symbols map. The type is 'dyn', because concrete types are determined by the type checker later on
-  symbols.insert({name, SymbolTableEntry(name, SymbolType(TY_INVALID), scope, declNode, orderIndex, isGlobal)});
+  symbols.insert({name, SymbolTableEntry(name, Type(TY_INVALID), scope, declNode, orderIndex, isGlobal)});
   // Set entry to declared
   SymbolTableEntry *entry = &symbols.at(name);
   entry->updateState(DECLARED, declNode);
@@ -44,7 +44,7 @@ SymbolTableEntry *SymbolTable::insert(const std::string &name, ASTNode *declNode
  * @param declNode AST node where the anonymous symbol is declared
  * @return Inserted entry
  */
-SymbolTableEntry *SymbolTable::insertAnonymous(const SymbolType &type, ASTNode *declNode, size_t numericSuffix) {
+SymbolTableEntry *SymbolTable::insertAnonymous(const Type &type, ASTNode *declNode, size_t numericSuffix) {
   // Check if the anonymous entry already exists
   if (SymbolTableEntry *anonSymbol = lookupAnonymous(declNode->codeLoc, numericSuffix))
     return anonSymbol;

--- a/src/symboltablebuilder/SymbolTable.h
+++ b/src/symboltablebuilder/SymbolTable.h
@@ -18,7 +18,7 @@ namespace spice::compiler {
 
 // Forward declarations
 class Scope;
-class SymbolType;
+class Type;
 struct CodeLoc;
 
 using CaptureMap = std::unordered_map<std::string /*name*/, Capture /*capture*/>;
@@ -39,7 +39,7 @@ public:
 
   // Public methods
   SymbolTableEntry *insert(const std::string &name, ASTNode *declNode);
-  SymbolTableEntry *insertAnonymous(const SymbolType &type, ASTNode *declNode, size_t numericSuffix = 0);
+  SymbolTableEntry *insertAnonymous(const Type &type, ASTNode *declNode, size_t numericSuffix = 0);
   void copySymbol(const std::string &originalName, const std::string &newName);
   SymbolTableEntry *lookup(const std::string &symbolName);
   SymbolTableEntry *lookupStrict(const std::string &symbolName);

--- a/src/symboltablebuilder/SymbolTableEntry.cpp
+++ b/src/symboltablebuilder/SymbolTableEntry.cpp
@@ -14,7 +14,7 @@ namespace spice::compiler {
  *
  * @return Current symbol type of this symbol
  */
-const SymbolType &SymbolTableEntry::getType() const { return type; }
+const Type &SymbolTableEntry::getType() const { return type; }
 
 /**
  * Update the type of this symbol.
@@ -22,7 +22,7 @@ const SymbolType &SymbolTableEntry::getType() const { return type; }
  * @param newType New type of the current symbol
  * @param overwriteExistingType Overwrites the existing type without throwing an error
  */
-void SymbolTableEntry::updateType(const SymbolType &newType, bool overwriteExistingType) {
+void SymbolTableEntry::updateType(const Type &newType, bool overwriteExistingType) {
   assert(overwriteExistingType || type.isOneOf({TY_INVALID, TY_DYN}));
   type = newType;
 }

--- a/src/symboltablebuilder/SymbolTableEntry.h
+++ b/src/symboltablebuilder/SymbolTableEntry.h
@@ -7,7 +7,7 @@
 #include <utility>
 
 #include <symboltablebuilder/Lifecycle.h>
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 
 #include <llvm/IR/DerivedTypes.h>
 #include <llvm/IR/Value.h>
@@ -28,12 +28,12 @@ union CompileTimeValue;
 class SymbolTableEntry {
 public:
   // Constructors
-  SymbolTableEntry(std::string name, SymbolType type, Scope *scope, ASTNode *declNode, size_t orderIndex, const bool global)
+  SymbolTableEntry(std::string name, Type type, Scope *scope, ASTNode *declNode, size_t orderIndex, const bool global)
       : name(std::move(name)), scope(scope), declNode(declNode), orderIndex(orderIndex), global(global), type(std::move(type)){};
 
   // Public methods
-  [[nodiscard]] const SymbolType &getType() const;
-  void updateType(const SymbolType &newType, bool overwriteExistingType);
+  [[nodiscard]] const Type &getType() const;
+  void updateType(const Type &newType, bool overwriteExistingType);
   void updateState(const LifecycleState &newState, ASTNode *node, bool force = false);
   [[nodiscard]] const CodeLoc &getDeclCodeLoc() const;
   [[nodiscard]] llvm::StructType *getStructLLVMType() const;
@@ -61,7 +61,7 @@ public:
 
 private:
   // Members
-  SymbolType type;
+  Type type;
   llvm::StructType *llvmStructType = nullptr; // For structs and interfaces only
   std::stack<llvm::Value *> memAddress;
   Lifecycle lifecycle;

--- a/src/symboltablebuilder/TypeChain.cpp
+++ b/src/symboltablebuilder/TypeChain.cpp
@@ -1,12 +1,12 @@
 // Copyright (c) 2021-2024 ChilliBits. All rights reserved.
 
-#include "SymbolType.h"
+#include "Type.h"
 
 #include <exception/CompilerError.h>
 
 namespace spice::compiler {
 
-bool operator==(const SymbolType::TypeChainElement &lhs, const SymbolType::TypeChainElement &rhs) {
+bool operator==(const Type::TypeChainElement &lhs, const Type::TypeChainElement &rhs) {
   // Check super type
   if (lhs.superType != rhs.superType)
     return false;
@@ -43,7 +43,7 @@ bool operator==(const SymbolType::TypeChainElement &lhs, const SymbolType::TypeC
   }
 }
 
-bool operator!=(const SymbolType::TypeChainElement &lhs, const SymbolType::TypeChainElement &rhs) { return !(lhs == rhs); }
+bool operator!=(const Type::TypeChainElement &lhs, const Type::TypeChainElement &rhs) { return !(lhs == rhs); }
 
 /**
  * Return the type name as string
@@ -51,7 +51,7 @@ bool operator!=(const SymbolType::TypeChainElement &lhs, const SymbolType::TypeC
  * @param withSize Also encode array sizes
  * @return Name as string
  */
-std::string SymbolType::TypeChainElement::getName(bool withSize) const {
+std::string Type::TypeChainElement::getName(bool withSize) const {
   switch (superType) {
   case TY_PTR:
     return "*";

--- a/src/symboltablebuilder/TypeSpecifiers.cpp
+++ b/src/symboltablebuilder/TypeSpecifiers.cpp
@@ -3,7 +3,7 @@
 #include "TypeSpecifiers.h"
 
 #include <exception/CompilerError.h>
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 
 namespace spice::compiler {
 

--- a/src/typechecker/ExprResult.h
+++ b/src/typechecker/ExprResult.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 
 namespace spice::compiler {
 
@@ -10,7 +10,7 @@ namespace spice::compiler {
 class SymbolTableEntry;
 
 struct ExprResult {
-  SymbolType type;
+  Type type;
   SymbolTableEntry *entry = nullptr;
 
   [[nodiscard]] bool isTemporary() const { return entry == nullptr; }

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -95,12 +95,12 @@ void FunctionManager::substantiateOptionalParams(const Function &baseFunction, s
     manifestations.push_back(baseFunction);
 }
 
-Function FunctionManager::createMainFunction(SymbolTableEntry *entry, const std::vector<SymbolType> &paramTypes,
+Function FunctionManager::createMainFunction(SymbolTableEntry *entry, const std::vector<Type> &paramTypes,
                                              ASTNode *declNode) {
   ParamList paramList;
-  for (const SymbolType &paramType : paramTypes)
+  for (const Type &paramType : paramTypes)
     paramList.push_back({paramType, false});
-  return {MAIN_FUNCTION_NAME, entry, SymbolType(TY_DYN), SymbolType(TY_INT), paramList, {}, declNode};
+  return {MAIN_FUNCTION_NAME, entry, Type(TY_DYN), Type(TY_INT), paramList, {}, declNode};
 }
 
 Function *FunctionManager::insertSubstantiation(Scope *insertScope, const Function &newManifestation, const ASTNode *declNode) {
@@ -133,7 +133,7 @@ Function *FunctionManager::insertSubstantiation(Scope *insertScope, const Functi
  * @param strictSpecifierMatching Match argument and this type specifiers strictly
  * @return Found function or nullptr
  */
-const Function *FunctionManager::lookupFunction(Scope *matchScope, const std::string &reqName, const SymbolType &reqThisType,
+const Function *FunctionManager::lookupFunction(Scope *matchScope, const std::string &reqName, const Type &reqThisType,
                                                 const ArgList &reqArgs, bool strictSpecifierMatching) {
   assert(reqThisType.isOneOf({TY_DYN, TY_STRUCT}));
 
@@ -189,8 +189,8 @@ const Function *FunctionManager::lookupFunction(Scope *matchScope, const std::st
  * @param callNode Call AST node for printing error messages
  * @return Matched function or nullptr
  */
-Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &reqName, const SymbolType &reqThisType,
-                                         const ArgList &reqArgs, const std::vector<SymbolType> &templateTypeHints,
+Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &reqName, const Type &reqThisType,
+                                         const ArgList &reqArgs, const std::vector<Type> &templateTypeHints,
                                          bool strictSpecifierMatching, const ASTNode *callNode) {
   assert(reqThisType.isOneOf({TY_DYN, TY_STRUCT, TY_INTERFACE}));
 
@@ -216,7 +216,7 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
       typeMapping.clear();
       for (size_t i = 0; i < std::min(templateTypeHints.size(), candidate.templateTypes.size()); i++) {
         const std::string &typeName = candidate.templateTypes.at(i).getSubType();
-        const SymbolType &templateType = templateTypeHints.at(i);
+        const Type &templateType = templateTypeHints.at(i);
         typeMapping.insert({typeName, templateType});
       }
 
@@ -298,7 +298,7 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
 }
 
 MatchResult FunctionManager::matchManifestation(Function &candidate, Scope *&matchScope, const std::string &reqName,
-                                                const SymbolType &reqThisType, const ArgList &reqArgs, TypeMapping &typeMapping,
+                                                const Type &reqThisType, const ArgList &reqArgs, TypeMapping &typeMapping,
                                                 bool strictSpecifierMatching, bool &forceSubstantiation,
                                                 const ASTNode *callNode) {
   // Check name requirement
@@ -320,7 +320,7 @@ MatchResult FunctionManager::matchManifestation(Function &candidate, Scope *&mat
   // Substantiate return type
   substantiateReturnType(candidate, typeMapping);
 
-  const SymbolType &thisType = candidate.thisType;
+  const Type &thisType = candidate.thisType;
   if (!thisType.is(TY_DYN)) {
     // If we only have the generic struct scope, lookup the concrete manifestation scope
     if (matchScope->isGenericScope) {
@@ -354,9 +354,9 @@ bool FunctionManager::matchName(const Function &candidate, const std::string &re
  * @param strictSpecifierMatching Match specifiers strictly
  * @return Fulfilled or not
  */
-bool FunctionManager::matchThisType(Function &candidate, const SymbolType &reqThisType, TypeMapping &typeMapping,
+bool FunctionManager::matchThisType(Function &candidate, const Type &reqThisType, TypeMapping &typeMapping,
                                     bool strictSpecifierMatching) {
-  SymbolType &candidateThisType = candidate.thisType;
+  Type &candidateThisType = candidate.thisType;
 
   // Shortcut for procedures
   if (candidateThisType.is(TY_DYN) && reqThisType.is(TY_DYN))
@@ -406,9 +406,9 @@ bool FunctionManager::matchArgTypes(Function &candidate, const ArgList &reqArgs,
   for (size_t i = 0; i < reqArgs.size(); i++) {
     // Retrieve actual and requested types
     assert(!candidateParamList.at(i).isOptional);
-    SymbolType &candidateParamType = candidateParamList.at(i).type;
+    Type &candidateParamType = candidateParamList.at(i).type;
     const Arg &requestedParamType = reqArgs.at(i);
-    const SymbolType &requestedType = requestedParamType.first;
+    const Type &requestedType = requestedParamType.first;
     const bool isArgTemporary = requestedParamType.second;
 
     // Check if the requested param type matches the candidate param type. The type mapping may be extended

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -17,14 +17,14 @@ struct ExprResult;
 class Function;
 class Scope;
 class SymbolTableEntry;
-class SymbolType;
+class Type;
 class ASTNode;
 class GenericType;
 
 // Typedefs
 using FunctionManifestationList = std::unordered_map</*mangledName=*/std::string, Function>;
 using FunctionRegistry = std::map</*fctId=*/std::string, /*manifestationList=*/FunctionManifestationList>;
-using Arg = std::pair</*type=*/SymbolType, /*isTemporary=*/bool>;
+using Arg = std::pair</*type=*/Type, /*isTemporary=*/bool>;
 using ArgList = std::vector<Arg>;
 
 enum class MatchResult : uint8_t {
@@ -42,13 +42,13 @@ public:
   static Function *insertFunction(Scope *insertScope, const Function &baseFunction,
                                   std::vector<Function *> *nodeFunctionList = nullptr);
   static void substantiateOptionalParams(const Function &baseFunction, std::vector<Function> &manifestations);
-  [[nodiscard]] static Function createMainFunction(SymbolTableEntry *entry, const std::vector<SymbolType> &paramTypes,
+  [[nodiscard]] static Function createMainFunction(SymbolTableEntry *entry, const std::vector<Type> &paramTypes,
                                                    ASTNode *declNode);
   [[nodiscard]] static const Function *lookupFunction(Scope *matchScope, const std::string &reqName,
-                                                      const SymbolType &reqThisType, const ArgList &reqArgs,
+                                                      const Type &reqThisType, const ArgList &reqArgs,
                                                       bool strictSpecifierMatching);
-  static Function *matchFunction(Scope *matchScope, const std::string &reqName, const SymbolType &reqThisType,
-                                 const ArgList &reqArgs, const std::vector<SymbolType> &templateTypeHints,
+  static Function *matchFunction(Scope *matchScope, const std::string &reqName, const Type &reqThisType,
+                                 const ArgList &reqArgs, const std::vector<Type> &templateTypeHints,
                                  bool strictSpecifierMatching, const ASTNode *callNode);
 
 private:
@@ -56,11 +56,11 @@ private:
   [[nodiscard]] static Function *insertSubstantiation(Scope *insertScope, const Function &newManifestation,
                                                       const ASTNode *declNode);
   [[nodiscard]] static MatchResult matchManifestation(Function &candidate, Scope *&matchScope, const std::string &reqName,
-                                                      const SymbolType &reqThisType, const ArgList &reqArgs,
+                                                      const Type &reqThisType, const ArgList &reqArgs,
                                                       TypeMapping &typeMapping, bool strictSpecifierMatching,
                                                       bool &forceSubstantiation, const ASTNode *callNode);
   [[nodiscard]] static bool matchName(const Function &candidate, const std::string &reqName);
-  [[nodiscard]] static bool matchThisType(Function &candidate, const SymbolType &reqThisType, TypeMapping &typeMapping,
+  [[nodiscard]] static bool matchThisType(Function &candidate, const Type &reqThisType, TypeMapping &typeMapping,
                                           bool strictSpecifierMatching);
   [[nodiscard]] static bool matchArgTypes(Function &candidate, const ArgList &reqArgs, TypeMapping &typeMapping,
                                           bool strictSpecifierMatching, bool &needsSubstantiation, const ASTNode *callNode);

--- a/src/typechecker/InterfaceManager.cpp
+++ b/src/typechecker/InterfaceManager.cpp
@@ -50,7 +50,7 @@ Interface *InterfaceManager::insertSubstantiation(Scope *insertScope, Interface 
  * @return Matched interface or nullptr
  */
 Interface *InterfaceManager::matchInterface(Scope *matchScope, const std::string &reqName,
-                                            const std::vector<SymbolType> &reqTemplateTypes, const ASTNode *node) {
+                                            const std::vector<Type> &reqTemplateTypes, const ASTNode *node) {
   // Copy the registry to prevent iterating over items, that are created within the loop
   InterfaceRegistry interfaceRegistry = matchScope->interfaces;
   // Loop over interface registry to find interfaces, that match the requirements of the instantiation
@@ -120,7 +120,7 @@ Interface *InterfaceManager::matchInterface(Scope *matchScope, const std::string
       substantiatedInterface->scope->isGenericScope = false;
 
       // Attach the template types to the new interface entry
-      SymbolType entryType = substantiatedInterface->entry->getType();
+      Type entryType = substantiatedInterface->entry->getType();
       entryType.setTemplateTypes(substantiatedInterface->getTemplateTypes());
       entryType.setBodyScope(substantiatedInterface->scope);
       substantiatedInterface->entry->updateType(entryType, true);
@@ -166,7 +166,7 @@ bool InterfaceManager::matchName(const Interface &candidate, const std::string &
  * @param reqTemplateTypes Requested interface template types
  * @return Fulfilled or not
  */
-bool InterfaceManager::matchTemplateTypes(Interface &candidate, const std::vector<SymbolType> &reqTemplateTypes,
+bool InterfaceManager::matchTemplateTypes(Interface &candidate, const std::vector<Type> &reqTemplateTypes,
                                           TypeMapping &typeMapping) {
   // Check if the number of types match
   const size_t typeCount = reqTemplateTypes.size();
@@ -180,8 +180,8 @@ bool InterfaceManager::matchTemplateTypes(Interface &candidate, const std::vecto
 
   // Loop over all template types
   for (size_t i = 0; i < typeCount; i++) {
-    const SymbolType &reqType = reqTemplateTypes.at(i);
-    SymbolType &candidateType = candidate.templateTypes.at(i);
+    const Type &reqType = reqTemplateTypes.at(i);
+    Type &candidateType = candidate.templateTypes.at(i);
 
     // Check if the requested template type matches the candidate template type. The type mapping may be extended
     if (!TypeMatcher::matchRequestedToCandidateType(candidateType, reqType, typeMapping, genericTypeResolver, false))

--- a/src/typechecker/InterfaceManager.h
+++ b/src/typechecker/InterfaceManager.h
@@ -25,13 +25,13 @@ public:
   // Public methods
   static Interface *insertInterface(Scope *insertScope, Interface &spiceInterface, std::vector<Interface *> *nodeInterfaceList);
   [[nodiscard]] static Interface *matchInterface(Scope *matchScope, const std::string &reqName,
-                                                 const std::vector<SymbolType> &reqTemplateTypes, const ASTNode *node);
+                                                 const std::vector<Type> &reqTemplateTypes, const ASTNode *node);
 
 private:
   // Private methods
   [[nodiscard]] static Interface *insertSubstantiation(Scope *insertScope, Interface &newManifestation, const ASTNode *declNode);
   [[nodiscard]] static bool matchName(const Interface &candidate, const std::string &reqName);
-  [[nodiscard]] static bool matchTemplateTypes(Interface &candidate, const std::vector<SymbolType> &reqTemplateTypes,
+  [[nodiscard]] static bool matchTemplateTypes(Interface &candidate, const std::vector<Type> &reqTemplateTypes,
                                                TypeMapping &typeMapping);
   static void substantiateSignatures(Interface &candidate, TypeMapping &typeMapping);
   [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Interface &candidate,

--- a/src/typechecker/MacroDefs.h
+++ b/src/typechecker/MacroDefs.h
@@ -7,13 +7,13 @@
 #define SOFT_ERROR_ER(node, type, message)                                                                                       \
   {                                                                                                                              \
     resourceManager.errorManager.addSoftError(node, type, message);                                                              \
-    return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_UNRESOLVED), manIdx)};                                          \
+    return ExprResult{node->setEvaluatedSymbolType(Type(TY_UNRESOLVED), manIdx)};                                          \
   }
 
 #define SOFT_ERROR_ST(node, type, message)                                                                                       \
   {                                                                                                                              \
     resourceManager.errorManager.addSoftError(node, type, message);                                                              \
-    return SymbolType(TY_UNRESOLVED);                                                                                            \
+    return Type(TY_UNRESOLVED);                                                                                            \
   }
 
 #define SOFT_ERROR_BOOL(node, type, message)                                                                                     \
@@ -31,7 +31,7 @@
 #define HANDLE_UNRESOLVED_TYPE_ER(var)                                                                                           \
   {                                                                                                                              \
     if (var.is(TY_UNRESOLVED))                                                                                                   \
-      return ExprResult{node->setEvaluatedSymbolType(SymbolType(TY_UNRESOLVED), manIdx)};                                        \
+      return ExprResult{node->setEvaluatedSymbolType(Type(TY_UNRESOLVED), manIdx)};                                        \
   }
 
 #define HANDLE_UNRESOLVED_TYPE_ST(var)                                                                                           \

--- a/src/typechecker/OpRuleManager.h
+++ b/src/typechecker/OpRuleManager.h
@@ -8,7 +8,7 @@
 
 #include <exception/SemanticError.h>
 #include <irgenerator/OpRuleConversionManager.h>
-#include <symboltablebuilder/SymbolType.h>
+#include <symboltablebuilder/Type.h>
 #include <typechecker/ExprResult.h>
 
 namespace spice::compiler {
@@ -615,31 +615,31 @@ public:
   explicit OpRuleManager(TypeChecker *typeChecker);
 
   // Public methods
-  static SymbolType getAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl = false,
+  static Type getAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl = false,
                                         const char *errMsgPrefix = "");
-  static SymbolType getFieldAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool imm,
+  static Type getFieldAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool imm,
                                              bool isDecl = false);
   ExprResult getPlusEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getMinusEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getMulEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getDivEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
-  static SymbolType getRemEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getSHLEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getSHREqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getAndEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getOrEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getXorEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getLogicalOrResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getLogicalAndResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getBitwiseOrResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getBitwiseXorResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getBitwiseAndResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getRemEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getSHLEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getSHREqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getAndEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getOrEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getXorEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getLogicalOrResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getLogicalAndResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getBitwiseOrResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getBitwiseXorResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getBitwiseAndResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
   ExprResult getEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getNotEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
-  static SymbolType getLessResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getGreaterResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getLessEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getGreaterEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getLessResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getGreaterResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getLessEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
+  static Type getGreaterEqualResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
   ExprResult getShiftLeftResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getShiftRightResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getPlusResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
@@ -647,16 +647,16 @@ public:
   ExprResult getMulResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getDivResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   static ExprResult getRemResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
-  static SymbolType getPrefixMinusResultType(const ASTNode *node, const ExprResult &lhs);
-  SymbolType getPrefixPlusPlusResultType(const ASTNode *node, const ExprResult &lhs);
-  SymbolType getPrefixMinusMinusResultType(const ASTNode *node, const ExprResult &lhs);
-  static SymbolType getPrefixNotResultType(const ASTNode *node, const ExprResult &lhs);
-  static SymbolType getPrefixBitwiseNotResultType(const ASTNode *node, const ExprResult &lhs);
-  static SymbolType getPrefixMulResultType(const ASTNode *node, const ExprResult &lhs);
-  static SymbolType getPrefixBitwiseAndResultType(const ASTNode *node, const ExprResult &lhs);
+  static Type getPrefixMinusResultType(const ASTNode *node, const ExprResult &lhs);
+  Type getPrefixPlusPlusResultType(const ASTNode *node, const ExprResult &lhs);
+  Type getPrefixMinusMinusResultType(const ASTNode *node, const ExprResult &lhs);
+  static Type getPrefixNotResultType(const ASTNode *node, const ExprResult &lhs);
+  static Type getPrefixBitwiseNotResultType(const ASTNode *node, const ExprResult &lhs);
+  static Type getPrefixMulResultType(const ASTNode *node, const ExprResult &lhs);
+  static Type getPrefixBitwiseAndResultType(const ASTNode *node, const ExprResult &lhs);
   ExprResult getPostfixPlusPlusResultType(ASTNode *node, const ExprResult &lhs, size_t opIdx);
   ExprResult getPostfixMinusMinusResultType(ASTNode *node, const ExprResult &lhs, size_t opIdx);
-  SymbolType getCastResultType(const ASTNode *node, SymbolType lhsType, const ExprResult &rhs);
+  Type getCastResultType(const ASTNode *node, Type lhsType, const ExprResult &rhs);
 
 private:
   // Members
@@ -664,21 +664,21 @@ private:
   GlobalResourceManager &resourceManager;
 
   // Private methods
-  static SymbolType getAssignResultTypeCommon(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl);
+  static Type getAssignResultTypeCommon(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl);
   template <size_t N>
   ExprResult isOperatorOverloadingFctAvailable(ASTNode *node, const char *fctName, const std::array<ExprResult, N> &op,
                                                size_t opIdx);
-  static SymbolType validateUnaryOperation(const ASTNode *node, const UnaryOpRule opRules[], size_t opRulesSize, const char *name,
-                                           const SymbolType &lhs);
-  static SymbolType validateBinaryOperation(const ASTNode *node, const BinaryOpRule opRules[], size_t opRulesSize,
-                                            const char *name, const SymbolType &lhs, const SymbolType &rhs,
+  static Type validateUnaryOperation(const ASTNode *node, const UnaryOpRule opRules[], size_t opRulesSize, const char *name,
+                                           const Type &lhs);
+  static Type validateBinaryOperation(const ASTNode *node, const BinaryOpRule opRules[], size_t opRulesSize,
+                                            const char *name, const Type &lhs, const Type &rhs,
                                             bool preserveSpecifiersFromLhs = false, const char *customMessagePrefix = "");
-  static SemanticError getExceptionUnary(const ASTNode *node, const char *name, const SymbolType &lhs);
-  static SemanticError getExceptionBinary(const ASTNode *node, const char *name, const SymbolType &lhs, const SymbolType &rhs,
+  static SemanticError getExceptionUnary(const ASTNode *node, const char *name, const Type &lhs);
+  static SemanticError getExceptionBinary(const ASTNode *node, const char *name, const Type &lhs, const Type &rhs,
                                           const char *messagePrefix);
-  void ensureUnsafeAllowed(const ASTNode *node, const char *name, const SymbolType &lhs) const;
-  void ensureUnsafeAllowed(const ASTNode *node, const char *name, const SymbolType &lhs, const SymbolType &rhs) const;
-  static void ensureNoConstAssign(const ASTNode *node, const SymbolType &lhs);
+  void ensureUnsafeAllowed(const ASTNode *node, const char *name, const Type &lhs) const;
+  void ensureUnsafeAllowed(const ASTNode *node, const char *name, const Type &lhs, const Type &rhs) const;
+  static void ensureNoConstAssign(const ASTNode *node, const Type &lhs);
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/StructManager.h
+++ b/src/typechecker/StructManager.h
@@ -15,7 +15,7 @@ namespace spice::compiler {
 struct CodeLoc;
 class Struct;
 class Scope;
-class SymbolType;
+class Type;
 class ASTNode;
 class GenericType;
 
@@ -28,13 +28,13 @@ public:
   // Public methods
   static Struct *insertStruct(Scope *insertScope, Struct &spiceStruct, std::vector<Struct *> *nodeStructList);
   [[nodiscard]] static Struct *matchStruct(Scope *matchScope, const std::string &reqName,
-                                           const std::vector<SymbolType> &reqTemplateTypes, const ASTNode *node);
+                                           const std::vector<Type> &reqTemplateTypes, const ASTNode *node);
 
 private:
   // Private methods
   [[nodiscard]] static Struct *insertSubstantiation(Scope *insertScope, Struct &newManifestation, const ASTNode *declNode);
   [[nodiscard]] static bool matchName(const Struct &candidate, const std::string &reqName);
-  [[nodiscard]] static bool matchTemplateTypes(Struct &candidate, const std::vector<SymbolType> &reqTemplateTypes,
+  [[nodiscard]] static bool matchTemplateTypes(Struct &candidate, const std::vector<Type> &reqTemplateTypes,
                                                TypeMapping &typeMapping);
   static void substantiateFieldTypes(Struct &candidate, TypeMapping &typeMapping);
   [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Struct &candidate,

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -132,13 +132,13 @@ private:
   bool typeCheckedMainFct = false;
 
   // Private methods
-  bool visitOrdinaryFctCall(FctCallNode *node, std::vector<SymbolType> &templateTypes, const std::string &fqFunctionName);
-  bool visitFctPtrCall(FctCallNode *node, const SymbolType &functionType) const;
-  bool visitMethodCall(FctCallNode *node, Scope *structScope, std::vector<SymbolType> &templateTypes) const;
+  bool visitOrdinaryFctCall(FctCallNode *node, std::vector<Type> &templateTypes, const std::string &fqFunctionName);
+  bool visitFctPtrCall(FctCallNode *node, const Type &functionType) const;
+  bool visitMethodCall(FctCallNode *node, Scope *structScope, std::vector<Type> &templateTypes) const;
   bool checkAsyncLambdaCaptureRules(LambdaBaseNode *node, const LambdaAttrNode *attrs) const;
-  [[nodiscard]] SymbolType mapLocalTypeToImportedScopeType(const Scope *targetScope, const SymbolType &symbolType) const;
-  [[nodiscard]] SymbolType mapImportedScopeTypeToLocalType(const Scope *sourceScope, const SymbolType &symbolType) const;
-  static void autoDeReference(SymbolType &symbolType);
+  [[nodiscard]] Type mapLocalTypeToImportedScopeType(const Scope *targetScope, const Type &symbolType) const;
+  [[nodiscard]] Type mapImportedScopeTypeToLocalType(const Scope *sourceScope, const Type &symbolType) const;
+  static void autoDeReference(Type &symbolType);
   std::vector<const Function *> &getOpFctPointers(ASTNode *node) const;
   void requestRevisitIfRequired(const Function *fct);
   void softError(const ASTNode *node, SemanticErrorType errorType, const std::string &message) const;

--- a/src/typechecker/TypeCheckerCheck.cpp
+++ b/src/typechecker/TypeCheckerCheck.cpp
@@ -160,11 +160,11 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
         visit(field->defaultValue());
 
     // Build struct type
-    const SymbolType structType = manifestation->entry->getType();
+    const Type structType = manifestation->entry->getType();
 
     // Check if the struct implements all methods of all attached interfaces
     size_t vtableIndex = 0;
-    for (const SymbolType &interfaceType : manifestation->interfaceTypes) {
+    for (const Type &interfaceType : manifestation->interfaceTypes) {
       // Retrieve interface instance
       const std::string interfaceName = interfaceType.getSubType();
       Scope *matchScope = interfaceType.getBodyScope()->parent;
@@ -174,8 +174,8 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
       // Check for all methods, that it is implemented by the struct
       for (const Function *expectedMethod : interface->methods) {
         const std::string methodName = expectedMethod->name;
-        std::vector<SymbolType> params = expectedMethod->getParamTypes();
-        SymbolType returnType = expectedMethod->returnType;
+        std::vector<Type> params = expectedMethod->getParamTypes();
+        Type returnType = expectedMethod->returnType;
 
         // Substantiate
         TypeMatcher::substantiateTypesWithTypeMapping(params, interface->typeMapping);
@@ -185,7 +185,7 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
         // Build args list
         ArgList args;
         args.reserve(params.size());
-        for (const SymbolType &param : params)
+        for (const Type &param : params)
           args.emplace_back(param, nullptr);
 
         Function *spiceFunction = FunctionManager::matchFunction(currentScope, methodName, structType, args, {}, true, node);

--- a/src/typechecker/TypeMatcher.h
+++ b/src/typechecker/TypeMatcher.h
@@ -7,7 +7,7 @@
 namespace spice::compiler {
 
 // Forward declarations
-class SymbolType;
+class Type;
 
 /**
  * Helper class for FunctionManager and StructManager to match generic types.
@@ -19,13 +19,13 @@ public:
   using ResolverFct = std::function<const GenericType *(const std::string &)>;
 
   // Public methods
-  static bool matchRequestedToCandidateTypes(const std::vector<SymbolType> &candidateType,
-                                             const std::vector<SymbolType> &reqTypes, TypeMapping &typeMapping,
+  static bool matchRequestedToCandidateTypes(const std::vector<Type> &candidateType,
+                                             const std::vector<Type> &reqTypes, TypeMapping &typeMapping,
                                              ResolverFct &resolverFct, bool strictSpecifiers);
-  static bool matchRequestedToCandidateType(SymbolType candidateType, SymbolType requestedType, TypeMapping &typeMapping,
+  static bool matchRequestedToCandidateType(Type candidateType, Type requestedType, TypeMapping &typeMapping,
                                             ResolverFct &resolverFct, bool strictSpecifierMatching);
-  static void substantiateTypesWithTypeMapping(std::vector<SymbolType> &symbolTypes, const TypeMapping &typeMapping);
-  static void substantiateTypeWithTypeMapping(SymbolType &symbolType, const TypeMapping &typeMapping);
+  static void substantiateTypesWithTypeMapping(std::vector<Type> &symbolTypes, const TypeMapping &typeMapping);
+  static void substantiateTypeWithTypeMapping(Type &symbolType, const TypeMapping &typeMapping);
 };
 
 } // namespace spice::compiler


### PR DESCRIPTION
Rename SymbolType to Type. This is a preparation for splitting up Type and QualType, which involves removing qualifier/specifier information from the Type and putting it into a separate class