### PR TITLE
Rework copy ctors

### DIFF
--- a/.run/spice build.run.xml
+++ b/.run/spice build.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d -ir -g ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O0 -d -ir -g ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/.run/spice build.run.xml
+++ b/.run/spice build.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O0 -d -ir -g ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d -ir -g ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,49 +1,11 @@
-type A struct {
-    heap int* heapField
-}
-
-p A.ctor() {
-    this.heapField = sNew<int>();
-    *this.heapField = 123;
-}
+import "std/iterator/number-iterator";
 
 f<int> main() {
-    A a;
-    A a2 = a;
-}
-
-
-
-
-/*import "std/io/cli-parser";
-
-type CliOptions struct {
-    bool sayHi = false
-}
-
-p callback(bool& value) {
-    printf("Callback called with value %d\n", value);
-}
-
-f<int> main(int argc, string[] argv) {
-    CliParser parser = CliParser("Test Program", "This is a simple test program");
-    parser.setVersion("v0.1.0");
-    parser.setFooter("Copyright (c) Marc Auberer 2021-2024");
-
-    CliOptions options;
-    parser.addFlag("--hi", options.sayHi, "Say hi to the user");
-    parser.addFlag("--callback", callback, "Call a callback function");
-    parser.addFlag("-cb", p(bool& value) {
-        printf("CB called with value %d\n", value);
-    }, "Call a callback function");
-
-    parser.parse(argc, argv);
-
-    // Print hi if requested
-    if options.sayHi {
-        printf("Hi!\n");
+    foreach double item : range(1, 5) {
+        printf("Item: %f", item);
     }
-}*/
+}
+
 
 /*f<int> greatestCommonDivisor(int a, int b) {
     while b != 0 {

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,8 +1,30 @@
-import "std/iterator/number-iterator";
+import "std/data/unordered-map";
+import "std/data/pair";
 
 f<int> main() {
-    foreach double item : range(1, 5) {
-        printf("Item: %f", item);
+    UnorderedMap<int, String> unorderedMap;
+
+    // Iterate over empty container
+    {
+        foreach Pair<int&, String&> item : unorderedMap {
+            printf("%d: %s\n", item.getFirst(), item.getSecond());
+        }
+    }
+
+    unorderedMap.upsert(1, String("1"));
+    unorderedMap.upsert(2, String("2"));
+    unorderedMap.upsert(3, String("3"));
+    unorderedMap.upsert(4, String("4"));
+    unorderedMap.upsert(5, String("5"));
+    unorderedMap.upsert(99, String("99"));
+    unorderedMap.upsert(100, String("100"));
+    unorderedMap.upsert(1265, String("1265"));
+    unorderedMap.upsert(101, String("101"));
+    unorderedMap.upsert(102, String("102"));
+
+    // Iterate over filled container
+    foreach Pair<int&, String&> item : unorderedMap {
+        printf("%d: %s\n", item.getFirst(), item.getSecond());
     }
 }
 

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,4 +1,21 @@
-import "std/io/cli-parser";
+type A struct {
+    heap int* heapField
+}
+
+p A.ctor() {
+    this.heapField = sNew<int>();
+    *this.heapField = 123;
+}
+
+f<int> main() {
+    A a;
+    A a2 = a;
+}
+
+
+
+
+/*import "std/io/cli-parser";
 
 type CliOptions struct {
     bool sayHi = false
@@ -26,7 +43,7 @@ f<int> main(int argc, string[] argv) {
     if options.sayHi {
         printf("Hi!\n");
     }
-}
+}*/
 
 /*f<int> greatestCommonDivisor(int a, int b) {
     while b != 0 {

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -27,3 +27,18 @@ f<int> main(int argc, string[] argv) {
         printf("Hi!\n");
     }
 }
+
+/*f<int> greatestCommonDivisor(int a, int b) {
+    while b != 0 {
+        int temp = b;
+        b = a % b;
+        a = temp;
+    }
+    return a;
+}
+
+f<int> main() {
+    int a = 56;
+    int gcd = greatestCommonDivisor(a, 98);
+    printf("GCD of %d and %d is %d.", a, 98, gcd);
+}*/

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,15 +1,29 @@
-f<int> greatestCommonDivisor(int a, int b) {
-    while b != 0 {
-        int temp = b;
-        b = a % b;
-        a = temp;
-    }
-    return a;
+import "std/io/cli-parser";
+
+type CliOptions struct {
+    bool sayHi = false
 }
 
-f<int> main() {
-    int a = 56;
-    int b = 98;
-    int gcd = greatestCommonDivisor(a, b);
-    printf("GCD of %d and %d is %d.", a, b, gcd);
+p callback(bool& value) {
+    printf("Callback called with value %d\n", value);
+}
+
+f<int> main(int argc, string[] argv) {
+    CliParser parser = CliParser("Test Program", "This is a simple test program");
+    parser.setVersion("v0.1.0");
+    parser.setFooter("Copyright (c) Marc Auberer 2021-2024");
+
+    CliOptions options;
+    parser.addFlag("--hi", options.sayHi, "Say hi to the user");
+    parser.addFlag("--callback", callback, "Call a callback function");
+    parser.addFlag("-cb", p(bool& value) {
+        printf("CB called with value %d\n", value);
+    }, "Call a callback function");
+
+    parser.parse(argc, argv);
+
+    // Print hi if requested
+    if options.sayHi {
+        printf("Hi!\n");
+    }
 }

--- a/src/Spice.g4
+++ b/src/Spice.g4
@@ -67,7 +67,7 @@ lenCall: LEN LPAREN assignExpr RPAREN;
 panicCall: PANIC LPAREN assignExpr RPAREN;
 
 // Expression loop
-assignExpr: ternaryExpr | prefixUnaryExpr assignOp assignExpr;
+assignExpr: prefixUnaryExpr assignOp assignExpr | ternaryExpr;
 ternaryExpr: logicalOrExpr (QUESTION_MARK logicalOrExpr? COLON logicalOrExpr)?;
 logicalOrExpr: logicalAndExpr (LOGICAL_OR logicalAndExpr)*;
 logicalAndExpr: bitwiseOrExpr (LOGICAL_AND bitwiseOrExpr)*;

--- a/src/ast/ASTBuilder.cpp
+++ b/src/ast/ASTBuilder.cpp
@@ -44,7 +44,6 @@ std::any ASTBuilder::visitFunctionDef(SpiceParser::FunctionDefContext *ctx) {
   // Enrich
   fctDefNode->hasParams = ctx->paramLst();
   fctDefNode->hasTemplateTypes = ctx->typeLst();
-  fctDefNode->closingBraceCodeLoc = CodeLoc(ctx->getStop(), sourceFile);
 
   // Visit children
   visitChildren(ctx);
@@ -70,7 +69,6 @@ std::any ASTBuilder::visitProcedureDef(SpiceParser::ProcedureDefContext *ctx) {
   // Enrich
   procDefNode->hasParams = ctx->paramLst();
   procDefNode->hasTemplateTypes = ctx->typeLst();
-  procDefNode->closingBraceCodeLoc = CodeLoc(ctx->getStop(), sourceFile);
 
   // Visit children
   visitChildren(ctx);
@@ -374,6 +372,9 @@ std::any ASTBuilder::visitAnonymousBlockStmt(SpiceParser::AnonymousBlockStmtCont
 
 std::any ASTBuilder::visitStmtLst(SpiceParser::StmtLstContext *ctx) {
   const auto stmtLstNode = createNode<StmtLstNode>(ctx);
+
+  // Enrich
+  stmtLstNode->closingBraceCodeLoc = CodeLoc(ctx->getStop(), sourceFile);
 
   // Visit children
   visitChildren(ctx);

--- a/src/ast/ASTNodes.cpp
+++ b/src/ast/ASTNodes.cpp
@@ -59,6 +59,11 @@ std::string ASTNode::getErrorMessage() const {
   return ss.str();
 }
 
+const StmtLstNode *ASTNode::getNextOuterStmtLst() const { // NOLINT(*-no-recursion)
+  assert(parent != nullptr && "Could not find next outer statement list");
+  return isStmtLstNode() ? spice_pointer_cast<const StmtLstNode *>(this) : parent->getNextOuterStmtLst();
+}
+
 bool MainFctDefNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable) const {
   return body()->returnsOnAllControlPaths(doSetPredecessorsUnreachable);
 }

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -163,6 +163,8 @@ public:
     return nullptr;                                                              // LCOV_EXCL_LINE
   }                                                                              // LCOV_EXCL_LINE
 
+  [[nodiscard]] const StmtLstNode *getNextOuterStmtLst() const;
+
   [[nodiscard]] virtual bool isFctOrProcDef() const { return false; }
   [[nodiscard]] virtual bool isStructDef() const { return false; }
   [[nodiscard]] virtual bool isParamNode() const { return false; }
@@ -311,7 +313,6 @@ public:
   Scope *structScope = nullptr;
   Scope *scope = nullptr;
   std::vector<Function *> manifestations;
-  CodeLoc closingBraceCodeLoc = CodeLoc(1, 0);
 };
 
 // ========================================================== FctDefNode =========================================================
@@ -847,6 +848,7 @@ public:
   // Public members
   size_t complexity = 0;
   std::vector<ResourcesForManifestationToCleanup> resourcesToCleanup;
+  CodeLoc closingBraceCodeLoc = CodeLoc(1, 0);
 };
 
 // ========================================================= TypeLstNode =========================================================

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -257,7 +257,7 @@ void Driver::addTestSubcommand() {
   CLI::App *subCmd = app.add_subcommand("test", "Builds your Spice program and runs all enclosed tests");
   subCmd->alias("t");
   subCmd->ignore_case();
-  subCmd->callback([&]() {
+  subCmd->callback([&] {
     shouldCompile = shouldExecute = true; // Requires the source file to be compiled
     cliOptions.testMode = true;           // Always enable assertions for tests, also in higher opt levels
     cliOptions.generateTestMain = true;   // An alternative entry function is generated
@@ -281,7 +281,7 @@ void Driver::addInstallSubcommand() {
       app.add_subcommand("install", "Builds your Spice program and installs it to a directory in the PATH variable");
   subCmd->alias("i");
   subCmd->ignore_case();
-  subCmd->callback([&]() {
+  subCmd->callback([&] {
     shouldCompile = true;
     shouldInstall = true;
     ensureNotDockerized();
@@ -298,7 +298,7 @@ void Driver::addUninstallSubcommand() {
   CLI::App *subCmd = app.add_subcommand("uninstall", "Builds your Spice program and runs it immediately");
   subCmd->alias("u");
   subCmd->ignore_case();
-  subCmd->callback([&]() {
+  subCmd->callback([&] {
     shouldUninstall = true;
     ensureNotDockerized();
   });
@@ -339,12 +339,12 @@ void Driver::addCompileSubcommandOptions(CLI::App *subCmd) {
                          "Generate lifetime markers to enhance optimizations");
 
   // Opt levels
-  subCmd->add_flag_callback("-O0", [&]() { cliOptions.optLevel = O0; }, "Disable optimization for the output executable.");
-  subCmd->add_flag_callback("-O1", [&]() { cliOptions.optLevel = O1; }, "Only basic optimization is executed.");
-  subCmd->add_flag_callback("-O2", [&]() { cliOptions.optLevel = O2; }, "More advanced optimization is applied.");
-  subCmd->add_flag_callback("-O3", [&]() { cliOptions.optLevel = O3; }, "Aggressive optimization for best performance.");
-  subCmd->add_flag_callback("-Os", [&]() { cliOptions.optLevel = Os; }, "Size optimization for output executable.");
-  subCmd->add_flag_callback("-Oz", [&]() { cliOptions.optLevel = Oz; }, "Aggressive optimization for best size.");
+  subCmd->add_flag_callback("-O0", [&] { cliOptions.optLevel = O0; }, "Disable optimization for the output executable.");
+  subCmd->add_flag_callback("-O1", [&] { cliOptions.optLevel = O1; }, "Only basic optimization is executed.");
+  subCmd->add_flag_callback("-O2", [&] { cliOptions.optLevel = O2; }, "More advanced optimization is applied.");
+  subCmd->add_flag_callback("-O3", [&] { cliOptions.optLevel = O3; }, "Aggressive optimization for best performance.");
+  subCmd->add_flag_callback("-Os", [&] { cliOptions.optLevel = Os; }, "Size optimization for output executable.");
+  subCmd->add_flag_callback("-Oz", [&] { cliOptions.optLevel = Oz; }, "Aggressive optimization for best size.");
   subCmd->add_flag<bool>("-lto", cliOptions.useLTO, "Enable link time optimization (LTO)");
 
   // --debug-output

--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -361,7 +361,7 @@ llvm::DIType *DebugInfoGenerator::getDITypeForQualType(const ASTNode *node, cons
     std::vector<llvm::Metadata *> fieldTypes;
     for (size_t i = 0; i < spiceStruct->scope->getFieldCount(); i++) {
       // Get field entry
-      const SymbolTableEntry *fieldEntry = spiceStruct->scope->symbolTable.lookupStrictByIndex(i);
+      const SymbolTableEntry *fieldEntry = spiceStruct->scope->lookupField(i);
       assert(fieldEntry != nullptr && fieldEntry->isField());
       if (fieldEntry->isImplicitField)
         continue;

--- a/src/irgenerator/GenBuiltinFunctions.cpp
+++ b/src/irgenerator/GenBuiltinFunctions.cpp
@@ -115,7 +115,7 @@ std::any IRGenerator::visitPanicCall(const PanicCallNode *node) {
   // Create unreachable instruction
   builder.CreateUnreachable();
   // Unreachable counts as terminator
-  blockAlreadyTerminated = true;
+  terminateBlock(node->getNextOuterStmtLst());
 
   return nullptr;
 }

--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -177,18 +177,18 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
     llvm::Value *idxAddrInPair = insertStructGEP(pairTy, pairPtr, 0, "idx_addr");
     LLVMExprResult idxResult = {.ptr = idxAddrInPair};
     assert(idxAddress != nullptr && idxEntry != nullptr);
-    doAssignment(idxAddress, idxEntry, idxResult, QualType(TY_LONG), true);
+    doAssignment(idxAddress, idxEntry, idxResult, QualType(TY_LONG), node, true);
     // Store item to item var
     llvm::Value *itemAddrInPair = insertStructGEP(pairTy, pairPtr, 1, "item_addr");
     LLVMExprResult itemResult = {.refPtr = itemAddrInPair};
-    doAssignment(itemAddress, itemEntry, itemResult, itemRefSTy, true);
+    doAssignment(itemAddress, itemEntry, itemResult, itemRefSTy, node, true);
   } else {
     // Call .get() on iterator
     assert(node->getFct);
     llvm::Function *getFct = stdFunctionManager.getIteratorGetFct(node->getFct);
     llvm::Value *getItemPtr = builder.CreateCall(getFct, iteratorPtr);
     LLVMExprResult getResult = {.ptr = getItemPtr};
-    doAssignment(itemAddress, itemEntry, getResult, itemRefSTy, true);
+    doAssignment(itemAddress, itemEntry, getResult, itemRefSTy, node, true);
   }
   // Visit body
   visit(node->body());

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -22,7 +22,7 @@ std::any IRGenerator::visitAssignExpr(const AssignExprNode *node) {
 
     // Normal assignment
     if (node->op == AssignExprNode::OP_ASSIGN)
-      return doAssignment(lhsNode, rhsNode);
+      return doAssignment(lhsNode, rhsNode, node);
 
     // Compound assignment
     // Get symbol types of left and right side

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -58,7 +58,7 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
       generateCtorOrDtorCall(varEntry, node->calledCopyCtor, {rhsAddress});
     } else {
       // Assign rhs to lhs
-      [[maybe_unused]] const LLVMExprResult assignResult = doAssignment(varAddress, varEntry, node->assignExpr(), true);
+      [[maybe_unused]] const LLVMExprResult assignResult = doAssignment(varAddress, varEntry, node->assignExpr(), node, true);
       assert(assignResult.entry == varEntry);
       varAddress = varEntry->getAddress();
       varEntry->updateAddress(varAddress);

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -22,6 +22,7 @@ std::any IRGenerator::visitStmtLst(const StmtLstNode *node) {
   }
 
   // Generate cleanup code of this scope, e.g. dtor calls for struct instances
+  diGenerator.setSourceLocation(node->getNextOuterStmtLst()->closingBraceCodeLoc);
   generateScopeCleanup(node);
 
   return nullptr;
@@ -102,7 +103,7 @@ std::any IRGenerator::visitTopLevelDefinitionAttr(const TopLevelDefinitionAttrNo
   return nullptr; // Noop
 }
 
-std::any IRGenerator::visitCaseConstant(const spice::compiler::CaseConstantNode *node) {
+std::any IRGenerator::visitCaseConstant(const CaseConstantNode *node) {
   if (node->constant())
     return visit(node->constant());
 
@@ -131,11 +132,8 @@ std::any IRGenerator::visitReturnStmt(const ReturnStmtNode *node) {
     }
   }
 
-  // Generate scope cleanup code
-  generateScopeCleanup(node->getParentScopeNode());
-
-  // Set block to terminated
-  blockAlreadyTerminated = true;
+  // Terminate the block (with scope cleanup)
+  terminateBlock(node->getParentScopeNode());
 
   // Create return instruction
   if (returnValue != nullptr) {
@@ -180,7 +178,7 @@ std::any IRGenerator::visitFallthroughStmt(const FallthroughStmtNode *node) {
 
 std::any IRGenerator::visitAssertStmt(const AssertStmtNode *node) {
   // Only generate assertions in debug build mode or in test mode
-  if (cliOptions.buildMode != BuildMode::DEBUG && !cliOptions.testMode)
+  if (cliOptions.buildMode != DEBUG && !cliOptions.testMode)
     return nullptr;
 
   diGenerator.setSourceLocation(node);

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -276,7 +276,6 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
 
     // Create return statement if the block is not terminated yet
     if (!blockAlreadyTerminated) {
-      diGenerator.setSourceLocation(node->closingBraceCodeLoc);
       llvm::Value *result = insertLoad(returnType, resultEntry->getAddress());
       builder.CreateRet(result);
     }
@@ -440,10 +439,8 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
     visit(node->body());
 
     // Create return statement if the block is not terminated yet
-    if (!blockAlreadyTerminated) {
-      diGenerator.setSourceLocation(node->closingBraceCodeLoc);
+    if (!blockAlreadyTerminated)
       builder.CreateRetVoid();
-    }
 
     // Conclude debug info for procedure
     diGenerator.concludeFunctionDebugInfo();
@@ -579,7 +576,7 @@ std::any IRGenerator::visitGlobalVarDef(const GlobalVarDefNode *node) {
   if (node->hasValue) { // Set the constant value as variable initializer
     const auto constantValue = std::any_cast<llvm::Constant *>(visit(node->constant()));
     var->setInitializer(constantValue);
-  } else if (cliOptions.buildMode == BuildMode::DEBUG) { // Set the default value as variable initializer
+  } else if (cliOptions.buildMode == DEBUG) { // Set the default value as variable initializer
     llvm::Constant *constantValue = getDefaultValueForSymbolType(node->entry->getQualType());
     var->setInitializer(constantValue);
   }

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -445,7 +445,7 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
     // Check if we have a copy ctor
     const QualType rhsSTypeNonRef = rhsSType.removeReferenceWrapper().toNonConst();
     Scope *structScope = rhsSTypeNonRef.getBodyScope();
-    const ArgList args = {{rhsSTypeNonRef.toConstRef(nullptr), rhs.isTemporary()}};
+    const ArgList args = {{rhsSTypeNonRef.toConstRef(node), rhs.isTemporary()}};
     const Function *copyCtor = FunctionManager::lookup(structScope, CTOR_FUNCTION_NAME, rhsSTypeNonRef, args, true);
     if (copyCtor != nullptr) {
       // Call copy ctor

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -251,7 +251,7 @@ llvm::Constant *IRGenerator::getDefaultValueForSymbolType(const QualType &symbol
     // Add default value for each struct field
     for (size_t i = 0; i < fieldCount; i++) {
       // Get entry of the field
-      const SymbolTableEntry *fieldEntry = structScope->symbolTable.lookupStrictByIndex(i);
+      const SymbolTableEntry *fieldEntry = structScope->lookupField(i);
       assert(fieldEntry != nullptr && fieldEntry->isField());
 
       // Retrieve default field value
@@ -321,6 +321,12 @@ void IRGenerator::switchToBlock(llvm::BasicBlock *block, llvm::Function *parentF
   // Set insert point to the block
   builder.SetInsertPoint(block);
   blockAlreadyTerminated = false;
+}
+
+void IRGenerator::terminateBlock(const StmtLstNode *stmtLstNode) {
+  diGenerator.setSourceLocation(stmtLstNode->closingBraceCodeLoc);
+  generateScopeCleanup(stmtLstNode);
+  blockAlreadyTerminated = true;
 }
 
 void IRGenerator::insertJump(llvm::BasicBlock *targetBlock) {

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -131,6 +131,7 @@ private:
   llvm::Constant *getConst(const CompileTimeValue &compileTimeValue, const QualType &type, const ASTNode *node) const;
   llvm::BasicBlock *createBlock(const std::string &blockName = "") const;
   void switchToBlock(llvm::BasicBlock *block, llvm::Function *parentFct = nullptr);
+  void terminateBlock(const StmtLstNode *stmtLstNode);
   void insertJump(llvm::BasicBlock *targetBlock);
   void insertCondJump(llvm::Value *condition, llvm::BasicBlock *trueBlock, llvm::BasicBlock *falseBlock,
                       Likeliness likeliness = UNSPECIFIED);

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -166,7 +166,7 @@ private:
   llvm::Function *generateImplicitProcedure(const std::function<void(void)> &generateBody, const Function *spiceProc);
   void generateCtorBodyPreamble(Scope *bodyScope);
   void generateDefaultCtor(const Function *ctorFunction);
-  void generateCopyCtorBodyPreamble(const Function *copyCtorFunction) const;
+  void generateCopyCtorBodyPreamble(const Function *copyCtorFunction);
   void generateDefaultCopyCtor(const Function *copyCtorFunction);
   void generateDtorBodyPreamble(const Function *dtorFunction) const;
   void generateDefaultDtor(const Function *dtorFunction);

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -136,12 +136,12 @@ private:
                       Likeliness likeliness = UNSPECIFIED);
   void verifyFunction(const llvm::Function *fct, const CodeLoc &codeLoc) const;
   void verifyModule(const CodeLoc &codeLoc) const;
-  LLVMExprResult doAssignment(const ASTNode *lhsNode, const ASTNode *rhsNode);
-  LLVMExprResult doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, const ASTNode *rhsNode, bool isDecl = false);
+  LLVMExprResult doAssignment(const ASTNode *lhsNode, const ASTNode *rhsNode, const ASTNode *node);
+  LLVMExprResult doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, const ASTNode *rhsNode, const ASTNode *node,
+                              bool isDecl = false);
   LLVMExprResult doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, LLVMExprResult &rhs, const QualType &rhsSType,
-                              bool isDecl);
-  llvm::Value *generateShallowCopy(llvm::Value *oldAddress, llvm::Type *varType, llvm::Value *targetAddress,
-                                   const std::string &name = "", bool isVolatile = false);
+                              const ASTNode *node, bool isDecl);
+  void generateShallowCopy(llvm::Value *oldAddress, llvm::Type *varType, llvm::Value *targetAddress, bool isVolatile) const;
   void autoDeReferencePtr(llvm::Value *&ptr, QualType &symbolType) const;
   llvm::GlobalVariable *createGlobalConst(const std::string &baseName, llvm::Constant *constant) const;
   llvm::Constant *createGlobalStringConst(const std::string &baseName, const std::string &value, const CodeLoc &codeLoc) const;

--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -19,10 +19,10 @@ OpRuleConversionManager::OpRuleConversionManager(SourceFile *sourceFile, IRGener
 
 LLVMExprResult OpRuleConversionManager::getPlusEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                          LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -74,10 +74,10 @@ LLVMExprResult OpRuleConversionManager::getPlusEqualInst(const ASTNode *node, LL
 
 LLVMExprResult OpRuleConversionManager::getMinusEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                           LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -130,10 +130,10 @@ LLVMExprResult OpRuleConversionManager::getMinusEqualInst(const ASTNode *node, L
 
 LLVMExprResult OpRuleConversionManager::getMulEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -177,10 +177,10 @@ LLVMExprResult OpRuleConversionManager::getMulEqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getDivEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -224,8 +224,8 @@ LLVMExprResult OpRuleConversionManager::getDivEqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getRemEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -265,8 +265,8 @@ LLVMExprResult OpRuleConversionManager::getRemEqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getSHLEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -298,8 +298,8 @@ LLVMExprResult OpRuleConversionManager::getSHLEqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getSHREqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -331,8 +331,8 @@ LLVMExprResult OpRuleConversionManager::getSHREqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getAndEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -364,8 +364,8 @@ LLVMExprResult OpRuleConversionManager::getAndEqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getOrEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                        LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -397,8 +397,8 @@ LLVMExprResult OpRuleConversionManager::getOrEqualInst(const ASTNode *node, LLVM
 
 LLVMExprResult OpRuleConversionManager::getXorEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -431,8 +431,8 @@ LLVMExprResult OpRuleConversionManager::getXorEqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getBitwiseOrInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                          LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
 
@@ -450,8 +450,8 @@ LLVMExprResult OpRuleConversionManager::getBitwiseOrInst(const ASTNode *node, LL
 
 LLVMExprResult OpRuleConversionManager::getBitwiseXorInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                           LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
 
@@ -469,8 +469,8 @@ LLVMExprResult OpRuleConversionManager::getBitwiseXorInst(const ASTNode *node, L
 
 LLVMExprResult OpRuleConversionManager::getBitwiseAndInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                           LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
 
@@ -488,10 +488,10 @@ LLVMExprResult OpRuleConversionManager::getBitwiseAndInst(const ASTNode *node, L
 
 LLVMExprResult OpRuleConversionManager::getEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                      LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -622,10 +622,10 @@ LLVMExprResult OpRuleConversionManager::getEqualInst(const ASTNode *node, LLVMEx
 
 LLVMExprResult OpRuleConversionManager::getNotEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                         LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -757,8 +757,8 @@ LLVMExprResult OpRuleConversionManager::getNotEqualInst(const ASTNode *node, LLV
 
 LLVMExprResult OpRuleConversionManager::getLessInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                     LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -821,8 +821,8 @@ LLVMExprResult OpRuleConversionManager::getLessInst(const ASTNode *node, LLVMExp
 
 LLVMExprResult OpRuleConversionManager::getGreaterInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                        LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -885,8 +885,8 @@ LLVMExprResult OpRuleConversionManager::getGreaterInst(const ASTNode *node, LLVM
 
 LLVMExprResult OpRuleConversionManager::getLessEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                          LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -949,8 +949,8 @@ LLVMExprResult OpRuleConversionManager::getLessEqualInst(const ASTNode *node, LL
 
 LLVMExprResult OpRuleConversionManager::getGreaterEqualInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                             LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1013,10 +1013,10 @@ LLVMExprResult OpRuleConversionManager::getGreaterEqualInst(const ASTNode *node,
 
 LLVMExprResult OpRuleConversionManager::getShiftLeftInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                          LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1059,10 +1059,10 @@ LLVMExprResult OpRuleConversionManager::getShiftLeftInst(const ASTNode *node, LL
 
 LLVMExprResult OpRuleConversionManager::getShiftRightInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                           LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1105,10 +1105,10 @@ LLVMExprResult OpRuleConversionManager::getShiftRightInst(const ASTNode *node, L
 
 LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                     LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1194,10 +1194,10 @@ LLVMExprResult OpRuleConversionManager::getPlusInst(const ASTNode *node, LLVMExp
 
 LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                      LLVMExprResult &rhs, QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1283,10 +1283,10 @@ LLVMExprResult OpRuleConversionManager::getMinusInst(const ASTNode *node, LLVMEx
 
 LLVMExprResult OpRuleConversionManager::getMulInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy, LLVMExprResult &rhs,
                                                    QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1352,10 +1352,10 @@ LLVMExprResult OpRuleConversionManager::getMulInst(const ASTNode *node, LLVMExpr
 
 LLVMExprResult OpRuleConversionManager::getDivInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy, LLVMExprResult &rhs,
                                                    QualType rhsSTy, size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
-  ResolverFct rhsP = [&]() { return irGenerator->resolveAddress(rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
+  ResolverFct rhsP = [&] { return irGenerator->resolveAddress(rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1422,8 +1422,8 @@ LLVMExprResult OpRuleConversionManager::getDivInst(const ASTNode *node, LLVMExpr
 
 LLVMExprResult OpRuleConversionManager::getRemInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy, LLVMExprResult &rhs,
                                                    QualType rhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);
@@ -1465,7 +1465,7 @@ LLVMExprResult OpRuleConversionManager::getRemInst(const ASTNode *node, LLVMExpr
 }
 
 LLVMExprResult OpRuleConversionManager::getPrefixMinusInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
 
   switch (lhsSTy.getSuperType()) {
@@ -1482,7 +1482,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixMinusInst(const ASTNode *node, 
 }
 
 LLVMExprResult OpRuleConversionManager::getPrefixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
 
   switch (lhsSTy.getSuperType()) {
@@ -1503,7 +1503,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixPlusPlusInst(const ASTNode *nod
 }
 
 LLVMExprResult OpRuleConversionManager::getPrefixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
 
   switch (lhsSTy.getSuperType()) {
@@ -1524,7 +1524,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixMinusMinusInst(const ASTNode *n
 }
 
 LLVMExprResult OpRuleConversionManager::getPrefixNotInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
 
   switch (lhsSTy.getSuperType()) {
@@ -1537,7 +1537,7 @@ LLVMExprResult OpRuleConversionManager::getPrefixNotInst(const ASTNode *node, LL
 }
 
 LLVMExprResult OpRuleConversionManager::getPrefixBitwiseNotInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
 
   switch (lhsSTy.getSuperType()) {
@@ -1553,8 +1553,8 @@ LLVMExprResult OpRuleConversionManager::getPrefixBitwiseNotInst(const ASTNode *n
 
 LLVMExprResult OpRuleConversionManager::getPostfixPlusPlusInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                                size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
 
   // Handle operator overloads
@@ -1580,8 +1580,8 @@ LLVMExprResult OpRuleConversionManager::getPostfixPlusPlusInst(const ASTNode *no
 
 LLVMExprResult OpRuleConversionManager::getPostfixMinusMinusInst(const ASTNode *node, LLVMExprResult &lhs, QualType lhsSTy,
                                                                  size_t opIdx) {
-  ResolverFct lhsV = [&]() { return irGenerator->resolveValue(lhsSTy, lhs); };
-  ResolverFct lhsP = [&]() { return irGenerator->resolveAddress(lhs); };
+  ResolverFct lhsV = [&] { return irGenerator->resolveValue(lhsSTy, lhs); };
+  ResolverFct lhsP = [&] { return irGenerator->resolveAddress(lhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
 
   // Handle operator overloads
@@ -1606,7 +1606,7 @@ LLVMExprResult OpRuleConversionManager::getPostfixMinusMinusInst(const ASTNode *
 }
 
 LLVMExprResult OpRuleConversionManager::getCastInst(const ASTNode *node, QualType lhsSTy, LLVMExprResult &rhs, QualType rhsSTy) {
-  ResolverFct rhsV = [&]() { return irGenerator->resolveValue(rhsSTy, rhs); };
+  ResolverFct rhsV = [&] { return irGenerator->resolveValue(rhsSTy, rhs); };
   lhsSTy = lhsSTy.removeReferenceWrapper();
   rhsSTy = rhsSTy.removeReferenceWrapper();
   llvm::Type *lhsT = lhsSTy.toLLVMType(irGenerator->sourceFile);

--- a/src/irgenerator/StdFunctionManager.cpp
+++ b/src/irgenerator/StdFunctionManager.cpp
@@ -79,6 +79,15 @@ llvm::Function *StdFunctionManager::getStringIsRawEqualStringStringFct() const {
   return getFunction(mangledName.c_str(), builder.getInt1Ty(), {builder.getPtrTy(), builder.getPtrTy()});
 }
 
+llvm::Function *StdFunctionManager::getAllocUnsafeLongFct() const {
+  QualType unsignedLong(TY_LONG);
+  unsignedLong.makeUnsigned();
+  const ParamList paramLst = {{unsignedLong, false}};
+  const Function function("sAllocUnsafe", nullptr, QualType(TY_DYN), QualType(TY_BYTE).toPtr(nullptr), paramLst, {}, nullptr);
+  const std::string mangledName = NameMangling::mangleFunction(function);
+  return getFunction(mangledName.c_str(), builder.getPtrTy(), {builder.getInt64Ty()});
+}
+
 llvm::Function *StdFunctionManager::getDeallocBytePtrRefFct() const {
   const ParamList paramLst = {{QualType(TY_BYTE).toPtr(nullptr).toRef(nullptr), false}};
   const Function function("sDealloc", nullptr, QualType(TY_DYN), QualType(TY_DYN), paramLst, {}, nullptr);

--- a/src/irgenerator/StdFunctionManager.h
+++ b/src/irgenerator/StdFunctionManager.h
@@ -25,6 +25,7 @@ public:
   [[nodiscard]] llvm::Function *getMemcpyIntrinsic() const;
   [[nodiscard]] llvm::Function *getStringGetRawLengthStringFct() const;
   [[nodiscard]] llvm::Function *getStringIsRawEqualStringStringFct() const;
+  [[nodiscard]] llvm::Function *getAllocUnsafeLongFct() const;
   [[nodiscard]] llvm::Function *getDeallocBytePtrRefFct() const;
   [[nodiscard]] llvm::Function *getIterateFct(const Function *spiceFunc) const;
   [[nodiscard]] llvm::Function *getIteratorFct(const Function *spiceFunc) const;

--- a/src/model/Struct.cpp
+++ b/src/model/Struct.cpp
@@ -16,23 +16,4 @@ bool Struct::hasReferenceFields() const {
   return std::ranges::any_of(fieldTypes, [](const QualType &fieldType) { return fieldType.isRef(); });
 }
 
-/**
- * Checks if there is at least one user-defined ctor procedure present, that is no copy ctor.
- *
- * @return Ctor present or not
- */
-bool Struct::hasUserDefinedCtor() const {
-  return false;
-}
-
-/**
- *  Checks if there is a user-defined copy ctor procedure present
- *
- * @return Copy ctor present or not
- */
-bool Struct::hasUserDefinedCopyCtor() const {
-  return false;
-}
-
-
 } // namespace spice::compiler

--- a/src/model/Struct.cpp
+++ b/src/model/Struct.cpp
@@ -16,4 +16,23 @@ bool Struct::hasReferenceFields() const {
   return std::ranges::any_of(fieldTypes, [](const QualType &fieldType) { return fieldType.isRef(); });
 }
 
+/**
+ * Checks if there is at least one user-defined ctor procedure present, that is no copy ctor.
+ *
+ * @return Ctor present or not
+ */
+bool Struct::hasUserDefinedCtor() const {
+  return false;
+}
+
+/**
+ *  Checks if there is a user-defined copy ctor procedure present
+ *
+ * @return Copy ctor present or not
+ */
+bool Struct::hasUserDefinedCopyCtor() const {
+  return false;
+}
+
+
 } // namespace spice::compiler

--- a/src/model/Struct.h
+++ b/src/model/Struct.h
@@ -21,6 +21,8 @@ public:
 
   // Public methods
   [[nodiscard]] bool hasReferenceFields() const;
+  [[nodiscard]] bool hasUserDefinedCtor() const;
+  [[nodiscard]] bool hasUserDefinedCopyCtor() const;
 
   // Public members
   QualTypeList fieldTypes;

--- a/src/model/Struct.h
+++ b/src/model/Struct.h
@@ -21,8 +21,6 @@ public:
 
   // Public methods
   [[nodiscard]] bool hasReferenceFields() const;
-  [[nodiscard]] bool hasUserDefinedCtor() const;
-  [[nodiscard]] bool hasUserDefinedCopyCtor() const;
 
   // Public members
   QualTypeList fieldTypes;

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -395,7 +395,7 @@ bool QualType::isSelfReferencingStructType(const QualType *typeToCompareWith) co
 
   Scope *baseTypeBodyScope = getBodyScope();
   for (size_t i = 0; i < baseTypeBodyScope->getFieldCount(); i++) {
-    const SymbolTableEntry *field = baseTypeBodyScope->symbolTable.lookupStrictByIndex(i);
+    const SymbolTableEntry *field = baseTypeBodyScope->lookupField(i);
     // Check if the base type of the field matches with the current type, which is also a base type
     // If yes, this is a self-referencing struct type
     if (field->getQualType().getBase() == *typeToCompareWith)
@@ -761,6 +761,7 @@ void QualType::makeConst(bool isConst) { specifiers.isConst = isConst; }
 void QualType::makeSigned(bool isSigned) {
   assert(isOneOf({TY_INT, TY_SHORT, TY_LONG, TY_BYTE, TY_CHAR, TY_BOOL}));
   specifiers.isSigned = isSigned;
+  specifiers.isUnsigned = !isSigned;
 }
 
 /**
@@ -770,6 +771,7 @@ void QualType::makeSigned(bool isSigned) {
  */
 void QualType::makeUnsigned(bool isUnsigned) {
   assert(isOneOf({TY_INT, TY_SHORT, TY_LONG, TY_BYTE, TY_CHAR, TY_BOOL}));
+  specifiers.isSigned = !isUnsigned;
   specifiers.isUnsigned = isUnsigned;
 }
 

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -81,8 +81,9 @@ public:
   [[nodiscard]] bool hasAnyGenericParts() const;
 
   // Complex queries on the type
+  [[nodiscard]] bool isTriviallyCopyable(const ASTNode *node) const;
   [[nodiscard]] bool doesImplement(const QualType &symbolType, const ASTNode *node) const;
-  [[nodiscard]] bool canBind(const QualType &otherType, bool isTemporary) const;
+  [[nodiscard]] bool canBind(const QualType &inputType, bool isTemporary) const;
   [[nodiscard]] bool matches(const QualType &otherType, bool ignoreArraySize, bool ignoreSpecifiers, bool allowConstify) const;
   [[nodiscard]] bool matchesInterfaceImplementedByStruct(const QualType &structType) const;
   [[nodiscard]] bool isSameContainerTypeAs(const QualType &other) const;

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -95,6 +95,10 @@ public:
   }
   ALWAYS_INLINE SymbolTableEntry *lookup(const std::string &symbolName) { return symbolTable.lookup(symbolName); }
   ALWAYS_INLINE SymbolTableEntry *lookupStrict(const std::string &symbolName) { return symbolTable.lookupStrict(symbolName); }
+  ALWAYS_INLINE SymbolTableEntry *lookupField(unsigned int n) {
+    assert(type == ScopeType::STRUCT);
+    return symbolTable.lookupStrictByIndex(n);
+  }
 
   // Public members
   Scope *parent;

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -227,7 +227,7 @@ llvm::Type *Type::toLLVMType(SourceFile *sourceFile) const { // NOLINT(misc-no-r
 
       // If the struct has no interface types, but a vtable was requested, add another ptr field type
       assert(structSymbol->declNode->isStructDef());
-      auto structDeclNode = spice_pointer_cast<StructDefNode *>(structSymbol->declNode);
+      const auto structDeclNode = spice_pointer_cast<StructDefNode *>(structSymbol->declNode);
       if (!structDeclNode->hasInterfaces && structDeclNode->emitVTable)
         fieldTypes.push_back(llvm::PointerType::get(context, 0));
 

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -233,7 +233,7 @@ llvm::Type *Type::toLLVMType(SourceFile *sourceFile) const { // NOLINT(misc-no-r
 
       // Collect all field types
       for (size_t i = 0; i < totalFieldCount; i++) {
-        const SymbolTableEntry *fieldSymbol = spiceStruct->scope->symbolTable.lookupStrictByIndex(i);
+        const SymbolTableEntry *fieldSymbol = spiceStruct->scope->lookupField(i);
         assert(fieldSymbol != nullptr);
         fieldTypes.push_back(sourceFile->getLLVMType(fieldSymbol->getQualType().getType()));
       }

--- a/src/typechecker/ExprResult.h
+++ b/src/typechecker/ExprResult.h
@@ -2,16 +2,15 @@
 
 #pragma once
 
-namespace spice::compiler {
+#include <symboltablebuilder/SymbolTableEntry.h>
 
-// Forward declarations
-class SymbolTableEntry;
+namespace spice::compiler {
 
 struct ExprResult {
   QualType type;
   SymbolTableEntry *entry = nullptr;
 
-  [[nodiscard]] bool isTemporary() const { return entry == nullptr; }
+  [[nodiscard]] bool isTemporary() const { return entry == nullptr || entry->anonymous; }
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -192,6 +192,7 @@ const Function *FunctionManager::lookup(Scope *matchScope, const std::string &re
  * Check if there is a function in the scope, fulfilling all given requirements and if found, return it.
  * If more than one function matches the requirement, an error gets thrown.
  *
+ * @param typeChecker Type Checker
  * @param matchScope Scope to match against
  * @param reqName Function name requirement
  * @param reqThisType This type requirement

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -6,6 +6,7 @@
 #include <ast/ASTNodes.h>
 #include <global/GlobalResourceManager.h>
 #include <global/RuntimeModuleManager.h>
+#include <typechecker/MacroDefs.h>
 #include <typechecker/TypeChecker.h>
 
 namespace spice::compiler {

--- a/src/typechecker/OpRuleManager.h
+++ b/src/typechecker/OpRuleManager.h
@@ -594,10 +594,10 @@ public:
   explicit OpRuleManager(TypeChecker *typeChecker);
 
   // Public methods
-  static QualType getAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl = false,
-                                      const char *errMsgPrefix = "");
-  static QualType getFieldAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool imm,
-                                           bool isDecl = false);
+  QualType getAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl = false,
+                               bool isReturn = false, const char *errMsgPrefix = "") const;
+  QualType getFieldAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool imm,
+                                    bool isDecl = false) const;
   ExprResult getPlusEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getMinusEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   ExprResult getMulEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
@@ -627,15 +627,15 @@ public:
   ExprResult getDivResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);
   static ExprResult getRemResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs);
   static QualType getPrefixMinusResultType(const ASTNode *node, const ExprResult &lhs);
-  QualType getPrefixPlusPlusResultType(const ASTNode *node, const ExprResult &lhs);
-  QualType getPrefixMinusMinusResultType(const ASTNode *node, const ExprResult &lhs);
+  QualType getPrefixPlusPlusResultType(const ASTNode *node, const ExprResult &lhs) const;
+  QualType getPrefixMinusMinusResultType(const ASTNode *node, const ExprResult &lhs) const;
   static QualType getPrefixNotResultType(const ASTNode *node, const ExprResult &lhs);
   static QualType getPrefixBitwiseNotResultType(const ASTNode *node, const ExprResult &lhs);
   static QualType getPrefixMulResultType(const ASTNode *node, const ExprResult &lhs);
   static QualType getPrefixBitwiseAndResultType(const ASTNode *node, const ExprResult &lhs);
   ExprResult getPostfixPlusPlusResultType(ASTNode *node, const ExprResult &lhs, size_t opIdx);
   ExprResult getPostfixMinusMinusResultType(ASTNode *node, const ExprResult &lhs, size_t opIdx);
-  QualType getCastResultType(const ASTNode *node, QualType lhsType, const ExprResult &rhs);
+  QualType getCastResultType(const ASTNode *node, QualType lhsType, const ExprResult &rhs) const;
 
 private:
   // Members
@@ -643,7 +643,8 @@ private:
   GlobalResourceManager &resourceManager;
 
   // Private methods
-  static QualType getAssignResultTypeCommon(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl);
+  static QualType getAssignResultTypeCommon(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl,
+                                            bool isReturn);
   template <size_t N>
   ExprResult isOperatorOverloadingFctAvailable(ASTNode *node, const char *fctName, const std::array<ExprResult, N> &op,
                                                size_t opIdx);
@@ -657,7 +658,7 @@ private:
                                           const char *messagePrefix);
   void ensureUnsafeAllowed(const ASTNode *node, const char *name, const QualType &lhs) const;
   void ensureUnsafeAllowed(const ASTNode *node, const char *name, const QualType &lhs, const QualType &rhs) const;
-  static void ensureNoConstAssign(const ASTNode *node, const QualType &lhs, bool isDecl = false);
+  static void ensureNoConstAssign(const ASTNode *node, const QualType &lhs, bool isDecl = false, bool isReturn = false);
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -143,7 +143,7 @@ Struct *StructManager::match(Scope *matchScope, const std::string &qt, const Qua
       const size_t explicitFieldsStartIdx = substantiatedStruct->scope->getFieldCount() - fieldCount;
       for (size_t i = 0; i < fieldCount; i++) {
         // Replace field type with concrete template type
-        SymbolTableEntry *fieldEntry = substantiatedStruct->scope->symbolTable.lookupStrictByIndex(explicitFieldsStartIdx + i);
+        SymbolTableEntry *fieldEntry = substantiatedStruct->scope->lookupField(explicitFieldsStartIdx + i);
         assert(fieldEntry != nullptr && fieldEntry->isField());
         QualType &fieldType = substantiatedStruct->fieldTypes.at(i);
         QualType baseType = fieldType.getBase();
@@ -254,7 +254,7 @@ void StructManager::substantiateFieldTypes(Struct &candidate, const TypeMapping 
   // Loop over all implicit fields and substantiate the generic ones
   const size_t fieldCount = candidate.scope->getFieldCount() - candidate.fieldTypes.size();
   for (size_t i = 0; i < fieldCount; i++) {
-    SymbolTableEntry *fieldEntry = candidate.scope->symbolTable.lookupStrictByIndex(i);
+    SymbolTableEntry *fieldEntry = candidate.scope->lookupField(i);
     QualType fieldType = fieldEntry->getQualType();
     if (fieldType.hasAnyGenericParts()) {
       TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping, node);

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -8,6 +8,7 @@
 #include <global/GlobalResourceManager.h>
 #include <symboltablebuilder/ScopeHandle.h>
 #include <symboltablebuilder/SymbolTableBuilder.h>
+#include <typechecker/MacroDefs.h>
 #include <typechecker/TypeMatcher.h>
 
 namespace spice::compiler {
@@ -167,7 +168,6 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
       Scope *matchScope = nameRegistryEntry->targetScope->parent;
       assert(matchScope->type == ScopeType::GLOBAL);
       QualType unsignedLongType(TY_LONG);
-      unsignedLongType.makeSigned(false);
       unsignedLongType.makeUnsigned(true);
       const ArgList argTypes = {Arg(iterableType, false), Arg(unsignedLongType, false)};
       const QualType thisType(TY_DYN);
@@ -2066,7 +2066,7 @@ std::any TypeChecker::visitStructInstantiation(StructInstantiationNode *node) {
       auto fieldResult = std::any_cast<ExprResult>(visit(assignExpr));
       HANDLE_UNRESOLVED_TYPE_ER(fieldResult.type)
       // Get expected type
-      SymbolTableEntry *expectedField = structScope->symbolTable.lookupStrictByIndex(explicitFieldsStartIdx + i);
+      SymbolTableEntry *expectedField = structScope->lookupField(explicitFieldsStartIdx + i);
       assert(expectedField != nullptr);
       const ExprResult expected = {expectedField->getQualType(), expectedField};
       const bool rhsIsImmediate = assignExpr->hasCompileTimeValue();

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -244,7 +244,7 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
     // Check item type
     const ExprResult itemResult = {itemType, itemVarSymbol};
     const ExprResult iteratorItemResult = {iteratorItemType, nullptr /* always a temporary */};
-    OpRuleManager::getAssignResultType(node->itemVarDecl(), itemResult, iteratorItemResult, true, ERROR_FOREACH_ITEM);
+    (void)opRuleManager.getAssignResultType(node->itemVarDecl(), itemResult, iteratorItemResult, true, false, ERROR_FOREACH_ITEM);
   }
 
   // Update type of item
@@ -261,7 +261,7 @@ std::any TypeChecker::visitWhileLoop(WhileLoopNode *node) {
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::WHILE_BODY);
 
   // Visit condition
-  QualType conditionType = std::any_cast<ExprResult>(visit(node->condition())).type;
+  const QualType conditionType = std::any_cast<ExprResult>(visit(node->condition())).type;
   HANDLE_UNRESOLVED_TYPE_PTR(conditionType)
   // Check if condition evaluates to bool
   if (!conditionType.is(TY_BOOL))
@@ -475,7 +475,7 @@ std::any TypeChecker::visitSignature(SignatureNode *node) {
         return static_cast<std::vector<Function *> *>(nullptr);
       }
       // Convert generic symbol type to generic type
-      GenericType *genericType = rootScope->lookupGenericType(templateType.getSubType());
+      const GenericType *genericType = rootScope->lookupGenericType(templateType.getSubType());
       assert(genericType != nullptr);
       usedGenericTypes.push_back(*genericType);
     }
@@ -516,7 +516,7 @@ std::any TypeChecker::visitSignature(SignatureNode *node) {
   }
 
   // Build signature object
-  Function signature(node->methodName, nullptr, QualType(TY_DYN), returnType, paramList, usedGenericTypes, node);
+  const Function signature(node->methodName, nullptr, QualType(TY_DYN), returnType, paramList, usedGenericTypes, node);
 
   // Add signature to current scope
   Function *manifestation = FunctionManager::insert(currentScope, signature, &node->signatureManifestations);
@@ -563,7 +563,7 @@ std::any TypeChecker::visitDeclStmt(DeclStmtNode *node) {
     // Check if type has to be inferred or both types are fixed
     if (!localVarType.is(TY_UNRESOLVED) && !rhsTy.is(TY_UNRESOLVED)) {
       const ExprResult lhsResult = {localVarType, localVarEntry};
-      localVarType = OpRuleManager::getAssignResultType(node, lhsResult, rhs, true);
+      localVarType = opRuleManager.getAssignResultType(node, lhsResult, rhs, true);
 
       // Call copy ctor if required
       if (localVarType.is(TY_STRUCT) && !node->isParam && !rhs.isTemporary()) {
@@ -649,7 +649,7 @@ std::any TypeChecker::visitReturnStmt(ReturnStmtNode *node) {
   // Retrieve return variable entry
   SymbolTableEntry *returnVar = currentScope->lookup(RETURN_VARIABLE_NAME);
   const bool isFunction = returnVar != nullptr;
-  QualType returnType = isFunction ? returnVar->getQualType() : QualType(TY_DYN);
+  const QualType returnType = isFunction ? returnVar->getQualType() : QualType(TY_DYN);
 
   // Check if procedure with return value
   if (!isFunction) {
@@ -670,7 +670,7 @@ std::any TypeChecker::visitReturnStmt(ReturnStmtNode *node) {
 
   // Check if types match
   const ExprResult returnResult = {returnType, returnVar};
-  OpRuleManager::getAssignResultType(node->assignExpr(), returnResult, rhs, true, ERROR_MSG_RETURN);
+  (void)opRuleManager.getAssignResultType(node->assignExpr(), returnResult, rhs, false, true, ERROR_MSG_RETURN);
 
   // Manage dtor call
   if (rhs.entry != nullptr) {
@@ -880,7 +880,7 @@ std::any TypeChecker::visitAssignExpr(AssignExprNode *node) {
     // Take a look at the operator
     if (node->op == AssignExprNode::OP_ASSIGN) {
       const bool isDecl = lhs.entry->isField() && !lhs.entry->getLifecycle().isInitialized();
-      rhsType = OpRuleManager::getAssignResultType(node, lhs, rhs, isDecl);
+      rhsType = opRuleManager.getAssignResultType(node, lhs, rhs, isDecl);
 
       // If there is an anonymous entry attached (e.g. for struct instantiation), delete it
       if (rhsEntry != nullptr && rhsEntry->anonymous) {
@@ -2072,7 +2072,7 @@ std::any TypeChecker::visitStructInstantiation(StructInstantiationNode *node) {
       const bool rhsIsImmediate = assignExpr->hasCompileTimeValue();
 
       // Check if actual type matches expected type
-      OpRuleManager::getFieldAssignResultType(assignExpr, expected, fieldResult, rhsIsImmediate, true);
+      (void)opRuleManager.getFieldAssignResultType(assignExpr, expected, fieldResult, rhsIsImmediate, true);
 
       // If there is an anonymous entry attached (e.g. for struct instantiation), delete it
       if (fieldResult.entry != nullptr && fieldResult.entry->anonymous) {
@@ -2094,7 +2094,7 @@ std::any TypeChecker::visitStructInstantiation(StructInstantiationNode *node) {
   // If not all values are constant, insert anonymous symbol to keep track of dtor calls for de-allocation
   SymbolTableEntry *anonymousEntry = nullptr;
   if (node->fieldLst() != nullptr)
-    if (std::ranges::any_of(node->fieldLst()->args(), [](AssignExprNode *field) { return !field->hasCompileTimeValue(); }))
+    if (std::ranges::any_of(node->fieldLst()->args(), [](const AssignExprNode *field) { return !field->hasCompileTimeValue(); }))
       anonymousEntry = currentScope->symbolTable.insertAnonymous(structType, node);
 
   // Remove public specifier to not have public local variables
@@ -2131,12 +2131,12 @@ std::any TypeChecker::visitLambdaFunc(LambdaFuncNode *node) {
   if (node->hasParams) {
     // Visit param list to retrieve the param names
     auto namedParamList = std::any_cast<NamedParamList>(visit(node->paramLst()));
-    for (const NamedParam &param : namedParamList) {
-      if (param.isOptional)
+    for (const auto &[name, qualType, isOptional] : namedParamList) {
+      if (isOptional)
         softError(node, LAMBDA_WITH_OPTIONAL_PARAMS, "Lambdas cannot have optional parameters");
 
-      paramTypes.push_back(param.qualType);
-      paramList.push_back({param.qualType, param.isOptional});
+      paramTypes.push_back(qualType);
+      paramList.push_back({qualType, isOptional});
     }
   }
 
@@ -2158,7 +2158,7 @@ std::any TypeChecker::visitLambdaFunc(LambdaFuncNode *node) {
   node->manifestations.at(manIdx).mangleSuffix = "." + std::to_string(manIdx);
 
   // Check special requirements if this is an async lambda
-  checkAsyncLambdaCaptureRules(node, node->lambdaAttr());
+  (void)checkAsyncLambdaCaptureRules(node, node->lambdaAttr());
 
   return ExprResult{node->setEvaluatedSymbolType(functionType, manIdx)};
 }
@@ -2205,7 +2205,7 @@ std::any TypeChecker::visitLambdaProc(LambdaProcNode *node) {
   node->manifestations.at(manIdx).mangleSuffix = "." + std::to_string(manIdx);
 
   // Check special requirements if this is an async lambda
-  checkAsyncLambdaCaptureRules(node, node->lambdaAttr());
+  (void)checkAsyncLambdaCaptureRules(node, node->lambdaAttr());
 
   return ExprResult{node->setEvaluatedSymbolType(functionType, manIdx)};
 }
@@ -2471,14 +2471,12 @@ std::any TypeChecker::visitCustomDataType(CustomDataTypeNode *node) {
       // Here, it is allowed to accept, that the struct/interface cannot be found, because there are self-referencing ones
       if (entryType.is(TY_STRUCT)) {
         const std::string structName = node->typeNameFragments.back();
-        Struct *spiceStruct = StructManager::match(localAccessScope, structName, templateTypes, node);
-        if (spiceStruct)
+        if (Struct *spiceStruct = StructManager::match(localAccessScope, structName, templateTypes, node))
           entryType = entryType.getWithBodyScope(spiceStruct->scope);
       } else {
         assert(entryType.is(TY_INTERFACE));
         const std::string interfaceName = node->typeNameFragments.back();
-        const Interface *spiceInterface = InterfaceManager::match(localAccessScope, interfaceName, templateTypes, node);
-        if (spiceInterface)
+        if (const Interface *spiceInterface = InterfaceManager::match(localAccessScope, interfaceName, templateTypes, node))
           entryType = entryType.getWithBodyScope(spiceInterface->scope);
       }
     }
@@ -2569,7 +2567,7 @@ QualType TypeChecker::mapLocalTypeToImportedScopeType(const Scope *targetScope, 
     return symbolType;
 
   // Match the scope of the symbol type against all scopes in the name registry of the target source file
-  for (const auto &[_, entry] : targetSourceFile->exportedNameRegistry)
+  for (const auto &entry : targetSourceFile->exportedNameRegistry | std::views::values)
     if (entry.targetEntry != nullptr && entry.targetEntry->getQualType().isBase(TY_STRUCT))
       for (const Struct *manifestation : *entry.targetEntry->declNode->getStructManifestations())
         if (manifestation->scope == symbolType.getBase().getBodyScope())
@@ -2593,13 +2591,13 @@ QualType TypeChecker::mapImportedScopeTypeToLocalType(const Scope *sourceScope, 
     return symbolType;
 
   // If the source scope is in the current source file, we can return the symbol type as is
-  SourceFile *sourceSourceFile = sourceScope->sourceFile;
+  const SourceFile *sourceSourceFile = sourceScope->sourceFile;
   if (sourceSourceFile == sourceFile)
     return symbolType;
 
   // Match the scope of the symbol type against all scopes in the name registry of this source file
   const QualType baseType = symbolType.getBase();
-  for (const auto &[_, entry] : sourceFile->exportedNameRegistry)
+  for (const auto &entry : sourceFile->exportedNameRegistry | std::views::values)
     if (entry.targetEntry != nullptr && entry.targetEntry->getQualType().isBase(TY_STRUCT))
       for (const Struct *manifestation : *entry.targetEntry->declNode->getStructManifestations())
         if (manifestation->scope == baseType.getBodyScope())

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -6,11 +6,8 @@
 #include <ast/ASTVisitor.h>
 #include <model/Function.h>
 #include <symboltablebuilder/Scope.h>
-#include <symboltablebuilder/SymbolTableEntry.h>
 #include <typechecker/FunctionManager.h>
-#include <typechecker/MacroDefs.h>
 #include <typechecker/OpRuleManager.h>
-#include <typechecker/StructManager.h>
 #include <util/CompilerWarning.h>
 
 namespace spice::compiler {
@@ -28,7 +25,7 @@ enum TypeCheckerMode : bool {
  * - Ensure that all actual types match the expected types
  * - Perform type inference
  */
-class TypeChecker : private CompilerPass, public ASTVisitor {
+class TypeChecker final : CompilerPass, public ASTVisitor {
 public:
   // Constructors
   TypeChecker(GlobalResourceManager &resourceManager, SourceFile *sourceFile, TypeCheckerMode typeCheckerMode);
@@ -149,11 +146,8 @@ private:
   // Implicit code generation
   void createDefaultStructMethod(const Struct &spiceStruct, const std::string &name, const ParamList &params) const;
   void createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
-  void createDefaultCtorBody(const Function *ctorFunction);
   void createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
-  void createDefaultCopyCtorBody(const Function *copyCtorFunction);
   void createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope);
-  void createDefaultDtorBody(const Function *dtorFunction);
   void createCtorBodyPreamble(const Scope *bodyScope);
   void createCopyCtorBodyPreamble(const Scope *bodyScope);
   void createDtorBodyPreamble(const Scope *bodyScope);

--- a/src/typechecker/TypeCheckerCheck.cpp
+++ b/src/typechecker/TypeCheckerCheck.cpp
@@ -213,18 +213,18 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
     // Generate default ctor body if required
     const Function *ctorFunc = FunctionManager::lookup(currentScope, CTOR_FUNCTION_NAME, structType, {}, true);
     if (ctorFunc != nullptr && ctorFunc->implicitDefault)
-      createDefaultCtorBody(ctorFunc);
+      createCtorBodyPreamble(ctorFunc->bodyScope);
 
     // Generate default copy ctor body if required
     const ArgList args = {{structType.toConstRef(node), false /* always non-temporary */}};
     const Function *copyCtorFunc = FunctionManager::lookup(currentScope, CTOR_FUNCTION_NAME, structType, args, true);
     if (copyCtorFunc != nullptr && copyCtorFunc->implicitDefault)
-      createDefaultCopyCtorBody(copyCtorFunc);
+      createCopyCtorBodyPreamble(copyCtorFunc->bodyScope);
 
     // Generate default dtor body if required
     const Function *dtorFunc = FunctionManager::lookup(currentScope, DTOR_FUNCTION_NAME, structType, {}, true);
     if (dtorFunc != nullptr && dtorFunc->implicitDefault)
-      createDefaultDtorBody(dtorFunc);
+      createDtorBodyPreamble(dtorFunc->bodyScope);
 
     // Return to the root scope
     currentScope = rootScope;

--- a/src/typechecker/TypeCheckerCheck.cpp
+++ b/src/typechecker/TypeCheckerCheck.cpp
@@ -89,7 +89,7 @@ std::any TypeChecker::visitProcDefCheck(ProcDefNode *node) {
   manIdx = 0; // Reset the manifestation index
 
   // Get all manifestations for this procedure definition
-  for (auto &manifestation : node->manifestations) {
+  for (Function *manifestation : node->manifestations) {
     // Skip non-substantiated or already checked procedures
     if (!manifestation->isFullySubstantiated() || manifestation->alreadyTypeChecked) {
       manIdx++; // Increase the manifestation index
@@ -143,7 +143,7 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
   manIdx = 0; // Reset the manifestation index
 
   // Get all manifestations for this procedure definition
-  for (auto &manifestation : node->structManifestations) {
+  for (Struct *manifestation : node->structManifestations) {
     // Skip non-substantiated or already checked procedures
     if (!manifestation->isFullySubstantiated()) {
       manIdx++; // Increase the manifestation index
@@ -167,7 +167,7 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
       // Retrieve interface instance
       const std::string interfaceName = interfaceType.getSubType();
       Scope *matchScope = interfaceType.getBodyScope()->parent;
-      Interface *interface = InterfaceManager::match(matchScope, interfaceName, interfaceType.getTemplateTypes(), node);
+      const Interface *interface = InterfaceManager::match(matchScope, interfaceName, interfaceType.getTemplateTypes(), node);
       assert(interface != nullptr);
 
       // Check for all methods, that it is implemented by the struct

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -34,24 +34,24 @@ void TypeChecker::createDefaultStructMethod(const Struct &spiceStruct, const std
 
   // Insert symbol for function into the symbol table
   const std::string entryName = Function::getSymbolTableEntryName(name, node->codeLoc);
-  SymbolTableEntry *fctEntry = structScope->insert(entryName, structEntry->declNode);
-  fctEntry->updateType(procedureType, true);
+  SymbolTableEntry *procEntry = structScope->insert(entryName, structEntry->declNode);
+  procEntry->updateType(procedureType, true);
 
   // Add to external name registry
-  sourceFile->addNameRegistryEntry(fqFctName, TY_PROCEDURE, fctEntry, structScope, true);
+  sourceFile->addNameRegistryEntry(fqFctName, TY_PROCEDURE, procEntry, structScope, true);
 
   // Create the default method
   const std::vector<GenericType> templateTypes = spiceStruct.templateTypes;
   const QualType returnType(TY_DYN);
-  Function defaultMethod(name, fctEntry, structType, returnType, params, templateTypes, structEntry->declNode);
+  Function defaultMethod(name, procEntry, structType, returnType, params, templateTypes, structEntry->declNode);
   defaultMethod.implicitDefault = true;
 
   // Create function scope
-  Scope *fctScope = structScope->createChildScope(defaultMethod.getSignature(false), ScopeType::FUNC_PROC_BODY, &node->codeLoc);
-  defaultMethod.bodyScope = fctScope;
+  Scope *procScope = structScope->createChildScope(defaultMethod.getSignature(false), ScopeType::FUNC_PROC_BODY, &node->codeLoc);
+  defaultMethod.bodyScope = procScope;
 
   // Create 'this' symbol in the function scope
-  SymbolTableEntry *thisEntry = fctScope->insert(THIS_VARIABLE_NAME, node);
+  SymbolTableEntry *thisEntry = procScope->insert(THIS_VARIABLE_NAME, node);
   thisEntry->updateType(structType.toPtr(node), true);
   thisEntry->used = true; // Always set to used to not print warnings for non-existing code
 

--- a/src/typechecker/TypeCheckerPrepare.cpp
+++ b/src/typechecker/TypeCheckerPrepare.cpp
@@ -7,6 +7,7 @@
 #include <global/GlobalResourceManager.h>
 #include <global/TypeRegistry.h>
 #include <symboltablebuilder/SymbolTableBuilder.h>
+#include <typechecker/MacroDefs.h>
 
 namespace spice::compiler {
 

--- a/src/typechecker/TypeCheckerPrepare.cpp
+++ b/src/typechecker/TypeCheckerPrepare.cpp
@@ -16,7 +16,7 @@ std::any TypeChecker::visitMainFctDefPrepare(MainFctDefNode *node) {
   node->returnsOnAllControlPaths(&returnsOnAllControlPaths);
 
   // Retrieve return type
-  QualType returnType(TY_INT);
+  const QualType returnType(TY_INT);
 
   // Change to function body scope
   currentScope = node->bodyScope;
@@ -516,7 +516,7 @@ std::any TypeChecker::visitEnumDefPrepare(EnumDefNode *node) {
 
   // Loop through all items without values
   uint32_t nextValue = 0;
-  QualType intSymbolType(TY_INT);
+  const QualType intSymbolType(TY_INT);
   for (EnumItemNode *enumItem : node->itemLst()->items()) {
     // Update type of enum item entry
     SymbolTableEntry *itemEntry = currentScope->lookupStrict(enumItem->itemName);
@@ -583,7 +583,7 @@ std::any TypeChecker::visitGlobalVarDefPrepare(GlobalVarDefNode *node) {
   HANDLE_UNRESOLVED_TYPE_PTR(globalVarType)
 
   if (node->constant()) { // Variable is initialized here
-    QualType rhsType = std::any_cast<ExprResult>(visit(node->constant())).type;
+    const QualType rhsType = std::any_cast<ExprResult>(visit(node->constant())).type;
     HANDLE_UNRESOLVED_TYPE_PTR(rhsType)
     if (globalVarType.is(TY_DYN)) { // Perform type inference
       globalVarType = rhsType;
@@ -645,7 +645,7 @@ std::any TypeChecker::visitExtDeclPrepare(ExtDeclNode *node) {
   }
 
   // Add function to current scope
-  Function spiceFunc = Function(node->extFunctionName, node->entry, QualType(TY_DYN), returnType, argList, {}, node);
+  const Function spiceFunc(node->extFunctionName, node->entry, QualType(TY_DYN), returnType, argList, {}, node);
   node->extFunction = FunctionManager::insert(currentScope, spiceFunc, &node->extFunctionManifestations);
   node->extFunction->mangleFunctionName = false;
 
@@ -662,7 +662,7 @@ std::any TypeChecker::visitExtDeclPrepare(ExtDeclNode *node) {
 
   // Prepare ext function type
   const SuperType superType = isFunction ? TY_FUNCTION : TY_PROCEDURE;
-  QualType extFunctionType = QualType(superType).getWithFunctionParamAndReturnTypes(returnType, argTypes);
+  const QualType extFunctionType = QualType(superType).getWithFunctionParamAndReturnTypes(returnType, argTypes);
 
   // Set type of external function
   node->entry->updateType(extFunctionType, false);

--- a/src/typechecker/TypeCheckerPrepare.cpp
+++ b/src/typechecker/TypeCheckerPrepare.cpp
@@ -457,7 +457,7 @@ std::any TypeChecker::visitInterfaceDefPrepare(InterfaceDefNode *node) {
   std::vector<Function *> methods;
   methods.reserve(node->signatures().size());
   for (SignatureNode *signature : node->signatures()) {
-    auto method = std::any_cast<std::vector<Function *> *>(visit(signature));
+    const auto method = std::any_cast<std::vector<Function *> *>(visit(signature));
     if (!method)
       return nullptr;
 
@@ -483,7 +483,7 @@ std::any TypeChecker::visitInterfaceDefPrepare(InterfaceDefNode *node) {
 
   // Request RTTI runtime, that is always required when dealing with interfaces due to polymorphism
   if (!sourceFile->isRttiRT())
-    sourceFile->requestRuntimeModule(RuntimeModule::RTTI_RT);
+    sourceFile->requestRuntimeModule(RTTI_RT);
 
   return nullptr;
 }

--- a/std/data/hash-table.spice
+++ b/std/data/hash-table.spice
@@ -14,6 +14,11 @@ type HashEntry<K, V> struct {
     V value
 }
 
+public p HashEntry.ctor(const HashEntry<K, V>& original) {
+    this.key = original.key;
+    this.value = original.value;
+}
+
 public type HashTable<K, V> struct : IIterable<Pair<K, V>> {
     Vector<LinkedList<HashEntry<K, V>>> buckets
 }

--- a/std/data/linked-list.spice
+++ b/std/data/linked-list.spice
@@ -35,8 +35,6 @@ public type LinkedList<T> struct : IIterable<T> {
     unsigned long size = 0l
 }
 
-public p LinkedList.ctor() {}
-
 /**
  * Pushes a new item to the back of the list
  *

--- a/std/data/vector.spice
+++ b/std/data/vector.spice
@@ -56,6 +56,15 @@ public p Vector.ctor(unsigned long initAllocItems, const T& defaultValue) {
     this.size = initAllocItems;
 }
 
+public p Vector.ctor(const Vector<T>& original) {
+    // Allocate space for the new vector
+    this.ctor(original.getCapacity());
+    // Set the correct size
+    this.size = original.size;
+    // Copy contents
+    sCopy(original.contents, this.contents, this.size);
+}
+
 /**
  * Checks if the vector contains any items at the moment
  *

--- a/std/data/vector.spice
+++ b/std/data/vector.spice
@@ -56,15 +56,6 @@ public p Vector.ctor(unsigned long initAllocItems, const T& defaultValue) {
     this.size = initAllocItems;
 }
 
-public p Vector.ctor(const Vector<T>& original) {
-    // Allocate space for the new vector
-    this.ctor(original.getCapacity());
-    // Set the correct size
-    this.size = original.size;
-    // Copy contents
-    sCopy(original.contents, this.contents, this.size);
-}
-
 /**
  * Checks if the vector contains any items at the moment
  *

--- a/std/io/filepath.spice
+++ b/std/io/filepath.spice
@@ -23,10 +23,6 @@ public p FilePath.ctor(const String& pathStr) {
     this.path = pathStr;
 }
 
-public p FilePath.ctor(const FilePath& other) {
-    this.path = other.path;
-}
-
 public p FilePath.replaceSeparator(char separator) {
     if separator != PATH_SEPARATOR_UNIX {
         this.path.replaceAll(PATH_SEPARATOR_UNIX, separator);

--- a/std/runtime/memory_rt.spice
+++ b/std/runtime/memory_rt.spice
@@ -21,6 +21,19 @@ public f<Result<heap byte*>> sAlloc(unsigned long size) {
 }
 
 /**
+  * Allocates a new block of memory of the given size.
+  * This panics in case of an out of memory situation.
+  *
+  * @param size The size of the block to allocate.
+  * @return A pointer to the allocated block
+  */
+public f<heap byte*> sAllocUnsafe(unsigned long size) {
+    heap byte* ptr = malloc(size);
+    if ptr != nil<heap byte*> { return ptr; }
+    panic(Error("OOM occurred in sAllocUnsafe"));
+}
+
+/**
   * Reallocates a block of memory to the given size.
   *
   * @param ptr The pointer to the block to reallocate.

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -219,7 +219,7 @@ void execTestCase(const TestCase &testCase) {
 #if not OS_WINDOWS // Windows does not give us the exit code, so we cannot check it on Windows
       // Check if the exit code matches the expected one
       const bool exitRefFileFound =
-          TestUtil::checkRefMatch(testCase.testPath / REF_NAME_EXIT_CODE, [&]() { return std::to_string(exitCode); });
+          TestUtil::checkRefMatch(testCase.testPath / REF_NAME_EXIT_CODE, [&] { return std::to_string(exitCode); });
       // If no exit code ref file exists, check against 0
       if (!exitRefFileFound) {
         EXPECT_EQ(0, exitCode) << "Program exited with non-zero exit code";

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-complex/debug.out
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-complex/debug.out
@@ -27,4 +27,4 @@ pair = {first = 2, second = }
 $1 = {contents = , capacity = 5, size = 5}
 $2 = 5
 All assertions passed!
-[Inferior 1 (process 41879) exited normally]
+[Inferior 1 (process 80512) exited normally]

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
@@ -276,171 +276,171 @@ foreach.body.L46:                                 ; preds = %foreach.head.L46
   %76 = load i32, ptr %item, align 4, !dbg !97
   %77 = add nsw i32 %76, 1, !dbg !97
   store i32 %77, ptr %item, align 4, !dbg !97
-  br label %foreach.tail.L46, !dbg !97
+  br label %foreach.tail.L46, !dbg !98
 
 foreach.tail.L46:                                 ; preds = %foreach.body.L46
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %10), !dbg !97
-  br label %foreach.head.L46, !dbg !97
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %10), !dbg !98
+  br label %foreach.head.L46, !dbg !98
 
 foreach.exit.L46:                                 ; preds = %foreach.head.L46
-  %78 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !98
-  %79 = load i32, ptr %78, align 4, !dbg !99
-  %80 = icmp eq i32 %79, 123, !dbg !99
-  br i1 %80, label %assert.exit.L49, label %assert.then.L49, !dbg !99, !prof !42
+  %78 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !99
+  %79 = load i32, ptr %78, align 4, !dbg !100
+  %80 = icmp eq i32 %79, 123, !dbg !100
+  br i1 %80, label %assert.exit.L49, label %assert.then.L49, !dbg !100, !prof !42
 
 assert.then.L49:                                  ; preds = %foreach.exit.L46
-  %81 = call i32 (ptr, ...) @printf(ptr @anon.string.16), !dbg !99
-  call void @exit(i32 1), !dbg !99
-  unreachable, !dbg !99
+  %81 = call i32 (ptr, ...) @printf(ptr @anon.string.16), !dbg !100
+  call void @exit(i32 1), !dbg !100
+  unreachable, !dbg !100
 
 assert.exit.L49:                                  ; preds = %foreach.exit.L46
-  %82 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !100
-  %83 = load i32, ptr %82, align 4, !dbg !101
-  %84 = icmp eq i32 %83, 4321, !dbg !101
-  br i1 %84, label %assert.exit.L50, label %assert.then.L50, !dbg !101, !prof !42
+  %82 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !101
+  %83 = load i32, ptr %82, align 4, !dbg !102
+  %84 = icmp eq i32 %83, 4321, !dbg !102
+  br i1 %84, label %assert.exit.L50, label %assert.then.L50, !dbg !102, !prof !42
 
 assert.then.L50:                                  ; preds = %assert.exit.L49
-  %85 = call i32 (ptr, ...) @printf(ptr @anon.string.17), !dbg !101
-  call void @exit(i32 1), !dbg !101
-  unreachable, !dbg !101
+  %85 = call i32 (ptr, ...) @printf(ptr @anon.string.17), !dbg !102
+  call void @exit(i32 1), !dbg !102
+  unreachable, !dbg !102
 
 assert.exit.L50:                                  ; preds = %assert.exit.L49
-  %86 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !102
-  %87 = load i32, ptr %86, align 4, !dbg !103
-  %88 = icmp eq i32 %87, 9876, !dbg !103
-  br i1 %88, label %assert.exit.L51, label %assert.then.L51, !dbg !103, !prof !42
+  %86 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !103
+  %87 = load i32, ptr %86, align 4, !dbg !104
+  %88 = icmp eq i32 %87, 9876, !dbg !104
+  br i1 %88, label %assert.exit.L51, label %assert.then.L51, !dbg !104, !prof !42
 
 assert.then.L51:                                  ; preds = %assert.exit.L50
-  %89 = call i32 (ptr, ...) @printf(ptr @anon.string.18), !dbg !103
-  call void @exit(i32 1), !dbg !103
-  unreachable, !dbg !103
+  %89 = call i32 (ptr, ...) @printf(ptr @anon.string.18), !dbg !104
+  call void @exit(i32 1), !dbg !104
+  unreachable, !dbg !104
 
 assert.exit.L51:                                  ; preds = %assert.exit.L50
-  %90 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !104
-    #dbg_declare(ptr %item1, !106, !DIExpression(), !107)
-  store %struct.VectorIterator %90, ptr %11, align 8, !dbg !104
-  br label %foreach.head.L54, !dbg !107
-
-foreach.head.L54:                                 ; preds = %foreach.tail.L54, %assert.exit.L51
-  %91 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !107
-  br i1 %91, label %foreach.body.L54, label %foreach.exit.L54, !dbg !107
-
-foreach.body.L54:                                 ; preds = %foreach.head.L54
-  %92 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %11), !dbg !107
-  store ptr %92, ptr %12, align 8, !dbg !107
-  %93 = load ptr, ptr %12, align 8, !dbg !108
-  %94 = load i32, ptr %93, align 4, !dbg !108
-  %95 = add nsw i32 %94, 1, !dbg !108
-  store i32 %95, ptr %93, align 4, !dbg !108
-  br label %foreach.tail.L54, !dbg !108
-
-foreach.tail.L54:                                 ; preds = %foreach.body.L54
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !108
+  %90 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !105
+    #dbg_declare(ptr %item1, !107, !DIExpression(), !108)
+  store %struct.VectorIterator %90, ptr %11, align 8, !dbg !105
   br label %foreach.head.L54, !dbg !108
 
+foreach.head.L54:                                 ; preds = %foreach.tail.L54, %assert.exit.L51
+  %91 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !108
+  br i1 %91, label %foreach.body.L54, label %foreach.exit.L54, !dbg !108
+
+foreach.body.L54:                                 ; preds = %foreach.head.L54
+  %92 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %11), !dbg !108
+  store ptr %92, ptr %12, align 8, !dbg !108
+  %93 = load ptr, ptr %12, align 8, !dbg !109
+  %94 = load i32, ptr %93, align 4, !dbg !109
+  %95 = add nsw i32 %94, 1, !dbg !109
+  store i32 %95, ptr %93, align 4, !dbg !109
+  br label %foreach.tail.L54, !dbg !110
+
+foreach.tail.L54:                                 ; preds = %foreach.body.L54
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !110
+  br label %foreach.head.L54, !dbg !110
+
 foreach.exit.L54:                                 ; preds = %foreach.head.L54
-  %96 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !109
-  %97 = load i32, ptr %96, align 4, !dbg !110
-  %98 = icmp eq i32 %97, 124, !dbg !110
-  br i1 %98, label %assert.exit.L57, label %assert.then.L57, !dbg !110, !prof !42
+  %96 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !111
+  %97 = load i32, ptr %96, align 4, !dbg !112
+  %98 = icmp eq i32 %97, 124, !dbg !112
+  br i1 %98, label %assert.exit.L57, label %assert.then.L57, !dbg !112, !prof !42
 
 assert.then.L57:                                  ; preds = %foreach.exit.L54
-  %99 = call i32 (ptr, ...) @printf(ptr @anon.string.19), !dbg !110
-  call void @exit(i32 1), !dbg !110
-  unreachable, !dbg !110
-
-assert.exit.L57:                                  ; preds = %foreach.exit.L54
-  %100 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !111
-  %101 = load i32, ptr %100, align 4, !dbg !112
-  %102 = icmp eq i32 %101, 4322, !dbg !112
-  br i1 %102, label %assert.exit.L58, label %assert.then.L58, !dbg !112, !prof !42
-
-assert.then.L58:                                  ; preds = %assert.exit.L57
-  %103 = call i32 (ptr, ...) @printf(ptr @anon.string.20), !dbg !112
+  %99 = call i32 (ptr, ...) @printf(ptr @anon.string.19), !dbg !112
   call void @exit(i32 1), !dbg !112
   unreachable, !dbg !112
 
-assert.exit.L58:                                  ; preds = %assert.exit.L57
-  %104 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !113
-  %105 = load i32, ptr %104, align 4, !dbg !114
-  %106 = icmp eq i32 %105, 9877, !dbg !114
-  br i1 %106, label %assert.exit.L59, label %assert.then.L59, !dbg !114, !prof !42
+assert.exit.L57:                                  ; preds = %foreach.exit.L54
+  %100 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !113
+  %101 = load i32, ptr %100, align 4, !dbg !114
+  %102 = icmp eq i32 %101, 4322, !dbg !114
+  br i1 %102, label %assert.exit.L58, label %assert.then.L58, !dbg !114, !prof !42
 
-assert.then.L59:                                  ; preds = %assert.exit.L58
-  %107 = call i32 (ptr, ...) @printf(ptr @anon.string.21), !dbg !114
+assert.then.L58:                                  ; preds = %assert.exit.L57
+  %103 = call i32 (ptr, ...) @printf(ptr @anon.string.20), !dbg !114
   call void @exit(i32 1), !dbg !114
   unreachable, !dbg !114
 
+assert.exit.L58:                                  ; preds = %assert.exit.L57
+  %104 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !115
+  %105 = load i32, ptr %104, align 4, !dbg !116
+  %106 = icmp eq i32 %105, 9877, !dbg !116
+  br i1 %106, label %assert.exit.L59, label %assert.then.L59, !dbg !116, !prof !42
+
+assert.then.L59:                                  ; preds = %assert.exit.L58
+  %107 = call i32 (ptr, ...) @printf(ptr @anon.string.21), !dbg !116
+  call void @exit(i32 1), !dbg !116
+  unreachable, !dbg !116
+
 assert.exit.L59:                                  ; preds = %assert.exit.L58
-  %108 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !115
-  store %struct.VectorIterator %108, ptr %13, align 8, !dbg !115
-    #dbg_declare(ptr %idx, !117, !DIExpression(), !119)
-    #dbg_declare(ptr %item2, !120, !DIExpression(), !121)
-  store i64 0, ptr %idx, align 8, !dbg !119
-  br label %foreach.head.L61, !dbg !121
+  %108 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !117
+  store %struct.VectorIterator %108, ptr %13, align 8, !dbg !117
+    #dbg_declare(ptr %idx, !119, !DIExpression(), !121)
+    #dbg_declare(ptr %item2, !122, !DIExpression(), !123)
+  store i64 0, ptr %idx, align 8, !dbg !121
+  br label %foreach.head.L61, !dbg !123
 
 foreach.head.L61:                                 ; preds = %foreach.tail.L61, %assert.exit.L59
-  %109 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %13), !dbg !121
-  br i1 %109, label %foreach.body.L61, label %foreach.exit.L61, !dbg !121
+  %109 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %13), !dbg !123
+  br i1 %109, label %foreach.body.L61, label %foreach.exit.L61, !dbg !123
 
 foreach.body.L61:                                 ; preds = %foreach.head.L61
-  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %13), !dbg !121
-  store %struct.Pair %pair3, ptr %pair_addr, align 8, !dbg !121
-  %110 = load i64, ptr %pair_addr, align 8, !dbg !121
-  store i64 %110, ptr %idx, align 8, !dbg !121
-  %item_addr = getelementptr inbounds %struct.Pair, ptr %pair_addr, i32 0, i32 1, !dbg !121
-  %111 = load ptr, ptr %item_addr, align 8, !dbg !121
-  store ptr %111, ptr %14, align 8, !dbg !121
-  %112 = load i64, ptr %idx, align 8, !dbg !122
-  %113 = trunc i64 %112 to i32, !dbg !122
-  %114 = load ptr, ptr %14, align 8, !dbg !122
-  %115 = load i32, ptr %114, align 4, !dbg !122
-  %116 = add nsw i32 %115, %113, !dbg !122
-  store i32 %116, ptr %114, align 4, !dbg !122
-  br label %foreach.tail.L61, !dbg !122
+  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %13), !dbg !123
+  store %struct.Pair %pair3, ptr %pair_addr, align 8, !dbg !123
+  %110 = load i64, ptr %pair_addr, align 8, !dbg !123
+  store i64 %110, ptr %idx, align 8, !dbg !123
+  %item_addr = getelementptr inbounds %struct.Pair, ptr %pair_addr, i32 0, i32 1, !dbg !123
+  %111 = load ptr, ptr %item_addr, align 8, !dbg !123
+  store ptr %111, ptr %14, align 8, !dbg !123
+  %112 = load i64, ptr %idx, align 8, !dbg !124
+  %113 = trunc i64 %112 to i32, !dbg !124
+  %114 = load ptr, ptr %14, align 8, !dbg !124
+  %115 = load i32, ptr %114, align 4, !dbg !124
+  %116 = add nsw i32 %115, %113, !dbg !124
+  store i32 %116, ptr %114, align 4, !dbg !124
+  br label %foreach.tail.L61, !dbg !125
 
 foreach.tail.L61:                                 ; preds = %foreach.body.L61
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %13), !dbg !122
-  br label %foreach.head.L61, !dbg !122
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %13), !dbg !125
+  br label %foreach.head.L61, !dbg !125
 
 foreach.exit.L61:                                 ; preds = %foreach.head.L61
-  %117 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !123
-  %118 = load i32, ptr %117, align 4, !dbg !124
-  %119 = icmp eq i32 %118, 124, !dbg !124
-  br i1 %119, label %assert.exit.L64, label %assert.then.L64, !dbg !124, !prof !42
+  %117 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !126
+  %118 = load i32, ptr %117, align 4, !dbg !127
+  %119 = icmp eq i32 %118, 124, !dbg !127
+  br i1 %119, label %assert.exit.L64, label %assert.then.L64, !dbg !127, !prof !42
 
 assert.then.L64:                                  ; preds = %foreach.exit.L61
-  %120 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !124
-  call void @exit(i32 1), !dbg !124
-  unreachable, !dbg !124
+  %120 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !127
+  call void @exit(i32 1), !dbg !127
+  unreachable, !dbg !127
 
 assert.exit.L64:                                  ; preds = %foreach.exit.L61
-  %121 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !125
-  %122 = load i32, ptr %121, align 4, !dbg !126
-  %123 = icmp eq i32 %122, 4323, !dbg !126
-  br i1 %123, label %assert.exit.L65, label %assert.then.L65, !dbg !126, !prof !42
+  %121 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !128
+  %122 = load i32, ptr %121, align 4, !dbg !129
+  %123 = icmp eq i32 %122, 4323, !dbg !129
+  br i1 %123, label %assert.exit.L65, label %assert.then.L65, !dbg !129, !prof !42
 
 assert.then.L65:                                  ; preds = %assert.exit.L64
-  %124 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !126
-  call void @exit(i32 1), !dbg !126
-  unreachable, !dbg !126
+  %124 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !129
+  call void @exit(i32 1), !dbg !129
+  unreachable, !dbg !129
 
 assert.exit.L65:                                  ; preds = %assert.exit.L64
-  %125 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !127
-  %126 = load i32, ptr %125, align 4, !dbg !128
-  %127 = icmp eq i32 %126, 9879, !dbg !128
-  br i1 %127, label %assert.exit.L66, label %assert.then.L66, !dbg !128, !prof !42
+  %125 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !130
+  %126 = load i32, ptr %125, align 4, !dbg !131
+  %127 = icmp eq i32 %126, 9879, !dbg !131
+  br i1 %127, label %assert.exit.L66, label %assert.then.L66, !dbg !131, !prof !42
 
 assert.then.L66:                                  ; preds = %assert.exit.L65
-  %128 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !128
-  call void @exit(i32 1), !dbg !128
-  unreachable, !dbg !128
+  %128 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !131
+  call void @exit(i32 1), !dbg !131
+  unreachable, !dbg !131
 
 assert.exit.L66:                                  ; preds = %assert.exit.L65
-  %129 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !129
-  call void @_ZN6VectorIiE4dtorEv(ptr %vi), !dbg !129
-  %130 = load i32, ptr %result, align 4, !dbg !129
-  ret i32 %130, !dbg !129
+  %129 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !132
+  call void @_ZN6VectorIiE4dtorEv(ptr %vi), !dbg !133
+  %130 = load i32, ptr %result, align 4, !dbg !133
+  ret i32 %130, !dbg !133
 }
 
 declare void @_ZN6VectorIiE4ctorEv(ptr)
@@ -587,35 +587,39 @@ attributes #2 = { cold noreturn nounwind }
 !95 = !DILocalVariable(name: "item", scope: !94, file: !5, line: 46, type: !18)
 !96 = !DILocation(line: 46, column: 13, scope: !94)
 !97 = !DILocation(line: 47, column: 9, scope: !94)
-!98 = !DILocation(line: 49, column: 19, scope: !15)
-!99 = !DILocation(line: 49, column: 25, scope: !15)
-!100 = !DILocation(line: 50, column: 19, scope: !15)
-!101 = !DILocation(line: 50, column: 25, scope: !15)
-!102 = !DILocation(line: 51, column: 19, scope: !15)
-!103 = !DILocation(line: 51, column: 25, scope: !15)
-!104 = !DILocation(line: 54, column: 25, scope: !105)
-!105 = distinct !DILexicalBlock(scope: !15, file: !5, line: 54, column: 5)
-!106 = !DILocalVariable(name: "item", scope: !105, file: !5, line: 54, type: !67)
-!107 = !DILocation(line: 54, column: 13, scope: !105)
-!108 = !DILocation(line: 55, column: 9, scope: !105)
-!109 = !DILocation(line: 57, column: 19, scope: !15)
-!110 = !DILocation(line: 57, column: 25, scope: !15)
-!111 = !DILocation(line: 58, column: 19, scope: !15)
-!112 = !DILocation(line: 58, column: 25, scope: !15)
-!113 = !DILocation(line: 59, column: 19, scope: !15)
-!114 = !DILocation(line: 59, column: 25, scope: !15)
-!115 = !DILocation(line: 61, column: 35, scope: !116)
-!116 = distinct !DILexicalBlock(scope: !15, file: !5, line: 61, column: 5)
-!117 = !DILocalVariable(name: "idx", scope: !116, file: !5, line: 61, type: !118)
-!118 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!119 = !DILocation(line: 61, column: 13, scope: !116)
-!120 = !DILocalVariable(name: "item", scope: !116, file: !5, line: 61, type: !67)
-!121 = !DILocation(line: 61, column: 23, scope: !116)
-!122 = !DILocation(line: 62, column: 9, scope: !116)
-!123 = !DILocation(line: 64, column: 19, scope: !15)
-!124 = !DILocation(line: 64, column: 25, scope: !15)
-!125 = !DILocation(line: 65, column: 19, scope: !15)
-!126 = !DILocation(line: 65, column: 25, scope: !15)
-!127 = !DILocation(line: 66, column: 19, scope: !15)
-!128 = !DILocation(line: 66, column: 25, scope: !15)
-!129 = !DILocation(line: 68, column: 5, scope: !15)
+!98 = !DILocation(line: 48, column: 5, scope: !94)
+!99 = !DILocation(line: 49, column: 19, scope: !15)
+!100 = !DILocation(line: 49, column: 25, scope: !15)
+!101 = !DILocation(line: 50, column: 19, scope: !15)
+!102 = !DILocation(line: 50, column: 25, scope: !15)
+!103 = !DILocation(line: 51, column: 19, scope: !15)
+!104 = !DILocation(line: 51, column: 25, scope: !15)
+!105 = !DILocation(line: 54, column: 25, scope: !106)
+!106 = distinct !DILexicalBlock(scope: !15, file: !5, line: 54, column: 5)
+!107 = !DILocalVariable(name: "item", scope: !106, file: !5, line: 54, type: !67)
+!108 = !DILocation(line: 54, column: 13, scope: !106)
+!109 = !DILocation(line: 55, column: 9, scope: !106)
+!110 = !DILocation(line: 56, column: 5, scope: !106)
+!111 = !DILocation(line: 57, column: 19, scope: !15)
+!112 = !DILocation(line: 57, column: 25, scope: !15)
+!113 = !DILocation(line: 58, column: 19, scope: !15)
+!114 = !DILocation(line: 58, column: 25, scope: !15)
+!115 = !DILocation(line: 59, column: 19, scope: !15)
+!116 = !DILocation(line: 59, column: 25, scope: !15)
+!117 = !DILocation(line: 61, column: 35, scope: !118)
+!118 = distinct !DILexicalBlock(scope: !15, file: !5, line: 61, column: 5)
+!119 = !DILocalVariable(name: "idx", scope: !118, file: !5, line: 61, type: !120)
+!120 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!121 = !DILocation(line: 61, column: 13, scope: !118)
+!122 = !DILocalVariable(name: "item", scope: !118, file: !5, line: 61, type: !67)
+!123 = !DILocation(line: 61, column: 23, scope: !118)
+!124 = !DILocation(line: 62, column: 9, scope: !118)
+!125 = !DILocation(line: 63, column: 5, scope: !118)
+!126 = !DILocation(line: 64, column: 19, scope: !15)
+!127 = !DILocation(line: 64, column: 25, scope: !15)
+!128 = !DILocation(line: 65, column: 19, scope: !15)
+!129 = !DILocation(line: 65, column: 25, scope: !15)
+!130 = !DILocation(line: 66, column: 19, scope: !15)
+!131 = !DILocation(line: 66, column: 25, scope: !15)
+!132 = !DILocation(line: 68, column: 5, scope: !15)
+!133 = !DILocation(line: 69, column: 1, scope: !15)

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
@@ -41,35 +41,35 @@ define private %struct.TestStruct @_Z3fctRi(ptr %0) !dbg !47 {
     #dbg_declare(ptr %ts, !57, !DIExpression(), !58)
   store i32 %6, ptr %7, align 4, !dbg !56
   %8 = load %struct.TestStruct, ptr %ts, align 8, !dbg !59
-  ret %struct.TestStruct %8, !dbg !59
+  ret %struct.TestStruct %8, !dbg !60
 }
 
 declare void @_ZN6String4ctorEPKc(ptr, ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @main() #1 !dbg !60 {
-    #dbg_declare(ptr %result, !63, !DIExpression(), !64)
+define dso_local i32 @main() #1 !dbg !61 {
+    #dbg_declare(ptr %result, !64, !DIExpression(), !65)
   %result = alloca i32, align 4
   %test = alloca i32, align 4
   %res = alloca %struct.TestStruct, align 8
-  store i32 0, ptr %result, align 4, !dbg !64
-    #dbg_declare(ptr %test, !65, !DIExpression(), !66)
-  store i32 987654, ptr %test, align 4, !dbg !67
-  %1 = call %struct.TestStruct @_Z3fctRi(ptr %test), !dbg !68
-    #dbg_declare(ptr %res, !69, !DIExpression(), !70)
-  store %struct.TestStruct %1, ptr %res, align 8, !dbg !68
-  %lng_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !71
-  %2 = load i64, ptr %lng_addr, align 8, !dbg !71
-  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 %2), !dbg !71
-  %4 = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 1, !dbg !72
-  %5 = call ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !72
-  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %5), !dbg !72
-  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !73
-  %7 = load i32, ptr %i_addr, align 4, !dbg !73
-  %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %7), !dbg !73
-  call void @_ZN10TestStruct4dtorEv(ptr %res), !dbg !73
-  %9 = load i32, ptr %result, align 4, !dbg !73
-  ret i32 %9, !dbg !73
+  store i32 0, ptr %result, align 4, !dbg !65
+    #dbg_declare(ptr %test, !66, !DIExpression(), !67)
+  store i32 987654, ptr %test, align 4, !dbg !68
+  %1 = call %struct.TestStruct @_Z3fctRi(ptr %test), !dbg !69
+    #dbg_declare(ptr %res, !70, !DIExpression(), !71)
+  store %struct.TestStruct %1, ptr %res, align 8, !dbg !69
+  %lng_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !72
+  %2 = load i64, ptr %lng_addr, align 8, !dbg !72
+  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 %2), !dbg !72
+  %4 = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 1, !dbg !73
+  %5 = call ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !73
+  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %5), !dbg !73
+  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !74
+  %7 = load i32, ptr %i_addr, align 4, !dbg !74
+  %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %7), !dbg !74
+  call void @_ZN10TestStruct4dtorEv(ptr %res), !dbg !75
+  %9 = load i32, ptr %result, align 4, !dbg !75
+  ret i32 %9, !dbg !75
 }
 
 ; Function Attrs: nofree nounwind
@@ -145,17 +145,19 @@ attributes #2 = { nofree nounwind }
 !57 = !DILocalVariable(name: "ts", scope: !47, file: !7, line: 8, type: !28)
 !58 = !DILocation(line: 8, column: 5, scope: !47)
 !59 = !DILocation(line: 9, column: 12, scope: !47)
-!60 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !7, file: !7, line: 12, type: !61, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !43)
-!61 = !DISubroutineType(types: !62)
-!62 = !{!42}
-!63 = !DILocalVariable(name: "result", scope: !60, file: !7, line: 12, type: !42)
-!64 = !DILocation(line: 12, column: 1, scope: !60)
-!65 = !DILocalVariable(name: "test", scope: !60, file: !7, line: 13, type: !42)
-!66 = !DILocation(line: 13, column: 5, scope: !60)
-!67 = !DILocation(line: 13, column: 16, scope: !60)
-!68 = !DILocation(line: 14, column: 32, scope: !60)
-!69 = !DILocalVariable(name: "res", scope: !60, file: !7, line: 14, type: !28)
-!70 = !DILocation(line: 14, column: 5, scope: !60)
-!71 = !DILocation(line: 15, column: 26, scope: !60)
-!72 = !DILocation(line: 16, column: 28, scope: !60)
-!73 = !DILocation(line: 17, column: 25, scope: !60)
+!60 = !DILocation(line: 10, column: 1, scope: !47)
+!61 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !7, file: !7, line: 12, type: !62, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !43)
+!62 = !DISubroutineType(types: !63)
+!63 = !{!42}
+!64 = !DILocalVariable(name: "result", scope: !61, file: !7, line: 12, type: !42)
+!65 = !DILocation(line: 12, column: 1, scope: !61)
+!66 = !DILocalVariable(name: "test", scope: !61, file: !7, line: 13, type: !42)
+!67 = !DILocation(line: 13, column: 5, scope: !61)
+!68 = !DILocation(line: 13, column: 16, scope: !61)
+!69 = !DILocation(line: 14, column: 32, scope: !61)
+!70 = !DILocalVariable(name: "res", scope: !61, file: !7, line: 14, type: !28)
+!71 = !DILocation(line: 14, column: 5, scope: !61)
+!72 = !DILocation(line: 15, column: 26, scope: !61)
+!73 = !DILocation(line: 16, column: 28, scope: !61)
+!74 = !DILocation(line: 17, column: 25, scope: !61)
+!75 = !DILocation(line: 18, column: 1, scope: !61)

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
@@ -30,11 +30,10 @@ define private void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 2 derefer
 define void @_ZN6Middle4ctorERK6Middle(ptr noundef nonnull align 2 dereferenceable(2) %0, ptr %1) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
-  %3 = load ptr, ptr %this, align 8
-  %4 = getelementptr inbounds %struct.Middle, ptr %3, i64 0, i32 0
-  %5 = load ptr, ptr %this, align 8
-  %6 = getelementptr inbounds %struct.Middle, ptr %5, i64 0, i32 0
-  call void @_ZN5Inner4ctorERK5Inner(ptr %6, ptr %4)
+  %3 = getelementptr inbounds %struct.Middle, ptr %1, i64 0, i32 0
+  %4 = load ptr, ptr %this, align 8
+  %5 = getelementptr inbounds %struct.Middle, ptr %4, i64 0, i32 0
+  call void @_ZN5Inner4ctorERK5Inner(ptr %5, ptr %3)
   ret void
 }
 
@@ -42,11 +41,10 @@ define void @_ZN6Middle4ctorERK6Middle(ptr noundef nonnull align 2 dereferenceab
 define void @_ZN5Outer4ctorERK5Outer(ptr noundef nonnull align 2 dereferenceable(2) %0, ptr %1) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
-  %3 = load ptr, ptr %this, align 8
-  %4 = getelementptr inbounds %struct.Outer, ptr %3, i64 0, i32 0
-  %5 = load ptr, ptr %this, align 8
-  %6 = getelementptr inbounds %struct.Outer, ptr %5, i64 0, i32 0
-  call void @_ZN6Middle4ctorERK6Middle(ptr %6, ptr %4)
+  %3 = getelementptr inbounds %struct.Outer, ptr %1, i64 0, i32 0
+  %4 = load ptr, ptr %this, align 8
+  %5 = getelementptr inbounds %struct.Outer, ptr %4, i64 0, i32 0
+  call void @_ZN6Middle4ctorERK6Middle(ptr %5, ptr %3)
   ret void
 }
 

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -23,9 +23,16 @@ define void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 8 dereferenceable
   %6 = getelementptr inbounds %struct.Inner, ptr %1, i64 0, i32 1
   %7 = getelementptr inbounds %struct.Inner, ptr %4, i64 0, i32 1
   %8 = load ptr, ptr %6, align 8
-  %9 = call ptr @_Z12sAllocUnsafem(i64 1)
-  store ptr %9, ptr %7, align 8
-  call void @llvm.memcpy.p0.p0.i64(ptr %9, ptr %8, i64 1, i1 false)
+  %9 = icmp ne ptr %8, null
+  br i1 %9, label %nullptrcheck.then, label %nullptrcheck.exit
+
+nullptrcheck.then:                                ; preds = %2
+  %10 = call ptr @_Z12sAllocUnsafem(i64 1)
+  store ptr %10, ptr %7, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %10, ptr %8, i64 1, i1 false)
+  br label %nullptrcheck.exit
+
+nullptrcheck.exit:                                ; preds = %nullptrcheck.then, %2
   ret void
 }
 

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -12,6 +12,28 @@ declare ptr @malloc(i64 noundef)
 
 declare void @free(ptr noundef)
 
+; Function Attrs: norecurse
+define void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 8 dereferenceable(16) %0, ptr %1) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %3 = getelementptr inbounds %struct.Inner, ptr %1, i64 0, i32 0
+  %4 = load ptr, ptr %this, align 8
+  %5 = getelementptr inbounds %struct.Inner, ptr %4, i64 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr %5, ptr %3, i64 8, i1 false)
+  %6 = getelementptr inbounds %struct.Inner, ptr %1, i64 0, i32 1
+  %7 = getelementptr inbounds %struct.Inner, ptr %4, i64 0, i32 1
+  %8 = load ptr, ptr %6, align 8
+  %9 = call ptr @_Z12sAllocUnsafem(i64 1)
+  store ptr %9, ptr %7, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %9, ptr %8, i64 1, i1 false)
+  ret void
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly, ptr noalias nocapture readonly, i64, i1 immarg) #1
+
+declare ptr @_Z12sAllocUnsafem(i64)
+
 define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -39,10 +61,10 @@ define private void @_ZN5Inner4dtorEv(ptr noundef nonnull align 8 dereferenceabl
 }
 
 ; Function Attrs: nofree nounwind
-declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #0
+declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 
 ; Function Attrs: norecurse
-define void @_ZN6Middle4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #1 {
+define void @_ZN6Middle4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -52,7 +74,18 @@ define void @_ZN6Middle4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %
 }
 
 ; Function Attrs: norecurse
-define void @_ZN6Middle4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #1 {
+define void @_ZN6Middle4ctorERK6Middle(ptr noundef nonnull align 8 dereferenceable(16) %0, ptr %1) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %3 = getelementptr inbounds %struct.Middle, ptr %1, i64 0, i32 0
+  %4 = load ptr, ptr %this, align 8
+  %5 = getelementptr inbounds %struct.Middle, ptr %4, i64 0, i32 0
+  call void @_ZN5Inner4ctorERK5Inner(ptr %5, ptr %3)
+  ret void
+}
+
+; Function Attrs: norecurse
+define void @_ZN6Middle4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -62,7 +95,7 @@ define void @_ZN6Middle4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %
 }
 
 ; Function Attrs: norecurse
-define void @_ZN5Outer4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #1 {
+define void @_ZN5Outer4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -72,7 +105,7 @@ define void @_ZN5Outer4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0
 }
 
 ; Function Attrs: norecurse
-define void @_ZN5Outer4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #1 {
+define void @_ZN5Outer4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -82,7 +115,7 @@ define void @_ZN5Outer4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @main() #2 {
+define dso_local i32 @main() #3 {
   %result = alloca i32, align 4
   %outer = alloca %struct.Outer, align 8
   store i32 0, ptr %result, align 4
@@ -92,6 +125,7 @@ define dso_local i32 @main() #2 {
   ret i32 %1
 }
 
-attributes #0 = { nofree nounwind }
-attributes #1 = { norecurse }
-attributes #2 = { noinline nounwind optnone uwtable }
+attributes #0 = { norecurse }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nofree nounwind }
+attributes #3 = { noinline nounwind optnone uwtable }

--- a/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
+++ b/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
@@ -114,6 +114,22 @@
         {
           "captures": [],
           "children": [],
+          "name": "MockIterator<T>.ctor<T>(const MockIterator<T>&)",
+          "symbols": [
+            {
+              "codeLoc": "L6C1",
+              "isGlobal": false,
+              "isVolatile": false,
+              "name": "this",
+              "orderIndex": 0,
+              "state": "declared",
+              "type": "MockIterator<T>*"
+            }
+          ]
+        },
+        {
+          "captures": [],
+          "children": [],
           "name": "MockIterator<T>.next<T>()",
           "symbols": [
             {
@@ -231,13 +247,13 @@
           "type": "f<public Pair<unsigned long,T&>>()"
         },
         {
-          "codeLoc": "L27C1",
+          "codeLoc": "L7C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "next:L27C1",
-          "orderIndex": 7,
+          "name": "item",
+          "orderIndex": 1,
           "state": "declared",
-          "type": "p()"
+          "type": "short"
         },
         {
           "codeLoc": "L23C1",
@@ -247,42 +263,6 @@
           "orderIndex": 6,
           "state": "declared",
           "type": "f<bool>()"
-        },
-        {
-          "codeLoc": "L15C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "get:L15C1",
-          "orderIndex": 4,
-          "state": "declared",
-          "type": "f<T&>()"
-        },
-        {
-          "codeLoc": "L27C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "next:L27C1",
-          "orderIndex": 7,
-          "state": "declared",
-          "type": "p()"
-        },
-        {
-          "codeLoc": "L11C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "ctor:L11C1",
-          "orderIndex": 3,
-          "state": "declared",
-          "type": "p()"
-        },
-        {
-          "codeLoc": "L15C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "get:L15C1",
-          "orderIndex": 4,
-          "state": "declared",
-          "type": "f<T&>()"
         },
         {
           "codeLoc": "L19C1",
@@ -294,22 +274,13 @@
           "type": "f<public Pair<unsigned long,T&>>()"
         },
         {
-          "codeLoc": "L8C5",
+          "codeLoc": "L15C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "cursor",
-          "orderIndex": 2,
-          "state": "initialized",
-          "type": "unsigned long"
-        },
-        {
-          "codeLoc": "L23C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "isValid:L23C1",
-          "orderIndex": 6,
+          "name": "get:L15C1",
+          "orderIndex": 4,
           "state": "declared",
-          "type": "f<bool>()"
+          "type": "f<T&>()"
         },
         {
           "codeLoc": "L11C1",
@@ -321,13 +292,49 @@
           "type": "p()"
         },
         {
-          "codeLoc": "L7C5",
+          "codeLoc": "L11C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "item",
-          "orderIndex": 1,
+          "name": "ctor:L11C1",
+          "orderIndex": 3,
           "state": "declared",
-          "type": "short"
+          "type": "p()"
+        },
+        {
+          "codeLoc": "L27C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "next:L27C1",
+          "orderIndex": 7,
+          "state": "declared",
+          "type": "p()"
+        },
+        {
+          "codeLoc": "L6C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "ctor:L6C1",
+          "orderIndex": 8,
+          "state": "declared",
+          "type": "public p()"
+        },
+        {
+          "codeLoc": "L15C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "get:L15C1",
+          "orderIndex": 4,
+          "state": "declared",
+          "type": "f<T&>()"
+        },
+        {
+          "codeLoc": "L23C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "isValid:L23C1",
+          "orderIndex": 6,
+          "state": "declared",
+          "type": "f<bool>()"
         },
         {
           "codeLoc": "L6C31",
@@ -337,6 +344,24 @@
           "orderIndex": 0,
           "state": "declared",
           "type": "public IIterator<short>"
+        },
+        {
+          "codeLoc": "L8C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "cursor",
+          "orderIndex": 2,
+          "state": "initialized",
+          "type": "unsigned long"
+        },
+        {
+          "codeLoc": "L27C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "next:L27C1",
+          "orderIndex": 7,
+          "state": "declared",
+          "type": "p()"
         }
       ]
     },
@@ -385,6 +410,22 @@
     {
       "captures": [],
       "children": [
+        {
+          "captures": [],
+          "children": [],
+          "name": "MockIterator<T>.ctor<T>(const MockIterator<T>&)",
+          "symbols": [
+            {
+              "codeLoc": "L6C1",
+              "isGlobal": false,
+              "isVolatile": false,
+              "name": "this",
+              "orderIndex": 0,
+              "state": "declared",
+              "type": "MockIterator<T>*"
+            }
+          ]
+        },
         {
           "captures": [],
           "children": [],
@@ -495,6 +536,15 @@
       ],
       "name": "struct:MockIterator",
       "symbols": [
+        {
+          "codeLoc": "L6C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "ctor:L6C1",
+          "orderIndex": 8,
+          "state": "declared",
+          "type": "public p()"
+        },
         {
           "codeLoc": "L27C1",
           "isGlobal": false,

--- a/test/test-files/typechecker/structs/error-constructor-not-found/exception.out
+++ b/test/test-files/typechecker/structs/error-constructor-not-found/exception.out
@@ -2,7 +2,7 @@
 Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
 
 [Error|Semantic] ./source.spice:7:29:
-Referenced undefined function: The struct 'TestStruct' does not provide a constructor
+Referenced undefined function: Function/procedure 'TestStruct.ctor()' could not be found
 
 7  Struct testStruct = TestStruct();
                        ^^^^^^^^^^^^

--- a/test/test-files/typechecker/structs/error-custom-copy-ctor-required/exception.out
+++ b/test/test-files/typechecker/structs/error-custom-copy-ctor-required/exception.out
@@ -1,8 +1,0 @@
-[Error|Compiler]:
-Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
-
-[Error|Semantic] ./source.spice:1:1:
-Missing mandatory copy ctor: The struct 'StructToCopy' requires a custom copy ctor, because it has heap-allocated fields.
-
-1  type StructToCopy struct {
-   ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/test-files/typechecker/structs/error-custom-copy-ctor-required/source.spice
+++ b/test/test-files/typechecker/structs/error-custom-copy-ctor-required/source.spice
@@ -1,7 +1,0 @@
-type StructToCopy struct {
-    heap int* intHeapPtr
-}
-
-f<int> main() {
-    StructToCopy stc;
-}

--- a/test/unittest/UnitDriver.cpp
+++ b/test/unittest/UnitDriver.cpp
@@ -22,8 +22,8 @@ TEST(DriverTest, TestBuildSubcommandMinimal) {
   ASSERT_FALSE(driver.shouldExecute);
   ASSERT_FALSE(driver.cliOptions.execute);
   ASSERT_EQ("../../media/test-project/test.spice", driver.cliOptions.mainSourceFile.relative_path().string());
-  ASSERT_EQ(OptLevel::O0, driver.cliOptions.optLevel);
-  ASSERT_EQ(BuildMode::DEBUG, driver.cliOptions.buildMode);
+  ASSERT_EQ(O0, driver.cliOptions.optLevel);
+  ASSERT_EQ(DEBUG, driver.cliOptions.buildMode);
   ASSERT_FALSE(driver.cliOptions.generateTestMain);
   ASSERT_FALSE(driver.cliOptions.testMode);
   ASSERT_FALSE(driver.cliOptions.noEntryFct);
@@ -43,8 +43,8 @@ TEST(DriverTest, TestBuildSubcommandComplex) {
   ASSERT_FALSE(driver.shouldExecute);
   ASSERT_FALSE(driver.cliOptions.execute);
   ASSERT_EQ("../../media/test-project/test.spice", driver.cliOptions.mainSourceFile.relative_path().string());
-  ASSERT_EQ(OptLevel::Os, driver.cliOptions.optLevel);        // -Os
-  ASSERT_EQ(BuildMode::RELEASE, driver.cliOptions.buildMode); // -m release
+  ASSERT_EQ(Os, driver.cliOptions.optLevel);        // -Os
+  ASSERT_EQ(RELEASE, driver.cliOptions.buildMode); // -m release
   ASSERT_FALSE(driver.cliOptions.generateTestMain);
   ASSERT_FALSE(driver.cliOptions.testMode);
   ASSERT_FALSE(driver.cliOptions.noEntryFct);
@@ -68,7 +68,7 @@ TEST(DriverTest, TestRunSubcommandMinimal) {
   ASSERT_TRUE(driver.shouldExecute);
   ASSERT_TRUE(driver.cliOptions.execute);
   ASSERT_EQ("../../media/test-project/test.spice", driver.cliOptions.mainSourceFile.relative_path().string());
-  ASSERT_EQ(OptLevel::O0, driver.cliOptions.optLevel);
+  ASSERT_EQ(O0, driver.cliOptions.optLevel);
   ASSERT_FALSE(driver.cliOptions.generateTestMain);
   ASSERT_FALSE(driver.cliOptions.testMode);
   ASSERT_FALSE(driver.cliOptions.noEntryFct);
@@ -88,7 +88,7 @@ TEST(DriverTest, TestRunSubcommandComplex) {
   ASSERT_TRUE(driver.shouldExecute);
   ASSERT_TRUE(driver.cliOptions.execute);
   ASSERT_EQ("../../media/test-project/test.spice", driver.cliOptions.mainSourceFile.relative_path().string());
-  ASSERT_EQ(OptLevel::O2, driver.cliOptions.optLevel); // -O2
+  ASSERT_EQ(O2, driver.cliOptions.optLevel); // -O2
   ASSERT_FALSE(driver.cliOptions.generateTestMain);
   ASSERT_FALSE(driver.cliOptions.testMode);
   ASSERT_FALSE(driver.cliOptions.noEntryFct);
@@ -172,7 +172,7 @@ TEST(DriverTest, TestUninstallSubcommandMinimal) {
   ASSERT_FALSE(driver.shouldExecute);
   ASSERT_FALSE(driver.cliOptions.execute);
   ASSERT_EQ("../../media/test-project/test.spice", driver.cliOptions.mainSourceFile.relative_path().string());
-  ASSERT_EQ(OptLevel::O0, driver.cliOptions.optLevel);
+  ASSERT_EQ(O0, driver.cliOptions.optLevel);
   ASSERT_FALSE(driver.cliOptions.generateTestMain);
   ASSERT_FALSE(driver.cliOptions.testMode);
   ASSERT_FALSE(driver.cliOptions.noEntryFct);

--- a/test/util/TestUtil.cpp
+++ b/test/util/TestUtil.cpp
@@ -100,7 +100,7 @@ void TestUtil::handleError(const TestCase &testCase, const std::exception &error
     FAIL() << "Expected no error, but got: " + errorWhat;
 
   // Check if the exception message matches the expected output
-  TestUtil::checkRefMatch(testCase.testPath / REF_NAME_ERROR_OUTPUT, [&]() { return errorWhat; });
+  TestUtil::checkRefMatch(testCase.testPath / REF_NAME_ERROR_OUTPUT, [&] { return errorWhat; });
 }
 
 /**


### PR DESCRIPTION
- Always generate a copy ctor if the struct contains a field of type struct that in turn has a copy ctor and/or if the struct has a heap field
- Make default copy ctor capable of copying the underlying buffer of owning heap-allocated fields
- Require a copy ctor for structs that are not trivially copyable
- On assignment, first check if a copy ctor exists, if not check if it is trivially copyable. If yes, do a shallow memcopy, if no throw a compile error
- Fix debug info on scope cleanup instructions
- Code quality improvements