### PR TITLE
Move to TypeRegistry

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,122 +1,53 @@
-import "bootstrap/bindings/llvm/llvm" as llvm;
-import "std/data/vector";
+import "std/data/doubly-linked-list";
 
 f<int> main() {
-    llvm::initializeNativeTarget();
-    llvm::initializeNativeAsmPrinter();
-
-    heap string targetTriple = llvm::getDefaultTargetTriple();
-    string error;
-    llvm::Target target = llvm::getTargetFromTriple(targetTriple, &error);
-    llvm::TargetMachine targetMachine = target.createTargetMachine(targetTriple, "generic", "", llvm::LLVMCodeGenOptLevel::Default, llvm::LLVMRelocMode::Default, llvm::LLVMCodeModel::Default);
-
-    llvm::LLVMContext context;
-    llvm::Module module = llvm::Module("test", context);
-    module.setDataLayout(targetMachine.createDataLayout());
-    //module.setTargetTriple(targetTriple); // This emits target dependent information in the IR, which is not what we want here.
-    llvm::Builder builder = llvm::Builder(context);
-
-    llvm::Type returnType = builder.getInt32Ty();
-    Vector<llvm::Type> argTypes;
-    llvm::Type funcType = llvm::getFunctionType(returnType, argTypes);
-    llvm::Function func = llvm::Function(module, "main", funcType);
-    func.setLinkage(llvm::LLVMLinkage::ExternalLinkage);
-
-    llvm::BasicBlock entry = llvm::BasicBlock(context, "");
-    func.pushBack(entry);
-    builder.setInsertPoint(entry);
-
-    llvm::Value calcResult = builder.createAdd(builder.getInt32(1), builder.getInt32(2), "calcResult");
-
-    llvm::Value helloWorldStr = builder.createGlobalStringPtr("Hello, world!\n", "helloWorldStr");
-    Vector<llvm::Type> printfArgTypes;
-    printfArgTypes.pushBack(builder.getPtrTy());
-    printfArgTypes.pushBack(builder.getInt32Ty());
-    llvm::Type printfFuncType = llvm::getFunctionType(builder.getInt32Ty(), printfArgTypes, true);
-    llvm::Function printfFunc = module.getOrInsertFunction("printf", printfFuncType);
-
-    Vector<llvm::Value> printfArgs;
-    printfArgs.pushBack(helloWorldStr);
-    printfArgs.pushBack(calcResult);
-    builder.createCall(printfFunc, printfArgs);
-
-    builder.createRet(builder.getInt32(0));
-
-    assert !llvm::verifyFunction(func);
-    string output;
-    assert !llvm::verifyModule(module, &output);
-
-    printf("Unoptimized IR:\n%s", module.print());
-
-    llvm::PassBuilderOptions pto;
-    llvm::PassBuilder passBuilder = llvm::PassBuilder(pto);
-    passBuilder.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O2);
-    passBuilder.addPass(llvm::AlwaysInlinerPass());
-    passBuilder.run(module, targetMachine);
-
-    printf("Optimized IR:\n%s", module.print());
-
-    targetMachine.emitToFile(module, "this-is-a-test.o", llvm::LLVMCodeGenFileType::ObjectFile);
+    DoublyLinkedList<String> list;
+    assert list.getSize() == 0;
+    assert list.isEmpty();
+    list.pushBack(String("Hello"));
+    assert list.getSize() == 1;
+    assert !list.isEmpty();
+    String var = String("World");
+    list.pushBack(var);
+    assert list.getSize() == 2;
+    list.pushFront(String("Hi"));
+    assert list.getSize() == 3;
+    assert list.getFront() == String("Hi");
+    assert list.getBack() == String("World");
+    list.removeFront();
+    assert list.getSize() == 2;
+    assert list.getFront() == String("Hello");
+    list.removeBack();
+    assert list.getSize() == 1;
+    assert list.getBack() == String("Hello");
+    list.pushBack(String("World"));
+    list.pushFront(String("Hi"));
+    list.pushBack(String("Programmers"));
+    assert list.getSize() == 4;
+    list.remove(String("World"));
+    assert list.getSize() == 3;
+    assert list.get(0) == String("Hi");
+    assert list.get(1) == String("Hello");
+    assert list.get(2) == String("Programmers");
+    list.removeAt(1);
+    assert list.getSize() == 2;
+    assert list.get(0) == String("Hi");
+    assert list.get(1) == String("Programmers");
+    printf("All assertions passed!\n");
 }
 
-/*import "std/iterator/array-iterator";
-import "std/data/pair";
+/*import "std/iterator/number-iterator";
 
 f<int> main() {
-    // Create test array to iterate over
-    int[5] a = [ 123, 4321, 9876, 321, -99 ];
+    NumberIterator<int> itInt = range(1, 10);
+    dyn idxAndValueInt = itInt.getIdx();
+    assert idxAndValueInt.getSecond() == 4;
+}*/
 
-    // Test base functionality
-    dyn it = iterate(a, len(a));
-    assert it.isValid();
-    assert it.get() == 123;
-    assert it.get() == 123;
-    it.next();
-    assert it.get() == 4321;
-    assert it.isValid();
-    it.next();
-    dyn pair = it.getIdx();
-    assert pair.getFirst() == 2;
-    assert pair.getSecond() == 9876;
-    it.next();
+/*import "std/data/hash-table";
 
-    // Test overloaded operators
-    it -= 3;
-    assert it.get() == 123;
-    assert it.isValid();
-    it++;
-    assert it.get() == 4321;
-    it--;
-    assert it.get() == 123;
-    it += 4;
-    assert it.get() == -99;
-    it.next();
-    assert !it.isValid();
-
-    // Test foreach value
-    foreach int item : iterate(a, len(a)) {
-        item++;
-    }
-    assert a[0] == 123;
-    assert a[1] == 4321;
-    assert a[2] == 9876;
-
-    // Test foreach ref
-    foreach int& item : iterate(a, len(a)) {
-        item++;
-    }
-    assert a[0] == 124;
-    assert a[1] == 4322;
-    assert a[2] == 9877;
-
-    foreach long idx, int& item : iterate(a, len(a)) {
-        item += idx;
-    }
-    assert a[0] == 124;
-    assert a[1] == 4323;
-    assert a[2] == 9879;
-
-    printf("All assertions passed!");
+f<int> main() {
+    HashTable<int, string> map = HashTable<int, string>(3l);
 }*/
 
 /*import "bootstrap/util/block-allocator";

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,26 +1,123 @@
-type T int|long;
-
-type TestStruct<T> struct {
-    T _f1
-    unsigned long length
-}
-
-p TestStruct.ctor(const unsigned long initialLength) {
-    this.length = initialLength;
-}
-
-p TestStruct.printLength() {
-    printf("%d\n", this.length);
-}
-
-type Alias alias TestStruct<long>;
+import "bootstrap/bindings/llvm/llvm" as llvm;
+import "std/data/vector";
 
 f<int> main() {
-    Alias a = Alias{12345l, (unsigned long) 54321l};
-    a.printLength();
-    dyn b = Alias(12l);
-    b.printLength();
+    llvm::initializeNativeTarget();
+    llvm::initializeNativeAsmPrinter();
+
+    heap string targetTriple = llvm::getDefaultTargetTriple();
+    string error;
+    llvm::Target target = llvm::getTargetFromTriple(targetTriple, &error);
+    llvm::TargetMachine targetMachine = target.createTargetMachine(targetTriple, "generic", "", llvm::LLVMCodeGenOptLevel::Default, llvm::LLVMRelocMode::Default, llvm::LLVMCodeModel::Default);
+
+    llvm::LLVMContext context;
+    llvm::Module module = llvm::Module("test", context);
+    module.setDataLayout(targetMachine.createDataLayout());
+    //module.setTargetTriple(targetTriple); // This emits target dependent information in the IR, which is not what we want here.
+    llvm::Builder builder = llvm::Builder(context);
+
+    llvm::Type returnType = builder.getInt32Ty();
+    Vector<llvm::Type> argTypes;
+    llvm::Type funcType = llvm::getFunctionType(returnType, argTypes);
+    llvm::Function func = llvm::Function(module, "main", funcType);
+    func.setLinkage(llvm::LLVMLinkage::ExternalLinkage);
+
+    llvm::BasicBlock entry = llvm::BasicBlock(context, "");
+    func.pushBack(entry);
+    builder.setInsertPoint(entry);
+
+    llvm::Value calcResult = builder.createAdd(builder.getInt32(1), builder.getInt32(2), "calcResult");
+
+    llvm::Value helloWorldStr = builder.createGlobalStringPtr("Hello, world!\n", "helloWorldStr");
+    Vector<llvm::Type> printfArgTypes;
+    printfArgTypes.pushBack(builder.getPtrTy());
+    printfArgTypes.pushBack(builder.getInt32Ty());
+    llvm::Type printfFuncType = llvm::getFunctionType(builder.getInt32Ty(), printfArgTypes, true);
+    llvm::Function printfFunc = module.getOrInsertFunction("printf", printfFuncType);
+
+    Vector<llvm::Value> printfArgs;
+    printfArgs.pushBack(helloWorldStr);
+    printfArgs.pushBack(calcResult);
+    builder.createCall(printfFunc, printfArgs);
+
+    builder.createRet(builder.getInt32(0));
+
+    assert !llvm::verifyFunction(func);
+    string output;
+    assert !llvm::verifyModule(module, &output);
+
+    printf("Unoptimized IR:\n%s", module.print());
+
+    llvm::PassBuilderOptions pto;
+    llvm::PassBuilder passBuilder = llvm::PassBuilder(pto);
+    passBuilder.buildPerModuleDefaultPipeline(llvm::OptimizationLevel::O2);
+    passBuilder.addPass(llvm::AlwaysInlinerPass());
+    passBuilder.run(module, targetMachine);
+
+    printf("Optimized IR:\n%s", module.print());
+
+    targetMachine.emitToFile(module, "this-is-a-test.o", llvm::LLVMCodeGenFileType::ObjectFile);
 }
+
+/*import "std/iterator/array-iterator";
+import "std/data/pair";
+
+f<int> main() {
+    // Create test array to iterate over
+    int[5] a = [ 123, 4321, 9876, 321, -99 ];
+
+    // Test base functionality
+    dyn it = iterate(a, len(a));
+    assert it.isValid();
+    assert it.get() == 123;
+    assert it.get() == 123;
+    it.next();
+    assert it.get() == 4321;
+    assert it.isValid();
+    it.next();
+    dyn pair = it.getIdx();
+    assert pair.getFirst() == 2;
+    assert pair.getSecond() == 9876;
+    it.next();
+
+    // Test overloaded operators
+    it -= 3;
+    assert it.get() == 123;
+    assert it.isValid();
+    it++;
+    assert it.get() == 4321;
+    it--;
+    assert it.get() == 123;
+    it += 4;
+    assert it.get() == -99;
+    it.next();
+    assert !it.isValid();
+
+    // Test foreach value
+    foreach int item : iterate(a, len(a)) {
+        item++;
+    }
+    assert a[0] == 123;
+    assert a[1] == 4321;
+    assert a[2] == 9876;
+
+    // Test foreach ref
+    foreach int& item : iterate(a, len(a)) {
+        item++;
+    }
+    assert a[0] == 124;
+    assert a[1] == 4322;
+    assert a[2] == 9877;
+
+    foreach long idx, int& item : iterate(a, len(a)) {
+        item += idx;
+    }
+    assert a[0] == 124;
+    assert a[1] == 4323;
+    assert a[2] == 9879;
+
+    printf("All assertions passed!");
+}*/
 
 /*import "bootstrap/util/block-allocator";
 import "bootstrap/util/memory";

--- a/src-bootstrap/bindings/llvm/llvm.spice
+++ b/src-bootstrap/bindings/llvm/llvm.spice
@@ -780,7 +780,7 @@ public f<Value> Builder.getStruct(const Vector<Value>& values, bool packed = fal
 public f<Value> Builder.getArray(Type ty, const Vector<Value>& values) {
     unsafe {
         LLVMValueRef* valuesRef = (LLVMValueRef*) values.getDataPtr();
-        LLVMValueRef valueRef = LLVMConstArray2(ty.self, valuesRef, (unsigned long) values.getSize());
+        LLVMValueRef valueRef = LLVMConstArray2(ty.self, valuesRef, values.getSize());
         return Value{ valueRef };
     }
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,11 +50,14 @@ set(SOURCES
         symboltablebuilder/SymbolTable.h
         symboltablebuilder/SymbolTableEntry.cpp
         symboltablebuilder/SymbolTableEntry.h
+        symboltablebuilder/QualType.cpp
+        symboltablebuilder/QualType.h
         symboltablebuilder/Capture.cpp
         symboltablebuilder/Capture.h
         symboltablebuilder/Type.cpp
         symboltablebuilder/Type.h
         symboltablebuilder/TypeChain.cpp
+        symboltablebuilder/TypeChain.h
         symboltablebuilder/TypeSpecifiers.cpp
         symboltablebuilder/TypeSpecifiers.h
         symboltablebuilder/Lifecycle.cpp
@@ -143,6 +146,8 @@ set(SOURCES
         util/CommonUtil.h
         util/FileUtil.cpp
         util/FileUtil.h
+        util/CustomHashFunctions.cpp
+        util/CustomHashFunctions.h
         util/CodeLoc.cpp
         util/CodeLoc.h
         util/CompilerWarning.cpp
@@ -153,8 +158,6 @@ set(SOURCES
         util/Memory.h
         util/RawStringOStream.cpp
         util/RawStringOStream.h
-        symboltablebuilder/QualType.cpp
-        symboltablebuilder/QualType.h
 )
 
 add_executable(spice ${SOURCES} ${ANTLR_Spice_CXX_OUTPUTS})

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -6,6 +6,7 @@
 #include <exception/AntlrThrowingErrorListener.h>
 #include <exception/CompilerError.h>
 #include <global/GlobalResourceManager.h>
+#include <global/TypeRegistry.h>
 #include <importcollector/ImportCollector.h>
 #include <irgenerator/IRGenerator.h>
 #include <iroptimizer/IROptimizer.h>
@@ -554,6 +555,7 @@ void SourceFile::runBackEnd() { // NOLINT(misc-no-recursion)
       CHECK_ABORT_FLAG_V()
       std::cout << "\nSuccessfully compiled " << std::to_string(resourceManager.sourceFiles.size()) << " source file(s)";
       std::cout << " or " << std::to_string(resourceManager.getTotalLineCount()) << " lines in total.\n";
+      std::cout << "Total number of types: " << std::to_string(TypeRegistry::getTypeCount()) << "\n";
       std::cout << "Total compile time: " << std::to_string(resourceManager.totalTimer.getDurationMilliseconds()) << " ms\n";
     }
   }
@@ -582,8 +584,8 @@ bool SourceFile::imports(const SourceFile *sourceFile) const {
   return std::ranges::any_of(dependencies, [=](const auto &dependency) { return dependency.second == sourceFile; });
 }
 
-bool SourceFile::isAlreadyImported(const std::string &filePathSearch,
-                                   std::vector<const SourceFile *> &circle) const { // NOLINT(misc-no-recursion)
+bool SourceFile::isAlreadyImported(const std::string &filePathSearch, // NOLINT(misc-no-recursion)
+                                   std::vector<const SourceFile *> &circle) const {
   circle.push_back(this);
   // Check if the current source file corresponds to the path to search
   if (std::filesystem::equivalent(filePath, filePathSearch))

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -6,9 +6,13 @@
 #include <string>
 #include <utility>
 
+// Ignore some warnings in ANTLR generated code
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #include <SpiceLexer.h>
 #include <SpiceParser.h>
 #include <Token.h>
+#pragma GCC diagnostic pop
 
 #include <ast/ASTNodes.h>
 #include <exception/AntlrThrowingErrorListener.h>

--- a/src/ast/ASTBuilder.h
+++ b/src/ast/ASTBuilder.h
@@ -6,8 +6,13 @@
 #include <functional>
 #include <utility>
 
-#include <CompilerPass.h>
+// Ignore some warnings in ANTLR generated code
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
 #include <SpiceVisitor.h>
+#pragma GCC diagnostic pop
+
+#include <CompilerPass.h>
 #include <util/CodeLoc.h>
 #include <util/GlobalDefinitions.h>
 

--- a/src/global/GlobalResourceManager.cpp
+++ b/src/global/GlobalResourceManager.cpp
@@ -4,6 +4,9 @@
 
 #include <SourceFile.h>
 #include <ast/ASTNodes.h>
+#include <global/TypeRegistry.h>
+#include <typechecker/FunctionManager.h>
+#include <typechecker/StructManager.h>
 #include <util/FileUtil.h>
 
 #include <llvm/MC/TargetRegistry.h>
@@ -61,7 +64,12 @@ GlobalResourceManager::GlobalResourceManager(const CliOptions &cliOptions)
 }
 
 GlobalResourceManager::~GlobalResourceManager() {
-  // Cleanup all global LLVM resources
+  // Cleanup all statics
+  TypeRegistry::clear();
+  FunctionManager::clear();
+  StructManager::clear();
+  InterfaceManager::clear();
+  // Cleanup all LLVM statics
   llvm::llvm_shutdown();
 }
 

--- a/src/global/TypeRegistry.cpp
+++ b/src/global/TypeRegistry.cpp
@@ -75,6 +75,8 @@ const Type *TypeRegistry::getOrInsert(const TypeChain &typeChain) { return getOr
  *
  * @return The number of types in the type registry
  */
-const size_t TypeRegistry::getTypeCount() { return types.size(); }
+size_t TypeRegistry::getTypeCount() { return types.size(); }
+
+void TypeRegistry::clear() { types.clear();}
 
 } // namespace spice::compiler

--- a/src/global/TypeRegistry.cpp
+++ b/src/global/TypeRegistry.cpp
@@ -9,6 +9,12 @@ namespace spice::compiler {
 // Static member initialization
 std::unordered_map<uint64_t, std::unique_ptr<Type>> TypeRegistry::types = {};
 
+/**
+ * Get or insert a type into the type registry
+ *
+ * @param type The type to insert
+ * @return The inserted type
+ */
 const Type *TypeRegistry::getOrInsert(const Type &&type) {
   const uint64_t hash = std::hash<Type>{}(type);
 
@@ -22,17 +28,53 @@ const Type *TypeRegistry::getOrInsert(const Type &&type) {
   return insertedElement.first->second.get();
 }
 
+/**
+ * Get or insert a type into the type registry
+ *
+ * @param superType The super type of the type
+ * @return The inserted type
+ */
 const Type *TypeRegistry::getOrInsert(SuperType superType) { return getOrInsert(Type(superType)); }
 
+/**
+ * Get or insert a type into the type registry
+ *
+ * @param superType The super type of the type
+ * @param subType The sub type of the type
+ * @return The inserted type
+ */
 const Type *TypeRegistry::getOrInsert(SuperType superType, const std::string &subType) {
   return getOrInsert(Type(superType, subType));
 }
 
+/**
+ * Get or insert a type into the type registry
+ *
+ * @param superType The super type of the type
+ * @param subType The sub type of the type
+ * @param typeId The type ID of the type
+ * @param data The data of the type
+ * @param templateTypes The template types of the type
+ * @return The inserted type
+ */
 const Type *TypeRegistry::getOrInsert(SuperType superType, const std::string &subType, uint64_t typeId,
                                       const TypeChainElementData &data, const QualTypeList &templateTypes) {
   return getOrInsert(Type(superType, subType, typeId, data, templateTypes));
 }
 
+/**
+ * Get or insert a type into the type registry
+ *
+ * @param typeChain The type chain of the type
+ * @return The inserted type
+ */
 const Type *TypeRegistry::getOrInsert(const TypeChain &typeChain) { return getOrInsert(Type(typeChain)); }
+
+/**
+ * Get the number of types in the type registry
+ *
+ * @return The number of types in the type registry
+ */
+const size_t TypeRegistry::getTypeCount() { return types.size(); }
 
 } // namespace spice::compiler

--- a/src/global/TypeRegistry.h
+++ b/src/global/TypeRegistry.h
@@ -5,12 +5,11 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <vector>
+
+#include <symboltablebuilder/Type.h>
 
 namespace spice::compiler {
-
-// Forward declarations
-class Type;
-enum SuperType : uint8_t;
 
 class TypeRegistry {
 public:
@@ -19,13 +18,18 @@ public:
   TypeRegistry(const TypeRegistry &) = delete;
 
   // Public methods
-  static const Type *get(const std::string &name);
-  static const Type *getOrInsert(Type type);
   static const Type *getOrInsert(SuperType superType);
+  static const Type *getOrInsert(SuperType superType, const std::string &subType);
+  static const Type *getOrInsert(SuperType superType, const std::string &subType, uint64_t typeId,
+                                 const TypeChainElementData &data, const QualTypeList &templateTypes);
+  static const Type *getOrInsert(const TypeChain& typeChain);
 
 private:
   // Private members
-  static std::unordered_map<std::string, std::unique_ptr<Type>> types;
+  static std::unordered_map<uint64_t, std::unique_ptr<Type>> types;
+
+  // Private methods
+  static const Type *getOrInsert(const Type &&type);
 };
 
 } // namespace spice::compiler

--- a/src/global/TypeRegistry.h
+++ b/src/global/TypeRegistry.h
@@ -23,7 +23,8 @@ public:
   static const Type *getOrInsert(SuperType superType, const std::string &subType, uint64_t typeId,
                                  const TypeChainElementData &data, const QualTypeList &templateTypes);
   static const Type *getOrInsert(const TypeChain& typeChain);
-  static const size_t getTypeCount();
+  static size_t getTypeCount();
+  static void clear();
 
 private:
   // Private members

--- a/src/global/TypeRegistry.h
+++ b/src/global/TypeRegistry.h
@@ -23,6 +23,7 @@ public:
   static const Type *getOrInsert(SuperType superType, const std::string &subType, uint64_t typeId,
                                  const TypeChainElementData &data, const QualTypeList &templateTypes);
   static const Type *getOrInsert(const TypeChain& typeChain);
+  static const size_t getTypeCount();
 
 private:
   // Private members

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -100,10 +100,6 @@ std::any IRGenerator::visitTernaryExpr(const TernaryExprNode *node) {
     trueValue = condValue;
     falseValue = resolveValue(node->operands()[1]);
   } else {
-    const QualType &op1Type = node->operands()[1]->getEvaluatedSymbolType(manIdx);
-    const QualType &op2Type = node->operands()[2]->getEvaluatedSymbolType(manIdx);
-    llvm::Type *op1Ty = op1Type.toLLVMType(context, currentScope);
-    llvm::Type *op2Ty = op2Type.toLLVMType(context, currentScope);
     trueValue = resolveValue(node->operands()[1]);
     falseValue = resolveValue(node->operands()[2]);
   }

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -496,8 +496,8 @@ void IRGenerator::generateTestMain() {
 
   // Prepare entry for test main
   QualType functionType(TY_FUNCTION);
-  functionType.getSpecifiers() = TypeSpecifiers::of(TY_FUNCTION);
-  functionType.getSpecifiers().isPublic = true;
+  functionType.setSpecifiers(TypeSpecifiers::of(TY_FUNCTION));
+  functionType.makePublic();
   SymbolTableEntry entry(MAIN_FUNCTION_NAME, functionType, rootScope, nullptr, 0, false);
 
   // Prepare test main function

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -175,11 +175,8 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
         assert(paramSymbol != nullptr);
         const QualType paramSymbolType = manifestation->getParamTypes().at(argIdx);
         // Pass the information if captures are taken for function/procedure types
-        if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures()) {
-          QualType paramSymbolSymbolType = paramSymbol->getQualType();
-          paramSymbolSymbolType.setHasLambdaCaptures(true);
-          paramSymbol->updateType(paramSymbolSymbolType, true);
-        }
+        if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures())
+          paramSymbol->updateType(paramSymbol->getQualType().getWithLambdaCaptures(), true);
         // Retrieve type of param
         llvm::Type *paramType = paramSymbolType.toLLVMType(context, currentScope);
         // Add it to the lists
@@ -347,11 +344,8 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
         assert(paramSymbol != nullptr);
         const QualType paramSymbolType = manifestation->getParamTypes().at(argIdx);
         // Pass the information if captures are taken for function/procedure types
-        if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures()) {
-          QualType paramSymbolSymbolType = paramSymbol->getQualType();
-          paramSymbolSymbolType.setHasLambdaCaptures(true);
-          paramSymbol->updateType(paramSymbolSymbolType, true);
-        }
+        if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures())
+          paramSymbol->updateType(paramSymbol->getQualType().getWithLambdaCaptures(), true);
         // Retrieve type of param
         llvm::Type *paramType = paramSymbolType.toLLVMType(context, currentScope);
         // Add it to the lists

--- a/src/irgenerator/NameMangling.cpp
+++ b/src/irgenerator/NameMangling.cpp
@@ -146,31 +146,33 @@ void NameMangling::mangleName(std::stringstream &out, const std::string &name, b
 }
 
 /**
- * Mangle a symbol type
+ * Mangle a symbol qualType
  * This should be mostly compatible with the C++ Itanium ABI name mangling scheme.
  *
  * @param out Output string stream
- * @param type Input symbol type
+ * @param qualType Input symbol qualType
  * @return Mangled name
  */
-void NameMangling::mangleType(std::stringstream &out, QualType type, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
-  // Replace generic type with concrete type
-  if (type.hasAnyGenericParts() && !typeMapping.empty())
-    TypeMatcher::substantiateTypeWithTypeMapping(type, typeMapping);
+void NameMangling::mangleType(std::stringstream &out, QualType qualType, const TypeMapping &typeMapping) { // NOLINT(*-no-recursion)
+  const Type *type = qualType.getType();
 
-  // Unwrap type chain
-  assert(!type.getType().typeChain.empty());
-  for (size_t i = type.getType().typeChain.size() - 1; i >= 1; i--)
-    mangleTypeChainElement(out, type.getType().typeChain.at(i), typeMapping, false);
+  // Replace generic qualType with concrete qualType
+  if (qualType.hasAnyGenericParts() && !typeMapping.empty())
+    TypeMatcher::substantiateTypeWithTypeMapping(qualType, typeMapping);
+
+  // Unwrap qualType chain
+  assert(!type->typeChain.empty());
+  for (size_t i = type->typeChain.size() - 1; i >= 1; i--)
+    mangleTypeChainElement(out, type->typeChain.at(i), typeMapping, false);
 
   // Specifiers
-  assert(type.getSpecifiers().isSigned == !type.getSpecifiers().isUnsigned);
-  const bool signedness = type.getSpecifiers().isSigned;
-  if (type.getSpecifiers().isConst && type.getType().typeChain.size() > 1)
+  assert(qualType.getSpecifiers().isSigned == !qualType.getSpecifiers().isUnsigned);
+  const bool signedness = qualType.getSpecifiers().isSigned;
+  if (qualType.getSpecifiers().isConst && type->typeChain.size() > 1)
     out << "K";
 
   // Base chain element
-  mangleTypeChainElement(out, type.getType().typeChain.front(), typeMapping, signedness);
+  mangleTypeChainElement(out, type->typeChain.front(), typeMapping, signedness);
 }
 
 /**

--- a/src/irgenerator/NameMangling.h
+++ b/src/irgenerator/NameMangling.h
@@ -56,12 +56,9 @@ public:
   [[nodiscard]] static std::string mangleVTable(const std::string &typeName);
 
 private:
-  // Typedefs
-  using TypeChainElement = Type::TypeChainElement;
-
   // Private methods
   static void mangleName(std::stringstream &out, const std::string &name, bool &nestedType);
-  static void mangleType(std::stringstream &out, QualType type, const TypeMapping &typeMapping);
+  static void mangleType(std::stringstream &out, QualType qualType, const TypeMapping &typeMapping);
   static void mangleTypeChainElement(std::stringstream &out, const TypeChainElement &chainElement, const TypeMapping &typeMapping,
                                      bool signedness);
 };

--- a/src/model/GenericType.h
+++ b/src/model/GenericType.h
@@ -20,8 +20,8 @@ public:
   // Constructors
   explicit GenericType(const QualType &type) : QualType(type){};
   explicit GenericType(const std::string &name) : QualType(TY_GENERIC, name) {}
-  GenericType(const std::string &name, const QualTypeList &typeConditions)
-      : QualType(TY_GENERIC, name), typeConditions(typeConditions) {}
+  GenericType(const std::string &name, QualTypeList typeConditions)
+      : QualType(TY_GENERIC, name), typeConditions(std::move(typeConditions)) {}
   GenericType() = default;
 
   // Public methods
@@ -35,7 +35,7 @@ private:
   QualTypeList typeConditions = {QualType(TY_DYN)};
 
   // Private methods
-  [[nodiscard]] [[deprecated]] bool checkTypeConditionOf(const QualType &type, bool ignoreArraySize, bool ignoreSpecifiers) const;
+  [[nodiscard]] bool checkTypeConditionOf(const QualType &type, bool ignoreArraySize, bool ignoreSpecifiers) const;
 };
 
 } // namespace spice::compiler

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -461,7 +461,7 @@ QualType QualType::toRef(const ASTNode *node) const {
  */
 QualType QualType::toConstRef(const ASTNode *node) const {
   QualType qualType = toRef(node);
-  qualType.specifiers.isConst = true;
+  qualType.makeConst();
   return qualType;
 }
 

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -302,7 +302,7 @@ bool QualType::canBind(const QualType &inputType, bool isTemporary) const {
  */
 bool QualType::matches(const QualType &otherType, bool ignoreArraySize, bool ignoreSpecifiers, bool allowConstify) const {
   // Compare type
-  if (!type->matches(*otherType.type, ignoreArraySize))
+  if (!type->matches(otherType.type, ignoreArraySize))
     return false;
 
   // Ignore or compare specifiers
@@ -734,7 +734,7 @@ void QualType::makeComposition(bool isComposition) { specifiers.isComposition = 
  * @param rhs Right-hand side type
  * @return Equal or not
  */
-bool operator==(const QualType &lhs, const QualType &rhs) { return *lhs.type == *rhs.type; }
+bool operator==(const QualType &lhs, const QualType &rhs) { return lhs.type == rhs.type; }
 
 /**
  * Check if two types are not equal

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -5,6 +5,7 @@
 #include <sstream>
 
 #include <SourceFile.h>
+#include <global/TypeRegistry.h>
 #include <model/Struct.h>
 #include <symboltablebuilder/Scope.h>
 #include <symboltablebuilder/Type.h>
@@ -13,28 +14,17 @@
 
 namespace spice::compiler {
 
-QualType::QualType(SuperType superType) : type(std::make_unique<Type>(superType)), specifiers(TypeSpecifiers::of(superType)) {}
+QualType::QualType(SuperType superType) : type(TypeRegistry::getOrInsert(superType)), specifiers(TypeSpecifiers::of(superType)) {}
 QualType::QualType(SuperType superType, const std::string &subType)
-    : type(std::make_unique<Type>(superType, subType)), specifiers(TypeSpecifiers::of(superType)) {}
-QualType::QualType(const Type &t, TypeSpecifiers specifiers) : type(std::make_unique<Type>(t)), specifiers(specifiers) {}
-
-// ToDo: Delete those two later on
-QualType::QualType(const QualType &other) {
-  type = std::make_unique<Type>(*other.type);
-  specifiers = other.specifiers;
-}
-QualType &QualType::operator=(const spice::compiler::QualType &other) {
-  type = std::make_unique<Type>(*other.type);
-  specifiers = other.specifiers;
-  return *this;
-}
+    : type(TypeRegistry::getOrInsert(superType, subType)), specifiers(TypeSpecifiers::of(superType)) {}
+QualType::QualType(const Type *t, TypeSpecifiers specifiers) : type(t), specifiers(specifiers) {}
 
 /**
  * Set the underlying type
  *
  * @return Type
  */
-void QualType::setType(const Type &newType) { type = std::make_unique<Type>(newType); }
+void QualType::setType(const Type *newType) { type = newType; }
 
 /**
  * Get the super type of the underlying type
@@ -65,25 +55,11 @@ unsigned int QualType::getArraySize() const { return type->getArraySize(); }
 Scope *QualType::getBodyScope() const { return type->getBodyScope(); }
 
 /**
- * Set the body scope of the underlying type
- *
- * @param newBodyScope New body scope
- */
-void QualType::setBodyScope(Scope *newBodyScope) { type->setBodyScope(newBodyScope); }
-
-/**
  * Get the function parameter types of the underlying type
  *
  * @return Function parameter types
  */
 const QualType &QualType::getFunctionReturnType() const { return type->getFunctionReturnType(); }
-
-/**
- * Set the function return type of the underlying type
- *
- * @param returnType New return type
- */
-void QualType::setFunctionReturnType(const QualType &returnType) { type->setFunctionReturnType(returnType); }
 
 /**
  * Get the function parameter types of the underlying type
@@ -93,27 +69,11 @@ void QualType::setFunctionReturnType(const QualType &returnType) { type->setFunc
 QualTypeList QualType::getFunctionParamTypes() const { return type->getFunctionParamTypes(); }
 
 /**
- * Set the function parameter types of the underlying type
- *
- * @param paramTypes New parameter types
- */
-void QualType::setFunctionParamTypes(const QualTypeList &paramTypes) { type->setFunctionParamTypes(paramTypes); }
-
-/**
  * Get the function parameter and return types of the underlying type
  *
  * @return Function parameter and return types
  */
 const QualTypeList &QualType::getFunctionParamAndReturnTypes() const { return type->getFunctionParamAndReturnTypes(); }
-
-/**
- * Set the function parameter and return types of the underlying type
- *
- * @param paramAndReturnTypes New parameter and return types
- */
-void QualType::setFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes) {
-  type->setFunctionParamAndReturnTypes(paramAndReturnTypes);
-}
 
 /**
  * Check if the underlying type has lambda captures
@@ -123,32 +83,11 @@ void QualType::setFunctionParamAndReturnTypes(const QualTypeList &paramAndReturn
 bool QualType::hasLambdaCaptures() const { return type->hasLambdaCaptures(); }
 
 /**
- * Set if the underlying type has lambda captures
- *
- * @param hasCaptures Has lambda captures or not
- */
-void QualType::setHasLambdaCaptures(bool hasCaptures) { type->setHasLambdaCaptures(hasCaptures); }
-
-/**
  * Get the template types of the underlying type
  *
  * @return Template types
  */
 const QualTypeList &QualType::getTemplateTypes() const { return type->getTemplateTypes(); }
-
-/**
- * Set the template types of the underlying type
- *
- * @param templateTypes New template types
- */
-void QualType::setTemplateTypes(const QualTypeList &templateTypes) { type->setTemplateTypes(templateTypes); }
-
-/**
- * Set the template types of the underlying base type
- *
- * @param templateTypes New template types
- */
-void QualType::setBaseTemplateTypes(const QualTypeList &templateTypes) { type->setBaseTemplateTypes(templateTypes); }
 
 /**
  * Get the struct instance for a struct type
@@ -273,8 +212,9 @@ bool QualType::isIterator(const ASTNode *node) const {
     return false;
 
   const QualType genericType(TY_GENERIC, "T");
-  const Type iteratorType(TY_INTERFACE, IITERATOR_NAME, TYPE_ID_ITERATOR_INTERFACE, {.bodyScope = nullptr}, {genericType});
-  const QualType iteratorQualType(iteratorType, TypeSpecifiers::of(TY_INTERFACE));
+  const TypeChainElementData data = {.bodyScope = nullptr};
+  const Type *itType = TypeRegistry::getOrInsert(TY_INTERFACE, IITERATOR_NAME, TYPE_ID_ITERATOR_INTERFACE, data, {genericType});
+  const QualType iteratorQualType(itType, TypeSpecifiers::of(TY_INTERFACE));
   return doesImplement(iteratorQualType, node);
 }
 
@@ -295,8 +235,9 @@ bool QualType::isIterable(const ASTNode *node) const {
     return false;
 
   const QualType genericType(TY_GENERIC, "T");
-  const Type iteratorType(Type(TY_INTERFACE, IITERATOR_NAME, TYPE_ID_ITERABLE_INTERFACE, {.bodyScope = nullptr}, {genericType}));
-  const QualType iteratorQualType(iteratorType, TypeSpecifiers::of(TY_INTERFACE));
+  const TypeChainElementData data = {.bodyScope = nullptr};
+  const Type *itType = TypeRegistry::getOrInsert(TY_INTERFACE, IITERATOR_NAME, TYPE_ID_ITERABLE_INTERFACE, data, {genericType});
+  const QualType iteratorQualType(itType, TypeSpecifiers::of(TY_INTERFACE));
   return doesImplement(iteratorQualType, node);
 }
 
@@ -393,7 +334,7 @@ bool QualType::matchesInterfaceImplementedByStruct(const QualType &otherType) co
  * @param other Other type
  * @return Same container type or not
  */
-bool QualType::isSameContainerTypeAs(const QualType &other) const { return type->isSameContainerTypeAs(*other.type); }
+bool QualType::isSameContainerTypeAs(const QualType &other) const { return type->isSameContainerTypeAs(other.type); }
 
 /**
  * Check if the given generic type list has a substantiation for the current (generic) type
@@ -401,7 +342,7 @@ bool QualType::isSameContainerTypeAs(const QualType &other) const { return type-
  * @param genericTypeList Generic type list
  * @return Has substantiation or not
  */
-bool QualType::isCoveredByGenericTypeList(std::vector<GenericType> &genericTypeList) const {
+bool QualType::isCoveredByGenericTypeList(std::vector<GenericType> &genericTypeList) const { // NOLINT(*-no-recursion)
   const QualType baseType = getBase();
   // Check if the symbol type itself is generic
   if (baseType.is(TY_GENERIC)) {
@@ -418,13 +359,17 @@ bool QualType::isCoveredByGenericTypeList(std::vector<GenericType> &genericTypeL
   bool covered = true;
   // Check template types
   const QualTypeList &baseTemplateTypes = baseType.getTemplateTypes();
-  auto outerPred = [&](const QualType &templateType) { return templateType.isCoveredByGenericTypeList(genericTypeList); };
+  auto outerPred = [&](const QualType &templateType) { // NOLINT(*-no-recursion)
+    return templateType.isCoveredByGenericTypeList(genericTypeList);
+  };
   covered &= std::ranges::all_of(baseTemplateTypes, outerPred);
 
   // If function/procedure, check param and return types
   if (baseType.isOneOf({TY_FUNCTION, TY_PROCEDURE})) {
     const QualTypeList &paramAndReturnTypes = baseType.getFunctionParamAndReturnTypes();
-    const auto innerPred = [&](const QualType &paramType) { return paramType.isCoveredByGenericTypeList(genericTypeList); };
+    const auto innerPred = [&](const QualType &paramType) { // NOLINT(*-no-recursion)
+      return paramType.isCoveredByGenericTypeList(genericTypeList);
+    };
     covered &= std::ranges::all_of(paramAndReturnTypes, innerPred);
   }
 
@@ -492,7 +437,7 @@ llvm::Type *QualType::toLLVMType(llvm::LLVMContext &context, Scope *accessScope)
  */
 QualType QualType::toPtr(const ASTNode *node) const {
   QualType newType = *this;
-  newType.type = std::make_unique<Type>(type->toPointer(node));
+  newType.type = type->toPtr(node);
   return newType;
 }
 
@@ -504,7 +449,7 @@ QualType QualType::toPtr(const ASTNode *node) const {
  */
 QualType QualType::toRef(const ASTNode *node) const {
   QualType newType = *this;
-  newType.type = std::make_unique<Type>(type->toReference(node));
+  newType.type = type->toRef(node);
   return newType;
 }
 
@@ -530,7 +475,7 @@ QualType QualType::toConstRef(const ASTNode *node) const {
  */
 QualType QualType::toArray(const ASTNode *node, size_t size, bool skipDynCheck /*=false*/) const {
   QualType newType = *this;
-  newType.type = std::make_unique<Type>(type->toArray(node, size, skipDynCheck));
+  newType.type = type->toArr(node, size, skipDynCheck);
   return newType;
 }
 
@@ -554,7 +499,7 @@ QualType QualType::toNonConst() const {
 QualType QualType::getContained() const {
   assert(isOneOf({TY_PTR, TY_ARRAY, TY_REF, TY_STRING}));
   QualType qualType = *this;
-  qualType.type = std::make_unique<Type>(type->getContainedTy());
+  qualType.type = type->getContained();
   return qualType;
 }
 
@@ -565,7 +510,7 @@ QualType QualType::getContained() const {
  */
 QualType QualType::getBase() const {
   QualType qualType = *this;
-  qualType.type = std::make_unique<Type>(type->getBase());
+  qualType.type = type->getBase();
   return qualType;
 }
 
@@ -584,11 +529,80 @@ QualType QualType::removeReferenceWrapper() const { return isRef() ? getContaine
  */
 QualType QualType::replaceBaseType(const QualType &newBaseType) const {
   // Create new type
-  Type newType = type->replaceBaseType(newBaseType.getType());
+  const Type *newType = type->replaceBase(newBaseType.getType());
   // Create new specifiers
   TypeSpecifiers newSpecifiers = specifiers.merge(newBaseType.specifiers);
   // Return the new qualified type
   return {newType, newSpecifiers};
+}
+
+/**
+ * Retrieve the same type, but with lambda captures enabled
+ *
+ * @return Same type with lambda captures
+ */
+QualType QualType::getWithLambdaCaptures(bool enabled /*=true*/) const {
+  // Create new type
+  const Type *newType = type->getWithLambdaCaptures(enabled);
+  // Return the new qualified type
+  return {newType, specifiers};
+}
+
+/**
+ * Retrieve the same type, but with a new body scope
+ *
+ * @return Same type with body scope
+ */
+QualType QualType::getWithBodyScope(Scope *bodyScope) const {
+  // Create new type
+  const Type *newType = type->getWithBodyScope(bodyScope);
+  // Return the new qualified type
+  return {newType, specifiers};
+}
+
+/**
+ * Retrieve the same type, but with new template types
+ *
+ * @param templateTypes New template types
+ * @return Same type with new template types
+ */
+QualType QualType::getWithTemplateTypes(const QualTypeList &templateTypes) const {
+  // Create new type
+  const Type *newType = type->getWithTemplateTypes(templateTypes);
+  // Return the new qualified type
+  return {newType, specifiers};
+}
+
+/**
+ * Retrieve the same type, but with new base template types
+ *
+ * @param paramAndReturnTypes New base template types
+ * @return Same type with new base template types
+ */
+QualType QualType::getWithBaseTemplateTypes(const QualTypeList &templateTypes) const {
+  // Create new type
+  const Type *newType = type->getWithBaseTemplateTypes(templateTypes);
+  // Return the new qualified type
+  return {newType, specifiers};
+}
+
+/**
+ * Retrieve the same type, but with new function parameter and return types
+ *
+ * @param paramAndReturnTypes New parameter types
+ * @return Same type with new parameter types
+ */
+QualType QualType::getWithFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes) const {
+  // Create new type
+  const Type *newType = type->getWithFunctionParamAndReturnTypes(paramAndReturnTypes);
+  // Return the new qualified type
+  return {newType, specifiers};
+}
+
+QualType QualType::getWithFunctionParamAndReturnTypes(const QualType &returnType, const QualTypeList &paramTypes) const {
+  QualTypeList paramAndReturnTypes = paramTypes;
+  paramAndReturnTypes.insert(paramAndReturnTypes.begin(), returnType);
+  return getWithFunctionParamAndReturnTypes(paramAndReturnTypes);
 }
 
 /**
@@ -738,6 +752,6 @@ bool operator!=(const QualType &lhs, const QualType &rhs) { return !(lhs == rhs)
  * @param typeA Candidate type
  * @param typeB Requested type
  */
-void QualType::unwrapBoth(QualType &typeA, QualType &typeB) { Type::unwrapBoth(*typeA.type, *typeB.type); }
+void QualType::unwrapBoth(QualType &typeA, QualType &typeB) { Type::unwrapBoth(typeA.type, typeB.type); }
 
 } // namespace spice::compiler

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -23,6 +23,16 @@ class GenericType;
 class QualType;
 enum SuperType : uint8_t;
 
+// Constants
+const char *const STROBJ_NAME = "String";
+const char *const RESULTOBJ_NAME = "Result";
+const char *const ERROBJ_NAME = "Error";
+const char *const TIOBJ_NAME = "TypeInfo";
+const char *const IITERATOR_NAME = "IIterator";
+const char *const ARRAY_ITERATOR_NAME = "ArrayIterator";
+const uint64_t TYPE_ID_ITERATOR_INTERFACE = 255;
+const uint64_t TYPE_ID_ITERABLE_INTERFACE = 256;
+
 // Typedefs
 using QualTypeList = std::vector<QualType>;
 
@@ -32,35 +42,23 @@ public:
   QualType() = default;
   explicit QualType(SuperType superType);
   QualType(SuperType superType, const std::string &subType);
-  QualType(const Type &type, TypeSpecifiers specifiers);
-
-  // ToDo: Remove those later on
-  QualType(const QualType &other);
-  QualType &operator=(const QualType &other);
+  QualType(const Type *type, TypeSpecifiers specifiers);
 
   // Getters and setters on type
-  [[nodiscard]] Type &getType() { return *type; }
-  [[nodiscard]] const Type &getType() const { return *type; }
-  void setType(const Type &newType);
+  [[nodiscard]] const Type *getType() const { return type; }
+  void setType(const Type *newType);
 
   // Getters on type parts
   [[nodiscard]] SuperType getSuperType() const;
   [[nodiscard]] const std::string &getSubType() const;
   [[nodiscard]] unsigned int getArraySize() const;
   [[nodiscard]] Scope *getBodyScope() const;
-  void setBodyScope(Scope *newBodyScope);
   [[nodiscard]] const QualType &getFunctionReturnType() const;
-  void setFunctionReturnType(const QualType &returnType);
   [[nodiscard]] QualTypeList getFunctionParamTypes() const;
-  void setFunctionParamTypes(const QualTypeList &paramTypes);
   [[nodiscard]] const QualTypeList &getFunctionParamAndReturnTypes() const;
-  void setFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes);
   [[nodiscard]] bool hasLambdaCaptures() const;
-  void setHasLambdaCaptures(bool hasCaptures);
   [[nodiscard]] const QualTypeList &getTemplateTypes() const;
-  void setTemplateTypes(const QualTypeList &templateTypes);
-  void setBaseTemplateTypes(const QualTypeList &templateTypes);
-  [[nodiscard]] Struct *getStruct(const ASTNode *node) const;
+  Struct *getStruct(const ASTNode *node) const;
   [[nodiscard]] Interface *getInterface(const ASTNode *node) const;
 
   // Queries on the type
@@ -106,10 +104,17 @@ public:
   [[nodiscard]] QualType getBase() const;
   [[nodiscard]] QualType removeReferenceWrapper() const;
   [[nodiscard]] QualType replaceBaseType(const QualType &newBaseType) const;
+  [[nodiscard]] QualType getWithLambdaCaptures(bool enabled = true) const;
+  [[nodiscard]] QualType getWithBodyScope(Scope *bodyScope) const;
+  [[nodiscard]] QualType getWithTemplateTypes(const QualTypeList &templateTypes) const;
+  [[nodiscard]] QualType getWithBaseTemplateTypes(const QualTypeList &templateTypes) const;
+  [[nodiscard]] QualType getWithFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes) const;
+  [[nodiscard]] QualType getWithFunctionParamAndReturnTypes(const QualType &returnType, const QualTypeList &paramTypes) const;
 
-  // Getters on specifiers
+  // Getters and setters on specifiers
   [[nodiscard]] TypeSpecifiers &getSpecifiers() { return specifiers; }
   [[nodiscard]] const TypeSpecifiers &getSpecifiers() const { return specifiers; }
+  void setSpecifiers(TypeSpecifiers newSpecifiers) { specifiers = newSpecifiers; }
 
   // Getters and setters on specifier parts
   [[nodiscard]] bool isConst() const;
@@ -136,7 +141,7 @@ public:
 
 private:
   // Private members
-  std::unique_ptr<Type> type;
+  const Type *type = nullptr;
   TypeSpecifiers specifiers;
 };
 

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -85,6 +85,7 @@ public:
   [[nodiscard]] bool matches(const QualType &otherType, bool ignoreArraySize, bool ignoreSpecifiers, bool allowConstify) const;
   [[nodiscard]] bool matchesInterfaceImplementedByStruct(const QualType &otherType) const;
   [[nodiscard]] bool isSameContainerTypeAs(const QualType &other) const;
+  [[nodiscard]] bool isSelfReferencingStructType(const QualType *typeToCompareWith = nullptr) const;
   [[nodiscard]] bool isCoveredByGenericTypeList(std::vector<GenericType> &genericTypeList) const;
 
   // Serialization

--- a/src/symboltablebuilder/SymbolTable.cpp
+++ b/src/symboltablebuilder/SymbolTable.cpp
@@ -68,10 +68,12 @@ SymbolTableEntry *SymbolTable::insertAnonymous(const QualType &type, ASTNode *de
  * @param originalName Original symbol name
  * @param newName New symbol name
  */
-void SymbolTable::copySymbol(const std::string &originalName, const std::string &newName) {
+SymbolTableEntry *SymbolTable::copySymbol(const std::string &originalName, const std::string &newName) {
   SymbolTableEntry *entryToCopy = lookupStrict(originalName);
   assert(entryToCopy != nullptr);
-  symbols.insert({newName, *entryToCopy});
+  auto [it, success] = symbols.insert({newName, *entryToCopy});
+  assert(success);
+  return &it->second;
 }
 
 /**

--- a/src/symboltablebuilder/SymbolTable.h
+++ b/src/symboltablebuilder/SymbolTable.h
@@ -40,7 +40,7 @@ public:
   // Public methods
   SymbolTableEntry *insert(const std::string &name, ASTNode *declNode);
   SymbolTableEntry *insertAnonymous(const QualType &type, ASTNode *declNode, size_t numericSuffix = 0);
-  void copySymbol(const std::string &originalName, const std::string &newName);
+  SymbolTableEntry *copySymbol(const std::string &originalName, const std::string &newName);
   SymbolTableEntry *lookup(const std::string &symbolName);
   SymbolTableEntry *lookupStrict(const std::string &symbolName);
   SymbolTableEntry *lookupInComposedFields(const std::string &name, std::vector<size_t> &indexPath);

--- a/src/symboltablebuilder/SymbolTableEntry.cpp
+++ b/src/symboltablebuilder/SymbolTableEntry.cpp
@@ -22,17 +22,6 @@ const QualType &SymbolTableEntry::getQualType() const { return qualType; }
  * @param newType New type of the current symbol
  * @param overwriteExistingType Overwrites the existing type without throwing an error
  */
-void SymbolTableEntry::updateType(const Type &newType, [[maybe_unused]] bool overwriteExistingType) {
-  assert(overwriteExistingType || qualType.isOneOf({TY_INVALID, TY_DYN}));
-  qualType.setType(newType);
-}
-
-/**
- * Update the type of this symbol.
- *
- * @param newType New type of the current symbol
- * @param overwriteExistingType Overwrites the existing type without throwing an error
- */
 void SymbolTableEntry::updateType(const QualType &newType, [[maybe_unused]] bool overwriteExistingType) {
   assert(overwriteExistingType || qualType.isOneOf({TY_INVALID, TY_DYN}));
   qualType = newType;

--- a/src/symboltablebuilder/SymbolTableEntry.h
+++ b/src/symboltablebuilder/SymbolTableEntry.h
@@ -35,7 +35,6 @@ public:
 
   // Public methods
   [[nodiscard]] const QualType &getQualType() const;
-  void updateType(const Type &newType, bool overwriteExistingType);
   void updateType(const QualType &newType, bool overwriteExistingType);
   void updateState(const LifecycleState &newState, ASTNode *node, bool force = false);
   [[nodiscard]] const CodeLoc &getDeclCodeLoc() const;

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -22,11 +22,11 @@ Type::Type(SuperType superType) : typeChain({TypeChainElement{superType}}) {}
 
 Type::Type(SuperType superType, const std::string &subType) : typeChain({TypeChainElement{superType, subType}}) {}
 
-Type::Type(SuperType superType, const std::string &subType, uint64_t typeId, const Type::TypeChainElementData &data,
+Type::Type(SuperType superType, const std::string &subType, uint64_t typeId, const TypeChainElementData &data,
            const QualTypeList &templateTypes)
     : typeChain({TypeChainElement(superType, subType, typeId, data, templateTypes)}) {}
 
-Type::Type(TypeChain types) : typeChain(std::move(types)) {}
+Type::Type(TypeChain typeChain) : typeChain(std::move(typeChain)) {}
 
 /**
  * Get the super type of the current type
@@ -69,16 +69,6 @@ Scope *Type::getBodyScope() const {
 }
 
 /**
- * Set the body scope of the current type
- *
- * @param bodyScope Body scope
- */
-void Type::setBodyScope(Scope *bodyScope) {
-  assert(isOneOf({TY_STRUCT, TY_INTERFACE}));
-  typeChain.back().data.bodyScope = bodyScope;
-}
-
-/**
  * Get the pointer type of the current type as a new type
  *
  * @param node AST node for error messages
@@ -109,12 +99,12 @@ const Type *Type::toPtr(const ASTNode *node) const {
   if (isRef())
     throw SemanticError(node, REF_POINTERS_ARE_NOT_ALLOWED, "Pointers to references are not allowed. Use pointer instead");
 
-  // Create new type
-  Type newType = *this;
-  newType.typeChain.emplace_back(TY_PTR);
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  newTypeChain.emplace_back(TY_PTR);
 
   // Register new type or return if already registered
-  return TypeRegistry::getOrInsert(newType);
+  return TypeRegistry::getOrInsert(newTypeChain);
 }
 
 /**
@@ -150,12 +140,12 @@ const Type *Type::toRef(const ASTNode *node) const {
   if (isRef())
     throw SemanticError(node, MULTI_REF_NOT_ALLOWED, "References to references are not allowed");
 
-  // Create new type
-  Type newType = *this;
-  newType.typeChain.emplace_back(TY_REF);
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  newTypeChain.emplace_back(TY_REF);
 
   // Register new type or return if already registered
-  return TypeRegistry::getOrInsert(newType);
+  return TypeRegistry::getOrInsert(newTypeChain);
 }
 
 /**
@@ -186,12 +176,12 @@ const Type *Type::toArr(const ASTNode *node, unsigned int size, bool skipDynChec
   if (!skipDynCheck && typeChain.back().superType == TY_DYN)
     throw SemanticError(node, DYN_ARRAYS_NOT_ALLOWED, "Just use the dyn type without '[]' instead");
 
-  // Create new type
-  Type newType = *this;
-  newType.typeChain.emplace_back(TY_ARRAY, TypeChainElementData{.arraySize = size});
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  newTypeChain.emplace_back(TY_ARRAY, TypeChainElementData{.arraySize = size});
 
   // Register new type or return if already registered
-  return TypeRegistry::getOrInsert(newType);
+  return TypeRegistry::getOrInsert(newTypeChain);
 }
 
 /**
@@ -217,13 +207,13 @@ const Type *Type::getContained() const {
   if (is(TY_STRING))
     return TypeRegistry::getOrInsert(TY_CHAR);
 
-  // Create new type
-  Type newType = *this;
-  assert(newType.typeChain.size() > 1);
-  newType.typeChain.pop_back();
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  assert(newTypeChain.size() > 1);
+  newTypeChain.pop_back();
 
   // Register new type or return if already registered
-  return TypeRegistry::getOrInsert(newType);
+  return TypeRegistry::getOrInsert(newTypeChain);
 }
 
 /**
@@ -252,19 +242,18 @@ Type Type::replaceBaseType(const Type &newBaseType) const {
  * @param newBaseType New base type
  * @return The new type
  */
-const Type *Type::replaceBase(const Type &newBaseType) const {
+const Type *Type::replaceBase(const Type *newBaseType) const {
   assert(!typeChain.empty());
 
   // Create new type
-  Type newType = *this;
-  TypeChain newTypeChain = newBaseType.typeChain;
+  TypeChain newTypeChain = newBaseType->typeChain;
   const bool doubleRef = newTypeChain.back().superType == TY_REF && typeChain.back().superType == TY_REF;
   for (size_t i = 1; i < typeChain.size(); i++)
     if (!doubleRef || i > 1)
       newTypeChain.push_back(typeChain.at(i));
 
   // Register new type or return if already registered
-  return TypeRegistry::getOrInsert(newType);
+  return TypeRegistry::getOrInsert(newTypeChain);
 }
 
 /**
@@ -272,7 +261,7 @@ const Type *Type::replaceBase(const Type &newBaseType) const {
  *
  * @return Type without reference wrapper
  */
-Type Type::removeReferenceWrapper() const { return isRef() ? getContainedTy() : *this; }
+const Type *Type::removeReferenceWrapper() const { return isRef() ? getContained() : this; }
 
 /**
  * Return the LLVM type for this symbol type
@@ -372,7 +361,7 @@ llvm::Type *Type::toLLVMType(llvm::LLVMContext &context, Scope *accessScope) con
   }
 
   if (isArray()) {
-    llvm::Type *containedType = getContainedTy().toLLVMType(context, accessScope);
+    llvm::Type *containedType = getContained()->toLLVMType(context, accessScope);
     return llvm::ArrayType::get(containedType, getArraySize());
   }
 
@@ -425,10 +414,10 @@ bool Type::isArray() const { return getSuperType() == TY_ARRAY; }
  * @param other Other symbol type
  * @return Same container type or not
  */
-bool Type::isSameContainerTypeAs(const Type &other) const {
-  const bool bothPtr = isPtr() && other.isPtr();
-  const bool bothRef = isRef() && other.isRef();
-  const bool bothArray = isArray() && other.isArray();
+bool Type::isSameContainerTypeAs(const Type *other) const {
+  const bool bothPtr = isPtr() && other->isPtr();
+  const bool bothRef = isRef() && other->isRef();
+  const bool bothArray = isArray() && other->isArray();
   return bothPtr || bothRef || bothArray;
 }
 
@@ -437,9 +426,88 @@ bool Type::isSameContainerTypeAs(const Type &other) const {
  *
  * @return Base type
  */
-Type Type::getBase() const {
+const Type *Type::getBase() const {
   assert(!typeChain.empty());
-  return Type({typeChain.front()});
+
+  // Create new type chain
+  const TypeChain newTypeChain = {typeChain.front()};
+
+  // Register new type or return if already registered
+  return TypeRegistry::getOrInsert(newTypeChain);
+}
+
+/**
+ * Retrieve the same type, but with lambda captures
+ *
+ * @return Type with lambda captures
+ */
+const Type *Type::getWithLambdaCaptures(bool enabled) const {
+  assert(getBase()->isOneOf({TY_FUNCTION, TY_PROCEDURE}));
+
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  newTypeChain.front().data.hasCaptures = enabled;
+
+  // Register new type or return if already registered
+  return TypeRegistry::getOrInsert(newTypeChain);
+}
+
+/**
+ * Retrieve the same type, but with the body scope removed
+ *
+ * @return Type with body scope removed
+ */
+const Type *Type::getWithBodyScope(Scope *bodyScope) const {
+  assert(getBase()->isOneOf({TY_STRUCT, TY_INTERFACE}));
+
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  newTypeChain.front().data.bodyScope = bodyScope;
+
+  // Register new type or return if already registered
+  return TypeRegistry::getOrInsert(newTypeChain);
+}
+
+/**
+ * Retrieve the same type, but with the given template types
+ *
+ * @return Type with new template types
+ */
+const Type *Type::getWithTemplateTypes(const QualTypeList &templateTypes) const {
+  assert(isOneOf({TY_STRUCT, TY_INTERFACE}));
+  return getWithBaseTemplateTypes(templateTypes);
+}
+
+/**
+ * Retrieve the same type, but with the given base template types
+ *
+ * @return Type with new base template types
+ */
+const Type *Type::getWithBaseTemplateTypes(const QualTypeList &templateTypes) const {
+  assert(getBase()->isOneOf({TY_STRUCT, TY_INTERFACE}));
+
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  newTypeChain.front().templateTypes = templateTypes;
+
+  // Register new type or return if already registered
+  return TypeRegistry::getOrInsert(newTypeChain);
+}
+
+/**
+ * Retrieve the same type, but with the param and return types removed
+ *
+ * @return Type with param and return types removed
+ */
+const Type *Type::getWithFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes) const {
+  assert(getBase()->isOneOf({TY_FUNCTION, TY_PROCEDURE}));
+
+  // Create new type chain
+  TypeChain newTypeChain = typeChain;
+  newTypeChain.front().paramTypes = paramAndReturnTypes;
+
+  // Register new type or return if already registered
+  return TypeRegistry::getOrInsert(newTypeChain);
 }
 
 /**
@@ -448,20 +516,20 @@ Type Type::getBase() const {
  * @return Contains generic parts or not
  */
 bool Type::hasAnyGenericParts() const { // NOLINT(misc-no-recursion)
-  const Type &baseType = getBase();
+  const Type *baseType = getBase();
 
   // Check if the type itself is generic
-  if (baseType.is(TY_GENERIC))
+  if (baseType->is(TY_GENERIC))
     return true;
 
   // Check if the type has generic template types
-  const auto templateTypes = baseType.getTemplateTypes();
+  const auto templateTypes = baseType->getTemplateTypes();
   if (std::ranges::any_of(templateTypes, [](const QualType &t) { return t.hasAnyGenericParts(); }))
     return true;
 
   // Check param and return types or functions/procedures
-  if (baseType.isOneOf({TY_FUNCTION, TY_PROCEDURE})) {
-    const auto paramTypes = baseType.getFunctionParamAndReturnTypes();
+  if (baseType->isOneOf({TY_FUNCTION, TY_PROCEDURE})) {
+    const auto paramTypes = baseType->getFunctionParamAndReturnTypes();
     if (std::ranges::any_of(paramTypes, [](const QualType &t) { return t.hasAnyGenericParts(); }))
       return true;
   }
@@ -470,27 +538,11 @@ bool Type::hasAnyGenericParts() const { // NOLINT(misc-no-recursion)
 }
 
 /**
- * Set the list of templates types
- */
-void Type::setTemplateTypes(const QualTypeList &templateTypes) {
-  assert(isOneOf({TY_STRUCT, TY_INTERFACE}));
-  typeChain.back().templateTypes = templateTypes;
-}
-
-/**
  * Retrieve template types of the current type
  *
  * @return Vector of template types
  */
 const QualTypeList &Type::getTemplateTypes() const { return typeChain.back().templateTypes; }
-
-/**
- * Set the list of templates types of the base type
- */
-void Type::setBaseTemplateTypes(const QualTypeList &templateTypes) {
-  assert(getBase().isOneOf({TY_STRUCT, TY_INTERFACE}));
-  typeChain.front().templateTypes = templateTypes;
-}
 
 /**
  * Check if the current type is of a certain super type
@@ -545,19 +597,6 @@ const QualType &Type::getFunctionReturnType() const {
 }
 
 /**
- * Set the return type of a function type
- *
- * @param returnType Function return type
- */
-void Type::setFunctionReturnType(const QualType &returnType) {
-  assert(is(TY_FUNCTION));
-  QualTypeList &paramTypes = typeChain.back().paramTypes;
-  if (paramTypes.empty())
-    paramTypes.resize(1);
-  paramTypes.at(0) = returnType;
-}
-
-/**
  * Get the param types of a function or procedure type
  *
  * @return Function param types
@@ -570,39 +609,13 @@ QualTypeList Type::getFunctionParamTypes() const {
 }
 
 /**
- * Set the param types of a function or procedure type
- *
- * @param paramTypes Function param types
- */
-void Type::setFunctionParamTypes(const QualTypeList &newParamTypes) {
-  assert(isOneOf({TY_FUNCTION, TY_PROCEDURE}));
-  QualTypeList &paramTypes = typeChain.back().paramTypes;
-  // Resize param types if required
-  if (paramTypes.size() < newParamTypes.size() + 1)
-    paramTypes.resize(newParamTypes.size() + 1, QualType(TY_DYN));
-  // Set the function param types
-  for (size_t i = 0; i < newParamTypes.size(); i++)
-    paramTypes.at(i + 1) = newParamTypes.at(i);
-}
-
-/**
  * Check if a function or procedure type has captures
  *
  * @return Has captures
  */
 bool Type::hasLambdaCaptures() const {
-  assert(getBase().isOneOf({TY_FUNCTION, TY_PROCEDURE}));
+  assert(getBase()->isOneOf({TY_FUNCTION, TY_PROCEDURE}));
   return typeChain.front().data.hasCaptures;
-}
-
-/**
- * Set has captures of a function or procedure type
- *
- * @param hasCaptures Has captures
- */
-void Type::setHasLambdaCaptures(bool hasCaptures) {
-  assert(getBase().isOneOf({TY_FUNCTION, TY_PROCEDURE}));
-  typeChain.front().data.hasCaptures = hasCaptures;
 }
 
 /**
@@ -611,18 +624,8 @@ void Type::setHasLambdaCaptures(bool hasCaptures) {
  * @return Function param and return types (first is return type, rest are param types)
  */
 const QualTypeList &Type::getFunctionParamAndReturnTypes() const {
-  assert(getBase().isOneOf({TY_FUNCTION, TY_PROCEDURE}));
+  assert(getBase()->isOneOf({TY_FUNCTION, TY_PROCEDURE}));
   return typeChain.front().paramTypes;
-}
-
-/**
- * Set the param and return types of a function or procedure base type
- *
- * @param newParamAndReturnTypes Function param and return types (first is return type, rest are param types)
- */
-void Type::setFunctionParamAndReturnTypes(const QualTypeList &newParamAndReturnTypes) {
-  assert(getBase().isOneOf({TY_FUNCTION, TY_PROCEDURE}));
-  typeChain.front().paramTypes = newParamAndReturnTypes;
 }
 
 bool operator==(const Type &lhs, const Type &rhs) { return lhs.typeChain == rhs.typeChain; }
@@ -644,8 +647,8 @@ bool Type::matches(const Type &otherType, bool ignoreArraySize) const {
 
   // Compare the elements
   for (size_t i = 0; i < typeChain.size(); i++) {
-    const Type::TypeChainElement &lhsElement = typeChain.at(i);
-    const Type::TypeChainElement &rhsElement = otherType.typeChain.at(i);
+    const TypeChainElement &lhsElement = typeChain.at(i);
+    const TypeChainElement &rhsElement = otherType.typeChain.at(i);
 
     // Ignore differences in array size
     if (ignoreArraySize && lhsElement.superType == TY_ARRAY && rhsElement.superType == TY_ARRAY)
@@ -667,20 +670,31 @@ bool Type::matches(const Type &otherType, bool ignoreArraySize) const {
  * @param typeA Candidate type
  * @param typeB Requested type
  */
-void Type::unwrapBoth(Type &typeA, Type &typeB) {
+void Type::unwrapBoth(const Type *&typeA, const Type *&typeB) {
   // Remove reference wrapper of front type if required
-  if (typeA.isRef() && !typeB.isRef())
-    typeA = typeA.removeReferenceWrapper();
+  if (typeA->isRef() && !typeB->isRef())
+    typeA = typeA->removeReferenceWrapper();
 
   // Remove reference wrapper of requested type if required
-  if (!typeA.isRef() && typeB.isRef() && !typeA.getBase().is(TY_GENERIC))
-    typeB = typeB.removeReferenceWrapper();
+  if (!typeA->isRef() && typeB->isRef() && !typeA->getBase()->is(TY_GENERIC))
+    typeB = typeB->removeReferenceWrapper();
 
   // Unwrap both types as far as possible
-  while (typeA.isSameContainerTypeAs(typeB)) {
-    typeB = typeB.getContainedTy();
-    typeA = typeA.getContainedTy();
+  while (typeA->isSameContainerTypeAs(typeB)) {
+    typeB = typeB->getContained();
+    typeA = typeA->getContained();
   }
+}
+
+/**
+ * Check if two types have the same type chain depth
+ *
+ * @param typeA First type
+ * @param typeB Second type
+ * @return Same depth or not
+ */
+bool Type::hasSameTypeChainDepth(const Type *typeA, const Type *typeB) {
+  return typeA->typeChain.size() == typeB->typeChain.size();
 }
 
 } // namespace spice::compiler

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -628,10 +628,6 @@ const QualTypeList &Type::getFunctionParamAndReturnTypes() const {
   return typeChain.front().paramTypes;
 }
 
-bool operator==(const Type &lhs, const Type &rhs) { return lhs.typeChain == rhs.typeChain; }
-
-bool operator!=(const Type &lhs, const Type &rhs) { return !(lhs == rhs); }
-
 /**
  * Check for the matching compatibility of two types.
  * Useful for struct and function matching as well as assignment type validation and function arg matching.
@@ -640,15 +636,15 @@ bool operator!=(const Type &lhs, const Type &rhs) { return !(lhs == rhs); }
  * @param ignoreArraySize Ignore array sizes
  * @return Matching or not
  */
-bool Type::matches(const Type &otherType, bool ignoreArraySize) const {
+bool Type::matches(const Type *otherType, bool ignoreArraySize) const {
   // If the size does not match, it is not equal
-  if (typeChain.size() != otherType.typeChain.size())
+  if (typeChain.size() != otherType->typeChain.size())
     return false;
 
   // Compare the elements
   for (size_t i = 0; i < typeChain.size(); i++) {
     const TypeChainElement &lhsElement = typeChain.at(i);
-    const TypeChainElement &rhsElement = otherType.typeChain.at(i);
+    const TypeChainElement &rhsElement = otherType->typeChain.at(i);
 
     // Ignore differences in array size
     if (ignoreArraySize && lhsElement.superType == TY_ARRAY && rhsElement.superType == TY_ARRAY)

--- a/src/symboltablebuilder/Type.h
+++ b/src/symboltablebuilder/Type.h
@@ -3,9 +3,11 @@
 #pragma once
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include <symboltablebuilder/QualType.h>
+#include <symboltablebuilder/TypeChain.h>
 #include <util/GlobalDefinitions.h>
 
 #include <llvm/IR/Type.h>
@@ -20,88 +22,11 @@ class GenericType;
 class Struct;
 class Interface;
 
-// Constants
-const char *const STROBJ_NAME = "String";
-const char *const RESULTOBJ_NAME = "Result";
-const char *const ERROBJ_NAME = "Error";
-const char *const TIOBJ_NAME = "TypeInfo";
-const char *const IITERATOR_NAME = "IIterator";
-const char *const ARRAY_ITERATOR_NAME = "ArrayIterator";
-const long ARRAY_SIZE_UNKNOWN = 0;
-const uint64_t TYPE_ID_ITERATOR_INTERFACE = 255;
-const uint64_t TYPE_ID_ITERABLE_INTERFACE = 256;
-
-enum SuperType : uint8_t {
-  TY_INVALID,
-  TY_UNRESOLVED,
-  TY_DOUBLE,
-  TY_INT,
-  TY_SHORT,
-  TY_LONG,
-  TY_BYTE,
-  TY_CHAR,
-  TY_STRING, // Alias for 'const char*'
-  TY_BOOL,
-  TY_STRUCT,
-  TY_INTERFACE,
-  TY_ENUM,
-  TY_GENERIC,
-  TY_ALIAS,
-  TY_DYN,
-  TY_PTR,
-  TY_REF,
-  TY_ARRAY,
-  TY_FUNCTION,
-  TY_PROCEDURE,
-  TY_IMPORT,
-};
-
 class Type {
 public:
-  // Unions
-  union TypeChainElementData {
-    unsigned int arraySize;     // TY_ARRAY
-    Scope *bodyScope = nullptr; // TY_STRUCT, TY_INTERFACE, TY_ENUM
-    bool hasCaptures;           // TY_FUNCTION, TY_PROCEDURE (lambdas)
-  };
-
-  // Structs
-  struct TypeChainElement {
-  public:
-    // Constructors
-    TypeChainElement() = default;
-    explicit TypeChainElement(SuperType superType) : superType(superType), typeId(superType){};
-    TypeChainElement(SuperType superType, std::string subType)
-        : superType(superType), subType(std::move(subType)), typeId(superType){};
-    TypeChainElement(SuperType superType, TypeChainElementData data) : superType(superType), typeId(superType), data(data){};
-    TypeChainElement(SuperType superType, std::string subType, uint64_t typeId, TypeChainElementData data,
-                     const QualTypeList &templateTypes)
-        : superType(superType), subType(std::move(subType)), typeId(typeId), data(data), templateTypes(templateTypes){};
-
-    // Overloaded operators
-    friend bool operator==(const TypeChainElement &lhs, const TypeChainElement &rhs);
-    friend bool operator!=(const TypeChainElement &lhs, const TypeChainElement &rhs);
-    void getName(std::stringstream &name, bool withSize) const;
-    [[nodiscard]] std::string getName(bool withSize) const;
-
-    // Public members
-    SuperType superType = TY_INVALID;
-    std::string subType;
-    uint64_t typeId = TY_INVALID;
-    TypeChainElementData data = {.arraySize = 0};
-    QualTypeList templateTypes;
-    QualTypeList paramTypes; // First type is the return type
-  };
-
-  // Make sure we have no unexpected increases in memory consumption
-  static_assert(sizeof(TypeChainElement) == 104);
-
-  // Typedefs
-  using TypeChain = std::vector<TypeChainElement>;
-
   // Constructors
   explicit Type(SuperType superType);
-  explicit Type(TypeChain types);
+  explicit Type(TypeChain typeChain);
   Type(SuperType superType, const std::string &subType);
   Type(SuperType superType, const std::string &subType, uint64_t typeId, const TypeChainElementData &data,
        const QualTypeList &templateTypes);
@@ -111,18 +36,11 @@ public:
   [[nodiscard]] const std::string &getSubType() const;
   [[nodiscard]] unsigned int getArraySize() const;
   [[nodiscard]] Scope *getBodyScope() const;
-  void setBodyScope(Scope *bodyScope);
   [[nodiscard]] const QualType &getFunctionReturnType() const;
-  void setFunctionReturnType(const QualType &returnType);
   [[nodiscard]] QualTypeList getFunctionParamTypes() const;
-  void setFunctionParamTypes(const QualTypeList &paramTypes);
   [[nodiscard]] const QualTypeList &getFunctionParamAndReturnTypes() const;
-  void setFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes);
   [[nodiscard]] bool hasLambdaCaptures() const;
-  void setHasLambdaCaptures(bool hasCaptures);
   [[nodiscard]] const QualTypeList &getTemplateTypes() const;
-  void setTemplateTypes(const QualTypeList &templateTypes);
-  void setBaseTemplateTypes(const QualTypeList &templateTypes);
 
   // Queries on the type
   [[nodiscard]] bool is(SuperType superType) const;
@@ -135,7 +53,7 @@ public:
   [[nodiscard]] bool hasAnyGenericParts() const;
 
   // Complex queries on the type
-  [[nodiscard]] bool isSameContainerTypeAs(const Type &other) const;
+  [[nodiscard]] bool isSameContainerTypeAs(const Type *other) const;
   [[nodiscard]] bool matches(const Type &otherType, bool ignoreArraySize) const;
 
   // Serialization
@@ -155,16 +73,22 @@ public:
   [[nodiscard]] [[deprecated]] Type getContainedTy() const;
   [[nodiscard]] const Type *getContained() const;
   [[nodiscard]] [[deprecated]] Type replaceBaseType(const Type &newBaseType) const;
-  [[nodiscard]] const Type *replaceBase(const Type &newBaseType) const;
-  [[nodiscard]] Type removeReferenceWrapper() const;
-  [[nodiscard]] Type getBase() const;
+  [[nodiscard]] const Type *replaceBase(const Type *newBaseType) const;
+  [[nodiscard]] const Type *removeReferenceWrapper() const;
+  [[nodiscard]] const Type *getBase() const;
+  [[nodiscard]] const Type *getWithLambdaCaptures(bool enabled) const;
+  [[nodiscard]] const Type *getWithBodyScope(Scope *bodyScope) const;
+  [[nodiscard]] const Type *getWithTemplateTypes(const QualTypeList &templateTypes) const;
+  [[nodiscard]] const Type *getWithBaseTemplateTypes(const QualTypeList &templateTypes) const;
+  [[nodiscard]] const Type *getWithFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes) const;
 
   // Overloaded operators
   friend bool operator==(const Type &lhs, const Type &rhs);
   friend bool operator!=(const Type &lhs, const Type &rhs);
 
   // Public static methods
-  static void unwrapBoth(Type &typeA, Type &typeB);
+  static void unwrapBoth(const Type *&typeA, const Type *&typeB);
+  static bool hasSameTypeChainDepth(const Type *typeA, const Type *typeB);
 
   // Public members
   TypeChain typeChain;

--- a/src/symboltablebuilder/Type.h
+++ b/src/symboltablebuilder/Type.h
@@ -54,7 +54,7 @@ public:
 
   // Complex queries on the type
   [[nodiscard]] bool isSameContainerTypeAs(const Type *other) const;
-  [[nodiscard]] bool matches(const Type &otherType, bool ignoreArraySize) const;
+  [[nodiscard]] bool matches(const Type *otherType, bool ignoreArraySize) const;
 
   // Serialization
   void getName(std::stringstream &name, bool withSize = false) const;
@@ -81,10 +81,6 @@ public:
   [[nodiscard]] const Type *getWithTemplateTypes(const QualTypeList &templateTypes) const;
   [[nodiscard]] const Type *getWithBaseTemplateTypes(const QualTypeList &templateTypes) const;
   [[nodiscard]] const Type *getWithFunctionParamAndReturnTypes(const QualTypeList &paramAndReturnTypes) const;
-
-  // Overloaded operators
-  friend bool operator==(const Type &lhs, const Type &rhs);
-  friend bool operator!=(const Type &lhs, const Type &rhs);
 
   // Public static methods
   static void unwrapBoth(const Type *&typeA, const Type *&typeB);

--- a/src/symboltablebuilder/TypeChain.cpp
+++ b/src/symboltablebuilder/TypeChain.cpp
@@ -15,19 +15,14 @@ bool operator==(const TypeChainElement &lhs, const TypeChainElement &rhs) {
   switch (lhs.superType) {
   case TY_ARRAY:
     return lhs.data.arraySize == rhs.data.arraySize;
-  case TY_STRUCT:    // fall-through
-  case TY_INTERFACE: // fall-through
-  case TY_ENUM: {
-    if (lhs.superType == TY_STRUCT) {
-      assert(lhs.data.bodyScope != nullptr && rhs.data.bodyScope != nullptr);
-      return lhs.typeId == rhs.typeId && lhs.templateTypes == rhs.templateTypes;
-    } else if (lhs.superType == TY_INTERFACE) {
-      return lhs.typeId == rhs.typeId;
-    } else {
-      assert(lhs.data.bodyScope != nullptr && rhs.data.bodyScope != nullptr);
-      return lhs.typeId == rhs.typeId && lhs.data.bodyScope == rhs.data.bodyScope;
-    }
-  }
+  case TY_STRUCT:
+    assert(lhs.data.bodyScope != nullptr && rhs.data.bodyScope != nullptr);
+    return lhs.typeId == rhs.typeId && lhs.templateTypes == rhs.templateTypes;
+  case TY_INTERFACE:
+    return lhs.typeId == rhs.typeId;
+  case TY_ENUM:
+    assert(lhs.data.bodyScope != nullptr && rhs.data.bodyScope != nullptr);
+    return lhs.typeId == rhs.typeId && lhs.data.bodyScope == rhs.data.bodyScope;
   case TY_FUNCTION: // fall-through
   case TY_PROCEDURE:
     if (lhs.paramTypes.size() != rhs.paramTypes.size())

--- a/src/symboltablebuilder/TypeChain.cpp
+++ b/src/symboltablebuilder/TypeChain.cpp
@@ -1,12 +1,12 @@
 // Copyright (c) 2021-2024 ChilliBits. All rights reserved.
 
-#include "Type.h"
+#include "TypeChain.h"
 
 #include <exception/CompilerError.h>
 
 namespace spice::compiler {
 
-bool operator==(const Type::TypeChainElement &lhs, const Type::TypeChainElement &rhs) {
+bool operator==(const TypeChainElement &lhs, const TypeChainElement &rhs) {
   // Check super type
   if (lhs.superType != rhs.superType)
     return false;
@@ -43,9 +43,9 @@ bool operator==(const Type::TypeChainElement &lhs, const Type::TypeChainElement 
   }
 }
 
-bool operator!=(const Type::TypeChainElement &lhs, const Type::TypeChainElement &rhs) { return !(lhs == rhs); }
+bool operator!=(const TypeChainElement &lhs, const TypeChainElement &rhs) { return !(lhs == rhs); }
 
-void Type::TypeChainElement::getName(std::stringstream &name, bool withSize) const {
+void TypeChainElement::getName(std::stringstream &name, bool withSize) const {
   switch (superType) {
   case TY_PTR:
     name << "*";
@@ -146,7 +146,7 @@ void Type::TypeChainElement::getName(std::stringstream &name, bool withSize) con
  * @param withSize Also encode array sizes
  * @return Name as string
  */
-std::string Type::TypeChainElement::getName(bool withSize) const {
+std::string TypeChainElement::getName(bool withSize) const {
   std::stringstream name;
   getName(name, withSize);
   return name.str();

--- a/src/symboltablebuilder/TypeChain.h
+++ b/src/symboltablebuilder/TypeChain.h
@@ -1,0 +1,85 @@
+// Copyright (c) 2021-2024 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <numeric>
+#include <symboltablebuilder/QualType.h>
+
+namespace spice::compiler {
+
+// Forward declarations
+class Scope;
+
+// Constants
+const long ARRAY_SIZE_UNKNOWN = 0;
+
+enum SuperType : uint8_t {
+  TY_INVALID,
+  TY_UNRESOLVED,
+  TY_DOUBLE,
+  TY_INT,
+  TY_SHORT,
+  TY_LONG,
+  TY_BYTE,
+  TY_CHAR,
+  TY_STRING, // Alias for 'const char*'
+  TY_BOOL,
+  TY_STRUCT,
+  TY_INTERFACE,
+  TY_ENUM,
+  TY_GENERIC,
+  TY_ALIAS,
+  TY_DYN,
+  TY_PTR,
+  TY_REF,
+  TY_ARRAY,
+  TY_FUNCTION,
+  TY_PROCEDURE,
+  TY_IMPORT,
+};
+
+union TypeChainElementData {
+  unsigned int arraySize;     // TY_ARRAY
+  Scope *bodyScope = nullptr; // TY_STRUCT, TY_INTERFACE, TY_ENUM
+  bool hasCaptures;           // TY_FUNCTION, TY_PROCEDURE (lambdas)
+};
+
+// Structs
+struct TypeChainElement {
+public:
+  // Constructors
+  TypeChainElement() = default;
+  explicit TypeChainElement(SuperType superType) : superType(superType), typeId(superType){};
+  TypeChainElement(SuperType superType, std::string subType)
+      : superType(superType), subType(std::move(subType)), typeId(superType){};
+  TypeChainElement(SuperType superType, TypeChainElementData data) : superType(superType), typeId(superType), data(data){};
+  TypeChainElement(SuperType superType, std::string subType, uint64_t typeId, TypeChainElementData data,
+                   QualTypeList templateTypes)
+      : superType(superType), subType(std::move(subType)), typeId(typeId), data(data), templateTypes(std::move(templateTypes)){};
+
+  // Overloaded operators
+  friend bool operator==(const TypeChainElement &lhs, const TypeChainElement &rhs);
+  friend bool operator!=(const TypeChainElement &lhs, const TypeChainElement &rhs);
+  void getName(std::stringstream &name, bool withSize) const;
+  [[nodiscard]] std::string getName(bool withSize) const;
+
+  // Public members
+  SuperType superType = TY_INVALID;
+  std::string subType;
+  uint64_t typeId = TY_INVALID;
+  TypeChainElementData data = {.arraySize = 0};
+  QualTypeList templateTypes;
+  QualTypeList paramTypes; // First type is the return type
+};
+
+// Make sure we have no unexpected increases in memory consumption
+static_assert(sizeof(TypeChainElement) == 104);
+
+// Typedefs
+using TypeChain = std::vector<TypeChainElement>;
+
+} // namespace spice::compiler
+

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -329,7 +329,7 @@ MatchResult FunctionManager::matchManifestation(Function &candidate, Scope *&mat
       assert(spiceStruct != nullptr);
       matchScope = spiceStruct->scope;
     }
-    candidate.thisType.setBodyScope(matchScope);
+    candidate.thisType = candidate.thisType.getWithBodyScope(matchScope);
   }
 
   return MatchResult::MATCHED;
@@ -428,7 +428,7 @@ bool FunctionManager::matchArgTypes(Function &candidate, const ArgList &reqArgs,
 
     // If we have a function/procedure type we need to take care of the information, if it takes captures
     if (requestedType.getBase().isOneOf({TY_FUNCTION, TY_PROCEDURE}) && requestedType.hasLambdaCaptures()) {
-      candidateParamType.setHasLambdaCaptures(true);
+      candidateParamType = candidateParamType.getWithLambdaCaptures();
       needsSubstantiation = true;
     }
   }

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -140,6 +140,11 @@ const Function *FunctionManager::lookupFunction(Scope *matchScope, const std::st
                                                 const ArgList &reqArgs, bool strictSpecifierMatching) {
   assert(reqThisType.isOneOf({TY_DYN, TY_STRUCT}));
 
+  // Do cache lookup
+  const uint64_t cacheKey = getCacheKey(matchScope, reqName, reqThisType, reqArgs, {});
+  if (lookupCache.contains(cacheKey))
+    return lookupCache.at(cacheKey);
+
   // Copy the registry to prevent iterating over items, that are created within the loop
   FunctionRegistry functionRegistry = matchScope->functions;
   // Loop over function registry to find functions, that match the requirements of the call

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -10,8 +10,12 @@
 #include <typechecker/ExprResult.h>
 #include <typechecker/TypeMatcher.h>
 #include <util/CodeLoc.h>
+#include <util/CustomHashFunctions.h>
 
 namespace spice::compiler {
+
+// Static member initialization
+std::unordered_map<uint64_t, Function *> FunctionManager::lookupCache = {};
 
 Function *FunctionManager::insertFunction(Scope *insertScope, const Function &baseFunction,
                                           std::vector<Function *> *nodeFunctionList) {
@@ -193,6 +197,11 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
                                          bool strictSpecifierMatching, const ASTNode *callNode) {
   assert(reqThisType.isOneOf({TY_DYN, TY_STRUCT, TY_INTERFACE}));
 
+  // Do cache lookup
+  const uint64_t cacheKey = getCacheKey(matchScope, reqName, reqThisType, reqArgs, templateTypeHints);
+  if (lookupCache.contains(cacheKey))
+    return lookupCache.at(cacheKey);
+
   // Copy the registry to prevent iterating over items, that are created within the loop
   FunctionRegistry functionRegistry = matchScope->functions;
   // Loop over function registry to find functions, that match the requirements of the call
@@ -255,8 +264,7 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
       // Copy function entry
       const std::string newSignature = substantiatedFunction->getSignature(false);
       matchScope->lookupStrict(presetFunction.entry->name)->used = true;
-      matchScope->symbolTable.copySymbol(presetFunction.entry->name, newSignature);
-      substantiatedFunction->entry = matchScope->lookupStrict(newSignature);
+      substantiatedFunction->entry = matchScope->symbolTable.copySymbol(presetFunction.entry->name, newSignature);
       assert(substantiatedFunction->entry != nullptr);
 
       // Copy function scope
@@ -292,6 +300,9 @@ Function *FunctionManager::matchFunction(Scope *matchScope, const std::string &r
   if (matches.size() > 1)
     throw SemanticError(callNode, FUNCTION_AMBIGUITY, "Multiple functions match the requested signature");
 
+  // Insert into cache
+  lookupCache[cacheKey] = matches.front();
+
   // Return the very match
   return matches.front();
 }
@@ -323,7 +334,7 @@ MatchResult FunctionManager::matchManifestation(Function &candidate, Scope *&mat
   if (!thisType.is(TY_DYN)) {
     // If we only have the generic struct scope, lookup the concrete manifestation scope
     if (matchScope->isGenericScope) {
-      const std::string structName = thisType.getSubType();
+      const std::string &structName = thisType.getSubType();
       Scope *scope = thisType.getBodyScope()->parent;
       Struct *spiceStruct = StructManager::matchStruct(scope, structName, thisType.getTemplateTypes(), candidate.declNode);
       assert(spiceStruct != nullptr);
@@ -462,5 +473,42 @@ const GenericType *FunctionManager::getGenericTypeOfCandidateByName(const Functi
   }
   return nullptr;
 }
+
+/**
+ * Calculate the cache key for the function lookup cache
+ *
+ * @param scope Scope to match against
+ * @param name Function name requirement
+ * @param thisType This type requirement
+ * @param args Argument requirement
+ * @param templateTypes Template type requirement
+ * @return Cache key
+ */
+uint64_t FunctionManager::getCacheKey(Scope *scope, const std::string &name, const QualType &thisType, const ArgList &args,
+                                      const QualTypeList &templateTypes) {
+  const auto pred1 = [](size_t acc, const Arg &val) {
+    // Combine the previous hash value with the current element's hash, adjusted by a prime number to reduce collisions
+    const uint64_t typeHash = std::hash<QualType>{}(val.first);
+    const uint64_t temporaryHash = std::hash<bool>{}(val.second);
+    const uint64_t newHash = typeHash ^ (temporaryHash << 1);
+    return acc * 31 + newHash;
+  };
+  const auto pred2 = [](size_t acc, const QualType &val) {
+    // Combine the previous hash value with the current element's hash, adjusted by a prime number to reduce collisions
+    return acc * 31 + std::hash<QualType>{}(val);
+  };
+  // Calculate the cache key
+  const uint64_t scopeHash = std::hash<Scope *>{}(scope);
+  const uint64_t hashName = std::hash<std::string>{}(name);
+  const uint64_t hashThisType = std::hash<QualType>{}(thisType);
+  const uint64_t hashArgs = std::accumulate(args.begin(), args.end(), 0u, pred1);
+  const uint64_t hashTemplateTypes = std::accumulate(templateTypes.begin(), templateTypes.end(), 0u, pred2);
+  return scopeHash ^ (hashName << 1) ^ (hashThisType << 2) ^ (hashArgs << 3) ^ (hashTemplateTypes << 4);
+}
+
+/**
+ * Clear all statics
+ */
+void FunctionManager::clear() { lookupCache.clear(); }
 
 } // namespace spice::compiler

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -48,8 +48,12 @@ public:
   static Function *matchFunction(Scope *matchScope, const std::string &reqName, const QualType &reqThisType,
                                  const ArgList &reqArgs, const QualTypeList &templateTypeHints, bool strictSpecifierMatching,
                                  const ASTNode *callNode);
+  static void clear();
 
 private:
+  // Private members
+  static std::unordered_map<uint64_t, Function *> lookupCache;
+
   // Private methods
   [[nodiscard]] static Function *insertSubstantiation(Scope *insertScope, const Function &newManifestation,
                                                       const ASTNode *declNode);
@@ -65,6 +69,8 @@ private:
   static void substantiateReturnType(Function &candidate, TypeMapping &typeMapping);
   [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Function &candidate,
                                                                           const std::string &templateTypeName);
+  [[nodiscard]] static uint64_t getCacheKey(Scope *scope, const std::string &name, const QualType &thisType,
+                                            const ArgList &args, const QualTypeList &templateTypes);
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/InterfaceManager.cpp
+++ b/src/typechecker/InterfaceManager.cpp
@@ -120,9 +120,9 @@ Interface *InterfaceManager::matchInterface(Scope *matchScope, const std::string
       substantiatedInterface->scope->isGenericScope = false;
 
       // Attach the template types to the new interface entry
-      QualType entryType = substantiatedInterface->entry->getQualType();
-      entryType.setTemplateTypes(substantiatedInterface->getTemplateTypes());
-      entryType.setBodyScope(substantiatedInterface->scope);
+      QualType entryType = substantiatedInterface->entry->getQualType()
+                               .getWithTemplateTypes(substantiatedInterface->getTemplateTypes())
+                               .getWithBodyScope(substantiatedInterface->scope);
       substantiatedInterface->entry->updateType(entryType, true);
 
       // Replace symbol types of method entries with concrete types

--- a/src/typechecker/InterfaceManager.h
+++ b/src/typechecker/InterfaceManager.h
@@ -26,8 +26,12 @@ public:
   static Interface *insertInterface(Scope *insertScope, Interface &spiceInterface, std::vector<Interface *> *nodeInterfaceList);
   [[nodiscard]] static Interface *matchInterface(Scope *matchScope, const std::string &reqName,
                                                  const QualTypeList &reqTemplateTypes, const ASTNode *node);
+  static void clear();
 
 private:
+  // Private members
+  static std::unordered_map<uint64_t, Interface *> lookupCache;
+
   // Private methods
   [[nodiscard]] static Interface *insertSubstantiation(Scope *insertScope, Interface &newManifestation, const ASTNode *declNode);
   [[nodiscard]] static bool matchName(const Interface &candidate, const std::string &reqName);
@@ -36,6 +40,7 @@ private:
   static void substantiateSignatures(Interface &candidate, TypeMapping &typeMapping);
   [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Interface &candidate,
                                                                           const std::string &templateTypeName);
+  [[nodiscard]] static uint64_t getCacheKey(Scope *scope, const std::string &name, const QualTypeList &templateTypes);
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -710,7 +710,7 @@ QualType OpRuleManager::validateBinaryOperation(const ASTNode *node, const Binar
   for (size_t i = 0; i < opRulesSize; i++) {
     const BinaryOpRule &rule = opRules[i];
     if (std::get<0>(rule) == lhs.getSuperType() && std::get<1>(rule) == rhs.getSuperType()) {
-      QualType resultType = QualType(SuperType(std::get<2>(rule)));
+      QualType resultType(SuperType(std::get<2>(rule)));
       if (preserveSpecifiersFromLhs)
         resultType.setSpecifiers(lhs.getSpecifiers());
       return resultType;

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -110,7 +110,7 @@ QualType OpRuleManager::getAssignResultTypeCommon(const ASTNode *node, const Exp
   if (lhsType.isPtr() && rhsType.isArray() && lhsType.getContained().matches(rhsType.getContained(), false, false, true))
     return lhsType;
   // Allow interface* = struct* or interface& = struct that implements this interface
-  const bool sameChainDepth = lhsType.getType().typeChain.size() == rhsType.getType().typeChain.size();
+  const bool sameChainDepth = Type::hasSameTypeChainDepth(lhsType.getType(), rhsType.getType());
   const bool typesCompatible = (lhsType.isPtr() && rhsType.isPtr() && sameChainDepth) || lhsType.isRef();
   if (typesCompatible && lhsType.isBase(TY_INTERFACE) && rhsType.isBase(TY_STRUCT)) {
     QualType lhsTypeCopy = lhsType;
@@ -712,7 +712,7 @@ QualType OpRuleManager::validateBinaryOperation(const ASTNode *node, const Binar
     if (std::get<0>(rule) == lhs.getSuperType() && std::get<1>(rule) == rhs.getSuperType()) {
       QualType resultType = QualType(SuperType(std::get<2>(rule)));
       if (preserveSpecifiersFromLhs)
-        resultType.getSpecifiers() = lhs.getSpecifiers();
+        resultType.setSpecifiers(lhs.getSpecifiers());
       return resultType;
     }
   }

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -124,9 +124,9 @@ Struct *StructManager::matchStruct(Scope *matchScope, const std::string &reqName
       substantiatedStruct->scope->isGenericScope = false;
 
       // Attach the template types to the new struct entry
-      QualType entryType = substantiatedStruct->entry->getQualType();
-      entryType.setTemplateTypes(substantiatedStruct->getTemplateTypes());
-      entryType.setBodyScope(substantiatedStruct->scope);
+      QualType entryType = substantiatedStruct->entry->getQualType()
+                               .getWithTemplateTypes(substantiatedStruct->getTemplateTypes())
+                               .getWithBodyScope(substantiatedStruct->scope);
       substantiatedStruct->entry->updateType(entryType, true);
 
       // Replace symbol types of field entries with concrete types
@@ -141,10 +141,8 @@ Struct *StructManager::matchStruct(Scope *matchScope, const std::string &reqName
         QualType baseType = fieldType.getBase();
 
         // Set the body scope of fields that are of type <candidate-struct>*
-        if (baseType.matches(substantiatedStruct->entry->getQualType(), false, true, true)) {
-          baseType.setBodyScope(substantiatedStruct->scope);
-          fieldType = fieldType.replaceBaseType(baseType);
-        }
+        if (baseType.matches(substantiatedStruct->entry->getQualType(), false, true, true))
+          fieldType = fieldType.replaceBaseType(baseType.getWithBodyScope(substantiatedStruct->scope));
 
         fieldEntry->updateType(fieldType, /*overwriteExistingType=*/true);
 

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -8,8 +8,12 @@
 #include <symboltablebuilder/SymbolTableBuilder.h>
 #include <typechecker/TypeMatcher.h>
 #include <util/CodeLoc.h>
+#include <util/CustomHashFunctions.h>
 
 namespace spice::compiler {
+
+// Static member initialization
+std::unordered_map<uint64_t, Struct *> StructManager::lookupCache = {};
 
 Struct *StructManager::insertStruct(Scope *insertScope, Struct &spiceStruct, std::vector<Struct *> *nodeStructList) {
   // Open a new manifestation list. Which gets filled by the substantiated manifestations of the struct
@@ -55,6 +59,11 @@ Struct *StructManager::insertSubstantiation(Scope *insertScope, Struct &newManif
  */
 Struct *StructManager::matchStruct(Scope *matchScope, const std::string &reqName, const QualTypeList &reqTemplateTypes,
                                    const ASTNode *node) {
+  // Do cache lookup
+  const uint64_t cacheKey = getCacheKey(matchScope, reqName, reqTemplateTypes);
+  if (lookupCache.contains(cacheKey))
+    return lookupCache.at(cacheKey);
+
   // Copy the registry to prevent iterating over items, that are created within the loop
   StructRegistry structRegistry = matchScope->structs;
   // Loop over struct registry to find structs, that match the requirements of the instantiation
@@ -112,8 +121,7 @@ Struct *StructManager::matchStruct(Scope *matchScope, const std::string &reqName
       // Copy struct entry
       const std::string newSignature = substantiatedStruct->getSignature();
       matchScope->lookupStrict(substantiatedStruct->name)->used = true;
-      matchScope->symbolTable.copySymbol(substantiatedStruct->name, newSignature);
-      substantiatedStruct->entry = matchScope->lookupStrict(newSignature);
+      substantiatedStruct->entry = matchScope->symbolTable.copySymbol(substantiatedStruct->name, newSignature);
       assert(substantiatedStruct->entry != nullptr);
 
       // Copy struct scope
@@ -182,6 +190,9 @@ Struct *StructManager::matchStruct(Scope *matchScope, const std::string &reqName
   // Check if more than one struct matches the requirements
   if (matches.size() > 1)
     throw SemanticError(node, STRUCT_AMBIGUITY, "Multiple structs match the requested signature");
+
+  // Insert into cache
+  lookupCache[cacheKey] = matches.front();
 
   return matches.front();
 }
@@ -270,5 +281,30 @@ const GenericType *StructManager::getGenericTypeOfCandidateByName(const Struct &
   }
   return nullptr;
 }
+
+/**
+ * Calculate the cache key for the struct lookup cache
+ *
+ * @param scope Scope to match against
+ * @param name Struct name requirement
+ * @param templateTypes Template types to substantiate generic types
+ * @return Cache key
+ */
+uint64_t StructManager::getCacheKey(Scope *scope, const std::string &name, const QualTypeList &templateTypes) {
+  const auto pred = [](size_t acc, const QualType &val) {
+    // Combine the previous hash value with the current element's hash, adjusted by a prime number to reduce collisions
+    return acc * 31 + std::hash<QualType>{}(val);
+  };
+  // Calculate the cache key
+  const uint64_t scopeHash = std::hash<Scope *>{}(scope);
+  const uint64_t hashName = std::hash<std::string>{}(name);
+  const uint64_t hashTemplateTypes = std::accumulate(templateTypes.begin(), templateTypes.end(), 0u, pred);
+  return scopeHash ^ (hashName << 1) ^ (hashTemplateTypes << 2);
+}
+
+/**
+ * Clear all statics
+ */
+void StructManager::clear() { lookupCache.clear(); }
 
 } // namespace spice::compiler

--- a/src/typechecker/StructManager.h
+++ b/src/typechecker/StructManager.h
@@ -27,10 +27,14 @@ class StructManager {
 public:
   // Public methods
   static Struct *insertStruct(Scope *insertScope, Struct &spiceStruct, std::vector<Struct *> *nodeStructList);
-  [[nodiscard]] static Struct *matchStruct(Scope *matchScope, const std::string &reqName, const QualTypeList &reqTemplateTypes,
+  [[nodiscard]] static Struct *matchStruct(Scope *matchScope, const std::string &qt, const QualTypeList &reqTemplateTypes,
                                            const ASTNode *node);
+  static void clear();
 
 private:
+  // Private members
+  static std::unordered_map<uint64_t, Struct *> lookupCache;
+
   // Private methods
   [[nodiscard]] static Struct *insertSubstantiation(Scope *insertScope, Struct &newManifestation, const ASTNode *declNode);
   [[nodiscard]] static bool matchName(const Struct &candidate, const std::string &reqName);
@@ -38,6 +42,7 @@ private:
   static void substantiateFieldTypes(Struct &candidate, TypeMapping &typeMapping);
   [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Struct &candidate,
                                                                           const std::string &templateTypeName);
+  [[nodiscard]] static uint64_t getCacheKey(Scope *scope, const std::string &name, const QualTypeList &templateTypes);
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -169,8 +169,8 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
       Scope *matchScope = nameRegistryEntry->targetScope->parent;
       assert(matchScope->type == ScopeType::GLOBAL);
       QualType unsignedLongType(TY_LONG);
-      unsignedLongType.getSpecifiers().isSigned = false;
-      unsignedLongType.getSpecifiers().isUnsigned = true;
+      unsignedLongType.makeSigned(false);
+      unsignedLongType.makeUnsigned(true);
       const ArgList argTypes = {Arg(iterableType, false), Arg(unsignedLongType, false)};
       const QualType thisType(TY_DYN);
       node->getIteratorFct = FunctionManager::matchFunction(matchScope, "iterate", thisType, argTypes, {}, true, iteratorNode);

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -263,10 +263,8 @@ void TypeChecker::createCtorBodyPreamble(Scope *bodyScope) {
       // Match ctor function, create the concrete manifestation and set it to used
       Scope *matchScope = fieldType.getBodyScope();
       Function *spiceFunc = FunctionManager::matchFunction(matchScope, CTOR_FUNCTION_NAME, fieldType, {}, {}, false, fieldNode);
-      if (spiceFunc != nullptr) {
-        fieldType.setBodyScope(spiceFunc->thisType.getBodyScope());
-        fieldSymbol->updateType(fieldType, true);
-      }
+      if (spiceFunc != nullptr)
+        fieldSymbol->updateType(fieldType.getWithBodyScope(spiceFunc->thisType.getBodyScope()), true);
     }
   }
 }
@@ -296,10 +294,8 @@ void TypeChecker::createCopyCtorBodyPreamble(Scope *bodyScope) {
       Scope *matchScope = fieldType.getBodyScope();
       const ArgList args = {{fieldType.toConstRef(fieldNode), false /* we always have the field as storage */}};
       Function *spiceFunc = FunctionManager::matchFunction(matchScope, CTOR_FUNCTION_NAME, fieldType, args, {}, false, fieldNode);
-      if (spiceFunc != nullptr) {
-        fieldType.setBodyScope(spiceFunc->thisType.getBodyScope());
-        fieldSymbol->updateType(fieldType, true);
-      }
+      if (spiceFunc != nullptr)
+        fieldSymbol->updateType(fieldType.getWithBodyScope(spiceFunc->thisType.getBodyScope()), true);
     }
   }
 }

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -29,7 +29,7 @@ void TypeChecker::createDefaultStructMethod(const Struct &spiceStruct, const std
 
   // Procedure type
   QualType procedureType(TY_PROCEDURE);
-  procedureType.getSpecifiers().isPublic = true; // Always public
+  procedureType.makePublic(); // Always public
 
   // Insert symbol for function into the symbol table
   const std::string entryName = Function::getSymbolTableEntryName(methodName, node->codeLoc);
@@ -229,7 +229,7 @@ void TypeChecker::createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *
     // Set dealloc function to used
     const QualType thisType(TY_DYN);
     QualType bytePtrRefType = QualType(TY_BYTE).toPtr(node).toRef(node);
-    bytePtrRefType.getSpecifiers().isHeap = true;
+    bytePtrRefType.makeHeap();
     const ArgList args = {{bytePtrRefType, false /* we always have the field as storage */}};
     Function *deallocFct = FunctionManager::matchFunction(matchScope, FCT_NAME_DEALLOC, thisType, args, {}, true, node);
     assert(deallocFct != nullptr);

--- a/src/util/CustomHashFunctions.cpp
+++ b/src/util/CustomHashFunctions.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2021-2024 ChilliBits. All rights reserved.
+
+#include "CustomHashFunctions.h"
+
+namespace std {
+
+size_t hash<spice::compiler::TypeChainElementData>::operator()(const spice::compiler::TypeChainElementData &data) const {
+  // Hash the body scope pointer, since it is the larges field
+  return std::hash<spice::compiler::Scope *>{}(data.bodyScope);
+}
+
+size_t hash<spice::compiler::TypeChainElement>::operator()(const spice::compiler::TypeChainElement &tce) const {
+  // Hasher for QualTypeList
+  const auto pred = [](size_t acc, const spice::compiler::QualType &val) {
+    // Combine the previous hash value with the current element's hash, adjusted by a prime number to reduce collisions
+    return acc * 31 + std::hash<spice::compiler::QualType>{}(val);
+  };
+  // Hash all fields
+  const size_t hashSuperType = std::hash<spice::compiler::SuperType>{}(tce.superType);
+  const size_t hashSubType = std::hash<std::string>{}(tce.subType) << 1;
+  const size_t hashTypeId = std::hash<uint64_t>{}(tce.typeId) << 2;
+  const size_t hashData = std::hash<spice::compiler::TypeChainElementData>{}(tce.data) << 3;
+  const size_t hashTemplateTypes = accumulate(tce.templateTypes.begin(), tce.templateTypes.end(), 0u, pred) << 4;
+  const size_t hashParamTypes = accumulate(tce.paramTypes.begin(), tce.paramTypes.end(), 0u, pred) << 5;
+  return hashSuperType ^ hashSubType ^ hashTypeId ^ hashData ^ hashTemplateTypes ^ hashParamTypes;
+}
+
+size_t hash<spice::compiler::Type>::operator()(const spice::compiler::Type &t) const {
+  return accumulate(t.typeChain.begin(), t.typeChain.end(), 0u, [](size_t acc, const spice::compiler::TypeChainElement &val) {
+    // Combine the previous hash value with the current element's hash, adjusted by a prime number to reduce collisions
+    return acc * 31 + std::hash<spice::compiler::TypeChainElement>{}(val);
+  });
+}
+
+size_t hash<spice::compiler::TypeSpecifiers>::operator()(const spice::compiler::TypeSpecifiers &specifiers) const {
+  const size_t hashConst = std::hash<bool>{}(specifiers.isConst);
+  const size_t hashSigned = std::hash<bool>{}(specifiers.isSigned) << 1;
+  const size_t hashUnsigned = std::hash<bool>{}(specifiers.isUnsigned) << 2;
+  const size_t hashHeap = std::hash<bool>{}(specifiers.isHeap) << 3;
+  const size_t hashPublic = std::hash<bool>{}(specifiers.isPublic) << 4;
+  const size_t hashInline = std::hash<bool>{}(specifiers.isInline) << 5;
+  const size_t hashComposition = std::hash<bool>{}(specifiers.isComposition) << 6;
+  return hashConst ^ hashSigned ^ hashUnsigned ^ hashHeap ^ hashPublic ^ hashInline ^ hashComposition;
+}
+
+size_t hash<spice::compiler::QualType>::operator()(const spice::compiler::QualType &qualType) const {
+  const size_t hashType = std::hash<const spice::compiler::Type *>{}(qualType.getType());
+  const size_t hashQualifiers = std::hash<spice::compiler::TypeSpecifiers>{}(qualType.getSpecifiers()) << 1;
+  return hashType ^ hashQualifiers;
+}
+
+} // namespace std

--- a/src/util/CustomHashFunctions.cpp
+++ b/src/util/CustomHashFunctions.cpp
@@ -4,11 +4,6 @@
 
 namespace std {
 
-size_t hash<spice::compiler::TypeChainElementData>::operator()(const spice::compiler::TypeChainElementData &data) const {
-  // Hash the body scope pointer, since it is the larges field
-  return std::hash<spice::compiler::Scope *>{}(data.bodyScope);
-}
-
 size_t hash<spice::compiler::TypeChainElement>::operator()(const spice::compiler::TypeChainElement &tce) const {
   // Hasher for QualTypeList
   const auto pred = [](size_t acc, const spice::compiler::QualType &val) {
@@ -19,7 +14,7 @@ size_t hash<spice::compiler::TypeChainElement>::operator()(const spice::compiler
   const size_t hashSuperType = std::hash<spice::compiler::SuperType>{}(tce.superType);
   const size_t hashSubType = std::hash<std::string>{}(tce.subType) << 1;
   const size_t hashTypeId = std::hash<uint64_t>{}(tce.typeId) << 2;
-  const size_t hashData = std::hash<spice::compiler::TypeChainElementData>{}(tce.data) << 3;
+  const size_t hashData = std::hash<spice::compiler::Scope *>{}(tce.data.bodyScope) << 3;
   const size_t hashTemplateTypes = accumulate(tce.templateTypes.begin(), tce.templateTypes.end(), 0u, pred) << 4;
   const size_t hashParamTypes = accumulate(tce.paramTypes.begin(), tce.paramTypes.end(), 0u, pred) << 5;
   return hashSuperType ^ hashSubType ^ hashTypeId ^ hashData ^ hashTemplateTypes ^ hashParamTypes;

--- a/src/util/CustomHashFunctions.h
+++ b/src/util/CustomHashFunctions.h
@@ -1,0 +1,36 @@
+// Copyright (c) 2021-2024 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <symboltablebuilder/QualType.h>
+#include <symboltablebuilder/Type.h>
+#include <symboltablebuilder/TypeChain.h>
+
+namespace std {
+
+// Implement hash functionality for the TypeChainElementData union
+template <> struct hash<spice::compiler::TypeChainElementData> {
+  size_t operator()(const spice::compiler::TypeChainElementData &data) const;
+};
+
+// Implement hash functionality for the TypeChainElement struct
+template <> struct hash<spice::compiler::TypeChainElement> {
+  size_t operator()(const spice::compiler::TypeChainElement &tce) const;
+};
+
+// Implement hash functionality for the Type class
+template <> struct hash<spice::compiler::Type> {
+  size_t operator()(const spice::compiler::Type &t) const;
+};
+
+// Implement hash functionality for the TypeSpecifiers class
+template <> struct hash<spice::compiler::TypeSpecifiers> {
+  size_t operator()(const spice::compiler::TypeSpecifiers &specifiers) const;
+};
+
+// Implement hash functionality for the QualType class
+template <> struct hash<spice::compiler::QualType> {
+  size_t operator()(const spice::compiler::QualType &qualType) const;
+};
+
+} // namespace std

--- a/src/util/CustomHashFunctions.h
+++ b/src/util/CustomHashFunctions.h
@@ -8,11 +8,6 @@
 
 namespace std {
 
-// Implement hash functionality for the TypeChainElementData union
-template <> struct hash<spice::compiler::TypeChainElementData> {
-  size_t operator()(const spice::compiler::TypeChainElementData &data) const;
-};
-
 // Implement hash functionality for the TypeChainElement struct
 template <> struct hash<spice::compiler::TypeChainElement> {
   size_t operator()(const spice::compiler::TypeChainElement &tce) const;

--- a/std/data/vector.spice
+++ b/std/data/vector.spice
@@ -275,7 +275,8 @@ public inline f<T&> VectorIterator.get() {
  * @return Pair of current index and reference to current item
  */
 public inline f<Pair<unsigned long, T&>> VectorIterator.getIdx() {
-    return Pair<unsigned long, T&>(this.cursor, this.vector.get(this.cursor));
+    T& item = this.vector.get(this.cursor);
+    return Pair<unsigned long, T&>(this.cursor, item);
 }
 
 /**


### PR DESCRIPTION
- Make use of the new TypeRegistry everywhere in the compiler
- Types are now provided via immutable `const Type*` and can be exchanged via QualType methods
- Make Type, TypeChainElement, TypeChainElementData and QualType hashable by `std::hash`
- Further improvements