### PR TITLE
Remove security options and ensure security in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,7 +92,7 @@ jobs:
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
 
       - name: Setup Dependencies
-        run: sudo apt-get install ninja-build uuid-dev
+        run: sudo apt-get install ninja-build uuid-dev checksec jq
 
       - name: Setup CCache
         uses: hendrikmuhs/ccache-action@v1
@@ -136,6 +136,10 @@ jobs:
         run: |
           mv ./src/spice spice
           chmod +x spice
+
+      - name: Run Checksec
+        working-directory: bin
+        run: checksec --file=./spice --output=json | jq
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/Options.cmake
+++ b/Options.cmake
@@ -137,21 +137,3 @@ if (SPICE_OVERLOAD_NEW_DELETE)
 else ()
     message(STATUS "Spice: New and delete operators are not overloaded")
 endif ()
-
-# RELRO (relocation read-only) security hardening
-option(SPICE_RELRO "Enable relocation read-only (RELRO) hardening" ON)
-if (SPICE_RELRO)
-    message(STATUS "Spice: RELRO hardening enabled (release build only)")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wl,-z,relro,-z,now")
-else ()
-    message(STATUS "Spice: RELRO hardening disabled")
-endif ()
-
-# Stack canary security hardening
-option(SPICE_STACK_PROTECTION "Enable stack canary security hardening" ON)
-if (SPICE_STACK_PROTECTION)
-    message(STATUS "Spice: Stack canaries enabled (release build only)")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -fstack-protector")
-else ()
-    message(STATUS "Spice: Stack canaries disabled")
-endif ()


### PR DESCRIPTION
- Remove security options because they are enabled by default when using gcc with cmake
- Check security options in CI (only Linux for now)