### PR TITLE
Fix missing memcpy of field in default copy ctor

### DIFF
--- a/.run/spice build.run.xml
+++ b/.run/spice build.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d -g ../../src-bootstrap/main.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d -g ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -O2 -d ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -169,7 +169,7 @@ void TypeChecker::createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Sco
       copyCtorRequired |= ctorFct != nullptr;
     }
 
-    // If we have a owning heap pointer, we need to do a memcpy of the heap storage and therefore need a default copy ctor
+    // If we have an owning heap pointer, we need to do a memcpy of the heap storage and therefore need a default copy ctor
     if (fieldType.isHeap()) {
       assert(fieldType.isPtr());
       copyCtorRequired = true;


### PR DESCRIPTION
Fix missing memcpy of field if field type is struct and no copy ctor exists