### PR TITLE
Add Git hash and LLVM version info to Spice executable version info

### DIFF
--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug-MinGW" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/Options.cmake
+++ b/Options.cmake
@@ -53,7 +53,14 @@ add_definitions(-DSPICE_GIT_HASH="${SPICE_GIT_HASH}")
 message(STATUS "Spice: Git hash is set to '${SPICE_GIT_HASH}'")
 
 # Spice built by
-set(SPICE_BUILT_BY "$ENV{USERNAME}" CACHE STRING "Spice built by person")
+if(DEFINED ENV{USERNAME})
+    set(SPICE_BUILT_BY "$ENV{USERNAME}")
+elseif(DEFINED ENV{USER})
+    set(SPICE_BUILT_BY "$ENV{USER}")
+else()
+    set(SPICE_BUILT_BY "unknown")
+endif()
+set(SPICE_BUILT_BY "${SPICE_BUILT_BY}" CACHE STRING "Spice built by person")
 add_definitions(-DSPICE_BUILT_BY="${SPICE_BUILT_BY}")
 message(STATUS "Spice: Built by is set to '${SPICE_BUILT_BY}'")
 

--- a/Options.cmake
+++ b/Options.cmake
@@ -39,6 +39,19 @@ set(SPICE_VERSION "dev" CACHE STRING "Spice build version")
 add_definitions(-DSPICE_VERSION="${SPICE_VERSION}")
 message(STATUS "Spice: Build version is set to '${SPICE_VERSION}'")
 
+# Spice Git hash (defaults to current Git hash)
+execute_process(
+        COMMAND git rev-parse HEAD
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        OUTPUT_VARIABLE SPICE_GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT SPICE_GIT_HASH)
+    set(SPICE_GIT_HASH "dev" CACHE STRING "Spice Git hash")
+endif()
+add_definitions(-DSPICE_GIT_HASH="${SPICE_GIT_HASH}")
+message(STATUS "Spice: Git hash is set to '${SPICE_GIT_HASH}'")
+
 # Spice built by
 set(SPICE_BUILT_BY "$ENV{USERNAME}" CACHE STRING "Spice built by person")
 add_definitions(-DSPICE_BUILT_BY="${SPICE_BUILT_BY}")

--- a/src/util/CommonUtil.cpp
+++ b/src/util/CommonUtil.cpp
@@ -166,8 +166,10 @@ std::string CommonUtil::getCircularImportMessage(std::stack<const SourceFile *> 
  */
 std::string CommonUtil::getVersionInfo() {
   std::stringstream versionString;
-  versionString << "spice version " << SPICE_VERSION << " " << SPICE_TARGET_OS << "/" << SPICE_TARGET_ARCH << "\n";
-  versionString << "built by: " << SPICE_BUILT_BY << "\n\n";
+  versionString << "Spice version: " << SPICE_VERSION << " " << SPICE_TARGET_OS << "/" << SPICE_TARGET_ARCH << "\n";
+  versionString << "Git hash:      " << SPICE_GIT_HASH << "\n";
+  versionString << "LLVM version:  " << LLVM_VERSION_STRING << "\n";
+  versionString << "built by:      " << SPICE_BUILT_BY << "\n\n";
   versionString << "(c) Marc Auberer 2021-2025";
   return versionString.str();
 }

--- a/test/driver/Driver.cpp
+++ b/test/driver/Driver.cpp
@@ -2,6 +2,8 @@
 
 #include "Driver.h"
 
+#include "util/CommonUtil.h"
+
 // GCOV_EXCL_START
 
 void Driver::createInterface() {
@@ -14,8 +16,7 @@ void Driver::createInterface() {
   // Add version flag
   const std::string versionName(SPICE_VERSION);
   const std::string builtBy(SPICE_BUILT_BY);
-  const std::string versionString = "Spice version " + versionName + "\nbuilt by: " + builtBy + "\n\n(c) Marc Auberer 2021-2025";
-  app.set_version_flag("--version,-v", versionString);
+  app.set_version_flag("--version,-v", spice::compiler::CommonUtil::getVersionInfo());
 }
 
 void Driver::addOptions(bool &updateRefs, bool &runBenchmarks, bool &enableLeakDetection, bool &skipNonGitHubTests) {


### PR DESCRIPTION
`-v`/`--version` now displays something like this:

```
root@vmd117252:~/spice/bin# ./spice -v
Spice version: 0.20.7 linux/amd64
Git hash:      67f80da7688516f4717d250b8b80a1677a660b77
LLVM version:  19.1.6
built by:      ghactions
```