### PR TITLE
Add ignoreUnusedReturnValue attribute for functions

### DIFF
--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O2 -d ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,165 +1,37 @@
-import "std/test/lifetime-object";
-
-/*f<LifetimeObject> spawnLO() {
-    return LifetimeObject();
-}
-
-f<LifetimeObject> decideOnLOConstRef(bool cond, const LifetimeObject& lo1, const LifetimeObject& lo2) {
-    cond ? lo1 : lo2; // Should not do a copy
-    LifetimeObject loCopy = cond ? lo1 : lo2; // Shoud do a copy
-    const LifetimeObject& loRef = cond ? lo1 : lo2; // Should not do a copy
-    return cond ? lo1 : lo2; // Return statement should do a copy
-}
-
-f<LifetimeObject> decideOnLORef(bool cond, LifetimeObject& lo1, LifetimeObject& lo2) {
-    cond ? lo1 : lo2; // Should not do a copy
-    LifetimeObject loCopy = cond ? lo1 : lo2; // Shoud do a copy
-    const LifetimeObject& loRef = cond ? lo1 : lo2; // Should not do a copy
-    return cond ? lo1 : lo2; // Return statement should do a copy
-}*/
-
-f<LifetimeObject> decideOnLOVal(bool cond, LifetimeObject lo1, LifetimeObject lo2) {
-    cond ? lo1 : lo2; // Shoud do a copy, although the result is ignored
-    LifetimeObject loCopy = cond ? lo1 : lo2; // Shoud do a copy
-    const LifetimeObject& loRef = cond ? lo1 : lo2; // Should not do a copy
-    return cond ? lo1 : lo2; // Return statement should do a copy
-}
+import "std/text/stringstream";
 
 f<int> main() {
-    // Ignored return value of ctor
-    /*printf("Ignored return value of ctor:\n");
-    {
-        LifetimeObject();
-    }
+    // Basic usage with raw string literals
+    StringStream ss1;
+    ss1 << "Hello" << " World!";
+    assert ss1.str() == "Hello World!";
 
-    // Normal lifecycle
-    printf("Normal lifecycle:\n");
-    {
-        LifetimeObject lo = LifetimeObject(); // ctor call
-        LifetimeObject loCopy = lo; // copy ctor call
-    }
+    // Basic usage with String values
+    StringStream ss2 = StringStream(String("This "));
+    ss2 << String("is") << String(" a ") << String("test!") << endl();
+    assert ss2.str() == "This is a test!\n";
 
-    // Return from lambda as value
-    printf("Return from lambda as value:\n");
-    {
-        const f<LifetimeObject>() spawnLO = f<LifetimeObject>() {
-            return LifetimeObject();
-        };
+    // Mixed usage
+    StringStream ss3 = StringStream("Hello");
+    ss3 << String(" fellow") << " Programmers" << endl();
+    assert ss3.str() == "Hello fellow Programmers\n";
 
-        // No return value receiver
-        spawnLO(); // Anonymous symbol
-        // Return value receiver - value
-        LifetimeObject lo = spawnLO(); // Assigned to lo
-        // Return value receiver - const ref
-        const LifetimeObject& loConstRef = spawnLO(); // Assigned to loConstRef
-    }
+    // Usage spread over multiple lines
+    StringStream ss4 = StringStream();
+    ss4 << "This ";
+    ss4 << "is ";
+    ss4 << "a ";
+    ss4 << "multiline ";
+    ss4 << "test";
+    ss4 << endl();
+    assert ss4.str() == "This is a multiline test\n";
 
-    // Return from lambda as reference
-    printf("Return from lambda as reference:\n");
-    {
-        LifetimeObject loOrig = LifetimeObject();
-        const f<LifetimeObject&>() spawnLO = f<LifetimeObject&>() {
-            return loOrig;
-        };
-
-        // No return value receiver
-        spawnLO(); // Anonymous symbol
-        // Return value receiver - value
-        LifetimeObject lo = spawnLO(); // Assigned to lo
-        // Return value receiver - const ref
-        const LifetimeObject& loConstRef = spawnLO(); // Assigned to loConstRef
-    }
-
-    // Return from lambda as const reference
-    printf("Return from lambda as const reference:\n");
-    {
-        LifetimeObject loOrig = LifetimeObject();
-        const f<const LifetimeObject&>() spawnLO = f<const LifetimeObject&>() {
-            return loOrig;
-        };
-
-        // No return value receiver
-        spawnLO(); // Anonymous symbol
-        // Return value receiver - value
-        LifetimeObject lo = spawnLO(); // Assigned to lo
-        // Return value receiver - const ref
-        const LifetimeObject& loConstRef = spawnLO(); // Assigned to loConstRef
-    }
-
-    // Return from function as value
-    printf("Return from function as value:\n");
-    {
-        // No return value receiver
-        spawnLO(); // Anonymous symbol
-        // Return value receiver - value
-        LifetimeObject lo = spawnLO(); // Assigned to lo
-        // Return value receiver - const ref
-        const LifetimeObject& loConstRef = spawnLO(); // Assigned to loConstRef
-    }
-
-    printf("Ternary (true temporary, false temporary)\n");
-    {
-        bool cond = true;
-        LifetimeObject loCopy1 = cond ? LifetimeObject() : LifetimeObject(); // ctor calls in both branches
-        LifetimeObject loCopy2 = !cond ? LifetimeObject() : LifetimeObject(); // ctor calls in both branches
-    }
-
-    printf("Ternary (true temporary, false not temporary)\n");
-    {
-        bool cond = true;
-        LifetimeObject lo = LifetimeObject();
-        LifetimeObject loCopy1 = cond ? LifetimeObject() : lo; // ctor in true branch, copy ctor in false branch
-        LifetimeObject loCopy2 = !cond ? LifetimeObject() : lo; // ctor in true branch, copy ctor in false branch
-    }
-
-    printf("Ternary (true not temporary, false temporary)\n");
-    {
-        bool cond = true;
-        LifetimeObject lo = LifetimeObject();
-        LifetimeObject loCopy1 = cond ? lo : LifetimeObject(); // copy ctor in true branch, ctor in false branch
-        LifetimeObject loCopy2 = !cond ? lo : LifetimeObject(); // copy ctor in true branch, ctor in false branch
-    }
-
-    printf("Ternary (true not temporary, false not temporary)\n");
-    {
-        bool cond = true;
-        LifetimeObject lo1 = LifetimeObject();
-        LifetimeObject lo2 = LifetimeObject();
-        LifetimeObject loCopy1 = cond ? lo1 : lo2; // copy ctor call in both branches
-        LifetimeObject loCopy2 = !cond ? lo1 : lo2; // copy ctor call in both branches
-    }
-
-    printf("Ternary function (const ref) return:\n");
-    {
-        bool cond = true;
-        LifetimeObject lo1 = LifetimeObject();
-        LifetimeObject lo2 = LifetimeObject();
-        LifetimeObject lo3 = decideOnLOConstRef(cond, lo1, lo2);
-        LifetimeObject lo4 = decideOnLOConstRef(!cond, lo1, lo2);
-    }
-
-    printf("Ternary function (ref) return:\n");
-    {
-        bool cond = true;
-        LifetimeObject lo1 = LifetimeObject();
-        LifetimeObject lo2 = LifetimeObject();
-        LifetimeObject lo3 = decideOnLORef(cond, lo1, lo2);
-        LifetimeObject lo4 = decideOnLORef(!cond, lo1, lo2);
-    }*/
-
-    printf("Ternary function (val) return:\n");
-    {
-        bool cond = true;
-        LifetimeObject lo1 = LifetimeObject();
-        LifetimeObject lo2 = LifetimeObject();
-        LifetimeObject lo3 = decideOnLOVal(cond, lo1, lo2);
-        LifetimeObject lo4 = decideOnLOVal(!cond, lo1, lo2);
-    }
-
-    /*printf("Ternary receiving function result:\n");
-    {
-        bool cond = false;
-        LifetimeObject lo1 = cond ? spawnLO() : spawnLO();
-        LifetimeObject lo2 = !cond ? (cond ? spawnLO() : spawnLO()) : spawnLO();
-    }*/
+    printf("All assertions passed!");
 }
+
+/*import "std/data/map";
+
+f<int> main() {
+    Map<string, int> map;
+    map["test"] = 1;
+}*/

--- a/src-bootstrap/ast/attributes.spice
+++ b/src-bootstrap/ast/attributes.spice
@@ -8,7 +8,7 @@ import "bootstrap/ast/ast-nodes";
 public const string ATTR_CORE_LINKER_FLAG = "core.linker.flag";
 public const string ATTR_CORE_LINUX_LINKER_FLAG = "core.linux.linker.flag";
 public const string ATTR_CORE_WINDOWS_LINKER_FLAG = "core.windows.linker.flag";
-public const string ATTR_CORE_LINKER_ADDITIONAL_SOURCE = "core.linker.additional_source";
+public const string ATTR_CORE_LINKER_ADDITIONAL_SOURCE = "core.linker.additionalSource";
 public const string ATTR_CORE_LINKER_DLL = "core.linker.dll";
 public const string ATTR_CORE_COMPILER_MANGLE = "core.compiler.mangle";
 public const string ATTR_CORE_COMPILER_MANGLED_NAME = "core.compiler.mangledName";
@@ -21,6 +21,7 @@ public const string ATTR_TEST = "test";
 public const string ATTR_TEST_NAME = "test.name";
 public const string ATTR_TEST_SKIP = "test.skip";
 public const string ATTR_ASYNC = "async";
+public const string ATTR_IGNORE_UNUSED_RETURN_VALUE = "ignoreUnusedReturnValue";
 
 // Structs
 type AttrConfigValue struct {

--- a/src-bootstrap/bindings/llvm/linker-flags.spice
+++ b/src-bootstrap/bindings/llvm/linker-flags.spice
@@ -214,5 +214,5 @@
     core.linker.flag = "-luuid",
     core.linker.flag = "-pthread",
     // Wrapper around target macro definitions
-    core.linker.additional_source = "target-wrapper.c"
+    core.linker.additionalSource = "target-wrapper.c"
 ]

--- a/src/ast/Attributes.h
+++ b/src/ast/Attributes.h
@@ -13,7 +13,7 @@ namespace spice::compiler {
 static constexpr const char *const ATTR_CORE_LINKER_FLAG = "core.linker.flag";
 static constexpr const char *const ATTR_CORE_LINUX_LINKER_FLAG = "core.linux.linker.flag";
 static constexpr const char *const ATTR_CORE_WINDOWS_LINKER_FLAG = "core.windows.linker.flag";
-static constexpr const char *const ATTR_CORE_LINKER_ADDITIONAL_SOURCE = "core.linker.additional_source";
+static constexpr const char *const ATTR_CORE_LINKER_ADDITIONAL_SOURCE = "core.linker.additionalSource";
 static constexpr const char *const ATTR_CORE_LINKER_DLL = "core.linker.dll";
 static constexpr const char *const ATTR_CORE_COMPILER_MANGLE = "core.compiler.mangle";
 static constexpr const char *const ATTR_CORE_COMPILER_MANGLED_NAME = "core.compiler.mangledName";
@@ -26,6 +26,7 @@ static constexpr const char *const ATTR_TEST = "test";
 static constexpr const char *const ATTR_TEST_NAME = "test.name";
 static constexpr const char *const ATTR_TEST_SKIP = "test.skip";
 static constexpr const char *const ATTR_ASYNC = "async";
+static constexpr const char *const ATTR_IGNORE_UNUSED_RETURN_VALUE = "ignoreUnusedReturnValue";
 
 static constexpr CompileTimeValue DEFAULT_BOOL_COMPILE_VALUE{.boolValue = true};
 
@@ -151,6 +152,13 @@ static const std::unordered_map<std::string, AttrConfigValue> ATTR_CONFIGS = {
     },
     {
         ATTR_ASYNC,
+        {
+            .target = AttrNode::AttrTarget::TARGET_FCT_PROC | AttrNode::AttrTarget::TARGET_LAMBDA,
+            .type = AttrNode::AttrType::TYPE_BOOL,
+        },
+    },
+    {
+        ATTR_IGNORE_UNUSED_RETURN_VALUE,
         {
             .target = AttrNode::AttrTarget::TARGET_FCT_PROC | AttrNode::AttrTarget::TARGET_LAMBDA,
             .type = AttrNode::AttrType::TYPE_BOOL,

--- a/src/symboltablebuilder/SymbolTableBuilder.cpp
+++ b/src/symboltablebuilder/SymbolTableBuilder.cpp
@@ -645,11 +645,11 @@ std::any SymbolTableBuilder::visitModAttr(ModAttrNode *node) {
   for (const CompileTimeValue *value : linkerFlagValues)
     resourceManager.linker.addLinkerFlag(resourceManager.compileTimeStringValues.at(value->stringValueOffset));
 
-  // core.linker.additional_source
+  // core.linker.additionalSource
   for (const CompileTimeValue *value : attrs->getAttrValuesByName(ATTR_CORE_LINKER_ADDITIONAL_SOURCE)) {
     const std::string &stringValue = resourceManager.compileTimeStringValues.at(value->stringValueOffset);
     const std::filesystem::path path = sourceFile->filePath.parent_path() / stringValue;
-    resourceManager.linker.addAdditionalSourcePath(std::filesystem::canonical(path));
+    resourceManager.linker.addAdditionalSourcePath(canonical(path));
   }
 
   return nullptr;

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -118,6 +118,7 @@ const Type *Type::toRef(const ASTNode *node) const {
  *
  * @param node AST node for error messages
  * @param size Size of the array
+ * @param skipDynCheck Skip check if array base type is dyn
  * @return Array type of the current type
  */
 const Type *Type::toArr(const ASTNode *node, unsigned int size, bool skipDynCheck /*=false*/) const {
@@ -468,6 +469,7 @@ bool Type::isOneOf(const std::initializer_list<SuperType> &superTypes) const {
 /**
  * Get the name of the symbol type as a string
  *
+ * @param name Get name of type
  * @param withSize Include the array size for sized types
  * @return Symbol type name
  */
@@ -481,7 +483,6 @@ void Type::getName(std::stringstream &name, bool withSize) const { // NOLINT(mis
  * Get the name of the symbol type as a string
  *
  * @param withSize Include the array size for sized types
- * @param ignorePublic Ignore any potential public specifier
  * @return Symbol type name
  */
 std::string Type::getName(bool withSize) const {
@@ -491,7 +492,7 @@ std::string Type::getName(bool withSize) const {
 }
 
 /**
- * Get the return type of a function type
+ * Get the return type of function type
  *
  * @return Function return type
  */

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -1886,8 +1886,8 @@ std::any TypeChecker::visitFctCall(FctCallNode *node) {
     bool ignoreUnusedReturnValue = false;
     if (!data.isFctPtrCall()) {
       assert(data.callee != nullptr);
-      const FctDefNode *fctDef = spice_pointer_cast<FctDefNode *>(data.callee->declNode);
-      ignoreUnusedReturnValue = fctDef->attrs && fctDef->attrs->attrLst->hasAttr(ATTR_IGNORE_UNUSED_RETURN_VALUE);
+      auto fctDef = dynamic_cast<const FctDefNode *>(data.callee->declNode);
+      ignoreUnusedReturnValue = fctDef && fctDef->attrs && fctDef->attrs->attrLst->hasAttr(ATTR_IGNORE_UNUSED_RETURN_VALUE);
     }
 
     if (!ignoreUnusedReturnValue)

--- a/std/data/binary-tree.spice
+++ b/std/data/binary-tree.spice
@@ -108,10 +108,10 @@ f<bool> BinaryTree.containsNode<T>(Node<T>* currentNode, const T& value) {
 }
 
 /**
- * Recursion helper to find the smallest node in the binary tree
+ * Recursion helper to delete a node with a certain value
  *
  * @param currentNode The current node to check
- * @return The smallest node
+ * @return The new root node
  */
 f<heap Node<T>*> BinaryTree.deleteNode<T>(heap Node<T>* currentNode, const T& value) {
     // We reached the end of the tree

--- a/std/data/deque.spice
+++ b/std/data/deque.spice
@@ -109,6 +109,7 @@ public p Deque.pushFront(const T& item) {
  *
  * @return First item
  */
+#[ignoreUnusedReturnValue]
 public f<T&> Deque.popFront() {
     if this.isEmpty() { panic(Error("Deque is empty")); }
 
@@ -128,6 +129,7 @@ public f<T&> Deque.popFront() {
  *
  * @return Last item
  */
+#[ignoreUnusedReturnValue]
 public f<T&> Deque.popBack() {
     if this.isEmpty() { panic(Error("Deque is empty")); }
 

--- a/std/data/queue.spice
+++ b/std/data/queue.spice
@@ -84,6 +84,7 @@ public p Queue.push(const T& item) {
  *
  * @return First item
  */
+#[ignoreUnusedReturnValue]
 public f<T&> Queue.pop() {
     this.size--;
     unsafe {

--- a/std/data/stack.spice
+++ b/std/data/stack.spice
@@ -74,6 +74,7 @@ public p Stack.push(const T& item) {
 /**
  * Retrieve item and remove it from the stack
  */
+#[ignoreUnusedReturnValue]
 public f<T&> Stack.pop() {
     if this.isEmpty() { panic(Error("The stack is empty")); }
     // Pop the element from the stack

--- a/std/io/cli-parser.spice
+++ b/std/io/cli-parser.spice
@@ -48,34 +48,42 @@ public f<CliSubcommand&> CliParser.addSubcommand(const String& name, const Strin
     return this.rootSubcommand.addSubcommand(name, description);
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<T>&> CliParser.addOption<T>(string name, T& targetVariable, string description) {
     return this.rootSubcommand.addOption(targetVariable, String(description));
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<T>&> CliParser.addOption<T>(const String& name, T& targetVariable, const String& description) {
     return this.rootSubcommand.addOption(targetVariable, description);
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<T>&> CliParser.addOption<T>(string name, p(T&) callback, string description) {
     return this.rootSubcommand.addOption(callback, String(description));
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<T>&> CliParser.addOption<T>(const String& name, p(T&) callback, const String& description) {
     return this.rootSubcommand.addOption(callback, description);
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliParser.addFlag(string name, bool& targetVariable, string description) {
    return  this.rootSubcommand.addFlag(String(name), targetVariable, String(description));
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliParser.addFlag(const String& name, bool& targetVariable, const String& description) {
    return  this.rootSubcommand.addFlag(name, targetVariable, description);
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliParser.addFlag(string name, p(bool&) callback, string description) {
     return this.rootSubcommand.addFlag(String(name), callback, String(description));
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliParser.addFlag(const String& name, p(bool&) callback, const String& description) {
     return this.rootSubcommand.addFlag(name, callback, description);
 }

--- a/std/io/cli-subcommand.spice
+++ b/std/io/cli-subcommand.spice
@@ -184,101 +184,121 @@ public f<CliSubcommand&> CliSubcommand.addSubcommand(const String& name, const S
     return this.subcommands.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<string>&> CliSubcommand.addOption(string name, string& targetVariable, string description) {
     this.stringOptions.pushBack(CliOption<string>(String(name), targetVariable, String(description)));
     return this.stringOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<string>&> CliSubcommand.addOption(const String& name, string& targetVariable, const String& description) {
     this.stringOptions.pushBack(CliOption<string>(name, targetVariable, description));
     return this.stringOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<string>&> CliSubcommand.addOption(string name, p(string&) callback, string description) {
     this.stringOptions.pushBack(CliOption<string>(String(name), callback, String(description)));
     return this.stringOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<string>&> CliSubcommand.addOption(const String& name, p(string&) callback, const String& description) {
     this.stringOptions.pushBack(CliOption<string>(name, callback, description));
     return this.stringOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<String>&> CliSubcommand.addOption(string name, String& targetVariable, string description) {
     this.stringObjOptions.pushBack(CliOption<String>(String(name), targetVariable, String(description)));
     return this.stringObjOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<String>&> CliSubcommand.addOption(const String& name, String& targetVariable, const String& description) {
     this.stringObjOptions.pushBack(CliOption<String>(name, targetVariable, description));
     return this.stringObjOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<String>&> CliSubcommand.addOption(string name, p(String&) callback, string description) {
     this.stringObjOptions.pushBack(CliOption<String>(String(name), callback, String(description)));
     return this.stringObjOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<String>&> CliSubcommand.addOption(const String& name, p(String&) callback, const String& description) {
     this.stringObjOptions.pushBack(CliOption<String>(name, callback, description));
     return this.stringObjOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<int>&> CliSubcommand.addOption(string name, int& targetVariable, string description) {
     this.intOptions.pushBack(CliOption<int>(String(name), targetVariable, String(description)));
     return this.intOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<int>&> CliSubcommand.addOption(const String& name, int& targetVariable, const String& description) {
     this.intOptions.pushBack(CliOption<int>(name, targetVariable, description));
     return this.intOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<int>&> CliSubcommand.addOption(string name, p(int&) callback, string description) {
     this.intOptions.pushBack(CliOption<int>(String(name), callback, String(description)));
     return this.intOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<int>&> CliSubcommand.addOption(const String& name, p(int&) callback, const String& description) {
     this.intOptions.pushBack(CliOption<int>(name, callback, description));
     return this.intOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<FilePath>&> CliSubcommand.addOption(string name, FilePath& targetVariable, string description) {
     this.filePathOptions.pushBack(CliOption<FilePath>(String(name), targetVariable, String(description)));
     return this.filePathOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<FilePath>&> CliSubcommand.addOption(const String& name, FilePath& targetVariable, const String& description) {
     this.filePathOptions.pushBack(CliOption<FilePath>(name, targetVariable, description));
     return this.filePathOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<FilePath>&> CliSubcommand.addOption(string name, p(FilePath&) callback, string description) {
     this.filePathOptions.pushBack(CliOption<FilePath>(String(name), callback, String(description)));
     return this.filePathOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<FilePath>&> CliSubcommand.addOption(const String& name, p(FilePath&) callback, const String& description) {
     this.filePathOptions.pushBack(CliOption<FilePath>(name, callback, description));
     return this.filePathOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliSubcommand.addFlag(string name, bool& targetVariable, string description) {
     this.boolOptions.pushBack(CliOption<bool>(String(name), targetVariable, String(description)));
     return this.boolOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliSubcommand.addFlag(const String& name, bool& targetVariable, const String& description) {
     this.boolOptions.pushBack(CliOption<bool>(name, targetVariable, description));
     return this.boolOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliSubcommand.addFlag(const string name, p(bool&) callback, string description) {
     this.boolOptions.pushBack(CliOption<bool>(String(name), callback, String(description)));
     return this.boolOptions.back();
 }
 
+#[ignoreUnusedReturnValue]
 public f<CliOption<bool>&> CliSubcommand.addFlag(const String& name, p(bool&) callback, const String& description) {
     this.boolOptions.pushBack(CliOption<bool>(name, callback, description));
     return this.boolOptions.back();

--- a/std/runtime/string_rt.spice
+++ b/std/runtime/string_rt.spice
@@ -508,6 +508,7 @@ public p String.reverse() {
  * @param needle Substring to replace
  * @param replacement Replacement for the substring
  */
+#[ignoreUnusedReturnValue]
 public f<bool> String.replace(
     string needle,
     string replacement,
@@ -560,6 +561,7 @@ public f<bool> String.replace(
  * @param needle Substring to replace
  * @param replacement Replacement for the substring
  */
+#[ignoreUnusedReturnValue]
 public f<unsigned long> String.replaceAll(string needle, string replacement) {
     unsigned long startIdx = 0l;
     unsigned long foundOccurrences = 0l;
@@ -577,6 +579,7 @@ public f<unsigned long> String.replaceAll(string needle, string replacement) {
     return foundOccurrences;
 }
 
+#[ignoreUnusedReturnValue]
 public f<unsigned long> String.replaceAll(char needle, char replacement) {
     const String needleStr = String(needle);
     const String replacementStr = String(replacement);

--- a/std/text/format.spice
+++ b/std/text/format.spice
@@ -80,22 +80,3 @@ public f<char> toLower(char c) {
     }
     return text;
 }*/
-
-/**
- * Returns the trimmed string of the given text
- *
- * @return Trimmed string
- */
-/*public f<String> trim(const String& input) {
-    unsigned long start = 0l;
-    unsigned long end = input.getLength() - 1l;
-
-    while isWhitespace(input[start]) {
-        start++;
-    }
-    while isWhitespace(input[end]) {
-        end--;
-    }
-
-    return input.substring(start, end);
-}*/


### PR DESCRIPTION
Add ignoreUnusedResultValue attribute for functions

Can be used like this:
```spice
#[ignoreUnusedReturnValue]
f<int> foo() {
  return 1;
}
```