### PR TITLE
Introduce TypeRegistry

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,8 @@ set(SOURCES
         global/CacheManager.h
         global/RuntimeModuleManager.cpp
         global/RuntimeModuleManager.h
+        global/TypeRegistry.cpp
+        global/TypeRegistry.h
         # Driver
         driver/Driver.cpp
         driver/Driver.h

--- a/src/global/TypeRegistry.cpp
+++ b/src/global/TypeRegistry.cpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2021-2024 ChilliBits. All rights reserved.
+
+#include "TypeRegistry.h"
+
+#include <symboltablebuilder/Type.h>
+
+namespace spice::compiler {
+
+// Static member initialization
+std::unordered_map<std::string, std::unique_ptr<Type>>TypeRegistry::types = {};
+
+const Type *TypeRegistry::get(const std::string &name) {
+  const auto it = types.find(name);
+  return it != types.end() ? it->second.get() : nullptr;
+}
+
+const Type *TypeRegistry::getOrInsert(Type type) {
+  const std::string name = type.getName();
+
+  // Check if type already exists
+  const auto it = types.find(name);
+  if (it != types.end())
+    return it->second.get();
+
+  // Create new type
+  const auto insertedElement = types.emplace(name, std::make_unique<Type>(std::move(type)));
+  return insertedElement.first->second.get();
+}
+
+const Type *TypeRegistry::getOrInsert(SuperType superType) {
+  return getOrInsert(Type(superType));
+}
+
+} // namespace spice::compiler

--- a/src/global/TypeRegistry.h
+++ b/src/global/TypeRegistry.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2021-2024 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace spice::compiler {
+
+// Forward declarations
+class Type;
+enum SuperType : uint8_t;
+
+class TypeRegistry {
+public:
+  // Constructors
+  TypeRegistry() = delete;
+  TypeRegistry(const TypeRegistry &) = delete;
+
+  // Public methods
+  static const Type *get(const std::string &name);
+  static const Type *getOrInsert(Type type);
+  static const Type *getOrInsert(SuperType superType);
+
+private:
+  // Private members
+  static std::unordered_map<std::string, std::unique_ptr<Type>> types;
+};
+
+} // namespace spice::compiler

--- a/src/symboltablebuilder/Type.h
+++ b/src/symboltablebuilder/Type.h
@@ -116,12 +116,17 @@ public:
   Type(TypeChain types, TypeSpecifiers specifiers);
 
   // Public methods
-  [[nodiscard]] Type toPointer(const ASTNode *node) const;
-  [[nodiscard]] Type toReference(const ASTNode *node) const;
+  [[nodiscard]] [[deprecated]] Type toPointer(const ASTNode *node) const;
+  [[nodiscard]] const Type *toPtr(const ASTNode *node) const;
+  [[nodiscard]] [[deprecated]] Type toReference(const ASTNode *node) const;
+  [[nodiscard]] const Type *toRef(const ASTNode *node) const;
   [[nodiscard]] Type toConstReference(const ASTNode *node) const;
-  [[nodiscard]] Type toArray(const ASTNode *node, unsigned int size = 0, bool skipDynCheck = false) const;
-  [[nodiscard]] Type getContainedTy() const;
-  [[nodiscard]] Type replaceBaseType(const Type &newBaseType) const;
+  [[nodiscard]] [[deprecated]] Type toArray(const ASTNode *node, unsigned int size = 0, bool skipDynCheck = false) const;
+  [[nodiscard]] const Type *toArr(const ASTNode *node, unsigned int size = 0, bool skipDynCheck = false) const;
+  [[nodiscard]] [[deprecated]] Type getContainedTy() const;
+  [[nodiscard]] const Type *getContained() const;
+  [[nodiscard]] [[deprecated]] Type replaceBaseType(const Type &newBaseType) const;
+  [[nodiscard]] const Type *replaceBase(const Type &newBaseType) const;
   [[nodiscard]] llvm::Type *toLLVMType(llvm::LLVMContext &context, Scope *accessScope) const;
   [[nodiscard]] ALWAYS_INLINE bool isPtr() const { return getSuperType() == TY_PTR; }
   [[nodiscard]] ALWAYS_INLINE bool isPtrOf(SuperType superType) const { return isPtr() && getContainedTy().is(superType); }


### PR DESCRIPTION
- Introduce TypeRegistry
- Provide new implementations of `toPtr`, `toRef`, `toArr`, `getContained`, `replaceBase` and deprecate the old ones