### PR TITLE
Use i64 GEP index type for pointer arithmetic

### DIFF
--- a/src/irgenerator/GenBuiltinFunctions.cpp
+++ b/src/irgenerator/GenBuiltinFunctions.cpp
@@ -24,7 +24,7 @@ std::any IRGenerator::visitPrintfCall(const PrintfCallNode *node) {
     llvm::Value *argVal;
     if (argSymbolType.isArray()) {
       llvm::Value *argValPtr = resolveAddress(arg);
-      llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(0)};
+      llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(0)};
       llvm::Type *argType = argSymbolType.toLLVMType(sourceFile);
       argVal = insertInBoundsGEP(argType, argValPtr, indices);
     } else if (argSymbolType.getBase().isStringObj()) {

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -669,7 +669,7 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
 
       // Calculate address of array item
       llvm::Type *lhsTy = lhsSTy.toLLVMType(sourceFile);
-      llvm::Value *indices[2] = {builder.getInt32(0), indexValue};
+      llvm::Value *indices[2] = {builder.getInt64(0), indexValue};
       lhs.ptr = insertInBoundsGEP(lhsTy, lhs.ptr, indices);
     } else { // Pointer
       // Make sure the value is present
@@ -709,7 +709,7 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
     QualType fieldSymbolType = lhs.entry->getQualType();
 
     // Get address of the field in the struct instance
-    std::vector<llvm::Value *> indices = {builder.getInt32(0)};
+    std::vector<llvm::Value *> indices = {builder.getInt64(0)};
     for (size_t index : indexPath)
       indices.push_back(builder.getInt32(index));
     const std::string name = fieldName + "_addr";

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -35,7 +35,7 @@ llvm::Value *IRGenerator::doImplicitCast(llvm::Value *src, QualType dstSTy, Qual
   }
   // GEP or bit-cast
   if (dstSTy.isArray() && srcSTy.isArray()) { // Special case that is used for passing arrays as pointer to functions
-    llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(0)};
+    llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(0)};
     src = insertInBoundsGEP(srcSTy.toLLVMType(sourceFile), src, indices);
   } else {
     src = insertLoad(srcSTy.toLLVMType(sourceFile), src);
@@ -72,7 +72,7 @@ void IRGenerator::generateCtorOrDtorCall(SymbolTableEntry *entry, const Function
     llvm::Type *thisType = thisVar->getQualType().getContained().toLLVMType(sourceFile);
     llvm::Value *thisPtr = insertLoad(builder.getPtrTy(), thisVar->getAddress());
     // Add field offset
-    llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(entry->orderIndex)};
+    llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(entry->orderIndex)};
     structAddr = insertInBoundsGEP(thisType, thisPtr, indices);
   } else {
     structAddr = entry->getAddress();
@@ -329,7 +329,7 @@ void IRGenerator::generateCtorBodyPreamble(Scope *bodyScope) {
     assert(spiceStruct->vTableData.vtableType != nullptr);
     // Store VTable to field address at index 0
     thisAddressLoaded = insertLoad(builder.getPtrTy(), thisAddress);
-    llvm::Value *indices[3] = {builder.getInt32(0), builder.getInt32(0), builder.getInt32(2)};
+    llvm::Value *indices[3] = {builder.getInt64(0), builder.getInt32(0), builder.getInt32(2)};
     llvm::Value *gepResult = insertInBoundsGEP(spiceStruct->vTableData.vtableType, spiceStruct->vTableData.vtable, indices);
     insertStore(gepResult, thisAddressLoaded);
   }
@@ -359,7 +359,7 @@ void IRGenerator::generateCtorBodyPreamble(Scope *bodyScope) {
       // Retrieve field address
       if (!thisAddressLoaded)
         thisAddressLoaded = insertLoad(builder.getPtrTy(), thisAddress);
-      llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(i)};
+      llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(i)};
       llvm::Value *fieldAddress = insertInBoundsGEP(structType, thisAddressLoaded, indices);
       // Retrieve default value
       llvm::Value *value;
@@ -416,7 +416,7 @@ void IRGenerator::generateCopyCtorBodyPreamble(const Function *copyCtorFunction)
         // Retrieve field address
         if (!thisAddressLoaded)
           thisAddressLoaded = insertLoad(builder.getPtrTy(), thisAddress);
-        llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(i)};
+        llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(i)};
         llvm::Value *fieldAddress = insertInBoundsGEP(structType, thisAddressLoaded, indices);
         generateCtorOrDtorCall(fieldSymbol, ctorFct, {fieldAddress});
       }
@@ -465,7 +465,7 @@ void IRGenerator::generateDtorBodyPreamble(const Function *dtorFunction) {
       // Retrieve field address
       if (!thisAddressLoaded)
         thisAddressLoaded = insertLoad(builder.getPtrTy(), thisAddress);
-      llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(i)};
+      llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(i)};
       llvm::Value *fieldAddress = insertInBoundsGEP(structType, thisAddressLoaded, indices);
       // Call dealloc function
       generateDeallocCall(fieldAddress);

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -96,7 +96,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
       structScope = fieldEntryType.getBase().getBodyScope();
       assert(structScope != nullptr);
       // Get address of field
-      llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(fieldEntry->orderIndex)};
+      llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(fieldEntry->orderIndex)};
       thisPtr = insertInBoundsGEP(structTy, thisPtr, indices);
       // Auto de-reference pointer and get new struct type
       autoDeReferencePtr(thisPtr, fieldEntryType);
@@ -313,7 +313,7 @@ std::any IRGenerator::visitArrayInitialization(const ArrayInitializationNode *no
     llvm::Value *arrayAddr = insertAlloca(arrayType);
 
     // Retrieve address of first item
-    llvm::Value *firstItemAddress = insertInBoundsGEP(arrayType, arrayAddr, builder.getInt32(0));
+    llvm::Value *firstItemAddress = insertInBoundsGEP(arrayType, arrayAddr, builder.getInt64(0));
 
     // Store all array items at their corresponding offsets
     llvm::Value *currentItemAddress = firstItemAddress;
@@ -322,7 +322,7 @@ std::any IRGenerator::visitArrayInitialization(const ArrayInitializationNode *no
       llvm::Value *itemValue = resolveValue(exprResult.node, exprResult);
       // Retrieve current item address
       if (i >= 1)
-        currentItemAddress = insertInBoundsGEP(itemType, currentItemAddress, builder.getInt32(1));
+        currentItemAddress = insertInBoundsGEP(itemType, currentItemAddress, builder.getInt64(1));
       // Store the item value
       const bool storeVolatile = exprResult.entry != nullptr && exprResult.entry->isVolatile;
       insertStore(itemValue, currentItemAddress, storeVolatile);

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -470,7 +470,7 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
     llvm::Value *rhsAddress = resolveAddress(rhs);
     assert(rhsAddress != nullptr);
     llvm::Type *elementTy = rhsSType.toLLVMType(sourceFile);
-    llvm::Value *indices[2] = {builder.getInt32(0), builder.getInt32(0)};
+    llvm::Value *indices[2] = {builder.getInt64(0), builder.getInt32(0)};
     llvm::Value *firstItemAddress = insertInBoundsGEP(elementTy, rhsAddress, indices);
     insertStore(firstItemAddress, lhsAddress);
     return LLVMExprResult{.value = rhsAddress, .ptr = lhsAddress, .entry = lhsEntry};

--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -1144,8 +1144,10 @@ LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExp
     llvm::Value *lhsLong = builder.CreateIntCast(lhsV(), rhsT, rhsSTy.isSigned());
     return {.value = builder.CreateAdd(lhsLong, rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
   }
-  case COMB(TY_INT, TY_PTR):
-    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsV())};
+  case COMB(TY_INT, TY_PTR): {
+    llvm::Value *lhsExt = builder.CreateIntCast(lhsV(), builder.getInt64Ty(), lhsSTy.isSigned());
+    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsExt)};
+  }
   case COMB(TY_SHORT, TY_DOUBLE): {
     llvm::Value *lhsFP = generateIToFp(lhsSTy, lhsV(), rhsT);
     return {.value = builder.CreateFAdd(lhsFP, rhsV())};
@@ -1160,8 +1162,10 @@ LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExp
     llvm::Value *lhsLong = builder.CreateIntCast(lhsV(), rhsT, rhsSTy.isSigned());
     return {.value = builder.CreateAdd(lhsLong, rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
   }
-  case COMB(TY_SHORT, TY_PTR):
-    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsV())};
+  case COMB(TY_SHORT, TY_PTR): {
+    llvm::Value *lhsExt = builder.CreateIntCast(lhsV(), builder.getInt64Ty(), lhsSTy.isSigned());
+    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsExt)};
+  }
   case COMB(TY_LONG, TY_DOUBLE): {
     llvm::Value *lhsFP = generateIToFp(lhsSTy, lhsV(), rhsT);
     return {.value = builder.CreateFAdd(lhsFP, rhsV())};
@@ -1173,15 +1177,19 @@ LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExp
   }
   case COMB(TY_LONG, TY_LONG):
     return {.value = builder.CreateAdd(lhsV(), rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
-  case COMB(TY_LONG, TY_PTR):
-    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsV())};
+  case COMB(TY_LONG, TY_PTR): {
+    llvm::Value *lhsExt = builder.CreateIntCast(lhsV(), builder.getInt64Ty(), lhsSTy.isSigned());
+    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsExt)};
+  }
   case COMB(TY_BYTE, TY_BYTE): // fallthrough
   case COMB(TY_CHAR, TY_CHAR):
     return {.value = builder.CreateAdd(lhsV(), rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
   case COMB(TY_PTR, TY_INT):   // fallthrough
   case COMB(TY_PTR, TY_SHORT): // fallthrough
-  case COMB(TY_PTR, TY_LONG):
-    return {.value = builder.CreateGEP(lhsSTy.getContained().toLLVMType(irGenerator->sourceFile), lhsV(), rhsV())};
+  case COMB(TY_PTR, TY_LONG): {
+    llvm::Value *rhsExt = builder.CreateIntCast(rhsV(), builder.getInt64Ty(), rhsSTy.isSigned());
+    return {.value = builder.CreateGEP(lhsSTy.getContained().toLLVMType(irGenerator->sourceFile), lhsV(), rhsExt)};
+  }
   default:                                                            // GCOV_EXCL_LINE
     throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: +"); // GCOV_EXCL_LINE
   }
@@ -1225,8 +1233,10 @@ LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMEx
     llvm::Value *lhsLong = builder.CreateIntCast(lhsV(), rhsT, rhsSTy.isSigned());
     return {.value = builder.CreateSub(lhsLong, rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
   }
-  case COMB(TY_INT, TY_PTR):
-    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsV())};
+  case COMB(TY_INT, TY_PTR): {
+    llvm::Value *lhsExt = builder.CreateIntCast(lhsV(), builder.getInt64Ty(), lhsSTy.isSigned());
+    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsExt)};
+  }
   case COMB(TY_SHORT, TY_DOUBLE): {
     llvm::Value *lhsFP = generateIToFp(lhsSTy, lhsV(), rhsT);
     return {.value = builder.CreateFSub(lhsFP, rhsV())};
@@ -1241,8 +1251,10 @@ LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMEx
     llvm::Value *lhsLong = builder.CreateIntCast(lhsV(), rhsT, rhsSTy.isSigned());
     return {.value = builder.CreateSub(lhsLong, rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
   }
-  case COMB(TY_SHORT, TY_PTR):
-    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsV())};
+  case COMB(TY_SHORT, TY_PTR): {
+    llvm::Value *lhsExt = builder.CreateIntCast(lhsV(), builder.getInt64Ty(), lhsSTy.isSigned());
+    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsExt)};
+  }
   case COMB(TY_LONG, TY_DOUBLE): {
     llvm::Value *lhsFP = generateIToFp(lhsSTy, lhsV(), rhsT);
     return {.value = builder.CreateFSub(lhsFP, rhsV())};
@@ -1254,15 +1266,19 @@ LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMEx
   }
   case COMB(TY_LONG, TY_LONG):
     return {.value = builder.CreateSub(lhsV(), rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
-  case COMB(TY_LONG, TY_PTR):
-    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsV())};
+  case COMB(TY_LONG, TY_PTR): {
+    llvm::Value *lhsExt = builder.CreateIntCast(lhsV(), builder.getInt64Ty(), lhsSTy.isSigned());
+    return {.value = builder.CreateGEP(rhsSTy.getContained().toLLVMType(irGenerator->sourceFile), rhsV(), lhsExt)};
+  }
   case COMB(TY_BYTE, TY_BYTE): // fallthrough
   case COMB(TY_CHAR, TY_CHAR):
     return {.value = builder.CreateSub(lhsV(), rhsV(), "", false, lhsSTy.isSigned() && rhsSTy.isSigned())};
   case COMB(TY_PTR, TY_INT):   // fallthrough
   case COMB(TY_PTR, TY_SHORT): // fallthrough
-  case COMB(TY_PTR, TY_LONG):
-    return {.value = builder.CreateGEP(lhsSTy.getContained().toLLVMType(irGenerator->sourceFile), lhsV(), rhsV())};
+  case COMB(TY_PTR, TY_LONG): {
+    llvm::Value *rhsExt = builder.CreateIntCast(rhsV(), builder.getInt64Ty(), rhsSTy.isSigned());
+    return {.value = builder.CreateGEP(lhsSTy.getContained().toLLVMType(irGenerator->sourceFile), lhsV(), rhsExt)};
+  }
   default:                                                            // GCOV_EXCL_LINE
     throw CompilerError(UNHANDLED_BRANCH, "Operator fallthrough: -"); // GCOV_EXCL_LINE
   }

--- a/test/test-files/irgenerator/arrays/success-arrays-multidimensional/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays-multidimensional/ir-code.ll
@@ -30,9 +30,9 @@ for.head.L4:                                      ; preds = %for.tail.L4, %for.b
 
 for.body.L4:                                      ; preds = %for.head.L4
   %5 = load i32, ptr %i, align 4
-  %6 = getelementptr inbounds [10 x [10 x i32]], ptr %a, i32 0, i32 %5
+  %6 = getelementptr inbounds [10 x [10 x i32]], ptr %a, i64 0, i32 %5
   %7 = load i32, ptr %j, align 4
-  %8 = getelementptr inbounds [10 x i32], ptr %6, i32 0, i32 %7
+  %8 = getelementptr inbounds [10 x i32], ptr %6, i64 0, i32 %7
   %9 = load i32, ptr %j, align 4
   %10 = load i32, ptr %i, align 4
   %11 = mul nsw i32 %10, %9
@@ -55,8 +55,8 @@ for.tail.L3:                                      ; preds = %for.exit.L4
   br label %for.head.L3
 
 for.exit.L3:                                      ; preds = %for.head.L3
-  %16 = getelementptr inbounds [10 x [10 x i32]], ptr %a, i32 0, i32 1
-  %17 = getelementptr inbounds [10 x i32], ptr %16, i32 0, i32 3
+  %16 = getelementptr inbounds [10 x [10 x i32]], ptr %a, i64 0, i32 1
+  %17 = getelementptr inbounds [10 x i32], ptr %16, i64 0, i32 3
   %18 = load i32, ptr %17, align 4
   %19 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %18)
   %20 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/arrays/success-arrays/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays/ir-code.ll
@@ -11,24 +11,24 @@ define dso_local i32 @main() #0 {
   %intArray = alloca [3 x i32], align 4
   store i32 0, ptr %result, align 4
   store i32 2, ptr %value0, align 4
-  %2 = getelementptr inbounds [3 x i32], ptr %1, i32 0
+  %2 = getelementptr inbounds [3 x i32], ptr %1, i64 0
   %3 = load i32, ptr %value0, align 4
   store i32 %3, ptr %2, align 4
-  %4 = getelementptr inbounds i32, ptr %2, i32 1
+  %4 = getelementptr inbounds i32, ptr %2, i64 1
   store i32 7, ptr %4, align 4
-  %5 = getelementptr inbounds i32, ptr %4, i32 1
+  %5 = getelementptr inbounds i32, ptr %4, i64 1
   store i32 4, ptr %5, align 4
   %6 = load [3 x i32], ptr %1, align 4
   store [3 x i32] %6, ptr %intArray, align 4
-  %7 = getelementptr inbounds [3 x i32], ptr %intArray, i32 0, i32 2
+  %7 = getelementptr inbounds [3 x i32], ptr %intArray, i64 0, i32 2
   %8 = load i32, ptr %7, align 4
   %9 = mul nsw i32 %8, 11
   store i32 %9, ptr %7, align 4
-  %10 = getelementptr inbounds [3 x i32], ptr %intArray, i32 0, i32 0
+  %10 = getelementptr inbounds [3 x i32], ptr %intArray, i64 0, i32 0
   store i32 3, ptr %10, align 4
-  %11 = getelementptr inbounds [3 x i32], ptr %intArray, i32 0, i32 0
+  %11 = getelementptr inbounds [3 x i32], ptr %intArray, i64 0, i32 0
   %12 = load i32, ptr %11, align 4
-  %13 = getelementptr inbounds [3 x i32], ptr %intArray, i32 0, i32 2
+  %13 = getelementptr inbounds [3 x i32], ptr %intArray, i64 0, i32 2
   %14 = load i32, ptr %13, align 4
   %15 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %12, i32 %14)
   %16 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/arrays/success-arrays2/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays2/ir-code.ll
@@ -12,13 +12,13 @@ define dso_local i32 @main() #0 {
   %intArray = alloca [10 x i32], align 4
   store i32 0, ptr %result, align 4
   store [10 x i32] [i32 1, i32 2, i32 4, i32 8, i32 16, i32 32, i32 64, i32 128, i32 256, i32 512], ptr %intArray, align 4
-  %1 = getelementptr inbounds [10 x i32], ptr %intArray, i32 0, i32 3
+  %1 = getelementptr inbounds [10 x i32], ptr %intArray, i64 0, i32 3
   %2 = load i32, ptr %1, align 4
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
-  %4 = getelementptr inbounds [10 x i32], ptr %intArray, i32 0, i32 7
+  %4 = getelementptr inbounds [10 x i32], ptr %intArray, i64 0, i32 7
   %5 = load i32, ptr %4, align 4
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %5)
-  %7 = getelementptr inbounds [10 x i32], ptr %intArray, i32 0, i32 9
+  %7 = getelementptr inbounds [10 x i32], ptr %intArray, i64 0, i32 9
   %8 = load i32, ptr %7, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %8)
   %10 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/arrays/success-arrays3/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays3/ir-code.ll
@@ -11,7 +11,7 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   store [2 x i32] zeroinitializer, ptr %intArray, align 4
   store [2 x i32] [i32 1, i32 2], ptr %intArray, align 4
-  %1 = getelementptr inbounds [2 x i32], ptr %intArray, i32 0, i32 1
+  %1 = getelementptr inbounds [2 x i32], ptr %intArray, i64 0, i32 1
   %2 = load i32, ptr %1, align 4
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
   %4 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
@@ -15,7 +15,7 @@ define void @_ZN10TestStruct4dtorEv(ptr noundef nonnull align 8 dereferenceable(
   call void @llvm.dbg.declare(metadata ptr %this, metadata !44, metadata !DIExpression()), !dbg !46
   store ptr %0, ptr %this, align 8, !dbg !46
   %2 = load ptr, ptr %this, align 8, !dbg !46
-  %3 = getelementptr inbounds %struct.TestStruct, ptr %2, i32 0, i32 1, !dbg !46
+  %3 = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 1, !dbg !46
   call void @_ZN6String4dtorEv(ptr %3), !dbg !46
   ret void, !dbg !46
 }
@@ -61,13 +61,13 @@ define dso_local i32 @main() #2 !dbg !60 {
   %1 = call %struct.TestStruct @_Z3fctRi(ptr %test), !dbg !68
   call void @llvm.dbg.declare(metadata ptr %res, metadata !69, metadata !DIExpression()), !dbg !70
   store %struct.TestStruct %1, ptr %res, align 8, !dbg !68
-  %lng_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i32 0, i32 0, !dbg !71
+  %lng_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !71
   %2 = load i64, ptr %lng_addr, align 8, !dbg !71
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 %2), !dbg !71
-  %4 = getelementptr inbounds %struct.TestStruct, ptr %res, i32 0, i32 1, !dbg !72
+  %4 = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 1, !dbg !72
   %5 = call ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !72
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %5), !dbg !72
-  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i32 0, i32 2, !dbg !73
+  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !73
   %7 = load i32, ptr %i_addr, align 4, !dbg !73
   %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %7), !dbg !73
   call void @_ZN10TestStruct4dtorEv(ptr %res), !dbg !73

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
@@ -18,7 +18,7 @@ define dso_local i32 @main() #0 {
   %pair_addr = alloca %struct.Pair, align 8
   store i32 0, ptr %result, align 4
   store [7 x i32] [i32 1, i32 5, i32 4, i32 0, i32 12, i32 12345, i32 9], ptr %intArray, align 4
-  %2 = getelementptr inbounds [7 x i32], ptr %intArray, i32 0, i32 0
+  %2 = getelementptr inbounds [7 x i32], ptr %intArray, i64 0, i32 0
   %3 = call %struct.ArrayIterator @_Z7iterateIiE13ArrayIteratorIiEPim(ptr %2, i64 7)
   store %struct.ArrayIterator %3, ptr %1, align 8
   store i64 0, ptr %index, align 8

--- a/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
@@ -101,7 +101,7 @@ for.head.L12:                                     ; preds = %for.tail.L12, %2
 
 for.body.L12:                                     ; preds = %for.head.L12
   %6 = load i64, ptr %i, align 8
-  %7 = getelementptr inbounds [2 x i32], ptr %list, i32 0, i64 %6
+  %7 = getelementptr inbounds [2 x i32], ptr %list, i64 0, i64 %6
   %8 = load i32, ptr %7, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %8)
   br label %for.tail.L12
@@ -130,18 +130,18 @@ define dso_local i32 @main() #1 {
   %resultList = alloca [2 x i32], align 4
   store i32 0, ptr %result, align 4
   store [7 x i16] [i16 1, i16 2, i16 3, i16 4, i16 5, i16 6, i16 7], ptr %numberList1, align 2
-  %2 = getelementptr inbounds [7 x i16], ptr %numberList1, i32 0, i32 0
+  %2 = getelementptr inbounds [7 x i16], ptr %numberList1, i64 0, i32 0
   %3 = call i32 @_Z10sumNumbersIsEiPsl(ptr %2, i64 7)
   store i32 %3, ptr %result1, align 4
   store [4 x i64] [i64 10, i64 12, i64 14, i64 16], ptr %numberList2, align 8
-  %4 = getelementptr inbounds [4 x i64], ptr %numberList2, i32 0, i32 0
+  %4 = getelementptr inbounds [4 x i64], ptr %numberList2, i64 0, i32 0
   %5 = call i32 @_Z10sumNumbersIlEiPll(ptr %4, i64 4)
   store i32 %5, ptr %result2, align 4
-  %6 = getelementptr inbounds [2 x i32], ptr %1, i32 0
+  %6 = getelementptr inbounds [2 x i32], ptr %1, i64 0
   %7 = load i32, ptr %result1, align 4
   store i32 %7, ptr %6, align 4
   %8 = load i32, ptr %result2, align 4
-  %9 = getelementptr inbounds i32, ptr %6, i32 1
+  %9 = getelementptr inbounds i32, ptr %6, i64 1
   store i32 %8, ptr %9, align 4
   %10 = load [2 x i32], ptr %1, align 4
   store [2 x i32] %10, ptr %resultList, align 4

--- a/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
@@ -15,7 +15,7 @@ define dso_local i32 @main() #0 {
   store ptr %dbl, ptr %doubleVec, align 8
   %1 = getelementptr inbounds %struct.Vector, ptr %doubleVec, i32 0, i32 1
   store i32 1, ptr %1, align 4
-  %cap_addr = getelementptr inbounds %struct.Vector, ptr %doubleVec, i32 0, i32 1
+  %cap_addr = getelementptr inbounds %struct.Vector, ptr %doubleVec, i64 0, i32 1
   %2 = load i32, ptr %cap_addr, align 4
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
   %4 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/generics/success-generic-type-ctor-call/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-type-ctor-call/ir-code.ll
@@ -10,7 +10,7 @@ define private void @_ZN6Nested4ctorEv(ptr noundef nonnull align 4 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Nested, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Nested, ptr %2, i64 0, i32 0
   store i32 1, ptr %3, align 4
   ret void
 }
@@ -20,7 +20,7 @@ define private void @_ZN4TestI6NestedE8testFuncEv(ptr noundef nonnull align 1 %0
   %t = alloca %struct.Nested, align 8
   store ptr %0, ptr %this, align 8
   call void @_ZN6Nested4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %t)
-  %i_addr = getelementptr inbounds %struct.Nested, ptr %t, i32 0, i32 0
+  %i_addr = getelementptr inbounds %struct.Nested, ptr %t, i64 0, i32 0
   %2 = load i32, ptr %i_addr, align 4
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
   ret void

--- a/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
@@ -29,11 +29,11 @@ define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV3Car, i32 0, i32 0, i32 2), ptr %2, align 8
-  %3 = getelementptr inbounds %struct.Car, ptr %2, i32 0, i32 1
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV3Car, i64 0, i32 0, i32 2), ptr %2, align 8
+  %3 = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
   store i1 false, ptr %3, align 1
   %4 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %4, i32 0, i32 1
+  %driving_addr = getelementptr inbounds %struct.Car, ptr %4, i64 0, i32 1
   store i1 false, ptr %driving_addr, align 1
   ret void
 }
@@ -44,7 +44,7 @@ define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable
   store ptr %0, ptr %this, align 8
   store i32 %1, ptr %param, align 4
   %3 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %3, i32 0, i32 1
+  %driving_addr = getelementptr inbounds %struct.Car, ptr %3, i64 0, i32 1
   store i1 true, ptr %driving_addr, align 1
   ret void
 }
@@ -54,7 +54,7 @@ define private i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %2, i32 0, i32 1
+  %driving_addr = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
   %3 = load i1, ptr %driving_addr, align 1
   ret i1 %3
 }

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
@@ -21,11 +21,11 @@ define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV3Car, i32 0, i32 0, i32 2), ptr %2, align 8
-  %3 = getelementptr inbounds %struct.Car, ptr %2, i32 0, i32 1
+  store ptr getelementptr inbounds ({ [4 x ptr] }, ptr @_ZTV3Car, i64 0, i32 0, i32 2), ptr %2, align 8
+  %3 = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
   store i1 false, ptr %3, align 1
   %4 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %4, i32 0, i32 1
+  %driving_addr = getelementptr inbounds %struct.Car, ptr %4, i64 0, i32 1
   store i1 false, ptr %driving_addr, align 1
   ret void
 }
@@ -36,7 +36,7 @@ define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable
   store ptr %0, ptr %this, align 8
   store i32 %1, ptr %param, align 4
   %3 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %3, i32 0, i32 1
+  %driving_addr = getelementptr inbounds %struct.Car, ptr %3, i64 0, i32 1
   store i1 true, ptr %driving_addr, align 1
   ret void
 }
@@ -46,7 +46,7 @@ define private i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %2, i32 0, i32 1
+  %driving_addr = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
   %3 = load i1, ptr %driving_addr, align 1
   ret i1 %3
 }

--- a/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
@@ -39,23 +39,23 @@ define private void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 derefer
   store ptr %2, ptr %lastName, align 8
   store i32 %3, ptr %age, align 4
   %5 = load ptr, ptr %this, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV6Person, i32 0, i32 0, i32 2), ptr %5, align 8
-  %6 = getelementptr inbounds %struct.Person, ptr %5, i32 0, i32 1
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV6Person, i64 0, i32 0, i32 2), ptr %5, align 8
+  %6 = getelementptr inbounds %struct.Person, ptr %5, i64 0, i32 1
   store ptr @0, ptr %6, align 8
-  %7 = getelementptr inbounds %struct.Person, ptr %5, i32 0, i32 2
+  %7 = getelementptr inbounds %struct.Person, ptr %5, i64 0, i32 2
   store ptr @1, ptr %7, align 8
-  %8 = getelementptr inbounds %struct.Person, ptr %5, i32 0, i32 3
+  %8 = getelementptr inbounds %struct.Person, ptr %5, i64 0, i32 3
   store i32 0, ptr %8, align 4
   %9 = load ptr, ptr %this, align 8
-  %firstName_addr = getelementptr inbounds %struct.Person, ptr %9, i32 0, i32 1
+  %firstName_addr = getelementptr inbounds %struct.Person, ptr %9, i64 0, i32 1
   %10 = load ptr, ptr %firstName, align 8
   store ptr %10, ptr %firstName_addr, align 8
   %11 = load ptr, ptr %this, align 8
-  %lastName_addr = getelementptr inbounds %struct.Person, ptr %11, i32 0, i32 2
+  %lastName_addr = getelementptr inbounds %struct.Person, ptr %11, i64 0, i32 2
   %12 = load ptr, ptr %lastName, align 8
   store ptr %12, ptr %lastName_addr, align 8
   %13 = load ptr, ptr %this, align 8
-  %age_addr = getelementptr inbounds %struct.Person, ptr %13, i32 0, i32 3
+  %age_addr = getelementptr inbounds %struct.Person, ptr %13, i64 0, i32 3
   %14 = load i32, ptr %age, align 4
   store i32 %14, ptr %age_addr, align 4
   ret void

--- a/test/test-files/irgenerator/interfaces/success-interface-param-struct-match/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-interface-param-struct-match/ir-code.ll
@@ -29,7 +29,7 @@ define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV4Test, i32 0, i32 0, i32 2), ptr %2, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV4Test, i64 0, i32 0, i32 2), ptr %2, align 8
   ret void
 }
 

--- a/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
@@ -30,11 +30,11 @@ define private void @_ZN9InnerTest4ctorEv(ptr noundef nonnull align 8 dereferenc
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV9InnerTest, i32 0, i32 0, i32 2), ptr %2, align 8
-  %3 = getelementptr inbounds %struct.InnerTest, ptr %2, i32 0, i32 1
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV9InnerTest, i64 0, i32 0, i32 2), ptr %2, align 8
+  %3 = getelementptr inbounds %struct.InnerTest, ptr %2, i64 0, i32 1
   store i32 0, ptr %3, align 4
   %4 = load ptr, ptr %this, align 8
-  %a_addr = getelementptr inbounds %struct.InnerTest, ptr %4, i32 0, i32 1
+  %a_addr = getelementptr inbounds %struct.InnerTest, ptr %4, i64 0, i32 1
   store i32 0, ptr %a_addr, align 4
   ret void
 }
@@ -64,7 +64,7 @@ define dso_local i32 @main() #1 {
   %vfct.addr = getelementptr inbounds ptr, ptr %vtable.addr, i64 0
   %fct = load ptr, ptr %vfct.addr, align 8
   call void %fct(ptr noundef nonnull align 8 dereferenceable(8) %1)
-  %2 = getelementptr inbounds %struct.Test, ptr %test, i32 0, i32 0
+  %2 = getelementptr inbounds %struct.Test, ptr %test, i64 0, i32 0
   %3 = load ptr, ptr %2, align 8
   %vtable.addr1 = load ptr, ptr %3, align 8
   %vfct.addr2 = getelementptr inbounds ptr, ptr %vtable.addr1, i64 0

--- a/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
@@ -57,12 +57,12 @@ for.head.L9:                                      ; preds = %for.tail.L9, %for.b
 for.body.L9:                                      ; preds = %for.head.L9
   %13 = load i32, ptr %j, align 4
   %14 = load ptr, ptr %array, align 8
-  %15 = getelementptr inbounds [10 x i32], ptr %14, i32 0, i32 %13
+  %15 = getelementptr inbounds [10 x i32], ptr %14, i64 0, i32 %13
   %16 = load i32, ptr %15, align 4
   %17 = load i32, ptr %j, align 4
   %18 = add nsw i32 %17, 1
   %19 = load ptr, ptr %array, align 8
-  %20 = getelementptr inbounds [10 x i32], ptr %19, i32 0, i32 %18
+  %20 = getelementptr inbounds [10 x i32], ptr %19, i64 0, i32 %18
   %21 = load i32, ptr %20, align 4
   %fct = load ptr, ptr %sortFct, align 8
   %22 = call i1 %fct(i32 %16, i32 %21)
@@ -71,11 +71,11 @@ for.body.L9:                                      ; preds = %for.head.L9
 if.then.L10:                                      ; preds = %for.body.L9
   %23 = load i32, ptr %j, align 4
   %24 = load ptr, ptr %array, align 8
-  %25 = getelementptr inbounds [10 x i32], ptr %24, i32 0, i32 %23
+  %25 = getelementptr inbounds [10 x i32], ptr %24, i64 0, i32 %23
   %26 = load i32, ptr %j, align 4
   %27 = add nsw i32 %26, 1
   %28 = load ptr, ptr %array, align 8
-  %29 = getelementptr inbounds [10 x i32], ptr %28, i32 0, i32 %27
+  %29 = getelementptr inbounds [10 x i32], ptr %28, i64 0, i32 %27
   call void @_Z4swapRiRi(ptr %25, ptr %29)
   br label %if.exit.L10
 
@@ -145,7 +145,7 @@ for.head.L24:                                     ; preds = %for.tail.L24, %1
 for.body.L24:                                     ; preds = %for.head.L24
   %5 = load i32, ptr %i, align 4
   %6 = load ptr, ptr %array, align 8
-  %7 = getelementptr inbounds [10 x i32], ptr %6, i32 0, i32 %5
+  %7 = getelementptr inbounds [10 x i32], ptr %6, i64 0, i32 %5
   %8 = load i32, ptr %7, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %8)
   br label %for.tail.L24

--- a/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
@@ -12,10 +12,10 @@ define private void @_ZN5Stamp5printEv(ptr noundef nonnull align 8 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %value_addr = getelementptr inbounds %struct.Stamp, ptr %2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Stamp, ptr %2, i64 0, i32 0
   %3 = load double, ptr %value_addr, align 8
   %4 = load ptr, ptr %this, align 8
-  %glued_addr = getelementptr inbounds %struct.Stamp, ptr %4, i32 0, i32 1
+  %glued_addr = getelementptr inbounds %struct.Stamp, ptr %4, i64 0, i32 1
   %5 = load i1, ptr %glued_addr, align 1
   %6 = zext i1 %5 to i32
   %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, double %3, i32 %6)
@@ -30,7 +30,7 @@ define private %struct.Stamp @_ZN6Letter8getStampEv(ptr noundef nonnull align 8 
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %stamp_addr = getelementptr inbounds %struct.Letter, ptr %2, i32 0, i32 1
+  %stamp_addr = getelementptr inbounds %struct.Letter, ptr %2, i64 0, i32 1
   %3 = load %struct.Stamp, ptr %stamp_addr, align 8
   ret %struct.Stamp %3
 }
@@ -42,8 +42,8 @@ define dso_local i32 @main() #1 {
   %stamp = alloca %struct.Stamp, align 8
   store i32 0, ptr %result, align 4
   store %struct.Letter { ptr @anon.string.0, %struct.Stamp { double 3.400000e+00, i1 true } }, ptr %letter, align 8
-  %stamp_addr = getelementptr inbounds %struct.Letter, ptr %letter, i32 0, i32 1
-  %glued_addr = getelementptr inbounds %struct.Stamp, ptr %stamp_addr, i32 0, i32 1
+  %stamp_addr = getelementptr inbounds %struct.Letter, ptr %letter, i64 0, i32 1
+  %glued_addr = getelementptr inbounds %struct.Stamp, ptr %stamp_addr, i64 0, i32 1
   %1 = load i1, ptr %glued_addr, align 1
   %2 = zext i1 %1 to i32
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %2)

--- a/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
@@ -33,14 +33,14 @@ define private i32 @_ZN10TestStructIhE7getTestEv(ptr noundef nonnull align 4 der
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %2, i32 0, i32 1
+  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 1
   %3 = load i32, ptr %test_addr, align 4
   %4 = icmp eq i32 %3, 1
   br i1 %4, label %if.then.L18, label %if.exit.L18
 
 if.then.L18:                                      ; preds = %1
   %5 = load ptr, ptr %this, align 8
-  %test_addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i32 0, i32 1
+  %test_addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i64 0, i32 1
   %6 = load i32, ptr %test_addr1, align 4
   %7 = add nsw i32 %6, 1
   store i32 %7, ptr %test_addr1, align 4
@@ -50,7 +50,7 @@ if.then.L18:                                      ; preds = %1
 
 if.exit.L18:                                      ; preds = %if.then.L18, %1
   %9 = load ptr, ptr %this, align 8
-  %test_addr2 = getelementptr inbounds %struct.TestStruct, ptr %9, i32 0, i32 1
+  %test_addr2 = getelementptr inbounds %struct.TestStruct, ptr %9, i64 0, i32 1
   %10 = load i32, ptr %test_addr2, align 4
   ret i32 %10
 }

--- a/test/test-files/irgenerator/methods/success-methods/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-methods/ir-code.ll
@@ -12,7 +12,7 @@ define private ptr @_ZN6Letter10getContentEv(ptr noundef nonnull align 8 derefer
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %content_addr = getelementptr inbounds %struct.Letter, ptr %2, i32 0, i32 0
+  %content_addr = getelementptr inbounds %struct.Letter, ptr %2, i64 0, i32 0
   %3 = load ptr, ptr %content_addr, align 8
   ret ptr %3
 }
@@ -23,7 +23,7 @@ define private void @_ZN6Letter10setContentEPKc(ptr noundef nonnull align 8 dere
   store ptr %0, ptr %this, align 8
   store ptr %1, ptr %text, align 8
   %3 = load ptr, ptr %this, align 8
-  %content_addr = getelementptr inbounds %struct.Letter, ptr %3, i32 0, i32 0
+  %content_addr = getelementptr inbounds %struct.Letter, ptr %3, i64 0, i32 0
   %4 = load ptr, ptr %text, align 8
   store ptr %4, ptr %content_addr, align 8
   ret void

--- a/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
@@ -22,10 +22,10 @@ define private void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferencea
   store ptr %0, ptr %this, align 8
   store i64 %1, ptr %initialValue, align 8
   %3 = load ptr, ptr %this, align 8
-  %4 = getelementptr inbounds %struct.Counter, ptr %3, i32 0, i32 0
+  %4 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
   store i64 0, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %5, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %5, i64 0, i32 0
   %6 = load i64, ptr %initialValue, align 8
   store i64 %6, ptr %value_addr, align 8
   ret void
@@ -36,7 +36,7 @@ define private i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 dereferen
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %2, i64 0, i32 0
   %3 = load i64, ptr %value_addr, align 8
   ret i64 %3
 }
@@ -48,8 +48,8 @@ define private %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Counter %0, %
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i32 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %4 = load i64, ptr %value_addr1, align 8
   %5 = load i64, ptr %value_addr, align 8
   %6 = add nsw i64 %5, %4
@@ -65,8 +65,8 @@ define private %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Counter %0, 
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i32 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %4 = load i64, ptr %value_addr1, align 8
   %5 = load i64, ptr %value_addr, align 8
   %6 = sub nsw i64 %5, %4
@@ -82,8 +82,8 @@ define private %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i32 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %4 = load i64, ptr %value_addr1, align 8
   %5 = load i64, ptr %value_addr, align 8
   %6 = mul nsw i64 %5, %4
@@ -99,8 +99,8 @@ define private %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i32 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %4 = load i64, ptr %value_addr1, align 8
   %5 = load i64, ptr %value_addr, align 8
   %6 = sdiv i64 %5, %4
@@ -116,8 +116,8 @@ define private %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i32 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %4 = load i64, ptr %value_addr1, align 8
   %5 = load i64, ptr %value_addr, align 8
   %6 = shl i64 %5, %4
@@ -133,8 +133,8 @@ define private %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i32 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %4 = load i64, ptr %value_addr1, align 8
   %5 = load i64, ptr %value_addr, align 8
   %6 = ashr i64 %5, %4
@@ -148,9 +148,9 @@ define private void @_Z12op.plusequalR7Counter7Counter(ptr %0, %struct.Counter %
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i32 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
   %4 = load i64, ptr %value_addr, align 8
   %5 = load i64, ptr %value_addr1, align 8
   %6 = add nsw i64 %5, %4
@@ -163,9 +163,9 @@ define private void @_Z13op.minusequalR7Counter7Counter(ptr %0, %struct.Counter 
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i32 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
   %4 = load i64, ptr %value_addr, align 8
   %5 = load i64, ptr %value_addr1, align 8
   %6 = sub nsw i64 %5, %4
@@ -178,9 +178,9 @@ define private void @_Z11op.mulequalR7Counter7Counter(ptr %0, %struct.Counter %1
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i32 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
   %4 = load i64, ptr %value_addr, align 8
   %5 = load i64, ptr %value_addr1, align 8
   %6 = mul nsw i64 %5, %4
@@ -193,9 +193,9 @@ define private void @_Z11op.divequalR7Counter7Counter(ptr %0, %struct.Counter %1
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i32 0, i32 0
+  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i32 0, i32 0
+  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
   %4 = load i64, ptr %value_addr, align 8
   %5 = load i64, ptr %value_addr1, align 8
   %6 = sdiv i64 %5, %4

--- a/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
@@ -12,7 +12,7 @@ define private ptr @_Z16op.plusplus.postR10TestStruct(ptr %0) {
   %ts = alloca ptr, align 8
   store ptr %0, ptr %ts, align 8
   %2 = load ptr, ptr %ts, align 8
-  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %2, i32 0, i32 0
+  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 0
   %3 = load i64, ptr %test_addr, align 8
   %4 = add nsw i64 %3, 1
   store i64 %4, ptr %test_addr, align 8
@@ -30,12 +30,12 @@ define dso_local i32 @main() #0 {
   %1 = load %struct.TestStruct, ptr %ts, align 8
   %2 = call ptr @_Z16op.plusplus.postR10TestStruct(ptr %ts)
   store ptr %2, ptr %output, align 8
-  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 0
+  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
   %3 = load i64, ptr %test_addr, align 8
   %4 = add nsw i64 %3, 1
   store i64 %4, ptr %test_addr, align 8
   %5 = load ptr, ptr %output, align 8
-  %test_addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i32 0, i32 0
+  %test_addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i64 0, i32 0
   %6 = load i64, ptr %test_addr1, align 8
   %7 = icmp eq i64 %6, 125
   br i1 %7, label %assert.exit.L14, label %assert.then.L14, !prof !0
@@ -46,7 +46,7 @@ assert.then.L14:                                  ; preds = %0
   unreachable
 
 assert.exit.L14:                                  ; preds = %0
-  %test_addr2 = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 0
+  %test_addr2 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
   %9 = load i64, ptr %test_addr2, align 8
   %10 = icmp eq i64 %9, 125
   br i1 %10, label %assert.exit.L15, label %assert.then.L15, !prof !0

--- a/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
@@ -20,18 +20,18 @@ define private void @_Z8testProcPPPPi(ptr %0) {
   %5 = load ptr, ptr %nums1, align 8
   %6 = load [4 x i32], ptr %5, align 4
   store [4 x i32] %6, ptr %nums2, align 4
-  %7 = getelementptr inbounds [4 x i32], ptr %nums2, i32 0, i32 2
+  %7 = getelementptr inbounds [4 x i32], ptr %nums2, i64 0, i32 2
   store i32 10, ptr %7, align 4
-  %8 = getelementptr inbounds [4 x i32], ptr %nums2, i32 0, i32 0
+  %8 = getelementptr inbounds [4 x i32], ptr %nums2, i64 0, i32 0
   %9 = load i32, ptr %8, align 4
   %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %9)
-  %11 = getelementptr inbounds [4 x i32], ptr %nums2, i32 0, i32 1
+  %11 = getelementptr inbounds [4 x i32], ptr %nums2, i64 0, i32 1
   %12 = load i32, ptr %11, align 4
   %13 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %12)
-  %14 = getelementptr inbounds [4 x i32], ptr %nums2, i32 0, i32 2
+  %14 = getelementptr inbounds [4 x i32], ptr %nums2, i64 0, i32 2
   %15 = load i32, ptr %14, align 4
   %16 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %15)
-  %17 = getelementptr inbounds [4 x i32], ptr %nums2, i32 0, i32 3
+  %17 = getelementptr inbounds [4 x i32], ptr %nums2, i64 0, i32 3
   %18 = load i32, ptr %17, align 4
   %19 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 %18)
   ret void
@@ -48,7 +48,7 @@ define dso_local i32 @main() #1 {
   %intArray2 = alloca ptr, align 8
   store i32 0, ptr %result, align 4
   store [4 x i32] [i32 1, i32 2, i32 3, i32 4], ptr %intArray, align 4
-  %1 = getelementptr inbounds [4 x i32], ptr %intArray, i32 0, i32 1
+  %1 = getelementptr inbounds [4 x i32], ptr %intArray, i64 0, i32 1
   %2 = load i32, ptr %1, align 4
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.4, i32 %2)
   store ptr %intArray, ptr %intArray1, align 8

--- a/test/test-files/irgenerator/pointers/success-pointer-arithmetic/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer-arithmetic/ir-code.ll
@@ -16,7 +16,7 @@ define dso_local i32 @main() #0 {
   %aPtr = alloca ptr, align 8
   store i32 0, ptr %result, align 4
   store [3 x i32] [i32 1, i32 2, i32 3], ptr %a, align 4
-  %1 = getelementptr inbounds [3 x i32], ptr %a, i32 0, i32 0
+  %1 = getelementptr inbounds [3 x i32], ptr %a, i64 0, i32 0
   store ptr %1, ptr %aPtr, align 8
   %2 = load ptr, ptr %aPtr, align 8
   %3 = load i32, ptr %2, align 4

--- a/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
@@ -13,7 +13,7 @@ define private void @_Z8birthdayP6Person(ptr %0) {
   %person = alloca ptr, align 8
   store ptr %0, ptr %person, align 8
   %2 = load ptr, ptr %person, align 8
-  %age_addr = getelementptr inbounds %struct.Person, ptr %2, i32 0, i32 2
+  %age_addr = getelementptr inbounds %struct.Person, ptr %2, i64 0, i32 2
   %3 = load i32, ptr %age_addr, align 4
   %4 = add i32 %3, 1
   store i32 %4, ptr %age_addr, align 4
@@ -30,16 +30,16 @@ define dso_local i32 @main() #0 {
   store ptr @anon.string.1, ptr %1, align 8
   %2 = getelementptr inbounds %struct.Person, ptr %mike, i32 0, i32 2
   store i32 32, ptr %2, align 4
-  %lastName_addr = getelementptr inbounds %struct.Person, ptr %mike, i32 0, i32 1
+  %lastName_addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 1
   %3 = load ptr, ptr %lastName_addr, align 8
-  %firstName_addr = getelementptr inbounds %struct.Person, ptr %mike, i32 0, i32 0
+  %firstName_addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 0
   %4 = load ptr, ptr %firstName_addr, align 8
   %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %3, ptr %4)
-  %age_addr = getelementptr inbounds %struct.Person, ptr %mike, i32 0, i32 2
+  %age_addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 2
   %6 = load i32, ptr %age_addr, align 4
   %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %6)
   call void @_Z8birthdayP6Person(ptr %mike)
-  %age_addr1 = getelementptr inbounds %struct.Person, ptr %mike, i32 0, i32 2
+  %age_addr1 = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 2
   %8 = load i32, ptr %age_addr1, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %8)
   %10 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
@@ -13,7 +13,7 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   store i32 123, ptr %1, align 4
   store ptr %1, ptr %str, align 8
-  %ref_addr = getelementptr inbounds %struct.Struct, ptr %str, i32 0, i32 0
+  %ref_addr = getelementptr inbounds %struct.Struct, ptr %str, i64 0, i32 0
   %2 = load ptr, ptr %ref_addr, align 8
   %3 = load i32, ptr %2, align 4
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3)

--- a/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
@@ -19,7 +19,7 @@ define private void @_Z4procRiRK6Struct(ptr %0, ptr %1) {
   %5 = add nsw i32 %4, 12
   store i32 %5, ptr %3, align 4
   %6 = load ptr, ptr %structRef, align 8
-  %ref_addr = getelementptr inbounds %struct.Struct, ptr %6, i32 0, i32 0
+  %ref_addr = getelementptr inbounds %struct.Struct, ptr %6, i64 0, i32 0
   %7 = load ptr, ptr %ref_addr, align 8
   %8 = load i32, ptr %7, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %8)
@@ -40,7 +40,7 @@ define private i32 @_Z4funcRdRK6Struct(ptr %0, ptr %1) {
   %5 = fmul double %4, -1.560000e+00
   store double %5, ptr %3, align 8
   %6 = load ptr, ptr %structRef, align 8
-  %b_addr = getelementptr inbounds %struct.Struct, ptr %6, i32 0, i32 1
+  %b_addr = getelementptr inbounds %struct.Struct, ptr %6, i64 0, i32 1
   %7 = load i1, ptr %b_addr, align 1
   %8 = zext i1 %7 to i32
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %8)

--- a/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
@@ -16,11 +16,11 @@ define dso_local i32 @main() #0 {
   store i1 true, ptr %ts, align 1
   %1 = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 1
   store ptr %t, ptr %1, align 8
-  %f2_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 1
+  %f2_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
   %2 = load ptr, ptr %f2_addr, align 8
   %3 = load i32, ptr %2, align 4
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3)
-  %f2_addr1 = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 1
+  %f2_addr1 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
   %5 = load ptr, ptr %f2_addr1, align 8
   %6 = load i32, ptr %5, align 4
   %7 = add nsw i32 %6, 1

--- a/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
@@ -14,17 +14,17 @@ define dso_local i32 @main() #0 {
   %d = alloca %struct.D, align 8
   store i32 0, ptr %result, align 4
   store %struct.D zeroinitializer, ptr %d, align 4
-  %f1_addr = getelementptr inbounds %struct.D, ptr %d, i32 0, i32 0, i32 0
+  %f1_addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 0, i32 0
   store i32 1, ptr %f1_addr, align 4
-  %f2_addr = getelementptr inbounds %struct.D, ptr %d, i32 0, i32 2
+  %f2_addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 2
   store i32 2, ptr %f2_addr, align 4
-  %f3_addr = getelementptr inbounds %struct.D, ptr %d, i32 0, i32 1, i32 1, i32 0
+  %f3_addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 1, i32 1, i32 0
   store i32 3, ptr %f3_addr, align 4
-  %f1_addr1 = getelementptr inbounds %struct.D, ptr %d, i32 0, i32 0, i32 0
+  %f1_addr1 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 0, i32 0
   %1 = load i32, ptr %f1_addr1, align 4
-  %f2_addr2 = getelementptr inbounds %struct.D, ptr %d, i32 0, i32 2
+  %f2_addr2 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 2
   %2 = load i32, ptr %f2_addr2, align 4
-  %f3_addr3 = getelementptr inbounds %struct.D, ptr %d, i32 0, i32 1, i32 1, i32 0
+  %f3_addr3 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 1, i32 1, i32 0
   %3 = load i32, ptr %f3_addr3, align 4
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1, i32 %2, i32 %3)
   %5 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
@@ -18,15 +18,15 @@ define private void @_ZN6Vector4ctorEv(ptr noundef nonnull align 8 dereferenceab
   store ptr %0, ptr %this, align 8
   store ptr @anon.string.0, ptr %msg, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Vector, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Vector, ptr %2, i64 0, i32 0
   store i1 false, ptr %3, align 1
-  %4 = getelementptr inbounds %struct.Vector, ptr %2, i32 0, i32 1
+  %4 = getelementptr inbounds %struct.Vector, ptr %2, i64 0, i32 1
   store ptr @0, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %5, i32 0, i32 0
+  %field1_addr = getelementptr inbounds %struct.Vector, ptr %5, i64 0, i32 0
   store i1 false, ptr %field1_addr, align 1
   %6 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %6, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.Vector, ptr %6, i64 0, i32 1
   %7 = load ptr, ptr %msg, align 8
   store ptr %7, ptr %field2_addr, align 8
   ret void
@@ -38,15 +38,15 @@ define private void @_ZN6Vector4ctorEPKc(ptr noundef nonnull align 8 dereference
   store ptr %0, ptr %this, align 8
   store ptr %1, ptr %msg, align 8
   %3 = load ptr, ptr %this, align 8
-  %4 = getelementptr inbounds %struct.Vector, ptr %3, i32 0, i32 0
+  %4 = getelementptr inbounds %struct.Vector, ptr %3, i64 0, i32 0
   store i1 false, ptr %4, align 1
-  %5 = getelementptr inbounds %struct.Vector, ptr %3, i32 0, i32 1
+  %5 = getelementptr inbounds %struct.Vector, ptr %3, i64 0, i32 1
   store ptr @1, ptr %5, align 8
   %6 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %6, i32 0, i32 0
+  %field1_addr = getelementptr inbounds %struct.Vector, ptr %6, i64 0, i32 0
   store i1 false, ptr %field1_addr, align 1
   %7 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %7, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.Vector, ptr %7, i64 0, i32 1
   %8 = load ptr, ptr %msg, align 8
   store ptr %8, ptr %field2_addr, align 8
   ret void
@@ -66,19 +66,19 @@ define dso_local i32 @main() #0 {
   %1 = alloca %struct.Vector, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN6Vector4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %vec)
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 0
+  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
   %2 = load i1, ptr %field1_addr, align 1
   %3 = zext i1 %2 to i32
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
   %4 = load ptr, ptr %field2_addr, align 8
   %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3, ptr %4)
   call void @_ZN6Vector4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr @anon.string.2)
   %6 = load %struct.Vector, ptr %1, align 8
   store %struct.Vector %6, ptr %vec, align 8
-  %field1_addr1 = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 0
+  %field1_addr1 = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
   %7 = load i1, ptr %field1_addr1, align 1
   %8 = zext i1 %7 to i32
-  %field2_addr2 = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 1
+  %field2_addr2 = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
   %9 = load ptr, ptr %field2_addr2, align 8
   %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %8, ptr %9)
   %11 = call ptr @_ZN6Vector4testEv(ptr noundef nonnull align 8 dereferenceable(16) %vec)

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
@@ -14,12 +14,12 @@ define private void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 2 derefer
   store ptr %0, ptr %this, align 8
   store ptr %1, ptr %other, align 8
   %3 = load ptr, ptr %this, align 8
-  %4 = getelementptr inbounds %struct.Inner, ptr %3, i32 0, i32 0
+  %4 = getelementptr inbounds %struct.Inner, ptr %3, i64 0, i32 0
   store i16 -43, ptr %4, align 2
   %5 = load ptr, ptr %this, align 8
-  %x_addr = getelementptr inbounds %struct.Inner, ptr %5, i32 0, i32 0
+  %x_addr = getelementptr inbounds %struct.Inner, ptr %5, i64 0, i32 0
   %6 = load ptr, ptr %other, align 8
-  %x_addr1 = getelementptr inbounds %struct.Inner, ptr %6, i32 0, i32 0
+  %x_addr1 = getelementptr inbounds %struct.Inner, ptr %6, i64 0, i32 0
   %7 = load i16, ptr %x_addr1, align 2
   %8 = add nsw i16 %7, 5
   store i16 %8, ptr %x_addr, align 2
@@ -31,9 +31,9 @@ define void @_ZN6Middle4ctorERK6Middle(ptr noundef nonnull align 2 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %3 = load ptr, ptr %this, align 8
-  %4 = getelementptr inbounds %struct.Middle, ptr %3, i32 0, i32 0
+  %4 = getelementptr inbounds %struct.Middle, ptr %3, i64 0, i32 0
   %5 = load ptr, ptr %this, align 8
-  %6 = getelementptr inbounds %struct.Middle, ptr %5, i32 0, i32 0
+  %6 = getelementptr inbounds %struct.Middle, ptr %5, i64 0, i32 0
   call void @_ZN5Inner4ctorERK5Inner(ptr %6, ptr %4)
   ret void
 }
@@ -43,9 +43,9 @@ define void @_ZN5Outer4ctorERK5Outer(ptr noundef nonnull align 2 dereferenceable
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %3 = load ptr, ptr %this, align 8
-  %4 = getelementptr inbounds %struct.Outer, ptr %3, i32 0, i32 0
+  %4 = getelementptr inbounds %struct.Outer, ptr %3, i64 0, i32 0
   %5 = load ptr, ptr %this, align 8
-  %6 = getelementptr inbounds %struct.Outer, ptr %5, i32 0, i32 0
+  %6 = getelementptr inbounds %struct.Outer, ptr %5, i64 0, i32 0
   call void @_ZN6Middle4ctorERK6Middle(ptr %6, ptr %4)
   ret void
 }
@@ -57,16 +57,16 @@ define dso_local i32 @main() #1 {
   %outer2 = alloca %struct.Outer, align 8
   store i32 0, ptr %result, align 4
   store %struct.Outer { %struct.Middle { %struct.Inner { i16 -43 } } }, ptr %outer, align 2
-  %middle_addr = getelementptr inbounds %struct.Outer, ptr %outer, i32 0, i32 0
-  %inner_addr = getelementptr inbounds %struct.Middle, ptr %middle_addr, i32 0, i32 0
-  %x_addr = getelementptr inbounds %struct.Inner, ptr %inner_addr, i32 0, i32 0
+  %middle_addr = getelementptr inbounds %struct.Outer, ptr %outer, i64 0, i32 0
+  %inner_addr = getelementptr inbounds %struct.Middle, ptr %middle_addr, i64 0, i32 0
+  %x_addr = getelementptr inbounds %struct.Inner, ptr %inner_addr, i64 0, i32 0
   %1 = load i16, ptr %x_addr, align 2
   %2 = sext i16 %1 to i32
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
   call void @_ZN5Outer4ctorERK5Outer(ptr %outer2, ptr %outer)
-  %middle_addr1 = getelementptr inbounds %struct.Outer, ptr %outer2, i32 0, i32 0
-  %inner_addr2 = getelementptr inbounds %struct.Middle, ptr %middle_addr1, i32 0, i32 0
-  %x_addr3 = getelementptr inbounds %struct.Inner, ptr %inner_addr2, i32 0, i32 0
+  %middle_addr1 = getelementptr inbounds %struct.Outer, ptr %outer2, i64 0, i32 0
+  %inner_addr2 = getelementptr inbounds %struct.Middle, ptr %middle_addr1, i64 0, i32 0
+  %x_addr3 = getelementptr inbounds %struct.Inner, ptr %inner_addr2, i64 0, i32 0
   %4 = load i16, ptr %x_addr3, align 2
   %5 = sext i16 %4 to i32
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %5)

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor/ir-code.ll
@@ -11,9 +11,9 @@ define void @_ZN12StructToCopy4ctorEv(ptr noundef nonnull align 4 dereferenceabl
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.StructToCopy, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.StructToCopy, ptr %2, i64 0, i32 0
   store i32 21, ptr %3, align 4
-  %4 = getelementptr inbounds %struct.StructToCopy, ptr %2, i32 0, i32 1
+  %4 = getelementptr inbounds %struct.StructToCopy, ptr %2, i64 0, i32 1
   store i1 false, ptr %4, align 1
   ret void
 }
@@ -25,17 +25,17 @@ define dso_local i32 @main() #1 {
   %stc2 = alloca %struct.StructToCopy, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN12StructToCopy4ctorEv(ptr %stc)
-  %a_addr = getelementptr inbounds %struct.StructToCopy, ptr %stc, i32 0, i32 0
+  %a_addr = getelementptr inbounds %struct.StructToCopy, ptr %stc, i64 0, i32 0
   %1 = load i32, ptr %a_addr, align 4
-  %b_addr = getelementptr inbounds %struct.StructToCopy, ptr %stc, i32 0, i32 1
+  %b_addr = getelementptr inbounds %struct.StructToCopy, ptr %stc, i64 0, i32 1
   %2 = load i1, ptr %b_addr, align 1
   %3 = zext i1 %2 to i32
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1, i32 %3)
   %5 = load %struct.StructToCopy, ptr %stc, align 4
   store %struct.StructToCopy %5, ptr %stc2, align 4
-  %a_addr1 = getelementptr inbounds %struct.StructToCopy, ptr %stc2, i32 0, i32 0
+  %a_addr1 = getelementptr inbounds %struct.StructToCopy, ptr %stc2, i64 0, i32 0
   %6 = load i32, ptr %a_addr1, align 4
-  %b_addr2 = getelementptr inbounds %struct.StructToCopy, ptr %stc2, i32 0, i32 1
+  %b_addr2 = getelementptr inbounds %struct.StructToCopy, ptr %stc2, i64 0, i32 1
   %7 = load i1, ptr %b_addr2, align 1
   %8 = zext i1 %7 to i32
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %6, i32 %8)

--- a/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
@@ -13,7 +13,7 @@ define void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %0)
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Inner, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Inner, ptr %2, i64 0, i32 0
   store ptr @anon.string.0, ptr %3, align 8
   ret void
 }
@@ -23,7 +23,7 @@ define void @_ZN6Middle4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %0
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Middle, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Middle, ptr %2, i64 0, i32 0
   call void @_ZN5Inner4ctorEv(ptr %3)
   ret void
 }
@@ -33,7 +33,7 @@ define void @_ZN5Outer4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %0)
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Outer, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Outer, ptr %2, i64 0, i32 0
   call void @_ZN6Middle4ctorEv(ptr %3)
   ret void
 }
@@ -44,9 +44,9 @@ define dso_local i32 @main() #1 {
   %outer = alloca %struct.Outer, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN5Outer4ctorEv(ptr %outer)
-  %middle_addr = getelementptr inbounds %struct.Outer, ptr %outer, i32 0, i32 0
-  %inner_addr = getelementptr inbounds %struct.Middle, ptr %middle_addr, i32 0, i32 0
-  %message_addr = getelementptr inbounds %struct.Inner, ptr %inner_addr, i32 0, i32 0
+  %middle_addr = getelementptr inbounds %struct.Outer, ptr %outer, i64 0, i32 0
+  %inner_addr = getelementptr inbounds %struct.Middle, ptr %middle_addr, i64 0, i32 0
+  %message_addr = getelementptr inbounds %struct.Inner, ptr %inner_addr, i64 0, i32 0
   %1 = load ptr, ptr %message_addr, align 8
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %1)
   %3 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
@@ -14,13 +14,13 @@ define void @_ZN10TestStruct4ctorEv(ptr noundef nonnull align 8 dereferenceable(
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.TestStruct, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 0
   store i32 123, ptr %3, align 4
-  %4 = getelementptr inbounds %struct.TestStruct, ptr %2, i32 0, i32 1
+  %4 = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 1
   store ptr @anon.string.0, ptr %4, align 8
-  %5 = getelementptr inbounds %struct.TestStruct, ptr %2, i32 0, i32 2
+  %5 = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 2
   store double 1.230000e+00, ptr %5, align 8
-  %6 = getelementptr inbounds %struct.TestStruct, ptr %2, i32 0, i32 3
+  %6 = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 3
   store i1 true, ptr %6, align 1
   ret void
 }
@@ -31,16 +31,16 @@ define dso_local i32 @main() #1 {
   %ts = alloca %struct.TestStruct, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN10TestStruct4ctorEv(ptr %ts)
-  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 0
+  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
   %1 = load i32, ptr %i_addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 1
+  %s_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
   %3 = load ptr, ptr %s_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
-  %d_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 2
+  %d_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 2
   %5 = load double, ptr %d_addr, align 8
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, double %5)
-  %b_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 3
+  %b_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 3
   %7 = load i1, ptr %b_addr, align 1
   %8 = zext i1 %7 to i32
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 %8)

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -16,12 +16,12 @@ define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceabl
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Inner, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Inner, ptr %2, i64 0, i32 0
   store ptr @anon.string.0, ptr %3, align 8
-  %4 = getelementptr inbounds %struct.Inner, ptr %2, i32 0, i32 1
+  %4 = getelementptr inbounds %struct.Inner, ptr %2, i64 0, i32 1
   store ptr null, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %data_addr = getelementptr inbounds %struct.Inner, ptr %5, i32 0, i32 1
+  %data_addr = getelementptr inbounds %struct.Inner, ptr %5, i64 0, i32 1
   %6 = call ptr @malloc(i64 10)
   store ptr %6, ptr %data_addr, align 8
   ret void
@@ -31,7 +31,7 @@ define private void @_ZN5Inner4dtorEv(ptr noundef nonnull align 8 dereferenceabl
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %data_addr = getelementptr inbounds %struct.Inner, ptr %2, i32 0, i32 1
+  %data_addr = getelementptr inbounds %struct.Inner, ptr %2, i64 0, i32 1
   %3 = load ptr, ptr %data_addr, align 8
   call void @free(ptr %3)
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
@@ -46,7 +46,7 @@ define void @_ZN6Middle4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Middle, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Middle, ptr %2, i64 0, i32 0
   call void @_ZN5Inner4ctorEv(ptr %3)
   ret void
 }
@@ -56,7 +56,7 @@ define void @_ZN6Middle4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Middle, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Middle, ptr %2, i64 0, i32 0
   call void @_ZN5Inner4dtorEv(ptr %3)
   ret void
 }
@@ -66,7 +66,7 @@ define void @_ZN5Outer4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Outer, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Outer, ptr %2, i64 0, i32 0
   call void @_ZN6Middle4ctorEv(ptr %3)
   ret void
 }
@@ -76,7 +76,7 @@ define void @_ZN5Outer4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Outer, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Outer, ptr %2, i64 0, i32 0
   call void @_ZN6Middle4dtorEv(ptr %3)
   ret void
 }

--- a/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
@@ -13,7 +13,7 @@ define void @_ZN20StructWithHeapFields4dtorEv(ptr noundef nonnull align 8 derefe
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.StructWithHeapFields, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.StructWithHeapFields, ptr %2, i64 0, i32 0
   call void @_Z8sDeallocRPh(ptr %3)
   ret void
 }
@@ -25,12 +25,12 @@ define private void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align 
   %res = alloca %struct.Result, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.StructWithHeapFields, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.StructWithHeapFields, ptr %2, i64 0, i32 0
   store ptr null, ptr %3, align 8
   %4 = call %struct.Result @_Z6sAllocm(i64 10)
   store %struct.Result %4, ptr %res, align 8
   %5 = load ptr, ptr %this, align 8
-  %data_addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i32 0, i32 0
+  %data_addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i64 0, i32 0
   %6 = call ptr @_ZN6ResultIPhE6unwrapEv(ptr noundef nonnull align 8 dereferenceable(24) %res)
   store ptr %6, ptr %data_addr, align 8
   ret void
@@ -49,14 +49,14 @@ define dso_local i32 @main() #1 {
   store ptr null, ptr %sPtr, align 8
   call void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %s)
   store ptr %s, ptr %sPtr, align 8
-  %data_addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %s, i32 0, i32 0
+  %data_addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %s, i64 0, i32 0
   %1 = load ptr, ptr %data_addr, align 8
   %2 = icmp eq ptr %1, null
   %3 = zext i1 %2 to i32
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3)
   call void @_ZN20StructWithHeapFields4dtorEv(ptr %s)
   %5 = load ptr, ptr %sPtr, align 8
-  %data_addr1 = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i32 0, i32 0
+  %data_addr1 = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i64 0, i32 0
   %6 = load ptr, ptr %data_addr1, align 8
   %7 = icmp eq ptr %6, null
   %8 = zext i1 %7 to i32

--- a/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
@@ -12,9 +12,9 @@ define void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0)
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Test, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 0
   store i32 12, ptr %3, align 4
-  %4 = getelementptr inbounds %struct.Test, ptr %2, i32 0, i32 1
+  %4 = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 1
   store ptr @anon.string.0, ptr %4, align 8
   ret void
 }
@@ -25,10 +25,10 @@ define dso_local i32 @main() #1 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr %t)
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 0
+  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %1 = load i32, ptr %i_addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 1
+  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %3 = load ptr, ptr %s_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
@@ -13,10 +13,10 @@ define dso_local i32 @main() #0 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   store %struct.Test { i32 12, ptr @anon.string.0 }, ptr %t, align 8
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 0
+  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %1 = load i32, ptr %i_addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 1
+  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %3 = load ptr, ptr %s_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
@@ -12,9 +12,9 @@ define void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0)
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Test, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 0
   store i32 0, ptr %3, align 4
-  %4 = getelementptr inbounds %struct.Test, ptr %2, i32 0, i32 1
+  %4 = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 1
   store ptr @anon.string.0, ptr %4, align 8
   ret void
 }
@@ -25,10 +25,10 @@ define dso_local i32 @main() #1 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr %t)
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 0
+  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %1 = load i32, ptr %i_addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 1
+  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %3 = load ptr, ptr %s_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
@@ -11,12 +11,12 @@ define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %3 = getelementptr inbounds %struct.Test, ptr %2, i32 0, i32 0
+  %3 = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 0
   store i32 12, ptr %3, align 4
-  %4 = getelementptr inbounds %struct.Test, ptr %2, i32 0, i32 1
+  %4 = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 1
   store ptr @0, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %i_addr = getelementptr inbounds %struct.Test, ptr %5, i32 0, i32 0
+  %i_addr = getelementptr inbounds %struct.Test, ptr %5, i64 0, i32 0
   store i32 14, ptr %i_addr, align 4
   ret void
 }
@@ -27,10 +27,10 @@ define dso_local i32 @main() #0 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %t)
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 0
+  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %1 = load i32, ptr %i_addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 1
+  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %3 = load ptr, ptr %s_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
@@ -16,7 +16,7 @@ define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceab
   store ptr %0, ptr %this, align 8
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
   %4 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %4, i32 0, i32 0
+  %field1_addr = getelementptr inbounds %struct.Vector, ptr %4, i64 0, i32 0
   store i1 true, ptr %2, align 1
   %5 = call i32 @memcmp(ptr %field1_addr, ptr %2, i64 0)
   %6 = icmp eq i32 %5, 0
@@ -29,7 +29,7 @@ assert.then.L8:                                   ; preds = %1
 
 assert.exit.L8:                                   ; preds = %1
   %8 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
   %9 = load ptr, ptr %field2_addr, align 8
   %10 = call i1 @_Z10isRawEqualPKcPKc(ptr %9, ptr @anon.string.1)
   br i1 %10, label %assert.exit.L9, label %assert.then.L9, !prof !0
@@ -60,10 +60,10 @@ define dso_local i32 @main() #3 {
   %vec = alloca %struct.Vector, align 8
   store i32 0, ptr %result, align 4
   store %struct.Vector { i1 true, ptr @anon.string.3 }, ptr %vec, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 0
+  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
   %1 = load i1, ptr %field1_addr, align 1
   %2 = zext i1 %1 to i32
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
   %3 = load ptr, ptr %field2_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %2, ptr %3)
   call void @_ZN6Vector4dtorEv(ptr %vec)

--- a/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
@@ -16,10 +16,10 @@ define dso_local i32 @main() #0 {
   %vec = alloca %struct.Vector, align 8
   store i32 0, ptr %result, align 4
   store %struct.Vector { i1 true, ptr @anon.string.0 }, ptr %vec, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 0
+  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
   %1 = load i1, ptr %field1_addr, align 1
   %2 = zext i1 %1 to i32
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
   %3 = load ptr, ptr %field2_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2, ptr %3)
   call void @_ZN6Vector4dtorEv(ptr %vec)
@@ -36,7 +36,7 @@ define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceab
   store ptr %0, ptr %this, align 8
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1)
   %4 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %4, i32 0, i32 0
+  %field1_addr = getelementptr inbounds %struct.Vector, ptr %4, i64 0, i32 0
   store i1 true, ptr %2, align 1
   %5 = call i32 @memcmp(ptr %field1_addr, ptr %2, i64 0)
   %6 = icmp eq i32 %5, 0
@@ -49,7 +49,7 @@ assert.then.L13:                                  ; preds = %1
 
 assert.exit.L13:                                  ; preds = %1
   %8 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
   %9 = load ptr, ptr %field2_addr, align 8
   %10 = call i1 @_Z10isRawEqualPKcPKc(ptr %9, ptr @anon.string.2)
   br i1 %10, label %assert.exit.L14, label %assert.then.L14, !prof !0

--- a/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
@@ -15,13 +15,13 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   %1 = call %struct.Socket @_Z16openServerSockett(i16 8080)
   store %struct.Socket %1, ptr %s, align 8
-  %nested_addr = getelementptr inbounds %struct.Socket, ptr %s, i32 0, i32 2
+  %nested_addr = getelementptr inbounds %struct.Socket, ptr %s, i64 0, i32 2
   %2 = load %struct.NestedSocket, ptr %nested_addr, align 8
   store %struct.NestedSocket %2, ptr %n, align 8
-  %testString_addr = getelementptr inbounds %struct.NestedSocket, ptr %n, i32 0, i32 0
+  %testString_addr = getelementptr inbounds %struct.NestedSocket, ptr %n, i64 0, i32 0
   %3 = load ptr, ptr %testString_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %3)
-  %sock_addr = getelementptr inbounds %struct.Socket, ptr %s, i32 0, i32 0
+  %sock_addr = getelementptr inbounds %struct.Socket, ptr %s, i64 0, i32 0
   %5 = load i32, ptr %sock_addr, align 4
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %5)
   %7 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
@@ -34,9 +34,9 @@ define void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(72) %0)
   %5 = alloca i32, align 4
   store ptr %0, ptr %this, align 8
   %6 = load ptr, ptr %this, align 8
-  %7 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 0
+  %7 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 0
   store i32 2, ptr %7, align 4
-  %8 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 1
+  %8 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 1
   br i1 false, label %lor.exit.L14C15, label %lor.1.L14C15
 
 lor.1.L14C15:                                     ; preds = %1
@@ -48,7 +48,7 @@ lor.2.L14C15:                                     ; preds = %lor.1.L14C15
 lor.exit.L14C15:                                  ; preds = %lor.2.L14C15, %lor.1.L14C15, %1
   %lor_phi = phi i1 [ false, %1 ], [ false, %lor.1.L14C15 ], [ true, %lor.2.L14C15 ]
   store i1 %lor_phi, ptr %8, align 1
-  %9 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 2
+  %9 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 2
   br i1 true, label %land.1.L15C15, label %land.exit.L15C15
 
 land.1.L15C15:                                    ; preds = %lor.exit.L14C15
@@ -60,43 +60,43 @@ land.2.L15C15:                                    ; preds = %land.1.L15C15
 land.exit.L15C15:                                 ; preds = %land.2.L15C15, %land.1.L15C15, %lor.exit.L14C15
   %land_phi = phi i1 [ true, %lor.exit.L14C15 ], [ false, %land.1.L15C15 ], [ true, %land.2.L15C15 ]
   store i1 %land_phi, ptr %9, align 1
-  %10 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 3
+  %10 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 3
   store i32 11, ptr %10, align 4
-  %11 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 4
+  %11 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 4
   store i16 10, ptr %11, align 2
-  %12 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 5
+  %12 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 5
   store i64 2, ptr %12, align 8
-  %13 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 6
+  %13 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 6
   store i1 true, ptr %13, align 1
-  %14 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 7
+  %14 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 7
   store i1 true, ptr %14, align 1
-  %15 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 8
+  %15 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 8
   store i1 true, ptr %15, align 1
-  %16 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 9
+  %16 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 9
   store i1 false, ptr %16, align 1
-  %17 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 10
+  %17 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 10
   store i1 true, ptr %17, align 1
-  %18 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 11
+  %18 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 11
   store i1 false, ptr %18, align 1
-  %19 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 12
+  %19 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 12
   store i32 333, ptr %19, align 4
-  %20 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 13
+  %20 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 13
   store i64 11, ptr %20, align 8
-  %21 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 14
+  %21 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 14
   store i8 63, ptr %21, align 1
-  %22 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 15
+  %22 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 15
   store i32 14, ptr %2, align 4
   store i32 13, ptr %22, align 4
-  %23 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 16
+  %23 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 16
   store i32 12, ptr %3, align 4
   store i32 13, ptr %23, align 4
-  %24 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 17
+  %24 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 17
   store i32 14, ptr %4, align 4
   store i32 14, ptr %24, align 4
-  %25 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 18
+  %25 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 18
   store i32 12, ptr %5, align 4
   store i32 12, ptr %25, align 4
-  %26 = getelementptr inbounds %struct.Test, ptr %6, i32 0, i32 19
+  %26 = getelementptr inbounds %struct.Test, ptr %6, i64 0, i32 19
   store i32 7, ptr %26, align 4
   ret void
 }
@@ -110,7 +110,7 @@ define dso_local i32 @main() #1 {
   %3 = alloca i1, align 1
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr %t)
-  %f1_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 0
+  %f1_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %4 = load i32, ptr %f1_addr, align 4
   %5 = icmp eq i32 %4, 2
   br i1 %5, label %assert.exit.L37, label %assert.then.L37, !prof !0
@@ -121,7 +121,7 @@ assert.then.L37:                                  ; preds = %0
   unreachable
 
 assert.exit.L37:                                  ; preds = %0
-  %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 1
+  %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %7 = load i1, ptr %f2_addr, align 1
   br i1 %7, label %assert.exit.L38, label %assert.then.L38, !prof !0
 
@@ -131,7 +131,7 @@ assert.then.L38:                                  ; preds = %assert.exit.L37
   unreachable
 
 assert.exit.L38:                                  ; preds = %assert.exit.L37
-  %f3_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 2
+  %f3_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 2
   %9 = load i1, ptr %f3_addr, align 1
   %10 = xor i1 %9, true
   store i1 %10, ptr %1, align 1
@@ -143,7 +143,7 @@ assert.then.L39:                                  ; preds = %assert.exit.L38
   unreachable
 
 assert.exit.L39:                                  ; preds = %assert.exit.L38
-  %f4_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 3
+  %f4_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 3
   %12 = load i32, ptr %f4_addr, align 4
   %13 = icmp eq i32 %12, 11
   br i1 %13, label %assert.exit.L40, label %assert.then.L40, !prof !0
@@ -154,7 +154,7 @@ assert.then.L40:                                  ; preds = %assert.exit.L39
   unreachable
 
 assert.exit.L40:                                  ; preds = %assert.exit.L39
-  %f5_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 4
+  %f5_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 4
   %15 = load i16, ptr %f5_addr, align 2
   %16 = icmp eq i16 %15, 10
   br i1 %16, label %assert.exit.L41, label %assert.then.L41, !prof !0
@@ -165,7 +165,7 @@ assert.then.L41:                                  ; preds = %assert.exit.L40
   unreachable
 
 assert.exit.L41:                                  ; preds = %assert.exit.L40
-  %f6_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 5
+  %f6_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 5
   %18 = load i64, ptr %f6_addr, align 8
   %19 = icmp eq i64 %18, 2
   br i1 %19, label %assert.exit.L42, label %assert.then.L42, !prof !0
@@ -176,7 +176,7 @@ assert.then.L42:                                  ; preds = %assert.exit.L41
   unreachable
 
 assert.exit.L42:                                  ; preds = %assert.exit.L41
-  %f7_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 6
+  %f7_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 6
   %21 = load i1, ptr %f7_addr, align 1
   br i1 %21, label %assert.exit.L43, label %assert.then.L43, !prof !0
 
@@ -186,7 +186,7 @@ assert.then.L43:                                  ; preds = %assert.exit.L42
   unreachable
 
 assert.exit.L43:                                  ; preds = %assert.exit.L42
-  %f8_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 7
+  %f8_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 7
   %23 = load i1, ptr %f8_addr, align 1
   br i1 %23, label %assert.exit.L44, label %assert.then.L44, !prof !0
 
@@ -196,7 +196,7 @@ assert.then.L44:                                  ; preds = %assert.exit.L43
   unreachable
 
 assert.exit.L44:                                  ; preds = %assert.exit.L43
-  %f9_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 8
+  %f9_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 8
   %25 = load i1, ptr %f9_addr, align 1
   br i1 %25, label %assert.exit.L45, label %assert.then.L45, !prof !0
 
@@ -206,7 +206,7 @@ assert.then.L45:                                  ; preds = %assert.exit.L44
   unreachable
 
 assert.exit.L45:                                  ; preds = %assert.exit.L44
-  %f10_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 9
+  %f10_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 9
   %27 = load i1, ptr %f10_addr, align 1
   %28 = xor i1 %27, true
   store i1 %28, ptr %2, align 1
@@ -218,7 +218,7 @@ assert.then.L46:                                  ; preds = %assert.exit.L45
   unreachable
 
 assert.exit.L46:                                  ; preds = %assert.exit.L45
-  %f11_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 10
+  %f11_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 10
   %30 = load i1, ptr %f11_addr, align 1
   br i1 %30, label %assert.exit.L47, label %assert.then.L47, !prof !0
 
@@ -228,7 +228,7 @@ assert.then.L47:                                  ; preds = %assert.exit.L46
   unreachable
 
 assert.exit.L47:                                  ; preds = %assert.exit.L46
-  %f12_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 11
+  %f12_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 11
   %32 = load i1, ptr %f12_addr, align 1
   %33 = xor i1 %32, true
   store i1 %33, ptr %3, align 1
@@ -240,7 +240,7 @@ assert.then.L48:                                  ; preds = %assert.exit.L47
   unreachable
 
 assert.exit.L48:                                  ; preds = %assert.exit.L47
-  %f13_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 12
+  %f13_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 12
   %35 = load i32, ptr %f13_addr, align 4
   %36 = icmp eq i32 %35, 333
   br i1 %36, label %assert.exit.L49, label %assert.then.L49, !prof !0
@@ -251,7 +251,7 @@ assert.then.L49:                                  ; preds = %assert.exit.L48
   unreachable
 
 assert.exit.L49:                                  ; preds = %assert.exit.L48
-  %f14_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 13
+  %f14_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 13
   %38 = load i64, ptr %f14_addr, align 8
   %39 = icmp eq i64 %38, 11
   br i1 %39, label %assert.exit.L50, label %assert.then.L50, !prof !0
@@ -262,7 +262,7 @@ assert.then.L50:                                  ; preds = %assert.exit.L49
   unreachable
 
 assert.exit.L50:                                  ; preds = %assert.exit.L49
-  %f15_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 14
+  %f15_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 14
   %41 = load i8, ptr %f15_addr, align 1
   %42 = icmp eq i8 %41, 63
   br i1 %42, label %assert.exit.L51, label %assert.then.L51, !prof !0
@@ -273,7 +273,7 @@ assert.then.L51:                                  ; preds = %assert.exit.L50
   unreachable
 
 assert.exit.L51:                                  ; preds = %assert.exit.L50
-  %f16_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 15
+  %f16_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 15
   %44 = load i32, ptr %f16_addr, align 4
   %45 = icmp eq i32 %44, 13
   br i1 %45, label %assert.exit.L52, label %assert.then.L52, !prof !0
@@ -284,7 +284,7 @@ assert.then.L52:                                  ; preds = %assert.exit.L51
   unreachable
 
 assert.exit.L52:                                  ; preds = %assert.exit.L51
-  %f17_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 16
+  %f17_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 16
   %47 = load i32, ptr %f17_addr, align 4
   %48 = icmp eq i32 %47, 13
   br i1 %48, label %assert.exit.L53, label %assert.then.L53, !prof !0
@@ -295,7 +295,7 @@ assert.then.L53:                                  ; preds = %assert.exit.L52
   unreachable
 
 assert.exit.L53:                                  ; preds = %assert.exit.L52
-  %f18_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 17
+  %f18_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 17
   %50 = load i32, ptr %f18_addr, align 4
   %51 = icmp eq i32 %50, 14
   br i1 %51, label %assert.exit.L54, label %assert.then.L54, !prof !0
@@ -306,7 +306,7 @@ assert.then.L54:                                  ; preds = %assert.exit.L53
   unreachable
 
 assert.exit.L54:                                  ; preds = %assert.exit.L53
-  %f19_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 18
+  %f19_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 18
   %53 = load i32, ptr %f19_addr, align 4
   %54 = icmp eq i32 %53, 12
   br i1 %54, label %assert.exit.L55, label %assert.then.L55, !prof !0
@@ -317,7 +317,7 @@ assert.then.L55:                                  ; preds = %assert.exit.L54
   unreachable
 
 assert.exit.L55:                                  ; preds = %assert.exit.L54
-  %f20_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 19
+  %f20_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 19
   %56 = load i32, ptr %f20_addr, align 4
   %57 = icmp eq i32 %56, 7
   br i1 %57, label %assert.exit.L56, label %assert.then.L56, !prof !0

--- a/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
@@ -21,9 +21,9 @@ define dso_local i32 @main() #0 {
   %tp = alloca %struct.TestPacked, align 8
   store i32 0, ptr %result, align 4
   store %struct.Test zeroinitializer, ptr %t, align 8
-  %f1_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 0
+  %f1_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   store i32 -2147483647, ptr %f1_addr, align 4
-  %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 1
+  %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   store i64 9223372036854775807, ptr %f2_addr, align 8
   br i1 true, label %assert.exit.L16, label %assert.then.L16, !prof !0
 
@@ -41,7 +41,7 @@ assert.then.L17:                                  ; preds = %assert.exit.L16
   unreachable
 
 assert.exit.L17:                                  ; preds = %assert.exit.L16
-  %f1_addr1 = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 0
+  %f1_addr1 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %3 = load i32, ptr %f1_addr1, align 4
   %4 = icmp eq i32 %3, -2147483647
   br i1 %4, label %assert.exit.L18, label %assert.then.L18, !prof !0
@@ -52,7 +52,7 @@ assert.then.L18:                                  ; preds = %assert.exit.L17
   unreachable
 
 assert.exit.L18:                                  ; preds = %assert.exit.L17
-  %f2_addr2 = getelementptr inbounds %struct.Test, ptr %t, i32 0, i32 1
+  %f2_addr2 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %6 = load i64, ptr %f2_addr2, align 8
   %7 = icmp eq i64 %6, 9223372036854775807
   br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !0
@@ -64,9 +64,9 @@ assert.then.L19:                                  ; preds = %assert.exit.L18
 
 assert.exit.L19:                                  ; preds = %assert.exit.L18
   store %struct.TestPacked zeroinitializer, ptr %tp, align 1
-  %f1_addr3 = getelementptr inbounds %struct.TestPacked, ptr %tp, i32 0, i32 0
+  %f1_addr3 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
   store i32 -2147483647, ptr %f1_addr3, align 4
-  %f2_addr4 = getelementptr inbounds %struct.TestPacked, ptr %tp, i32 0, i32 1
+  %f2_addr4 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
   store i64 9223372036854775807, ptr %f2_addr4, align 8
   br i1 true, label %assert.exit.L25, label %assert.then.L25, !prof !0
 
@@ -84,7 +84,7 @@ assert.then.L26:                                  ; preds = %assert.exit.L25
   unreachable
 
 assert.exit.L26:                                  ; preds = %assert.exit.L25
-  %f1_addr5 = getelementptr inbounds %struct.TestPacked, ptr %tp, i32 0, i32 0
+  %f1_addr5 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
   %11 = load i32, ptr %f1_addr5, align 4
   %12 = icmp eq i32 %11, -2147483647
   br i1 %12, label %assert.exit.L27, label %assert.then.L27, !prof !0
@@ -95,7 +95,7 @@ assert.then.L27:                                  ; preds = %assert.exit.L26
   unreachable
 
 assert.exit.L27:                                  ; preds = %assert.exit.L26
-  %f2_addr6 = getelementptr inbounds %struct.TestPacked, ptr %tp, i32 0, i32 1
+  %f2_addr6 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
   %14 = load i64, ptr %f2_addr6, align 8
   %15 = icmp eq i64 %14, 9223372036854775807
   br i1 %15, label %assert.exit.L28, label %assert.then.L28, !prof !0

--- a/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
@@ -13,9 +13,9 @@ define dso_local i32 @main() #0 {
   %john = alloca %struct.Person, align 8
   store i32 0, ptr %result, align 4
   store %struct.Person { ptr @anon.string.0, ptr @anon.string.1, i32 46 }, ptr %john, align 8
-  %age_addr = getelementptr inbounds %struct.Person, ptr %john, i32 0, i32 2
+  %age_addr = getelementptr inbounds %struct.Person, ptr %john, i64 0, i32 2
   store i32 47, ptr %age_addr, align 4
-  %age_addr1 = getelementptr inbounds %struct.Person, ptr %john, i32 0, i32 2
+  %age_addr1 = getelementptr inbounds %struct.Person, ptr %john, i64 0, i32 2
   %1 = load i32, ptr %age_addr1, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
   %3 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
@@ -29,11 +29,11 @@ define private %struct.ShoppingCart @_Z15newShoppingCartv() {
   %items = alloca [3 x %struct.ShoppingItem], align 8
   %1 = alloca %struct.ShoppingCart, align 8
   store [3 x %struct.ShoppingItem] [%struct.ShoppingItem { ptr @0, double 0.000000e+00, ptr @1 }, %struct.ShoppingItem { ptr @0, double 0.000000e+00, ptr @1 }, %struct.ShoppingItem { ptr @0, double 0.000000e+00, ptr @1 }], ptr %items, align 8
-  %2 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items, i32 0, i32 0
+  %2 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items, i64 0, i32 0
   store %struct.ShoppingItem { ptr @anon.string.0, double 1.000000e+02, ptr @anon.string.1 }, ptr %2, align 8
-  %3 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items, i32 0, i32 1
+  %3 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items, i64 0, i32 1
   store %struct.ShoppingItem { ptr @anon.string.2, double 1.255000e+02, ptr @anon.string.3 }, ptr %3, align 8
-  %4 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items, i32 0, i32 2
+  %4 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items, i64 0, i32 2
   store %struct.ShoppingItem { ptr @anon.string.4, double 6.000000e+00, ptr @anon.string.5 }, ptr %4, align 8
   store ptr @anon.string.6, ptr %1, align 8
   %5 = load [3 x %struct.ShoppingItem], ptr %items, align 8
@@ -63,16 +63,16 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   %1 = call %struct.ShoppingCart @_Z15newShoppingCartv()
   store %struct.ShoppingCart %1, ptr %shoppingCart, align 8
-  %items_addr = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i32 0, i32 1
-  %2 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items_addr, i32 0, i32 1
-  %name_addr = getelementptr inbounds %struct.ShoppingItem, ptr %2, i32 0, i32 0
+  %items_addr = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i64 0, i32 1
+  %2 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items_addr, i64 0, i32 1
+  %name_addr = getelementptr inbounds %struct.ShoppingItem, ptr %2, i64 0, i32 0
   %3 = load ptr, ptr %name_addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %3)
   %5 = call %struct.ShoppingCart @_Z19anotherShoppingCartv()
   store %struct.ShoppingCart %5, ptr %shoppingCart, align 8
-  %items_addr1 = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i32 0, i32 1
-  %6 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items_addr1, i32 0, i32 2
-  %unit_addr = getelementptr inbounds %struct.ShoppingItem, ptr %6, i32 0, i32 2
+  %items_addr1 = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i64 0, i32 1
+  %6 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items_addr1, i64 0, i32 2
+  %unit_addr = getelementptr inbounds %struct.ShoppingItem, ptr %6, i64 0, i32 2
   %7 = load ptr, ptr %unit_addr, align 8
   %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %7)
   %9 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
@@ -29,21 +29,21 @@ define dso_local i32 @main() #0 {
 
 while.head.L21:                                   ; preds = %while.body.L21, %0
   %4 = load ptr, ptr %curNode, align 8
-  %parent_addr = getelementptr inbounds %struct.TreeNode, ptr %4, i32 0, i32 0
+  %parent_addr = getelementptr inbounds %struct.TreeNode, ptr %4, i64 0, i32 0
   %5 = load ptr, ptr %parent_addr, align 8
   %6 = icmp ne ptr %5, null
   br i1 %6, label %while.body.L21, label %while.exit.L21
 
 while.body.L21:                                   ; preds = %while.head.L21
   %7 = load ptr, ptr %curNode, align 8
-  %parent_addr1 = getelementptr inbounds %struct.TreeNode, ptr %7, i32 0, i32 0
+  %parent_addr1 = getelementptr inbounds %struct.TreeNode, ptr %7, i64 0, i32 0
   %8 = load ptr, ptr %parent_addr1, align 8
   store ptr %8, ptr %curNode, align 8
   br label %while.head.L21
 
 while.exit.L21:                                   ; preds = %while.head.L21
   %9 = load ptr, ptr %curNode, align 8
-  %value_addr = getelementptr inbounds %struct.TreeNode, ptr %9, i32 0, i32 1
+  %value_addr = getelementptr inbounds %struct.TreeNode, ptr %9, i64 0, i32 1
   %10 = load i32, ptr %value_addr, align 4
   %11 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %10)
   %12 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct/ir-code.ll
@@ -29,18 +29,18 @@ define dso_local i32 @main() #0 {
   store ptr %nestedInstance, ptr %3, align 8
   %4 = load %struct.TestStruct, ptr %instance, align 8
   store %struct.TestStruct %4, ptr %instance1, align 8
-  %nested_addr = getelementptr inbounds %struct.TestStruct, ptr %instance, i32 0, i32 2
+  %nested_addr = getelementptr inbounds %struct.TestStruct, ptr %instance, i64 0, i32 2
   %5 = load ptr, ptr %nested_addr, align 8
-  %nested2_addr = getelementptr inbounds %struct.Nested, ptr %5, i32 0, i32 1
+  %nested2_addr = getelementptr inbounds %struct.Nested, ptr %5, i64 0, i32 1
   %6 = load ptr, ptr %nested2_addr, align 8
   %7 = load i1, ptr %6, align 1
   %8 = zext i1 %7 to i32
-  %field2_addr = getelementptr inbounds %struct.TestStruct, ptr %instance1, i32 0, i32 1
+  %field2_addr = getelementptr inbounds %struct.TestStruct, ptr %instance1, i64 0, i32 1
   %9 = load double, ptr %field2_addr, align 8
   %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %8, double %9)
-  %nested_addr1 = getelementptr inbounds %struct.TestStruct, ptr %instance1, i32 0, i32 2
+  %nested_addr1 = getelementptr inbounds %struct.TestStruct, ptr %instance1, i64 0, i32 2
   %11 = load ptr, ptr %nested_addr1, align 8
-  %nested1_addr = getelementptr inbounds %struct.Nested, ptr %11, i32 0, i32 0
+  %nested1_addr = getelementptr inbounds %struct.Nested, ptr %11, i64 0, i32 0
   %12 = load ptr, ptr %nested1_addr, align 8
   %13 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %12)
   %14 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
@@ -57,8 +57,8 @@ define dso_local i32 @main() #0 {
   %19 = zext i1 %18 to i32
   %20 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.7, i32 %19)
   store [4 x %struct.NestedStruct] [%struct.NestedStruct { i32 0, ptr @1 }, %struct.NestedStruct { i32 0, ptr @1 }, %struct.NestedStruct { i32 0, ptr @1 }, %struct.NestedStruct { i32 0, ptr @1 }], ptr %structArrayVar, align 8
-  %21 = getelementptr inbounds [4 x %struct.NestedStruct], ptr %structArrayVar, i32 0, i32 2
-  %field2_addr = getelementptr inbounds %struct.NestedStruct, ptr %21, i32 0, i32 1
+  %21 = getelementptr inbounds [4 x %struct.NestedStruct], ptr %structArrayVar, i64 0, i32 2
+  %field2_addr = getelementptr inbounds %struct.NestedStruct, ptr %21, i64 0, i32 1
   %22 = load ptr, ptr %field2_addr, align 8
   %23 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.8, ptr %22)
   %24 = load i32, ptr %result, align 4


### PR DESCRIPTION
Use i64 GEP index type for pointer arithmetic. This should improve both compiletime and runtime performance.