### PR TITLE
Avoid direct access to children vector of ASTNode

### DIFF
--- a/src/ast/ASTNodes.cpp
+++ b/src/ast/ASTNodes.cpp
@@ -130,11 +130,11 @@ bool DefaultBranchNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreacha
 
 bool StmtLstNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable) const {
   // An empty statement list does not return at all
-  if (children.empty())
+  if (statements.empty())
     return false;
   // A statement list returns on all control paths, if the one direct child statement returns on all control paths
   bool returnsOnAllControlPaths = false;
-  for (ASTNode *child : children) {
+  for (StmtNode *child : statements) {
     assert(child != nullptr);
 
     // Prevent marking instructions as unreachable if doSetPredecessorsUnreachable is set to false
@@ -189,7 +189,7 @@ bool AssertStmtNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable
 bool AssignExprNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable) const {
   // If it's a ternary, do the default thing
   if (op == OP_NONE)
-    return children.front()->returnsOnAllControlPaths(doSetPredecessorsUnreachable);
+    return ternaryExpr->returnsOnAllControlPaths(doSetPredecessorsUnreachable);
 
   // If it's a modification on the result variable, we technically return from the function, but at the end of the function.
   const bool hasAtomicExpr = lhs->postfixUnaryExpr && lhs->postfixUnaryExpr->atomicExpr;
@@ -210,8 +210,8 @@ bool TernaryExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue TernaryExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (!trueExpr && !falseExpr)
+    return condition->getCompileTimeValue();
 
   // If the condition has no compile time value, we do not need to evaluate the true and false values
   if (!condition->hasCompileTimeValue())
@@ -231,15 +231,14 @@ bool LogicalOrExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue LogicalOrExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   // Check if one expression evaluates to 'true'
   for (const LogicalAndExprNode *op : operands) {
     assert(op->hasCompileTimeValue());
     // If one operand evaluates to 'true' the whole expression is 'true'
-    const CompileTimeValue opCompileTimeValue = op->getCompileTimeValue();
-    if (opCompileTimeValue.boolValue)
+    if (const CompileTimeValue opCompileTimeValue = op->getCompileTimeValue(); opCompileTimeValue.boolValue)
       return CompileTimeValue{.boolValue = true};
   }
 
@@ -252,15 +251,14 @@ bool LogicalAndExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue LogicalAndExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   // Check if all expressions evaluate to 'true'
   for (const BitwiseOrExprNode *op : operands) {
     assert(op->hasCompileTimeValue());
     // If one operand evaluates to 'false' the whole expression is 'false'
-    const CompileTimeValue opCompileTimeValue = op->getCompileTimeValue();
-    if (!opCompileTimeValue.boolValue)
+    if (const CompileTimeValue opCompileTimeValue = op->getCompileTimeValue(); !opCompileTimeValue.boolValue)
       return CompileTimeValue{.boolValue = false};
   }
 
@@ -273,8 +271,8 @@ bool BitwiseOrExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue BitwiseOrExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   CompileTimeValue result = operands.front()->getCompileTimeValue();
   for (size_t i = 1; i < operands.size(); i++) {
@@ -291,8 +289,8 @@ bool BitwiseXorExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue BitwiseXorExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   CompileTimeValue result = operands.front()->getCompileTimeValue();
   for (size_t i = 1; i < operands.size(); i++) {
@@ -309,8 +307,8 @@ bool BitwiseAndExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue BitwiseAndExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   CompileTimeValue result = operands.front()->getCompileTimeValue();
   for (size_t i = 1; i < operands.size(); i++) {
@@ -327,8 +325,8 @@ bool EqualityExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue EqualityExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   const CompileTimeValue op0Value = operands.at(0)->getCompileTimeValue();
   const CompileTimeValue op1Value = operands.at(1)->getCompileTimeValue();
@@ -345,8 +343,8 @@ bool RelationalExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue RelationalExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   const CompileTimeValue op0Value = operands.at(0)->getCompileTimeValue();
   const CompileTimeValue op1Value = operands.at(1)->getCompileTimeValue();
@@ -367,8 +365,8 @@ bool ShiftExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue ShiftExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   const CompileTimeValue op0Value = operands.at(0)->getCompileTimeValue();
   const CompileTimeValue op1Value = operands.at(1)->getCompileTimeValue();
@@ -385,8 +383,8 @@ bool AdditiveExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue AdditiveExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   CompileTimeValue result = operands.front()->getCompileTimeValue();
   OpQueue opQueueCopy = opQueue;
@@ -410,8 +408,8 @@ bool MultiplicativeExprNode::hasCompileTimeValue() const {
 }
 
 CompileTimeValue MultiplicativeExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
+  if (operands.size() == 1)
+    return operands.front()->getCompileTimeValue();
 
   CompileTimeValue result = operands.front()->getCompileTimeValue();
   OpQueue opQueueCopy = opQueue;
@@ -438,8 +436,6 @@ CompileTimeValue MultiplicativeExprNode::getCompileTimeValue() const {
 bool CastExprNode::hasCompileTimeValue() const { return prefixUnaryExpr->hasCompileTimeValue(); }
 
 CompileTimeValue CastExprNode::getCompileTimeValue() const {
-  if (children.size() == 1)
-    return children.front()->getCompileTimeValue();
   return prefixUnaryExpr->getCompileTimeValue();
 }
 
@@ -521,8 +517,7 @@ void DataTypeNode::setFieldTypeRecursive() { // NOLINT(*-no-recursion)
   // Set the current node to field type
   isFieldType = true;
   // Do the same for all template nodes
-  const CustomDataTypeNode *customType = baseDataType->customDataType;
-  if (customType != nullptr && customType->templateTypeLst)
+  if (const CustomDataTypeNode *customType = baseDataType->customDataType; customType != nullptr && customType->templateTypeLst)
     for (DataTypeNode *templateNode : customType->templateTypeLst->dataTypes)
       templateNode->setFieldTypeRecursive();
 }

--- a/src/ast/ASTNodes.cpp
+++ b/src/ast/ASTNodes.cpp
@@ -497,12 +497,12 @@ bool FctCallNode::hasReturnValueReceiver() const {
   const ASTNode *node = parent;
   while (!node->isAssignExpr()) {
     // As soon as we have a node with more than one child, we know that the return value is used
-    if (node->children.size() > 1)
+    if (node->getChildren().size() > 1)
       return true;
     node = node->parent;
   }
   // Also check the condition of the assign expression
-  return node->children.size() > 1 || !node->parent->isExprStmt();
+  return node->getChildren().size() > 1 || !node->parent->isExprStmt();
 }
 
 bool LambdaFuncNode::returnsOnAllControlPaths(bool *overrideUnreachable) const {

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -73,9 +73,11 @@ public:
     node->parent = this;
   }
 
-  void resizeToNumberOfManifestations(size_t manifestationCount) { // NOLINT(misc-no-recursion)
+  ALWAYS_INLINE const std::vector<ASTNode *> &getChildren() const { return children; }
+
+  void resizeToNumberOfManifestations(const size_t manifestationCount) { // NOLINT(misc-no-recursion)
     // Resize children
-    for (ASTNode *child : children) {
+    for (ASTNode *child : getChildren()) {
       assert(child != nullptr);
       child->resizeToNumberOfManifestations(manifestationCount);
     }
@@ -105,18 +107,21 @@ public:
   [[nodiscard]] const QualType &getEvaluatedSymbolType(const size_t idx) const { // NOLINT(misc-no-recursion)
     if (!symbolTypes.empty() && !symbolTypes.at(idx).is(TY_INVALID))
       return symbolTypes.at(idx);
+    const std::vector<ASTNode *> &children = getChildren();
     if (children.size() != 1)
       throw CompilerError(INTERNAL_ERROR, "Cannot deduce evaluated symbol type");
     return children.front()->getEvaluatedSymbolType(idx);
   }
 
   [[nodiscard]] virtual bool hasCompileTimeValue() const { // NOLINT(misc-no-recursion)
+    const std::vector<ASTNode *> &children = getChildren();
     if (children.size() != 1)
       return false;
     return children.front()->hasCompileTimeValue();
   }
 
   [[nodiscard]] virtual CompileTimeValue getCompileTimeValue() const { // NOLINT(misc-no-recursion)
+    const std::vector<ASTNode *> &children = getChildren();
     if (children.size() != 1)
       return {};
     return children.front()->getCompileTimeValue();
@@ -125,6 +130,7 @@ public:
   [[nodiscard]] std::string getErrorMessage() const;
 
   [[nodiscard]] virtual bool returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable) const { // NOLINT(misc-no-recursion)
+    const std::vector<ASTNode *> &children = getChildren();
     return children.size() == 1 && children.front()->returnsOnAllControlPaths(doSetPredecessorsUnreachable);
   }
 

--- a/src/ast/AbstractASTVisitor.cpp
+++ b/src/ast/AbstractASTVisitor.cpp
@@ -9,7 +9,7 @@ namespace spice::compiler {
 std::any AbstractASTVisitor::visit(ASTNode *node) { return node->accept(this); }
 
 std::any AbstractASTVisitor::visitChildren(ASTNode *node) {
-  for (ASTNode *child : node->children) {
+  for (ASTNode *child : node->getChildren()) {
     assert(child != nullptr);
     child->accept(this);
   }

--- a/src/ast/ParallelizableASTVisitor.cpp
+++ b/src/ast/ParallelizableASTVisitor.cpp
@@ -9,7 +9,7 @@ namespace spice::compiler {
 std::any ParallelizableASTVisitor::visit(const ASTNode *node) { return node->accept(this); }
 
 std::any ParallelizableASTVisitor::visitChildren(const ASTNode *node) {
-  for (const ASTNode *child : node->children)
+  for (const ASTNode *child : node->getChildren())
     if (child != nullptr)
       child->accept(this);
   return nullptr;

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -11,7 +11,7 @@ namespace spice::compiler {
 
 std::any IRGenerator::visitStmtLst(const StmtLstNode *node) {
   // Generate instructions in the scope
-  for (const ASTNode *stmt : node->children) {
+  for (const StmtNode *stmt : node->statements) {
     if (!stmt)
       continue;
     // Check if we can cancel generating instructions for this code branch

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -393,7 +393,7 @@ std::any TypeChecker::visitAnonymousBlockStmt(AnonymousBlockStmtNode *node) {
 
 std::any TypeChecker::visitStmtLst(StmtLstNode *node) {
   // Visit nodes in this scope
-  for (ASTNode *stmt : node->children) {
+  for (StmtNode *stmt : node->statements) {
     if (!stmt)
       continue;
     // Print warning if statement is unreachable
@@ -999,7 +999,7 @@ std::any TypeChecker::visitTernaryExpr(TernaryExprNode *node) {
 
 std::any TypeChecker::visitLogicalOrExpr(LogicalOrExprNode *node) {
   // Check if a logical or operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit leftmost operand
@@ -1018,7 +1018,7 @@ std::any TypeChecker::visitLogicalOrExpr(LogicalOrExprNode *node) {
 
 std::any TypeChecker::visitLogicalAndExpr(LogicalAndExprNode *node) {
   // Check if a logical and operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit leftmost operand
@@ -1037,7 +1037,7 @@ std::any TypeChecker::visitLogicalAndExpr(LogicalAndExprNode *node) {
 
 std::any TypeChecker::visitBitwiseOrExpr(BitwiseOrExprNode *node) {
   // Check if a bitwise or operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit leftmost operand
@@ -1056,7 +1056,7 @@ std::any TypeChecker::visitBitwiseOrExpr(BitwiseOrExprNode *node) {
 
 std::any TypeChecker::visitBitwiseXorExpr(BitwiseXorExprNode *node) {
   // Check if a bitwise xor operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit leftmost operand
@@ -1075,7 +1075,7 @@ std::any TypeChecker::visitBitwiseXorExpr(BitwiseXorExprNode *node) {
 
 std::any TypeChecker::visitBitwiseAndExpr(BitwiseAndExprNode *node) {
   // Check if a bitwise and operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit leftmost operand
@@ -1094,7 +1094,7 @@ std::any TypeChecker::visitBitwiseAndExpr(BitwiseAndExprNode *node) {
 
 std::any TypeChecker::visitEqualityExpr(EqualityExprNode *node) {
   // Check if at least one equality operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit right side first, then left side
@@ -1122,7 +1122,7 @@ std::any TypeChecker::visitEqualityExpr(EqualityExprNode *node) {
 
 std::any TypeChecker::visitRelationalExpr(RelationalExprNode *node) {
   // Check if a relational operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit right side first, then left side
@@ -1149,7 +1149,7 @@ std::any TypeChecker::visitRelationalExpr(RelationalExprNode *node) {
 
 std::any TypeChecker::visitShiftExpr(ShiftExprNode *node) {
   // Check if at least one shift operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit right side first, then left
@@ -1173,7 +1173,7 @@ std::any TypeChecker::visitShiftExpr(ShiftExprNode *node) {
 
 std::any TypeChecker::visitAdditiveExpr(AdditiveExprNode *node) {
   // Check if at least one additive operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit leftmost operand
@@ -1207,7 +1207,7 @@ std::any TypeChecker::visitAdditiveExpr(AdditiveExprNode *node) {
 
 std::any TypeChecker::visitMultiplicativeExpr(MultiplicativeExprNode *node) {
   // Check if at least one multiplicative operator is applied
-  if (node->children.size() == 1)
+  if (node->operands.size() == 1)
     return visit(node->operands.front());
 
   // Visit leftmost operand

--- a/src/visualizer/ASTVisualizer.h
+++ b/src/visualizer/ASTVisualizer.h
@@ -136,7 +136,7 @@ private:
     parentNodeIds.push(nodeId); // Set parentNodeId for children
 
     // Visit all the children
-    for (ASTNode *child : node->children)
+    for (ASTNode *child : node->getChildren())
       if (child != nullptr)
         result << " " << std::any_cast<std::string>(visit(child));
 


### PR DESCRIPTION
Prepare transition to ASTNode member access, by reducing the read accesses to children vector of ASTNode class.