### PR TITLE
Re-implement getChildren mechanism on ASTNode

### DIFF
--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug-MinGW" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,19 +1,5 @@
-import "std/data/optional";
-import "std/data/stack";
-
 f<int> main() {
-    Stack<double> doubleStack = Stack<double>();
-    doubleStack.push(4.566);
-
-    dyn oi = Optional<Stack<double>>();
-    printf("%d\n", oi.isPresent());
-    oi.set(doubleStack);
-    printf("%d\n", oi.isPresent());
-    dyn res = oi.get();
-    printf("%d\n", res.getSize());
-    oi.clear();
-    printf("%d\n", oi.isPresent());
-
-    dyn oi2 = Optional<String>(String("This is a test"));
-    assert oi2.isPresent();
+    f<int>(int, int) add = f<int>(int x, int y) {
+        return "String";
+    };
 }

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,5 +1,11 @@
+type T dyn;
+
+f<int> print<T>(T g) {
+    printf("%d", g);
+    return 0;
+}
+
 f<int> main() {
-    f<int>(int, int) add = f<int>(int x, int y) {
-        return "String";
-    };
+    print(1);
+    print("string");
 }

--- a/src/ast/ASTBuilder.cpp
+++ b/src/ast/ASTBuilder.cpp
@@ -1563,7 +1563,7 @@ std::any ASTBuilder::visitFunctionDataType(SpiceParser::FunctionDataTypeContext 
 }
 
 std::any ASTBuilder::visitAssignOp(SpiceParser::AssignOpContext *ctx) {
-  const auto assignExprNode = spice_pointer_cast<AssignExprNode *>(parentStack.top());
+  const auto assignExprNode = resumeForExpansion<AssignExprNode>();
 
   // Extract assign operator
   if (ctx->ASSIGN())
@@ -1595,7 +1595,7 @@ std::any ASTBuilder::visitAssignOp(SpiceParser::AssignOpContext *ctx) {
 }
 
 std::any ASTBuilder::visitOverloadableOp(SpiceParser::OverloadableOpContext *ctx) {
-  const auto fctNameNode = spice_pointer_cast<FctNameNode *>(parentStack.top());
+  const auto fctNameNode = resumeForExpansion<FctNameNode>();
 
   // Enrich
   if (ctx->PLUS())

--- a/src/ast/ASTBuilder.cpp
+++ b/src/ast/ASTBuilder.cpp
@@ -8,7 +8,6 @@
 #include <ast/ASTNodes.h>
 #include <ast/Attributes.h>
 #include <exception/ParserError.h>
-#include <global/GlobalResourceManager.h>
 #include <typechecker/OpRuleManager.h>
 #include <util/GlobalDefinitions.h>
 
@@ -339,7 +338,7 @@ std::any ASTBuilder::visitForLoop(SpiceParser::ForLoopContext *ctx) {
 }
 
 std::any ASTBuilder::visitForHead(SpiceParser::ForHeadContext *ctx) {
-  auto forLoopNode = resumeForExpansion<ForLoopNode>();
+  const auto forLoopNode = resumeForExpansion<ForLoopNode>();
 
   // Visit children
   forLoopNode->initDecl = std::any_cast<DeclStmtNode *>(visit(ctx->declStmt()));
@@ -363,7 +362,7 @@ std::any ASTBuilder::visitForeachLoop(SpiceParser::ForeachLoopContext *ctx) {
 }
 
 std::any ASTBuilder::visitForeachHead(SpiceParser::ForeachHeadContext *ctx) {
-  auto foreachLoopNode = resumeForExpansion<ForeachLoopNode>();
+  const auto foreachLoopNode = resumeForExpansion<ForeachLoopNode>();
 
   // Visit children
   if (ctx->declStmt().size() == 1) {
@@ -1634,33 +1633,6 @@ std::any ASTBuilder::visitOverloadableOp(SpiceParser::OverloadableOpContext *ctx
   fctNameNode->nameFragments.push_back(fctNameNode->name);
 
   return nullptr;
-}
-
-template <typename T> T *ASTBuilder::createNode(const ParserRuleContext *ctx) {
-  ASTNode *parent = nullptr;
-  if constexpr (!std::is_same_v<T, EntryNode>)
-    parent = parentStack.top();
-
-  // Create the new node
-  T *node = resourceManager.astNodeAlloc.allocate<T>(getCodeLoc(ctx));
-
-  // If this is not the entry node, we need to add the new node to its parent
-  if constexpr (!std::is_same_v<T, EntryNode>)
-    parent->addChild(node);
-
-  // This node is the parent for its children
-  parentStack.push(node);
-
-  return node;
-}
-
-template <typename T> T *ASTBuilder::resumeForExpansion() { return spice_pointer_cast<T *>(parentStack.top()); }
-
-template <typename T> T *ASTBuilder::concludeNode(T *node) {
-  // This node is no longer the parent for its children
-  assert(parentStack.top() == node);
-  parentStack.pop();
-  return node;
 }
 
 int32_t ASTBuilder::parseInt(TerminalNode *terminal) {

--- a/src/ast/ASTBuilder.h
+++ b/src/ast/ASTBuilder.h
@@ -19,6 +19,7 @@ namespace spice::compiler {
 
 // Forward declarations
 class ASTNode;
+class EntryNode;
 class ConstantNode;
 
 static constexpr const char *const RESERVED_KEYWORDS[] = {"new", "stash", "pick", "sync", "class"};
@@ -135,6 +136,8 @@ private:
   template <typename T> ALWAYS_INLINE T *createNode(const ParserRuleContext *ctx) {
     // Create the new node
     T *node = resourceManager.astNodeAlloc.allocate<T>(getCodeLoc(ctx));
+    if constexpr (!std::is_same_v<T, EntryNode>)
+      node->parent = parentStack.top();
     // This node is the parent for its children
     parentStack.push(node);
     return node;

--- a/src/ast/ASTBuilder.h
+++ b/src/ast/ASTBuilder.h
@@ -11,6 +11,7 @@
 #pragma GCC diagnostic pop
 
 #include <CompilerPass.h>
+#include <global/GlobalResourceManager.h>
 #include <util/CodeLoc.h>
 #include <util/GlobalDefinitions.h>
 
@@ -131,14 +132,29 @@ private:
   std::stack<ASTNode *> parentStack;
 
   // Private methods
-  template <typename T> T *createNode(const ParserRuleContext *ctx);
-  template <typename T> T *resumeForExpansion();
-  template <typename T> T *concludeNode(T *node);
-  ALWAYS_INLINE CodeLoc getCodeLoc(const ParserRuleContext *ctx) {
+  template <typename T> ALWAYS_INLINE T *createNode(const ParserRuleContext *ctx) {
+    // Create the new node
+    T *node = resourceManager.astNodeAlloc.allocate<T>(getCodeLoc(ctx));
+    // This node is the parent for its children
+    parentStack.push(node);
+    return node;
+  }
+
+  template <typename T> ALWAYS_INLINE T *resumeForExpansion() const { return spice_pointer_cast<T *>(parentStack.top()); }
+
+  template <typename T> ALWAYS_INLINE T *concludeNode(T *node) {
+    // This node is no longer the parent for its children
+    assert(parentStack.top() == node);
+    parentStack.pop();
+    return node;
+  }
+
+  ALWAYS_INLINE CodeLoc getCodeLoc(const ParserRuleContext *ctx) const {
     const size_t startIdx = ctx->start->getStartIndex();
     const size_t stopIdx = ctx->stop ? ctx->stop->getStopIndex() : startIdx;
     return {ctx->start, startIdx, stopIdx, sourceFile};
   }
+
   int32_t parseInt(TerminalNode *terminal);
   int16_t parseShort(TerminalNode *terminal);
   int64_t parseLong(TerminalNode *terminal);

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -185,7 +185,7 @@ public:
 };
 
 // Make sure we have no unexpected increases in memory consumption
-static_assert(sizeof(ASTNode) == 104);
+static_assert(sizeof(ASTNode) == 80);
 
 // ========================================================== EntryNode ==========================================================
 

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -72,12 +72,6 @@ public:
   virtual std::any accept(AbstractASTVisitor *visitor) = 0;
   virtual std::any accept(ParallelizableASTVisitor *visitor) const = 0;
 
-  // Public methods
-  ALWAYS_INLINE void addChild(ASTNode *node) {
-    children.push_back(node);
-    node->parent = this;
-  }
-
   template <typename... Args> ALWAYS_INLINE std::vector<ASTNode *> collectChildren(Args &&...args) const {
     std::vector<ASTNode *> children;
 
@@ -185,7 +179,6 @@ public:
 
   // Public members
   ASTNode *parent = nullptr;
-  std::vector<ASTNode *> children;
   const CodeLoc codeLoc;
   QualTypeList symbolTypes;
   bool unreachable = false;

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -199,12 +199,12 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitEntry(this); }
 
   // Other methods
-  GET_CHILDREN(topLevelDefs, modAttrs, importDefs);
+  GET_CHILDREN(importDefs, modAttrs, topLevelDefs);
 
   // Public members
-  std::vector<TopLevelDefNode *> topLevelDefs;
-  std::vector<ModAttrNode *> modAttrs;
   std::vector<ImportDefNode *> importDefs;
+  std::vector<ModAttrNode *> modAttrs;
+  std::vector<TopLevelDefNode *> topLevelDefs;
 };
 
 // ======================================================= TopLevelDefNode =======================================================

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -372,7 +372,7 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitStructDef(this); }
 
   // Other methods
-  GET_CHILDREN(attrs, specifierLst, fields, templateTypeLst, interfaceTypeLst);
+  GET_CHILDREN(attrs, specifierLst, templateTypeLst, interfaceTypeLst, fields);
   std::vector<Struct *> *getStructManifestations() override { return &structManifestations; }
   std::vector<Function *> *getFctManifestations(const std::string &fctName) override {
     if (!defaultFctManifestations.contains(fctName))
@@ -384,9 +384,9 @@ public:
   // Public members
   TopLevelDefinitionAttrNode *attrs = nullptr;
   SpecifierLstNode *specifierLst = nullptr;
-  std::vector<FieldNode *> fields;
   TypeLstNode *templateTypeLst = nullptr;
   TypeLstNode *interfaceTypeLst = nullptr;
+  std::vector<FieldNode *> fields;
   bool hasTemplateTypes = false;
   bool hasInterfaces = false;
   bool emitVTable = false;
@@ -411,14 +411,14 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitInterfaceDef(this); }
 
   // Other methods
-  GET_CHILDREN(attrs, specifierLst, signatures, templateTypeLst);
+  GET_CHILDREN(attrs, specifierLst, templateTypeLst, signatures);
   std::vector<Interface *> *getInterfaceManifestations() override { return &interfaceManifestations; }
 
   // Public members
   TopLevelDefinitionAttrNode *attrs = nullptr;
   SpecifierLstNode *specifierLst = nullptr;
-  std::vector<SignatureNode *> signatures;
   TypeLstNode *templateTypeLst = nullptr;
+  std::vector<SignatureNode *> signatures;
   bool hasTemplateTypes = false;
   TypeSpecifiers interfaceSpecifiers = TypeSpecifiers::of(TY_INTERFACE);
   std::string interfaceName;
@@ -681,13 +681,13 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitDoWhileLoop(this); }
 
   // Other methods
-  GET_CHILDREN(condition, body);
+  GET_CHILDREN(body, condition);
   [[nodiscard]] std::string getScopeId() const { return "dowhile:" + codeLoc.toString(); }
   [[nodiscard]] bool returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable) const override;
 
   // Public members
-  AssignExprNode *condition = nullptr;
   StmtLstNode *body = nullptr;
+  AssignExprNode *condition = nullptr;
   Scope *bodyScope = nullptr;
 };
 
@@ -1405,8 +1405,10 @@ public:
   [[nodiscard]] bool hasCompileTimeValue() const override { return false; }
 
   // Public members
-  AssignExprNode *assignExpr = nullptr;
-  DataTypeNode *dataType = nullptr;
+  union {
+    AssignExprNode *assignExpr = nullptr;
+    DataTypeNode *dataType;
+  };
   bool isType = false;
 };
 
@@ -1426,8 +1428,10 @@ public:
   [[nodiscard]] bool hasCompileTimeValue() const override { return false; }
 
   // Public members
-  AssignExprNode *assignExpr = nullptr;
-  DataTypeNode *dataType = nullptr;
+  union {
+    AssignExprNode *assignExpr = nullptr;
+    DataTypeNode *dataType;
+  };
   bool isType = false;
 };
 

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -315,6 +315,7 @@ public:
   // Public members
   TopLevelDefinitionAttrNode *attrs = nullptr;
   SpecifierLstNode *specifierLst = nullptr;
+  FctNameNode *name;
   TypeLstNode *templateTypeLst = nullptr;
   ParamLstNode *paramLst = nullptr;
   StmtLstNode *body = nullptr;
@@ -322,7 +323,6 @@ public:
   bool hasTemplateTypes = false;
   bool hasParams = false;
   TypeSpecifiers specifiers = TypeSpecifiers::of(TY_FUNCTION);
-  FctNameNode *name;
   SymbolTableEntry *entry = nullptr;
   Scope *structScope = nullptr;
   Scope *scope = nullptr;
@@ -341,7 +341,7 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitFctDef(this); }
 
   // Other methods
-  GET_CHILDREN(attrs, specifierLst, templateTypeLst, paramLst, body, returnType);
+  GET_CHILDREN(attrs, specifierLst, returnType, name, templateTypeLst, paramLst, body);
   [[nodiscard]] std::string getScopeId() const { return "fct:" + codeLoc.toString(); }
 
   // Public members
@@ -360,7 +360,7 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitProcDef(this); }
 
   // Other methods
-  GET_CHILDREN(attrs, specifierLst, templateTypeLst, paramLst, body);
+  GET_CHILDREN(attrs, specifierLst, name, templateTypeLst, paramLst, body);
   [[nodiscard]] std::string getScopeId() const { return "proc:" + codeLoc.toString(); }
 
   // Public members
@@ -2115,7 +2115,6 @@ public:
   using ExprNode::ExprNode;
 
   // Other methods
-  GET_CHILDREN(paramLst);
   [[nodiscard]] std::string getScopeId() const { return "lambda:" + codeLoc.toString(); }
   [[nodiscard]] bool hasCompileTimeValue() const override { return false; }
   void customItemsInitialization(const size_t manifestationCount) override { manifestations.resize(manifestationCount); }
@@ -2139,7 +2138,7 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitLambdaFunc(this); }
 
   // Other methods
-  GET_CHILDREN(returnType, body, lambdaAttr);
+  GET_CHILDREN(returnType, paramLst, body, lambdaAttr);
   [[nodiscard]] bool returnsOnAllControlPaths(bool *overrideUnreachable) const override;
 
   // Public members
@@ -2160,7 +2159,7 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitLambdaProc(this); }
 
   // Other methods
-  GET_CHILDREN(body, lambdaAttr);
+  GET_CHILDREN(paramLst, body, lambdaAttr);
   bool returnsOnAllControlPaths(bool *overrideUnreachable) const override;
 
   // Public members
@@ -2180,7 +2179,7 @@ public:
   std::any accept(ParallelizableASTVisitor *visitor) const override { return visitor->visitLambdaExpr(this); }
 
   // Other methods
-  GET_CHILDREN(lambdaExpr);
+  GET_CHILDREN(paramLst, lambdaExpr);
 
   // Public members
   AssignExprNode *lambdaExpr = nullptr;

--- a/src/util/CommonUtil.h
+++ b/src/util/CommonUtil.h
@@ -11,6 +11,13 @@ namespace spice::compiler {
 // Forward declarations
 class SourceFile;
 
+// Compile time check, if T is a vector of a class, that is derived from BaseT
+template <typename T, typename BaseT> struct is_vector_of_derived_from {
+  using ElTy = std::remove_pointer_t<typename T::value_type>;
+  static constexpr bool value = std::is_base_of_v<BaseT, ElTy> && std::is_same_v<T, std::vector<typename T::value_type>>;
+};
+template <typename T, typename BaseT> constexpr bool is_vector_of_derived_from_v = is_vector_of_derived_from<T, BaseT>::value;
+
 /**
  * Util for general simplification of tasks
  */

--- a/test/unittest/UnitBlockAllocator.cpp
+++ b/test/unittest/UnitBlockAllocator.cpp
@@ -24,6 +24,9 @@ class DummyNode final : public ASTNode {
   // Visitor methods
   std::any accept(AbstractASTVisitor *visitor) override { return {}; }             // LCOV_EXCL_LINE
   std::any accept(ParallelizableASTVisitor *visitor) const override { return {}; } // LCOV_EXCL_LINE
+
+  // Other methods
+  GET_CHILDREN();
 };
 static constexpr size_t DUMMY_NODE_SIZE = sizeof(DummyNode);
 static_assert(DUMMY_NODE_SIZE == 104, "DummyNode size has changed. Update test accordingly.");

--- a/test/unittest/UnitBlockAllocator.cpp
+++ b/test/unittest/UnitBlockAllocator.cpp
@@ -29,7 +29,7 @@ class DummyNode final : public ASTNode {
   GET_CHILDREN();
 };
 static constexpr size_t DUMMY_NODE_SIZE = sizeof(DummyNode);
-static_assert(DUMMY_NODE_SIZE == 104, "DummyNode size has changed. Update test accordingly.");
+static_assert(DUMMY_NODE_SIZE == 80, "DummyNode size has changed. Update test accordingly.");
 
 class MockMemoryManager final : public MemoryManager {
 public:
@@ -39,7 +39,7 @@ public:
 
 TEST(BlockAllocatorTest, TestBlockAllocatorLarge) {
   destructedDummyNodes = 0;                     // Reset destruction counter
-  static constexpr size_t NODE_COUNT = 100'000; // 100.000 * 104 bytes = 10.4 MB
+  static constexpr size_t NODE_COUNT = 100'000; // 100.000 * 80 bytes = 8.0 MB
 
   {
     // Create allocator, that can hold 5 nodes per block
@@ -58,7 +58,7 @@ TEST(BlockAllocatorTest, TestBlockAllocatorLarge) {
 
     // Check if stats are correct
     ASSERT_EQ(NODE_COUNT, alloc.getAllocationCount());
-    ASSERT_EQ(13'000'000, alloc.getTotalAllocatedSize());
+    ASSERT_EQ(10'000'000, alloc.getTotalAllocatedSize());
 
     // Block Allocator gets destructed here and with that, all allocated nodes should be destructed
   }
@@ -68,7 +68,7 @@ TEST(BlockAllocatorTest, TestBlockAllocatorLarge) {
 
 TEST(BlockAllocatorTest, TestBlockAllocatorUnevenBlockSize) {
   destructedDummyNodes = 0;                   // Reset destruction counter
-  static constexpr size_t NODE_COUNT = 1'000; // 1.000 * 104 bytes = 104 KB
+  static constexpr size_t NODE_COUNT = 1'000; // 1.000 * 80 bytes = 80 KB
 
   {
     // Create allocator, that can hold 4.5 nodes per block
@@ -87,7 +87,7 @@ TEST(BlockAllocatorTest, TestBlockAllocatorUnevenBlockSize) {
 
     // Check if stats are correct
     ASSERT_EQ(NODE_COUNT, alloc.getAllocationCount());
-    ASSERT_EQ(117'000, alloc.getTotalAllocatedSize());
+    ASSERT_EQ(90'000, alloc.getTotalAllocatedSize());
 
     // Block Allocator gets destructed here and with that, all allocated nodes should be destructed
   }
@@ -97,7 +97,7 @@ TEST(BlockAllocatorTest, TestBlockAllocatorUnevenBlockSize) {
 
 TEST(BlockAllocatorTest, TestBlockAllocatorOOM) {
   destructedDummyNodes = 0;                // Reset destruction counter
-  static constexpr size_t NODE_COUNT = 10; // 10 * 104 bytes = 1.04 KB
+  static constexpr size_t NODE_COUNT = 10; // 10 * 80 bytes = 0.8 KB
 
   // Prepare mock methods
   MockMemoryManager mockMemoryManager;


### PR DESCRIPTION
`getChildren()` now does no longer return a reference to the `children` member of an ASTNode, which was a `std::vector<ASTNode *>`. Now this member was removed and we construct the vector from the child members of each individual class using template and macro magic. Removing the `children` member reduces the memory consumption of the `ASTNode` base class from 104 to 80 bytes. As this class serves as parent class for each and every ASTNode class, there is a 23% decrease in memuse for the AST expected.