### PR TITLE
Add experimental cli flag to generate lifetime markers

### DIFF
--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O1 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/docs/docs/cli/build.md
+++ b/docs/docs/cli/build.md
@@ -19,26 +19,27 @@ The `build` subcommand can be used to compile your Spice project to an executabl
 ## Options
 You can apply following options to the `build` subcommand:
 
-| Option       | Long                 | Description                                                                                                     |
-|--------------|----------------------|-----------------------------------------------------------------------------------------------------------------|
-| `-d`         | `--debug-output`     | Print compiler output for debugging.                                                                            |
-| `-cst`       | `--dump-cst`         | Dump CST as serialized string and SVG image                                                                     |
-| `-ast`       | `--dump-ast`         | Dump AST as serialized string and SVG image                                                                     |
-| `-symtab`    | `--dump-symtab`      | Dump serialized symbol tables                                                                                   |
-| `-types`     | `--dump-types`       | Dump all used types                                                                                             |
-| `-ir`        | `--dump-ir`          | Dump LLVM-IR                                                                                                    |
-| `-s`, `-asm` | `--dump-assembly`    | Dump Assembly code                                                                                              |
-| `-b`, `-obj` | `--dump-object-file` | Dump object files                                                                                               |
-| -            | `--dump-to-files`    | Redirect all dumps to files instead of printing them to the screen                                              |
-| -            | `--abort-after-dump` | Abort the compilation process after dumping the first requested resource                                        |
-| `-j <n>`     | `--jobs <n>`         | Set number of jobs to parallelize compilation (default is auto)                                                 |
-| `-t`         | `--target`           | Target triple for the emitted executable (for cross-compiling). <br> Format: `<arch><sub>-<vendor>-<sys>-<abi>` |
-| `-o`         | `--output`           | Set path for executable output.                                                                                 |
-| `-O<n>`      | -                    | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz`                            |
-| `-m`         | `--build-mode`       | Controls the build mode. Valid values are `debug`, `release` and `test`.                                        |
-| `-lto`       | -                    | Enable link-time-optimization                                                                                   |
-| `-g`         | `--debug-info`       | Generate debug info to debug the executable in GDB, etc.                                                        |
-| -            | `--static`           | Produce stand-alone executable by linking statically                                                            |
-| -            | `--no-entry`         | Do not require or generate main function (useful for web assembly target)                                       |
-| -            | `--disable-verifier` | Disable LLVM module and function verification (only recommended for debugging the compiler)                     |
-| -            | `--ignore-cache`     | Compile always and ignore the compile cache                                                                     |
+| Option       | Long                       | Description                                                                                                     |
+|--------------|----------------------------|-----------------------------------------------------------------------------------------------------------------|
+| `-d`         | `--debug-output`           | Print compiler output for debugging.                                                                            |
+| `-cst`       | `--dump-cst`               | Dump CST as serialized string and SVG image                                                                     |
+| `-ast`       | `--dump-ast`               | Dump AST as serialized string and SVG image                                                                     |
+| `-symtab`    | `--dump-symtab`            | Dump serialized symbol tables                                                                                   |
+| `-types`     | `--dump-types`             | Dump all used types                                                                                             |
+| `-ir`        | `--dump-ir`                | Dump LLVM-IR                                                                                                    |
+| `-s`, `-asm` | `--dump-assembly`          | Dump Assembly code                                                                                              |
+| `-b`, `-obj` | `--dump-object-file`       | Dump object files                                                                                               |
+| -            | `--dump-to-files`          | Redirect all dumps to files instead of printing them to the screen                                              |
+| -            | `--abort-after-dump`       | Abort the compilation process after dumping the first requested resource                                        |
+| `-j <n>`     | `--jobs <n>`               | Set number of jobs to parallelize compilation (default is auto)                                                 |
+| `-t`         | `--target`                 | Target triple for the emitted executable (for cross-compiling). <br> Format: `<arch><sub>-<vendor>-<sys>-<abi>` |
+| `-o`         | `--output`                 | Set path for executable output.                                                                                 |
+| `-O<n>`      | -                          | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz`                            |
+| `-m`         | `--build-mode`             | Controls the build mode. Valid values are `debug`, `release` and `test`.                                        |
+| `-lto`       | -                          | Enable link-time-optimization                                                                                   |
+| `-g`         | `--debug-info`             | Generate debug info to debug the executable in GDB, etc.                                                        |
+| -            | `--static`                 | Produce stand-alone executable by linking statically                                                            |
+| -            | `--no-entry`               | Do not require or generate main function (useful for web assembly target)                                       |
+| -            | `--disable-verifier`       | Disable LLVM module and function verification (only recommended for debugging the compiler)                     |
+| -            | `--ignore-cache`           | Compile always and ignore the compile cache                                                                     |
+| -            | `--use-lifetime-markers`   | Generate lifetime markers to enhance optimizations                                                              |

--- a/docs/docs/cli/install.md
+++ b/docs/docs/cli/install.md
@@ -19,19 +19,20 @@ The `install` subcommand can be used to compile your Spice project to an executa
 ## Options
 You can apply following options to the `install` subcommand:
 
-| Option       | Long                 | Description                                                                          |
-|--------------|----------------------|--------------------------------------------------------------------------------------|
-| `-d`         | `--debug-output`     | Print compiler output for debugging.                                                 |
-| `-cst`       | `--dump-cst`         | Dump CST as serialized string and SVG image                                          |
-| `-ast`       | `--dump-ast`         | Dump AST as serialized string and SVG image                                          |
-| `-symtab`    | `--dump-symtab`      | Dump serialized symbol tables                                                        |
-| `-types`     | `--dump-types`       | Dump all used types                                                                  |
-| `-ir`        | `--dump-ir`          | Dump LLVM-IR                                                                         |
-| `-s`, `-asm` | `--dump-assembly`    | Dump Assembly code                                                                   |
-| `-b`, `-obj` | `--dump-object-file` | Dump object files                                                                    |
-| `-d`         | `--debug-output`     | Print compiler output for debugging.                                                 |
-| `-j <n>`     | `--jobs <n>`         | Set number of jobs to parallelize compilation (Default is auto)                      |
-| `-o`         | `--output`           | Set path for executable output.                                                      |
-| `-O<n>`      | -                    | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz` |
-| `-m`         | `--build-mode`       | Controls the build mode. Valid values are `debug` and `release`                      |
-| -            | `--ignore-cache`     | Compile always and ignore the compile cache                                          |
+| Option       | Long                       | Description                                                                          |
+|--------------|----------------------------|--------------------------------------------------------------------------------------|
+| `-d`         | `--debug-output`           | Print compiler output for debugging.                                                 |
+| `-cst`       | `--dump-cst`               | Dump CST as serialized string and SVG image                                          |
+| `-ast`       | `--dump-ast`               | Dump AST as serialized string and SVG image                                          |
+| `-symtab`    | `--dump-symtab`            | Dump serialized symbol tables                                                        |
+| `-types`     | `--dump-types`             | Dump all used types                                                                  |
+| `-ir`        | `--dump-ir`                | Dump LLVM-IR                                                                         |
+| `-s`, `-asm` | `--dump-assembly`          | Dump Assembly code                                                                   |
+| `-b`, `-obj` | `--dump-object-file`       | Dump object files                                                                    |
+| `-d`         | `--debug-output`           | Print compiler output for debugging.                                                 |
+| `-j <n>`     | `--jobs <n>`               | Set number of jobs to parallelize compilation (Default is auto)                      |
+| `-o`         | `--output`                 | Set path for executable output.                                                      |
+| `-O<n>`      | -                          | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz` |
+| `-m`         | `--build-mode`             | Controls the build mode. Valid values are `debug` and `release`                      |
+| -            | `--ignore-cache`           | Compile always and ignore the compile cache                                          |
+| -            | `--use-lifetime-markers`   | Generate lifetime markers to enhance optimizations                                   |

--- a/docs/docs/cli/run.md
+++ b/docs/docs/cli/run.md
@@ -19,20 +19,21 @@ The `run` subcommand can be used to compile your Spice project to an executable 
 ## Options
 You can apply following options to the `run` subcommand:
 
-| Option       | Long                 | Description                                                                                 |
-|--------------|----------------------|---------------------------------------------------------------------------------------------|
-| `-d`         | `--debug-output`     | Print compiler output for debugging.                                                        |
-| `-cst`       | `--dump-cst`         | Dump CST as serialized string and SVG image                                                 |
-| `-ast`       | `--dump-ast`         | Dump AST as serialized string and SVG image                                                 |
-| `-symtab`    | `--dump-symtab`      | Dump serialized symbol tables                                                               |
-| `-types`     | `--dump-types`       | Dump all used types                                                                         |
-| `-ir`        | `--dump-ir`          | Dump LLVM-IR                                                                                |
-| `-s`, `-asm` | `--dump-assembly`    | Dump Assembly code                                                                          |
-| `-b`, `-obj` | `--dump-object-file` | Dump object files                                                                           |
-| `-j <n>`     | `--jobs <n>`         | Set number of jobs to parallelize compilation (default is auto)                             |
-| `-o`         | `--output`           | Set path for executable output.                                                             |
-| `-O<x>`      | -                    | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz`        |
-| `-m`         | `--build-mode`       | Controls the build mode. Valid values are `debug` and `release`                             |
-| `-g`         | `--debug-info`       | Generate debug info to debug the executable in GDB, etc.                                    |
-| -            | `--disable-verifier` | Disable LLVM module and function verification (only recommended for debugging the compiler) |
-| -            | `--ignore-cache`     | Compile always and ignore the compile cache                                                 |
+| Option       | Long                       | Description                                                                                 |
+|--------------|----------------------------|---------------------------------------------------------------------------------------------|
+| `-d`         | `--debug-output`           | Print compiler output for debugging.                                                        |
+| `-cst`       | `--dump-cst`               | Dump CST as serialized string and SVG image                                                 |
+| `-ast`       | `--dump-ast`               | Dump AST as serialized string and SVG image                                                 |
+| `-symtab`    | `--dump-symtab`            | Dump serialized symbol tables                                                               |
+| `-types`     | `--dump-types`             | Dump all used types                                                                         |
+| `-ir`        | `--dump-ir`                | Dump LLVM-IR                                                                                |
+| `-s`, `-asm` | `--dump-assembly`          | Dump Assembly code                                                                          |
+| `-b`, `-obj` | `--dump-object-file`       | Dump object files                                                                           |
+| `-j <n>`     | `--jobs <n>`               | Set number of jobs to parallelize compilation (default is auto)                             |
+| `-o`         | `--output`                 | Set path for executable output.                                                             |
+| `-O<x>`      | -                          | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz`        |
+| `-m`         | `--build-mode`             | Controls the build mode. Valid values are `debug` and `release`                             |
+| `-g`         | `--debug-info`             | Generate debug info to debug the executable in GDB, etc.                                    |
+| -            | `--disable-verifier`       | Disable LLVM module and function verification (only recommended for debugging the compiler) |
+| -            | `--ignore-cache`           | Compile always and ignore the compile cache                                                 |
+| -            | `--use-lifetime-markers`   | Generate lifetime markers to enhance optimizations                                          |

--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -19,17 +19,18 @@ The `test` subcommand can be used to run individual tests or the whole test suit
 ## Options
 You can apply following options to the `test` subcommand:
 
-| Option       | Long                 | Description                                                                                 |
-|--------------|----------------------|---------------------------------------------------------------------------------------------|
-| `-d`         | `--debug-output`     | Print compiler output for debugging.                                                        |
-| `-cst`       | `--dump-cst`         | Dump CST as serialized string and SVG image                                                 |
-| `-ast`       | `--dump-ast`         | Dump AST as serialized string and SVG image                                                 |
-| `-symtab`    | `--dump-symtab`      | Dump serialized symbol tables                                                               |
-| `-types`     | `--dump-types`       | Dump all used types                                                                         |
-| `-ir`        | `--dump-ir`          | Dump LLVM-IR                                                                                |
-| `-s`, `-asm` | `--dump-assembly`    | Dump Assembly code                                                                          |
-| `-j <n>`     | `--jobs <n>`         | Set number of jobs to parallelize compilation (default is auto)                             |
-| `-O<x>`      | -                    | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz`        |
-| `-g`         | `--debug-info`       | Generate debug info to debug the executable in GDB, etc.                                    |
-| -            | `--disable-verifier` | Disable LLVM module and function verification (only recommended for debugging the compiler) |
-| -            | `--ignore-cache`     | Compile always and ignore the compile cache                                                 |
+| Option       | Long                         | Description                                                                                 |
+|--------------|------------------------------|---------------------------------------------------------------------------------------------|
+| `-d`         | `--debug-output`             | Print compiler output for debugging.                                                        |
+| `-cst`       | `--dump-cst`                 | Dump CST as serialized string and SVG image                                                 |
+| `-ast`       | `--dump-ast`                 | Dump AST as serialized string and SVG image                                                 |
+| `-symtab`    | `--dump-symtab`              | Dump serialized symbol tables                                                               |
+| `-types`     | `--dump-types`               | Dump all used types                                                                         |
+| `-ir`        | `--dump-ir`                  | Dump LLVM-IR                                                                                |
+| `-s`, `-asm` | `--dump-assembly`            | Dump Assembly code                                                                          |
+| `-j <n>`     | `--jobs <n>`                 | Set number of jobs to parallelize compilation (default is auto)                             |
+| `-O<x>`      | -                            | Set optimization level. <br> Valid options: `-O0`, `-O1`, `-O2`, `-O3`, `-Os`, `-Oz`        |
+| `-g`         | `--debug-info`               | Generate debug info to debug the executable in GDB, etc.                                    |
+| -            | `--disable-verifier`         | Disable LLVM module and function verification (only recommended for debugging the compiler) |
+| -            | `--ignore-cache`             | Compile always and ignore the compile cache                                                 |
+| -            | `--use-lifetime-markers`     | Generate lifetime markers to enhance optimizations                                          |

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,5 +1,44 @@
-f<int> main() {
+// Algorithm taken from: https://stackoverflow.com/a/54967370/14945975
+// Please note: With iterations > 20 the numbers get huge and do not fit in a long
 
+f<int> main() {
+    long q = 1l;
+    long q_new;
+    long r = 0l;
+    long r_new;
+    long t = 1l;
+    long t_new;
+    long k = 1l;
+    long k_new;
+    long m = 3l;
+    long x = 3l;
+
+    int iterations = 20; // Change here
+    int printedDigits = 0;
+
+    for int i = 0; i < iterations; i++ {
+        if 4l * q + r - t < m * t {
+            printf("%d", m);
+            if printedDigits == 0 { printf("."); }
+            printedDigits++;
+            q_new = 10l * q;
+            r_new = 10l * (r - m * t);
+            m = (10l * (3l * q + r)) / t - 10l * m;
+            q = q_new;
+            r = r_new;
+        } else {
+            q_new = q * k;
+            r_new = (2l * q + r) * x;
+            t_new = t * x;
+            k_new = k + 1l;
+            m = (q * (7l * k + 2l) + r * x) / (t * x);
+            x += 2l;
+            q = q_new;
+            r = r_new;
+            t = t_new;
+            k = k_new;
+        }
+    }
 }
 
 /*import "std/os/env";

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -334,6 +334,9 @@ void Driver::addCompileSubcommandOptions(CLI::App *subCmd) {
   subCmd->add_option<unsigned short>("--jobs,-j", cliOptions.compileJobCount, "Compile jobs (threads), used for compilation");
   // --ignore-cache
   subCmd->add_flag<bool>("--ignore-cache", cliOptions.ignoreCache, "Force re-compilation of all source files");
+  // --use-lifetime-markers
+  subCmd->add_flag<bool>("--use-lifetime-markers", cliOptions.useLifetimeMarkers,
+                         "Generate lifetime markers to enhance optimizations");
 
   // Opt levels
   subCmd->add_flag_callback(

--- a/src/driver/Driver.h
+++ b/src/driver/Driver.h
@@ -63,6 +63,7 @@ struct CliOptions {
     bool abortAfterDump = false;
   } dumpSettings;
   bool namesForIRValues = false;
+  bool useLifetimeMarkers = false;
   OptLevel optLevel = OptLevel::O0; // Default optimization level for debug build mode is O0
   bool useLTO = false;
   bool noEntryFct = false;

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -67,6 +67,13 @@ llvm::Value *IRGenerator::insertAlloca(llvm::Type *llvmType, std::string varName
     // Restore old basic block
     builder.SetInsertPoint(currentBlock);
   }
+
+  // Insert lifetime start marker
+  if (cliOptions.useLifetimeMarkers) {
+    const uint64_t sizeInBytes = module->getDataLayout().getTypeAllocSize(llvmType);
+    builder.CreateLifetimeStart(allocaInsertInst, builder.getInt64(sizeInBytes));
+  }
+
   return static_cast<llvm::Value *>(allocaInsertInst);
 }
 

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -1,12 +1,12 @@
 // Copyright (c) 2021-2024 ChilliBits. All rights reserved.
 
 #include "TypeChecker.h"
-#include "TypeMatcher.h"
 
 #include <SourceFile.h>
 #include <ast/ASTBuilder.h>
 #include <ast/ASTNodes.h>
 #include <symboltablebuilder/SymbolTableBuilder.h>
+#include <typechecker/TypeMatcher.h>
 
 namespace spice::compiler {
 

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -64,6 +64,7 @@ void execTestCase(const TestCase &testCase) {
           /* abortAfterDump */ false,
       },
       /* namesForIRValues= */ true,
+      /* useLifetimeMarkers= */ false,
       /* optLevel= */ OptLevel::O0,
       /* useLTO= */ std::filesystem::exists(testCase.testPath / CTL_LTO),
       /* noEntryFct= */ std::filesystem::exists(testCase.testPath / CTL_RUN_BUILTIN_TESTS),


### PR DESCRIPTION
Add experimental cli flag `--use-lifetime-markers` to generate lifetime markers. This helps the optimizer reasoning about DSE and RLE optimizations.