### PR TITLE
Migrate TypeMatcher to QualType

### DIFF
--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -83,7 +83,7 @@ public:
       child->resizeToNumberOfManifestations(manifestationCount);
     }
     // Reserve this node
-    symbolTypes.resize(manifestationCount, Type(TY_INVALID));
+    symbolTypes.resize(manifestationCount, QualType(TY_INVALID));
     // Do custom work
     customItemsInitialization(manifestationCount);
   }

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -448,7 +448,8 @@ void IRGenerator::generateDtorBodyPreamble(const Function *dtorFunction) {
     const QualType &fieldType = fieldSymbol->getQualType();
     if (fieldType.is(TY_STRUCT)) {
       // Lookup dtor function and generate call if found
-      const Function *dtorFct = FunctionManager::lookupFunction(fieldType.getType().getBodyScope(), DTOR_FUNCTION_NAME, fieldType, {}, false);
+      const Function *dtorFct =
+          FunctionManager::lookupFunction(fieldType.getType().getBodyScope(), DTOR_FUNCTION_NAME, fieldType, {}, false);
       if (dtorFct)
         generateCtorOrDtorCall(fieldSymbol, dtorFct, {});
       continue;
@@ -494,13 +495,13 @@ void IRGenerator::generateTestMain() {
   llvm::Constant *skippedMsg = createGlobalStringConst("skippedMsg", TEST_CASE_SKIPPED_MSG, *rootScope->codeLoc);
 
   // Prepare entry for test main
-  Type functionType(TY_FUNCTION);
-  functionType.specifiers = TypeSpecifiers::of(TY_FUNCTION);
-  functionType.specifiers.isPublic = true;
+  QualType functionType(TY_FUNCTION);
+  functionType.getType().specifiers = TypeSpecifiers::of(TY_FUNCTION);
+  functionType.getType().specifiers.isPublic = true;
   SymbolTableEntry entry(MAIN_FUNCTION_NAME, functionType, rootScope, nullptr, 0, false);
 
   // Prepare test main function
-  Function testMain(MAIN_FUNCTION_NAME, &entry, Type(TY_DYN), Type(TY_INT), {}, {}, nullptr);
+  Function testMain(MAIN_FUNCTION_NAME, &entry, QualType(TY_DYN), QualType(TY_INT), {}, {}, nullptr);
   testMain.used = true; // Mark as used to prevent removal
   testMain.implicitDefault = true;
   testMain.mangleFunctionName = false;

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -45,7 +45,7 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
   llvm::Type *varTy = varSymbolType.getType().toLLVMType(context, accessScope);
 
   // Check if right side is dyn array. If this is the case we have an empty array initializer and need the default value
-  const bool rhsIsDynArray = node->hasAssignment && node->assignExpr()->getEvaluatedSymbolType(manIdx).getType().isArrayOf(TY_DYN);
+  const bool rhsIsDynArray = node->hasAssignment && node->assignExpr()->getEvaluatedSymbolType(manIdx).isArrayOf(TY_DYN);
 
   // Check if the declaration is with an assignment or the default value
   llvm::Value *varAddress = nullptr;

--- a/src/irgenerator/NameMangling.cpp
+++ b/src/irgenerator/NameMangling.cpp
@@ -153,26 +153,24 @@ void NameMangling::mangleName(std::stringstream &out, const std::string &name, b
  * @param type Input symbol type
  * @return Mangled name
  */
-void NameMangling::mangleType(std::stringstream &out, QualType qt, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
-  Type type = qt.getType();
-
+void NameMangling::mangleType(std::stringstream &out, QualType type, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
   // Replace generic type with concrete type
   if (type.hasAnyGenericParts() && !typeMapping.empty())
     TypeMatcher::substantiateTypeWithTypeMapping(type, typeMapping);
 
   // Unwrap type chain
-  assert(!type.typeChain.empty());
-  for (size_t i = type.typeChain.size() - 1; i >= 1; i--)
-    mangleTypeChainElement(out, type.typeChain.at(i), typeMapping, false);
+  assert(!type.getType().typeChain.empty());
+  for (size_t i = type.getType().typeChain.size() - 1; i >= 1; i--)
+    mangleTypeChainElement(out, type.getType().typeChain.at(i), typeMapping, false);
 
   // Specifiers
-  assert(type.specifiers.isSigned == !type.specifiers.isUnsigned);
-  const bool signedness = type.specifiers.isSigned;
-  if (type.specifiers.isConst && type.typeChain.size() > 1)
+  assert(type.getType().specifiers.isSigned == !type.getType().specifiers.isUnsigned);
+  const bool signedness = type.getType().specifiers.isSigned;
+  if (type.getType().specifiers.isConst && type.getType().typeChain.size() > 1)
     out << "K";
 
   // Base chain element
-  mangleTypeChainElement(out, type.typeChain.front(), typeMapping, signedness);
+  mangleTypeChainElement(out, type.getType().typeChain.front(), typeMapping, signedness);
 }
 
 /**

--- a/src/irgenerator/NameMangling.h
+++ b/src/irgenerator/NameMangling.h
@@ -61,7 +61,7 @@ private:
 
   // Private methods
   static void mangleName(std::stringstream &out, const std::string &name, bool &nestedType);
-  static void mangleType(std::stringstream &out, QualType qt, const TypeMapping &typeMapping);
+  static void mangleType(std::stringstream &out, QualType type, const TypeMapping &typeMapping);
   static void mangleTypeChainElement(std::stringstream &out, const TypeChainElement &chainElement, const TypeMapping &typeMapping,
                                      bool signedness);
 };

--- a/src/irgenerator/StdFunctionManager.cpp
+++ b/src/irgenerator/StdFunctionManager.cpp
@@ -58,22 +58,22 @@ llvm::Function *StdFunctionManager::getMemcpyIntrinsic() const {
 }
 
 llvm::Function *StdFunctionManager::getStringGetRawLengthStringFct() const {
-  const ParamList paramLst = {{Type(TY_STRING), false}};
-  const Function function("getRawLength", nullptr, Type(TY_DYN), Type(TY_LONG), paramLst, {}, nullptr);
+  const ParamList paramLst = {{QualType(TY_STRING), false}};
+  const Function function("getRawLength", nullptr, QualType(TY_DYN), QualType(TY_LONG), paramLst, {}, nullptr);
   const std::string mangledName = NameMangling::mangleFunction(function);
   return getFunction(mangledName.c_str(), builder.getInt64Ty(), {builder.getPtrTy()});
 }
 
 llvm::Function *StdFunctionManager::getStringIsRawEqualStringStringFct() const {
-  const ParamList paramLst = {{Type(TY_STRING), false}, {Type(TY_STRING), false}};
-  const Function function("isRawEqual", nullptr, Type(TY_DYN), Type(TY_BOOL), paramLst, {}, nullptr);
+  const ParamList paramLst = {{QualType(TY_STRING), false}, {QualType(TY_STRING), false}};
+  const Function function("isRawEqual", nullptr, QualType(TY_DYN), QualType(TY_BOOL), paramLst, {}, nullptr);
   const std::string mangledName = NameMangling::mangleFunction(function);
   return getFunction(mangledName.c_str(), builder.getInt1Ty(), {builder.getPtrTy(), builder.getPtrTy()});
 }
 
 llvm::Function *StdFunctionManager::getDeallocBytePtrRefFct() const {
-  const ParamList paramLst = {{Type(TY_BYTE).toPointer(nullptr).toReference(nullptr), false}};
-  const Function function("sDealloc", nullptr, Type(TY_DYN), Type(TY_DYN), paramLst, {}, nullptr);
+  const ParamList paramLst = {{QualType(TY_BYTE).toPtr(nullptr).toRef(nullptr), false}};
+  const Function function("sDealloc", nullptr, QualType(TY_DYN), QualType(TY_DYN), paramLst, {}, nullptr);
   const std::string mangledName = NameMangling::mangleFunction(function);
   return getProcedure(mangledName.c_str(), {builder.getPtrTy()});
 }

--- a/src/model/GenericType.h
+++ b/src/model/GenericType.h
@@ -25,8 +25,7 @@ public:
   GenericType() = default;
 
   // Public methods
-  [[nodiscard]] [[deprecated]] bool checkConditionsOf(const QualType &type, bool ignoreArraySize = false,
-                                                      bool ignoreSpecifiers = false) const;
+  [[nodiscard]] bool checkConditionsOf(const QualType &type, bool ignoreArraySize = false, bool ignoreSpecifiers = false) const;
 
   // Public members
   bool used = false;
@@ -36,8 +35,7 @@ private:
   std::vector<QualType> typeConditions = {QualType(TY_DYN)};
 
   // Private methods
-  [[nodiscard]] [[deprecated]] bool checkTypeConditionOf(const QualType &type, bool ignoreArraySize,
-                                                         bool ignoreSpecifiers) const;
+  [[nodiscard]] [[deprecated]] bool checkTypeConditionOf(const QualType &type, bool ignoreArraySize, bool ignoreSpecifiers) const;
 };
 
 } // namespace spice::compiler

--- a/src/model/StructBase.cpp
+++ b/src/model/StructBase.cpp
@@ -62,7 +62,7 @@ std::string StructBase::getSignature(const std::string &name, const std::vector<
  * @return Substantiated generics or not
  */
 bool StructBase::hasSubstantiatedGenerics() const {
-  const auto lambda = [](const GenericType &genericType) { return genericType.getType().hasAnyGenericParts(); };
+  const auto lambda = [](const GenericType &genericType) { return genericType.hasAnyGenericParts(); };
   return std::ranges::none_of(templateTypes, lambda);
 }
 

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -143,6 +143,8 @@ SuperType QualType::getSuperType() const { return type->getSuperType(); }
 
 const std::string &QualType::getSubType() const { return type->getSubType(); }
 
+bool QualType::hasAnyGenericParts() const { return type->hasAnyGenericParts(); }
+
 /**
  * Check if a certain input type can be bound (assigned) to the current type->
  *

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -10,7 +10,7 @@ namespace spice::compiler {
 
 QualType::QualType(Type t) : type(std::make_unique<Type>(std::move(t))) /*, specifiers(this->type->specifiers)*/ {}
 QualType::QualType(SuperType superType) : type(std::make_unique<Type>(superType)) {}
-QualType::QualType(SuperType superType, const std::string &subtype) : type(std::make_unique<Type>(superType, subtype)) {}
+QualType::QualType(SuperType superType, const std::string &subType) : type(std::make_unique<Type>(superType, subType)) {}
 QualType::QualType(Type t, TypeSpecifiers specifiers) : type(std::make_unique<Type>(std::move(t))) /*, specifiers(specifiers)*/ {}
 
 // ToDo: Delete those two later on
@@ -173,6 +173,10 @@ bool QualType::matches(const QualType &otherType, bool ignoreArraySize, bool ign
 
   // Ignore or compare specifiers
   return ignoreSpecifiers || type->specifiers.match(otherType.type->specifiers, allowConstify);
+}
+
+bool QualType::isSameContainerTypeAs(const QualType &other) const {
+  return type->isSameContainerTypeAs(*other.type);
 }
 
 /**

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -67,6 +67,7 @@ public:
   [[nodiscard]] bool isConstRef() const;
   [[nodiscard]] SuperType getSuperType() const;
   [[nodiscard]] const std::string &getSubType() const;
+  [[nodiscard]] bool hasAnyGenericParts() const;
   [[nodiscard]] bool canBind(const QualType &otherType, bool isTemporary) const;
   [[nodiscard]] bool matches(const QualType &otherType, bool ignoreArraySize, bool ignoreSpecifiers, bool allowConstify) const;
   [[nodiscard]] llvm::Type *toLLVMType(llvm::LLVMContext &context, Scope *accessScope) const;

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -25,7 +25,7 @@ public:
   QualType() = default;
   [[deprecated]] /*ToDo: explicit*/ QualType(Type type);
   explicit QualType(SuperType superType);
-  QualType(SuperType superType, const std::string &subtype);
+  QualType(SuperType superType, const std::string &subType);
   QualType(Type type, TypeSpecifiers specifiers);
 
   // ToDo: Remove those later on
@@ -70,6 +70,7 @@ public:
   [[nodiscard]] bool hasAnyGenericParts() const;
   [[nodiscard]] bool canBind(const QualType &otherType, bool isTemporary) const;
   [[nodiscard]] bool matches(const QualType &otherType, bool ignoreArraySize, bool ignoreSpecifiers, bool allowConstify) const;
+  [[nodiscard]] bool isSameContainerTypeAs(const QualType &other) const;
   [[nodiscard]] llvm::Type *toLLVMType(llvm::LLVMContext &context, Scope *accessScope) const;
 
   // Get new type, based on this one

--- a/src/symboltablebuilder/SymbolTableEntry.h
+++ b/src/symboltablebuilder/SymbolTableEntry.h
@@ -32,9 +32,6 @@ public:
   SymbolTableEntry(std::string name, const QualType& qualType, Scope *scope, ASTNode *declNode, size_t orderIndex, const bool global)
       : name(std::move(name)), scope(scope), declNode(declNode), orderIndex(orderIndex), global(global),
         qualType(qualType){};
-  SymbolTableEntry(std::string name, const Type &type, Scope *scope, ASTNode *declNode, size_t orderIndex, const bool global)
-      : name(std::move(name)), scope(scope), declNode(declNode), orderIndex(orderIndex), global(global),
-        qualType(type){};
 
   // Public methods
   [[nodiscard]] const QualType &getQualType() const;

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -421,11 +421,14 @@ bool Type::isBase(SuperType superType) const {
  * Check if the current type is of the same container type like the other type.
  * Only TY_PTR, TY_REF and TY_ARRAY are considered as container types.
  *
- * @param otherType Other symbol type
+ * @param other Other symbol type
  * @return Same container type or not
  */
-bool Type::isSameContainerTypeAs(const Type &otherType) const {
-  return (isPtr() && otherType.isPtr()) || (isRef() && otherType.isRef()) || (isArray() && otherType.isArray());
+bool Type::isSameContainerTypeAs(const Type &other) const {
+  const bool bothPtr = isPtr() && other.isPtr();
+  const bool bothRef = isRef() && other.isRef();
+  const bool bothArray = isArray() && other.isArray();
+  return bothPtr || bothRef || bothArray;
 }
 
 /**

--- a/src/symboltablebuilder/Type.h
+++ b/src/symboltablebuilder/Type.h
@@ -125,20 +125,10 @@ public:
   [[nodiscard]] const Type *replaceBase(const Type &newBaseType) const;
   [[nodiscard]] llvm::Type *toLLVMType(llvm::LLVMContext &context, Scope *accessScope) const;
   [[nodiscard]] ALWAYS_INLINE bool isPtr() const { return getSuperType() == TY_PTR; }
-  [[nodiscard]] ALWAYS_INLINE bool isPtrOf(SuperType superType) const { return isPtr() && getContainedTy().is(superType); }
   [[nodiscard]] ALWAYS_INLINE bool isRef() const { return getSuperType() == TY_REF; }
   [[nodiscard]] ALWAYS_INLINE bool isConstRef() const { return getSuperType() == TY_REF && isConst(); }
-  [[nodiscard]] [[maybe_unused]] ALWAYS_INLINE bool isRefOf(SuperType superType) const {
-    return isRef() && getContainedTy().is(superType);
-  }
   [[nodiscard]] ALWAYS_INLINE bool isArray() const { return getSuperType() == TY_ARRAY; }
-  [[nodiscard]] [[maybe_unused]] ALWAYS_INLINE bool isArrayOf(SuperType superType) const {
-    return isArray() && getContainedTy().is(superType);
-  }
   [[nodiscard]] ALWAYS_INLINE bool is(SuperType superType) const { return getSuperType() == superType; }
-  [[nodiscard]] ALWAYS_INLINE bool is(SuperType superType, const std::string &subType) const {
-    return getSuperType() == superType && getSubType() == subType;
-  }
   [[nodiscard]] ALWAYS_INLINE bool isPrimitive() const {
     return isOneOf({TY_DOUBLE, TY_INT, TY_SHORT, TY_LONG, TY_BYTE, TY_CHAR, TY_STRING, TY_BOOL});
   }

--- a/src/symboltablebuilder/Type.h
+++ b/src/symboltablebuilder/Type.h
@@ -142,7 +142,7 @@ public:
     const SuperType superType = getSuperType();
     return std::ranges::any_of(superTypes, [&superType](SuperType type) { return type == superType; });
   }
-  [[nodiscard]] bool isSameContainerTypeAs(const Type &otherType) const;
+  [[nodiscard]] bool isSameContainerTypeAs(const Type &other) const;
   [[nodiscard]] ALWAYS_INLINE SuperType getSuperType() const {
     assert(!typeChain.empty());
     return typeChain.back().superType;
@@ -152,11 +152,6 @@ public:
     return typeChain.back().subType;
   }
   [[nodiscard]] ALWAYS_INLINE Type removeReferenceWrapper() const { return isRef() ? getContainedTy() : *this; }
-  [[nodiscard]] ALWAYS_INLINE Type getNonConst() const {
-    Type type = *this;
-    type.specifiers.isConst = false;
-    return type;
-  }
   [[nodiscard]] Type getBase() const;
   [[nodiscard]] bool hasAnyGenericParts() const;
   void setTemplateTypes(const std::vector<QualType> &templateTypes);
@@ -174,15 +169,10 @@ public:
     assert(isOneOf({TY_INT, TY_SHORT, TY_LONG, TY_BYTE, TY_CHAR, TY_BOOL}));
     return specifiers.isSigned;
   }
-  [[nodiscard]] ALWAYS_INLINE bool isInline() const {
-    assert(isOneOf({TY_FUNCTION, TY_PROCEDURE}));
-    return specifiers.isInline;
-  }
   [[nodiscard]] ALWAYS_INLINE bool isPublic() const {
     assert(isPrimitive() /* Global variables */ || isOneOf({TY_FUNCTION, TY_PROCEDURE, TY_ENUM, TY_STRUCT, TY_INTERFACE}));
     return specifiers.isPublic;
   }
-  [[nodiscard]] ALWAYS_INLINE bool isHeap() const { return specifiers.isHeap; }
   ALWAYS_INLINE void setBodyScope(Scope *bodyScope) {
     assert(isOneOf({TY_STRUCT, TY_INTERFACE}));
     typeChain.back().data.bodyScope = bodyScope;

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -374,8 +374,8 @@ bool FunctionManager::matchThisType(Function &candidate, const QualType &reqThis
     return false;
 
   // Substantiate the candidate param type, based on the type mapping
-  if (candidateThisType.getType().hasAnyGenericParts())
-    TypeMatcher::substantiateTypeWithTypeMapping(candidateThisType.getType(), typeMapping);
+  if (candidateThisType.hasAnyGenericParts())
+    TypeMatcher::substantiateTypeWithTypeMapping(candidateThisType, typeMapping);
 
   return true;
 }
@@ -418,8 +418,8 @@ bool FunctionManager::matchArgTypes(Function &candidate, const ArgList &reqArgs,
       return false;
 
     // Substantiate the candidate param type, based on the type mapping
-    if (candidateParamType.getType().hasAnyGenericParts())
-      TypeMatcher::substantiateTypeWithTypeMapping(candidateParamType.getType(), typeMapping);
+    if (candidateParamType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(candidateParamType, typeMapping);
 
     // Check if we try to bind a non-ref temporary to a non-const ref parameter
     if (!candidateParamType.canBind(requestedType, isArgTemporary)) {
@@ -445,8 +445,8 @@ bool FunctionManager::matchArgTypes(Function &candidate, const ArgList &reqArgs,
  * @param typeMapping Concrete template type mapping
  */
 void FunctionManager::substantiateReturnType(Function &candidate, TypeMapping &typeMapping) {
-  if (candidate.returnType.getType().hasAnyGenericParts())
-    TypeMatcher::substantiateTypeWithTypeMapping(candidate.returnType.getType(), typeMapping);
+  if (candidate.returnType.hasAnyGenericParts())
+    TypeMatcher::substantiateTypeWithTypeMapping(candidate.returnType, typeMapping);
 }
 
 /**

--- a/src/typechecker/InterfaceManager.cpp
+++ b/src/typechecker/InterfaceManager.cpp
@@ -188,8 +188,8 @@ bool InterfaceManager::matchTemplateTypes(Interface &candidate, const std::vecto
       return false;
 
     // Substantiate the candidate param type, based on the type mapping
-    if (candidateType.getType().hasAnyGenericParts())
-      TypeMatcher::substantiateTypeWithTypeMapping(candidateType.getType(), typeMapping);
+    if (candidateType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(candidateType, typeMapping);
   }
 
   return true;
@@ -215,7 +215,7 @@ void InterfaceManager::substantiateSignatures(Interface &candidate, TypeMapping 
     // Substantiate param types
     for (Param &paramType : method->paramList)
       if (paramType.type.isBase(TY_GENERIC))
-        TypeMatcher::substantiateTypeWithTypeMapping(paramType.type.getType(), typeMapping);
+        TypeMatcher::substantiateTypeWithTypeMapping(paramType.type, typeMapping);
   }
 }
 

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -156,7 +156,7 @@ Struct *StructManager::matchStruct(Scope *matchScope, const std::string &reqName
       // Instantiate implemented interfaces if required
       for (QualType &interfaceType : substantiatedStruct->interfaceTypes) {
         // Skip non-generic interfaces
-        if (!interfaceType.getType().hasAnyGenericParts())
+        if (!interfaceType.hasAnyGenericParts())
           continue;
 
         // Build template types
@@ -226,8 +226,8 @@ bool StructManager::matchTemplateTypes(Struct &candidate, const std::vector<Qual
       return false;
 
     // Substantiate the candidate param type, based on the type mapping
-    if (candidateType.getType().hasAnyGenericParts())
-      TypeMatcher::substantiateTypeWithTypeMapping(candidateType.getType(), typeMapping);
+    if (candidateType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(candidateType, typeMapping);
   }
 
   return true;
@@ -245,16 +245,16 @@ void StructManager::substantiateFieldTypes(Struct &candidate, TypeMapping &typeM
   for (size_t i = 0; i < fieldCount; i++) {
     SymbolTableEntry *fieldEntry = candidate.scope->symbolTable.lookupStrictByIndex(i);
     QualType fieldType = fieldEntry->getQualType();
-    if (fieldType.getType().hasAnyGenericParts()) {
-      TypeMatcher::substantiateTypeWithTypeMapping(fieldType.getType(), typeMapping);
+    if (fieldType.hasAnyGenericParts()) {
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping);
       fieldEntry->updateType(fieldType, true);
     }
   }
 
   // Loop over all explicit field types and substantiate the generic ones
   for (QualType &fieldType : candidate.fieldTypes)
-    if (fieldType.getType().hasAnyGenericParts())
-      TypeMatcher::substantiateTypeWithTypeMapping(fieldType.getType(), typeMapping);
+    if (fieldType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping);
 }
 
 /**

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -245,7 +245,7 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
   }
 
   // Update type of item
-  itemVarSymbol->updateType(itemType.getType(), true);
+  itemVarSymbol->updateType(itemType, true);
 
   // Visit body
   visit(node->body());
@@ -521,11 +521,11 @@ std::any TypeChecker::visitSignature(SignatureNode *node) {
   manifestation->used = true;
 
   // Prepare signature type
-  Type signatureType(isFunction ? TY_FUNCTION : TY_PROCEDURE);
-  signatureType.specifiers = node->signatureSpecifiers;
+  QualType signatureType(isFunction ? TY_FUNCTION : TY_PROCEDURE);
+  signatureType.getType().specifiers = node->signatureSpecifiers;
   if (isFunction)
-    signatureType.setFunctionReturnType(returnType);
-  signatureType.setFunctionParamTypes(paramTypes);
+    signatureType.getType().setFunctionReturnType(returnType);
+  signatureType.getType().setFunctionParamTypes(paramTypes);
 
   // Set entry to signature type
   assert(node->entry != nullptr);

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -556,7 +556,7 @@ std::any TypeChecker::visitDeclStmt(DeclStmtNode *node) {
     localVarType = std::any_cast<QualType>(visit(node->dataType()));
 
     // Infer the type left to right if the right side is an empty array initialization
-    if (rhsTy.getType().isArrayOf(TY_DYN))
+    if (rhsTy.isArrayOf(TY_DYN))
       rhsTy = QualType(localVarType);
 
     // Check if type has to be inferred or both types are fixed
@@ -783,8 +783,8 @@ std::any TypeChecker::visitPrintfCall(PrintfCallNode *node) {
       break;
     }
     case 's': {
-      if (!argType.is(TY_STRING) && !argType.getType().isStringObj() && !argType.getType().isPtrOf(TY_CHAR) &&
-          !argType.getType().isArrayOf(TY_CHAR))
+      if (!argType.is(TY_STRING) && !argType.getType().isStringObj() && !argType.isPtrTo(TY_CHAR) &&
+          !argType.isArrayOf(TY_CHAR))
         SOFT_ERROR_ER(assignment, PRINTF_TYPE_ERROR,
                       "The placeholder string expects string, String, char* or char[], but got " + argType.getName(false))
       placeholderCount++;
@@ -1625,7 +1625,7 @@ std::any TypeChecker::visitFctCall(FctCallNode *node) {
       // Visit argument
       const auto argResult = std::any_cast<ExprResult>(visit(arg));
       HANDLE_UNRESOLVED_TYPE_ER(argResult.type)
-      assert(!argResult.type.getType().hasAnyGenericParts());
+      assert(!argResult.type.hasAnyGenericParts());
       // Save arg type to arg types list
       data.argResults.push_back(argResult);
     }

--- a/src/typechecker/TypeCheckerCheck.cpp
+++ b/src/typechecker/TypeCheckerCheck.cpp
@@ -182,8 +182,8 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
 
         // Substantiate
         TypeMatcher::substantiateTypesWithTypeMapping(params, interface->typeMapping);
-        if (returnType.getType().hasAnyGenericParts())
-          TypeMatcher::substantiateTypeWithTypeMapping(returnType.getType(), interface->typeMapping);
+        if (returnType.hasAnyGenericParts())
+          TypeMatcher::substantiateTypeWithTypeMapping(returnType, interface->typeMapping);
 
         // Build args list
         ArgList args;

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -255,8 +255,8 @@ void TypeChecker::createCtorBodyPreamble(Scope *bodyScope) {
     if (fieldSymbol->isImplicitField)
       continue;
     QualType fieldType = fieldSymbol->getQualType();
-    if (fieldType.getType().hasAnyGenericParts())
-      TypeMatcher::substantiateTypeWithTypeMapping(fieldType.getType(), typeMapping);
+    if (fieldType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping);
 
     if (fieldType.is(TY_STRUCT)) {
       auto fieldNode = spice_pointer_cast<FieldNode *>(fieldSymbol->declNode);
@@ -287,8 +287,8 @@ void TypeChecker::createCopyCtorBodyPreamble(Scope *bodyScope) {
     if (fieldSymbol->isImplicitField)
       continue;
     QualType fieldType = fieldSymbol->getQualType();
-    if (fieldType.getType().hasAnyGenericParts())
-      TypeMatcher::substantiateTypeWithTypeMapping(fieldType.getType(), typeMapping);
+    if (fieldType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping);
 
     if (fieldType.is(TY_STRUCT)) {
       auto fieldNode = spice_pointer_cast<FieldNode *>(fieldSymbol->declNode);
@@ -319,8 +319,8 @@ void TypeChecker::createDtorBodyPreamble(Scope *bodyScope) {
     if (fieldSymbol->isImplicitField)
       continue;
     QualType fieldType = fieldSymbol->getQualType();
-    if (fieldType.getType().hasAnyGenericParts())
-      TypeMatcher::substantiateTypeWithTypeMapping(fieldType.getType(), typeMapping);
+    if (fieldType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping);
 
     if (fieldType.is(TY_STRUCT)) {
       auto fieldNode = spice_pointer_cast<FieldNode *>(fieldSymbol->declNode);

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -28,8 +28,8 @@ void TypeChecker::createDefaultStructMethod(const Struct &spiceStruct, const std
   const std::string fqFctName = structType.getSubType() + MEMBER_ACCESS_TOKEN + methodName;
 
   // Procedure type
-  Type procedureType(TY_PROCEDURE);
-  procedureType.specifiers.isPublic = true; // Always public
+  QualType procedureType(TY_PROCEDURE);
+  procedureType.getType().specifiers.isPublic = true; // Always public
 
   // Insert symbol for function into the symbol table
   const std::string entryName = Function::getSymbolTableEntryName(methodName, node->codeLoc);

--- a/src/typechecker/TypeCheckerPrepare.cpp
+++ b/src/typechecker/TypeCheckerPrepare.cpp
@@ -140,10 +140,10 @@ std::any TypeChecker::visitFctDefPrepare(FctDefNode *node) {
   assert(currentScope->type == ScopeType::GLOBAL || currentScope->type == ScopeType::STRUCT);
 
   // Prepare type of function
-  Type functionType(TY_FUNCTION);
-  functionType.specifiers = node->specifiers;
-  functionType.setFunctionReturnType(returnType);
-  functionType.setFunctionParamTypes(paramTypes);
+  QualType functionType(TY_FUNCTION);
+  functionType.getType().specifiers = node->specifiers;
+  functionType.getType().setFunctionReturnType(returnType);
+  functionType.getType().setFunctionParamTypes(paramTypes);
 
   // Update type of function entry
   SymbolTableEntry *functionEntry = currentScope->lookupStrict(node->getSymbolTableEntryName());
@@ -273,9 +273,9 @@ std::any TypeChecker::visitProcDefPrepare(ProcDefNode *node) {
   assert(currentScope->type == ScopeType::GLOBAL || currentScope->type == ScopeType::STRUCT);
 
   // Prepare type of procedure
-  Type procedureType(TY_PROCEDURE);
-  procedureType.specifiers = node->specifiers;
-  procedureType.setFunctionParamTypes(paramTypes);
+  QualType procedureType(TY_PROCEDURE);
+  procedureType.getType().specifiers = node->specifiers;
+  procedureType.getType().setFunctionParamTypes(paramTypes);
 
   // Update type of procedure entry
   SymbolTableEntry *procedureEntry = currentScope->lookupStrict(node->getSymbolTableEntryName());
@@ -366,8 +366,8 @@ std::any TypeChecker::visitStructDefPrepare(StructDefNode *node) {
   // Update type of struct entry
   assert(node->entry != nullptr);
   const Type::TypeChainElementData data = {.bodyScope = node->structScope};
-  Type structType(TY_STRUCT, node->structName, node->typeId, data, usedTemplateTypes);
-  structType.specifiers = node->structSpecifiers;
+  QualType structType(Type(TY_STRUCT, node->structName, node->typeId, data, usedTemplateTypes));
+  structType.getType().specifiers = node->structSpecifiers;
   node->entry->updateType(structType, false);
 
   // Change to struct scope
@@ -495,8 +495,8 @@ std::any TypeChecker::visitInterfaceDefPrepare(InterfaceDefNode *node) {
 std::any TypeChecker::visitEnumDefPrepare(EnumDefNode *node) {
   // Update type of enum entry
   const Type::TypeChainElementData data = {.bodyScope = node->enumScope};
-  Type enumType(TY_ENUM, node->enumName, node->typeId, data, {});
-  enumType.specifiers = node->enumSpecifiers;
+  QualType enumType(Type(TY_ENUM, node->enumName, node->typeId, data, {}));
+  enumType.getType().specifiers = node->enumSpecifiers;
   assert(node->entry != nullptr);
   node->entry->updateType(enumType, false);
 
@@ -522,7 +522,7 @@ std::any TypeChecker::visitEnumDefPrepare(EnumDefNode *node) {
 
   // Loop through all items without values
   uint32_t nextValue = 0;
-  Type intSymbolType(TY_INT);
+  QualType intSymbolType(TY_INT);
   for (EnumItemNode *enumItem : node->itemLst()->items()) {
     // Update type of enum item entry
     SymbolTableEntry *itemEntry = currentScope->lookupStrict(enumItem->itemName);
@@ -571,8 +571,8 @@ std::any TypeChecker::visitAliasDefPrepare(AliasDefNode *node) {
   assert(node->entry != nullptr && node->aliasedTypeContainerEntry != nullptr);
 
   // Update type of alias entry
-  Type aliasType(TY_ALIAS, node->dataTypeString);
-  aliasType.specifiers = node->aliasSpecifiers;
+  QualType aliasType(TY_ALIAS, node->dataTypeString);
+  aliasType.getType().specifiers = node->aliasSpecifiers;
   node->entry->updateType(aliasType, false);
 
   // Update type of the aliased type container entry
@@ -668,10 +668,10 @@ std::any TypeChecker::visitExtDeclPrepare(ExtDeclNode *node) {
   }
 
   // Prepare ext function type
-  Type extFunctionType(isFunction ? TY_FUNCTION : TY_PROCEDURE);
+  QualType extFunctionType(isFunction ? TY_FUNCTION : TY_PROCEDURE);
   if (isFunction)
-    extFunctionType.setFunctionReturnType(returnType);
-  extFunctionType.setFunctionParamTypes(argTypes);
+    extFunctionType.getType().setFunctionReturnType(returnType);
+  extFunctionType.getType().setFunctionParamTypes(argTypes);
 
   // Set type of external function
   node->entry->updateType(extFunctionType, false);
@@ -684,7 +684,7 @@ std::any TypeChecker::visitExtDeclPrepare(ExtDeclNode *node) {
 
 std::any TypeChecker::visitImportDefPrepare(ImportDefNode *node) {
   // Set entry to import type
-  const Type importType(TY_IMPORT, node->importName);
+  const QualType importType(TY_IMPORT, node->importName);
   assert(node->entry != nullptr);
   node->entry->updateType(importType, false);
 

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -70,8 +70,9 @@ bool TypeMatcher::matchRequestedToCandidateType(QualType candidateType, QualType
       requestedType.getType().specifiers.eraseWithMask(candidateType.getType().specifiers);
 
       // Add to type mapping
-      const Type newMappingType = requestedType.hasAnyGenericParts() ? candidateType : requestedType;
-      assert(newMappingType.is(TY_GENERIC) || newMappingType.specifiers.isSigned != newMappingType.specifiers.isUnsigned);
+      const QualType newMappingType = requestedType.hasAnyGenericParts() ? candidateType : requestedType;
+      assert(newMappingType.is(TY_GENERIC) ||
+             newMappingType.getType().specifiers.isSigned != newMappingType.getType().specifiers.isUnsigned);
       typeMapping.insert({genericTypeName, newMappingType});
 
       return true; // The type was successfully matched, by enriching the type mapping
@@ -118,7 +119,7 @@ void TypeMatcher::substantiateTypeWithTypeMapping(QualType &type, const TypeMapp
   if (type.isBase(TY_GENERIC)) { // The symbol type itself is generic
     const std::string genericTypeName = type.getBase().getSubType();
     assert(typeMapping.contains(genericTypeName));
-    const Type &replacementType = typeMapping.at(genericTypeName);
+    const QualType &replacementType = typeMapping.at(genericTypeName);
     type = type.replaceBaseType(replacementType);
   } else { // The symbol type itself is non-generic, but one or several template or param types are
     if (type.getBase().isOneOf({TY_FUNCTION, TY_PROCEDURE})) {

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -25,15 +25,15 @@ bool TypeMatcher::matchRequestedToCandidateTypes(const std::vector<QualType> &ca
   return true;
 }
 
-bool TypeMatcher::matchRequestedToCandidateType(Type candidateType, Type requestedType, TypeMapping &typeMapping,
+bool TypeMatcher::matchRequestedToCandidateType(QualType candidateType, QualType requestedType, TypeMapping &typeMapping,
                                                 ResolverFct &resolverFct, bool strictSpecifierMatching) {
   // Unwrap as far as possible and remove reference wrappers if possible
-  Type::unwrapBoth(candidateType, requestedType);
+  QualType::unwrapBoth(candidateType, requestedType);
 
   // If the candidate does not contain any generic parts, we can simply check for type equality
   if (!candidateType.hasAnyGenericParts()) {
     // Check if the right one is a struct that implements the interface on the left
-    if (candidateType.matchesInterfaceImplementedByStruct(requestedType))
+    if (candidateType.getType().matchesInterfaceImplementedByStruct(requestedType.getType()))
       return true;
     // Normal equality check
     return candidateType.matches(requestedType, true, !strictSpecifierMatching, true);
@@ -45,10 +45,10 @@ bool TypeMatcher::matchRequestedToCandidateType(Type candidateType, Type request
 
     // Check if we know the concrete type for that generic type name already
     if (typeMapping.contains(genericTypeName)) { // This is a known generic type
-      Type knownConcreteType = typeMapping.at(genericTypeName);
+      QualType knownConcreteType = typeMapping.at(genericTypeName);
 
       // Merge specifiers of candidate type and known concrete type together
-      knownConcreteType.specifiers = knownConcreteType.specifiers.merge(candidateType.specifiers);
+      knownConcreteType.getType().specifiers = knownConcreteType.getType().specifiers.merge(candidateType.getType().specifiers);
 
       // Remove reference wrapper of candidate type if required
       if (!requestedType.isRef())
@@ -67,7 +67,7 @@ bool TypeMatcher::matchRequestedToCandidateType(Type candidateType, Type request
 
       // Zero out all specifiers in the requested type, that are present in the candidate type
       // This is to set all specifiers that are not present in the candidate type to the generic type replacement
-      requestedType.specifiers.eraseWithMask(candidateType.specifiers);
+      requestedType.getType().specifiers.eraseWithMask(candidateType.getType().specifiers);
 
       // Add to type mapping
       const Type newMappingType = requestedType.hasAnyGenericParts() ? candidateType : requestedType;
@@ -84,19 +84,19 @@ bool TypeMatcher::matchRequestedToCandidateType(Type candidateType, Type request
     // If we have a function/procedure type, check the param and return types. Otherwise, check the template types
     if (candidateType.isOneOf({TY_FUNCTION, TY_PROCEDURE})) {
       // Check param  and return types
-      const std::vector<QualType> &candidatePRTypes = candidateType.getFunctionParamAndReturnTypes();
-      const std::vector<QualType> &requestedPRTypes = requestedType.getFunctionParamAndReturnTypes();
+      const std::vector<QualType> &candidatePRTypes = candidateType.getType().getFunctionParamAndReturnTypes();
+      const std::vector<QualType> &requestedPRTypes = requestedType.getType().getFunctionParamAndReturnTypes();
       if (!matchRequestedToCandidateTypes(candidatePRTypes, requestedPRTypes, typeMapping, resolverFct, strictSpecifierMatching))
         return false;
     } else {
       if (requestedType.getSubType() != candidateType.getSubType())
         return false;
-      if (requestedType.getBodyScope()->parent != candidateType.getBodyScope()->parent)
+      if (requestedType.getType().getBodyScope()->parent != candidateType.getType().getBodyScope()->parent)
         return false;
 
       // Check template types
-      const std::vector<QualType> &candidateTTypes = candidateType.getTemplateTypes();
-      const std::vector<QualType> &requestedTTypes = requestedType.getTemplateTypes();
+      const std::vector<QualType> &candidateTTypes = candidateType.getType().getTemplateTypes();
+      const std::vector<QualType> &requestedTTypes = requestedType.getType().getTemplateTypes();
       if (!matchRequestedToCandidateTypes(candidateTTypes, requestedTTypes, typeMapping, resolverFct, strictSpecifierMatching))
         return false;
     }
@@ -107,11 +107,11 @@ bool TypeMatcher::matchRequestedToCandidateType(Type candidateType, Type request
 
 void TypeMatcher::substantiateTypesWithTypeMapping(std::vector<QualType> &qualTypes, const TypeMapping &typeMapping) {
   for (QualType &qualType : qualTypes)
-    if (qualType.getType().hasAnyGenericParts())
-      substantiateTypeWithTypeMapping(qualType.getType(), typeMapping);
+    if (qualType.hasAnyGenericParts())
+      substantiateTypeWithTypeMapping(qualType, typeMapping);
 }
 
-void TypeMatcher::substantiateTypeWithTypeMapping(Type &type, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
+void TypeMatcher::substantiateTypeWithTypeMapping(QualType &type, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
   assert(type.hasAnyGenericParts());
 
   // Check if the type itself is generic
@@ -123,20 +123,20 @@ void TypeMatcher::substantiateTypeWithTypeMapping(Type &type, const TypeMapping 
   } else { // The symbol type itself is non-generic, but one or several template or param types are
     if (type.getBase().isOneOf({TY_FUNCTION, TY_PROCEDURE})) {
       // Substantiate each param type
-      std::vector<QualType> paramTypes = type.getFunctionParamAndReturnTypes();
+      std::vector<QualType> paramTypes = type.getType().getFunctionParamAndReturnTypes();
       for (QualType &paramType : paramTypes)
-        if (paramType.getType().hasAnyGenericParts())
-          substantiateTypeWithTypeMapping(paramType.getType(), typeMapping);
+        if (paramType.hasAnyGenericParts())
+          substantiateTypeWithTypeMapping(paramType, typeMapping);
       // Attach the list of concrete param types to the symbol type
-      type.setFunctionParamAndReturnTypes(paramTypes);
+      type.getType().setFunctionParamAndReturnTypes(paramTypes);
     } else {
       // Substantiate each template type
-      std::vector<QualType> templateTypes = type.getBase().getTemplateTypes();
+      std::vector<QualType> templateTypes = type.getBase().getType().getTemplateTypes();
       for (QualType &templateType : templateTypes)
-        if (templateType.getType().hasAnyGenericParts())
-          substantiateTypeWithTypeMapping(templateType.getType(), typeMapping);
+        if (templateType.hasAnyGenericParts())
+          substantiateTypeWithTypeMapping(templateType, typeMapping);
       // Attach the list of concrete template types to the symbol type
-      type.setBaseTemplateTypes(templateTypes);
+      type.getType().setBaseTemplateTypes(templateTypes);
     }
   }
 }

--- a/src/typechecker/TypeMatcher.h
+++ b/src/typechecker/TypeMatcher.h
@@ -19,10 +19,10 @@ public:
   // Public methods
   static bool matchRequestedToCandidateTypes(const std::vector<QualType> &candidateTypes, const std::vector<QualType> &reqTypes,
                                              TypeMapping &typeMapping, ResolverFct &resolverFct, bool strictSpecifiers);
-  static bool matchRequestedToCandidateType(Type candidateType, Type requestedType, TypeMapping &typeMapping,
+  static bool matchRequestedToCandidateType(QualType candidateType, QualType requestedType, TypeMapping &typeMapping,
                                             ResolverFct &resolverFct, bool strictSpecifierMatching);
   static void substantiateTypesWithTypeMapping(std::vector<QualType> &qualTypes, const TypeMapping &typeMapping);
-  static void substantiateTypeWithTypeMapping(Type &type, const TypeMapping &typeMapping);
+  static void substantiateTypeWithTypeMapping(QualType &type, const TypeMapping &typeMapping);
 };
 
 } // namespace spice::compiler


### PR DESCRIPTION
- Migrate TypeMatcher to QualType
- Get rid of `getType()` method on SymbolTableEntry