### PR TITLE
Also emit module flags when compiling without debug info

### DIFF
--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -35,14 +35,6 @@ void DebugInfoGenerator::initialize(const std::string &sourceFileName, std::file
 
   module->addModuleFlag(llvm::Module::Max, "Dwarf Version", llvm::dwarf::DWARF_VERSION);
   module->addModuleFlag(llvm::Module::Warning, "Debug Info Version", llvm::DEBUG_METADATA_VERSION);
-  module->addModuleFlag(llvm::Module::Error, "wchar_size", 4);
-  module->addModuleFlag(llvm::Module::Min, "PIC Level", llvm::PICLevel::BigPIC);
-  module->addModuleFlag(llvm::Module::Max, "PIE Level", llvm::PIELevel::Large);
-  module->addModuleFlag(llvm::Module::Max, "uwtable", 2);
-  module->addModuleFlag(llvm::Module::Max, "frame-pointer", 2);
-
-  llvm::NamedMDNode *identifierMetadata = module->getOrInsertNamedMetadata("llvm.ident");
-  identifierMetadata->addOperand(llvm::MDNode::get(context, llvm::MDString::get(context, producerString)));
 
   // Create another DIFile as scope for subprograms
   diFile = diBuilder->createFile(sourceFileName, sourceFileDir.string());

--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -19,7 +19,6 @@ namespace spice::compiler {
 void DebugInfoGenerator::initialize(const std::string &sourceFileName, std::filesystem::path sourceFileDir) {
   llvm::Module *module = irGenerator->module;
   llvm::LLVMContext &context = irGenerator->context;
-  const std::string producerString = "spice version " + std::string(SPICE_VERSION) + " (https://github.com/spicelang/spice)";
 
   // Create DIBuilder
   diBuilder = std::make_unique<llvm::DIBuilder>(*module);
@@ -29,7 +28,7 @@ void DebugInfoGenerator::initialize(const std::string &sourceFileName, std::file
   absolutePath.make_preferred();
   sourceFileDir.make_preferred();
   llvm::DIFile *cuDiFile = diBuilder->createFile(absolutePath.string(), sourceFileDir.string());
-  compileUnit = diBuilder->createCompileUnit(llvm::dwarf::DW_LANG_C_plus_plus_14, cuDiFile, producerString,
+  compileUnit = diBuilder->createCompileUnit(llvm::dwarf::DW_LANG_C_plus_plus_14, cuDiFile, PRODUCER_STRING,
                                              irGenerator->cliOptions.optLevel > O0, "", 0, "", llvm::DICompileUnit::FullDebug, 0,
                                              false, false, llvm::DICompileUnit::DebugNameTableKind::None);
 

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -25,9 +25,8 @@ IRGenerator::IRGenerator(GlobalResourceManager &resourceManager, SourceFile *sou
   module->setFramePointer(llvm::FramePointerKind::All);
 
   // Add module identifier metadata
-  const std::string producerString = "spice version " + std::string(SPICE_VERSION) + " (https://github.com/spicelang/spice)";
   llvm::NamedMDNode *identifierMetadata = module->getOrInsertNamedMetadata("llvm.ident");
-  identifierMetadata->addOperand(llvm::MDNode::get(context, llvm::MDString::get(context, producerString)));
+  identifierMetadata->addOperand(llvm::MDNode::get(context, llvm::MDString::get(context, PRODUCER_STRING)));
 
   // Initialize debug info generator
   if (cliOptions.generateDebugInfo)

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -19,6 +19,15 @@ IRGenerator::IRGenerator(GlobalResourceManager &resourceManager, SourceFile *sou
   // Attach information to the module
   module->setTargetTriple(cliOptions.targetTriple);
   module->setDataLayout(sourceFile->targetMachine->createDataLayout());
+  module->setPICLevel(llvm::PICLevel::BigPIC);
+  module->setPIELevel(llvm::PIELevel::Large);
+  module->setUwtable(llvm::UWTableKind::Default);
+  module->setFramePointer(llvm::FramePointerKind::All);
+
+  // Add module identifier metadata
+  const std::string producerString = "spice version " + std::string(SPICE_VERSION) + " (https://github.com/spicelang/spice)";
+  llvm::NamedMDNode *identifierMetadata = module->getOrInsertNamedMetadata("llvm.ident");
+  identifierMetadata->addOperand(llvm::MDNode::get(context, llvm::MDString::get(context, producerString)));
 
   // Initialize debug info generator
   if (cliOptions.generateDebugInfo)

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -15,6 +15,7 @@ namespace spice::compiler {
 const char *const ANON_GLOBAL_STRING_NAME = "anon.string.";
 const char *const ANON_GLOBAL_ARRAY_NAME = "anon.array.";
 const char *const CAPTURES_PARAM_NAME = "captures";
+static const std::string PRODUCER_STRING = "spice version " + std::string(SPICE_VERSION) + " (https://github.com/spicelang/spice)";
 
 enum Likeliness : uint8_t {
   UNSPECIFIED,

--- a/test/test-files/benchmark/success-ackermann/assembly.asm
+++ b/test/test-files/benchmark/success-ackermann/assembly.asm
@@ -40,8 +40,6 @@
 	.p2align	4, 0x90
 	.type	main,@function
 main:                                   # @main
-.Lmain$local:
-	.type	.Lmain$local,@function
 	.cfi_startproc
 # %bb.0:
 	pushq	%rax
@@ -61,7 +59,6 @@ main:                                   # @main
 	retq
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main
-	.size	.Lmain$local, .Lfunc_end1-main
 	.cfi_endproc
                                         # -- End function
 	.type	.Lprintf.str.0,@object          # @printf.str.0
@@ -70,4 +67,5 @@ main:                                   # @main
 	.asciz	"Ackermann of base m=%d and n=%d: %d"
 	.size	.Lprintf.str.0, 36
 
+	.ident	"spice version dev (https://github.com/spicelang/spice)"
 	.section	".note.GNU-stack","",@progbits

--- a/test/test-files/benchmark/success-ackermann/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-ackermann/ir-code-O3.ll
@@ -45,3 +45,12 @@ attributes #0 = { nofree nosync nounwind memory(none) }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
 attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-ackermann/ir-code.ll
+++ b/test/test-files/benchmark/success-ackermann/ir-code.ll
@@ -63,3 +63,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-faculty/assembly.asm
+++ b/test/test-files/benchmark/success-faculty/assembly.asm
@@ -103,8 +103,6 @@
 	.p2align	4, 0x90
 	.type	main,@function
 main:                                   # @main
-.Lmain$local:
-	.type	.Lmain$local,@function
 	.cfi_startproc
 # %bb.0:
 	pushq	%rax
@@ -122,7 +120,6 @@ main:                                   # @main
 	retq
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main
-	.size	.Lmain$local, .Lfunc_end1-main
 	.cfi_endproc
                                         # -- End function
 	.type	.Lprintf.str.0,@object          # @printf.str.0
@@ -131,4 +128,5 @@ main:                                   # @main
 	.asciz	"Faculty of %d is: %d"
 	.size	.Lprintf.str.0, 21
 
+	.ident	"spice version dev (https://github.com/spicelang/spice)"
 	.section	".note.GNU-stack","",@progbits

--- a/test/test-files/benchmark/success-faculty/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-faculty/ir-code-O3.ll
@@ -37,7 +37,7 @@ vector.body:                                      ; preds = %vector.body, %vecto
   %index.next = add nuw i32 %index, 8
   %vec.ind.next = add <4 x i32> %vec.ind, <i32 -8, i32 -8, i32 -8, i32 -8>
   %6 = icmp eq i32 %index.next, %n.vec
-  br i1 %6, label %middle.block, label %vector.body, !llvm.loop !0
+  br i1 %6, label %middle.block, label %vector.body, !llvm.loop !5
 
 middle.block:                                     ; preds = %vector.body
   %bin.rdx = mul <4 x i32> %5, %4
@@ -55,7 +55,7 @@ if.exit.L2:                                       ; preds = %if.exit.L2.preheade
   %8 = add nsw i32 %.tr4, -1
   %9 = mul nsw i32 %.tr4, %accumulator.tr3
   %10 = icmp ult i32 %.tr4, 3
-  br i1 %10, label %common.ret, label %if.exit.L2, !llvm.loop !3
+  br i1 %10, label %common.ret, label %if.exit.L2, !llvm.loop !8
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
@@ -77,7 +77,15 @@ attributes #2 = { nofree nounwind }
 attributes #3 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #4 = { nounwind }
 
-!0 = distinct !{!0, !1, !2}
-!1 = !{!"llvm.loop.isvectorized", i32 1}
-!2 = !{!"llvm.loop.unroll.runtime.disable"}
-!3 = distinct !{!3, !2, !1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = distinct !{!5, !6, !7}
+!6 = !{!"llvm.loop.isvectorized", i32 1}
+!7 = !{!"llvm.loop.unroll.runtime.disable"}
+!8 = distinct !{!8, !7, !6}

--- a/test/test-files/benchmark/success-faculty/ir-code.ll
+++ b/test/test-files/benchmark/success-faculty/ir-code.ll
@@ -47,3 +47,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-fibonacci-threaded/assembly.asm
+++ b/test/test-files/benchmark/success-fibonacci-threaded/assembly.asm
@@ -40,8 +40,6 @@
 	.p2align	4, 0x90
 	.type	main,@function
 main:                                   # @main
-.Lmain$local:
-	.type	.Lmain$local,@function
 	.cfi_startproc
 # %bb.0:                                # %for.body.L11
 	pushq	%rbp
@@ -214,7 +212,6 @@ main:                                   # @main
 	retq
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main
-	.size	.Lmain$local, .Lfunc_end1-main
 	.cfi_endproc
                                         # -- End function
 	.p2align	4, 0x90                         # -- Begin function _Z15lambda.L12C29.0v
@@ -248,4 +245,5 @@ main:                                   # @main
 	.asciz	"Started all threads. Waiting for results ..."
 	.size	.Lstr, 45
 
+	.ident	"spice version dev (https://github.com/spicelang/spice)"
 	.section	".note.GNU-stack","",@progbits

--- a/test/test-files/benchmark/success-fibonacci-threaded/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-fibonacci-threaded/ir-code-O3.ll
@@ -167,3 +167,12 @@ attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #4 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-fibonacci/assembly.asm
+++ b/test/test-files/benchmark/success-fibonacci/assembly.asm
@@ -40,8 +40,6 @@
 	.p2align	4, 0x90
 	.type	main,@function
 main:                                   # @main
-.Lmain$local:
-	.type	.Lmain$local,@function
 	.cfi_startproc
 # %bb.0:
 	pushq	%rax
@@ -58,7 +56,6 @@ main:                                   # @main
 	retq
 .Lfunc_end1:
 	.size	main, .Lfunc_end1-main
-	.size	.Lmain$local, .Lfunc_end1-main
 	.cfi_endproc
                                         # -- End function
 	.type	.Lprintf.str.0,@object          # @printf.str.0
@@ -67,4 +64,5 @@ main:                                   # @main
 	.asciz	"Result: %d"
 	.size	.Lprintf.str.0, 11
 
+	.ident	"spice version dev (https://github.com/spicelang/spice)"
 	.section	".note.GNU-stack","",@progbits

--- a/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
@@ -39,3 +39,12 @@ attributes #0 = { nofree nosync nounwind memory(none) }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
 attributes #3 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-fibonacci/ir-code.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code.ll
@@ -41,3 +41,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-hello-world/assembly.asm
+++ b/test/test-files/benchmark/success-hello-world/assembly.asm
@@ -4,8 +4,6 @@
 	.p2align	4, 0x90
 	.type	main,@function
 main:                                   # @main
-.Lmain$local:
-	.type	.Lmain$local,@function
 	.cfi_startproc
 # %bb.0:
 	pushq	%rax
@@ -19,7 +17,6 @@ main:                                   # @main
 	retq
 .Lfunc_end0:
 	.size	main, .Lfunc_end0-main
-	.size	.Lmain$local, .Lfunc_end0-main
 	.cfi_endproc
                                         # -- End function
 	.type	.Lprintf.str.0,@object          # @printf.str.0
@@ -28,4 +25,5 @@ main:                                   # @main
 	.asciz	"Hello World!"
 	.size	.Lprintf.str.0, 13
 
+	.ident	"spice version dev (https://github.com/spicelang/spice)"
 	.section	".note.GNU-stack","",@progbits

--- a/test/test-files/benchmark/success-hello-world/ir-code-O2.ll
+++ b/test/test-files/benchmark/success-hello-world/ir-code-O2.ll
@@ -14,3 +14,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-hello-world2/assembly.asm
+++ b/test/test-files/benchmark/success-hello-world2/assembly.asm
@@ -4,8 +4,6 @@
 	.p2align	4, 0x90
 	.type	main,@function
 main:                                   # @main
-.Lmain$local:
-	.type	.Lmain$local,@function
 	.cfi_startproc
 # %bb.0:                                # %while.body.L5
 	pushq	%rax
@@ -40,7 +38,7 @@ main:                                   # @main
 	retq
 .Lfunc_end0:
 	.size	main, .Lfunc_end0-main
-	.size	.Lmain$local, .Lfunc_end0-main
 	.cfi_endproc
                                         # -- End function
+	.ident	"spice version dev (https://github.com/spicelang/spice)"
 	.section	".note.GNU-stack","",@progbits

--- a/test/test-files/benchmark/success-hello-world2/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-hello-world2/ir-code-O3.ll
@@ -24,3 +24,12 @@ declare noundef i32 @putchar(i32 noundef) local_unnamed_addr #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-pidigits/assembly.asm
+++ b/test/test-files/benchmark/success-pidigits/assembly.asm
@@ -4,8 +4,6 @@
 	.p2align	4, 0x90
 	.type	main,@function
 main:                                   # @main
-.Lmain$local:
-	.type	.Lmain$local,@function
 	.cfi_startproc
 # %bb.0:
 	pushq	%rbp
@@ -131,7 +129,6 @@ main:                                   # @main
 	retq
 .Lfunc_end0:
 	.size	main, .Lfunc_end0-main
-	.size	.Lmain$local, .Lfunc_end0-main
 	.cfi_endproc
                                         # -- End function
 	.type	.Lprintf.str.0,@object          # @printf.str.0
@@ -140,4 +137,5 @@ main:                                   # @main
 	.asciz	"%d"
 	.size	.Lprintf.str.0, 3
 
+	.ident	"spice version dev (https://github.com/spicelang/spice)"
 	.section	".note.GNU-stack","",@progbits

--- a/test/test-files/benchmark/success-pidigits/ir-code-O1.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O1.ll
@@ -85,3 +85,12 @@ declare noundef i32 @putchar(i32 noundef) local_unnamed_addr #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-pidigits/ir-code-O2.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O2.ll
@@ -85,3 +85,12 @@ declare noundef i32 @putchar(i32 noundef) local_unnamed_addr #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-pidigits/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-O3.ll
@@ -85,3 +85,12 @@ declare noundef i32 @putchar(i32 noundef) local_unnamed_addr #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-pidigits/ir-code-Os.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-Os.ll
@@ -85,3 +85,12 @@ declare noundef i32 @putchar(i32 noundef) local_unnamed_addr #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-pidigits/ir-code-Oz.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code-Oz.ll
@@ -85,3 +85,12 @@ declare noundef i32 @putchar(i32 noundef) local_unnamed_addr #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/benchmark/success-pidigits/ir-code.ll
+++ b/test/test-files/benchmark/success-pidigits/ir-code.ll
@@ -162,3 +162,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/anonymous-blocks/success-anonymous-block/ir-code.ll
+++ b/test/test-files/irgenerator/anonymous-blocks/success-anonymous-block/ir-code.ll
@@ -20,3 +20,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/anonymous-blocks/success-nested-anonymous-blocks/ir-code.ll
+++ b/test/test-files/irgenerator/anonymous-blocks/success-nested-anonymous-blocks/ir-code.ll
@@ -25,3 +25,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/arrays/success-arrays-multidimensional/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays-multidimensional/ir-code.ll
@@ -68,3 +68,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/arrays/success-arrays/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays/ir-code.ll
@@ -40,3 +40,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/arrays/success-arrays2/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays2/ir-code.ll
@@ -30,3 +30,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/arrays/success-arrays3/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-arrays3/ir-code.ll
@@ -23,3 +23,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/arrays/success-string-char-access/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-string-char-access/ir-code.ll
@@ -27,3 +27,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/assertions/success-basic-assertion/ir-code.ll
+++ b/test/test-files/irgenerator/assertions/success-basic-assertion/ir-code.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 define dso_local i32 @main() #0 {
   %result = alloca i32, align 4
   store i32 0, ptr %result, align 4
-  br i1 true, label %assert.exit.L2, label %assert.then.L2, !prof !0
+  br i1 true, label %assert.exit.L2, label %assert.then.L2, !prof !5
 
 assert.then.L2:                                   ; preds = %0
   %1 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -18,7 +18,7 @@ assert.then.L2:                                   ; preds = %0
 
 assert.exit.L2:                                   ; preds = %0
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
-  br i1 false, label %assert.exit.L5, label %assert.then.L5, !prof !0
+  br i1 false, label %assert.exit.L5, label %assert.then.L5, !prof !5
 
 assert.then.L5:                                   ; preds = %assert.exit.L2
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -40,4 +40,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/builtins/success-alignof/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-alignof/ir-code-O2.ll
@@ -34,3 +34,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-alignof/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-alignof/ir-code.ll
@@ -39,3 +39,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-len/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-len/ir-code-O2.ll
@@ -14,3 +14,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-len/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-len/ir-code.ll
@@ -20,3 +20,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code-O2.ll
@@ -27,3 +27,12 @@ attributes #1 = { cold noreturn nounwind }
 attributes #2 = { noinline nounwind optnone uwtable }
 attributes #3 = { nofree nounwind }
 attributes #4 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code.ll
@@ -27,3 +27,12 @@ define dso_local i32 @main() #2 {
 attributes #0 = { nofree nounwind }
 attributes #1 = { cold noreturn nounwind }
 attributes #2 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-printf/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-printf/ir-code-O2.ll
@@ -14,3 +14,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-printf/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-printf/ir-code.ll
@@ -17,3 +17,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
@@ -34,3 +34,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
@@ -39,3 +39,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-syscall/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-syscall/ir-code-O2.ll
@@ -14,3 +14,12 @@ declare i64 @_Z12getRawLengthPKc(ptr) local_unnamed_addr
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-syscall/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-syscall/ir-code.ll
@@ -21,3 +21,12 @@ define dso_local i32 @main() #0 {
 declare i64 @_Z12getRawLengthPKc(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/cli-args/success-cli-args/ir-code.ll
+++ b/test/test-files/irgenerator/cli-args/success-cli-args/ir-code.ll
@@ -40,3 +40,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
@@ -35,8 +35,8 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [24 x i8] c"All assertions passed!\0A\00", align 1, !dbg !0
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @main(i32 %0, ptr %1) #0 !dbg !15 {
-    #dbg_declare(ptr %result, !23, !DIExpression(), !24)
+define dso_local i32 @main(i32 %0, ptr %1) #0 !dbg !14 {
+    #dbg_declare(ptr %result, !22, !DIExpression(), !23)
   %result = alloca i32, align 4
   %_argc = alloca i32, align 4
   %_argv = alloca ptr, align 8
@@ -58,385 +58,385 @@ define dso_local i32 @main(i32 %0, ptr %1) #0 !dbg !15 {
   %item2 = alloca ptr, align 8
   %pair_addr = alloca %struct.Pair, align 8
   %12 = alloca ptr, align 8
-  store i32 0, ptr %result, align 4, !dbg !24
-    #dbg_declare(ptr %_argc, !25, !DIExpression(), !24)
-  store i32 %0, ptr %_argc, align 4, !dbg !24
-    #dbg_declare(ptr %_argv, !26, !DIExpression(), !24)
-  store ptr %1, ptr %_argv, align 8, !dbg !24
-    #dbg_declare(ptr %vi, !27, !DIExpression(), !35)
-  call void @_ZN6VectorIiE4ctorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !36
-  store i32 123, ptr %3, align 4, !dbg !37
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %3), !dbg !37
-  store i32 4321, ptr %4, align 4, !dbg !38
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %4), !dbg !38
-  store i32 9876, ptr %5, align 4, !dbg !39
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %5), !dbg !39
-  %13 = call i64 @_ZN6VectorIiE7getSizeEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !40
-  %14 = icmp eq i64 %13, 3, !dbg !41
-  br i1 %14, label %assert.exit.L10, label %assert.then.L10, !dbg !41, !prof !42
+  store i32 0, ptr %result, align 4, !dbg !23
+    #dbg_declare(ptr %_argc, !24, !DIExpression(), !23)
+  store i32 %0, ptr %_argc, align 4, !dbg !23
+    #dbg_declare(ptr %_argv, !25, !DIExpression(), !23)
+  store ptr %1, ptr %_argv, align 8, !dbg !23
+    #dbg_declare(ptr %vi, !26, !DIExpression(), !34)
+  call void @_ZN6VectorIiE4ctorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !35
+  store i32 123, ptr %3, align 4, !dbg !36
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %3), !dbg !36
+  store i32 4321, ptr %4, align 4, !dbg !37
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %4), !dbg !37
+  store i32 9876, ptr %5, align 4, !dbg !38
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %5), !dbg !38
+  %13 = call i64 @_ZN6VectorIiE7getSizeEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !39
+  %14 = icmp eq i64 %13, 3, !dbg !40
+  br i1 %14, label %assert.exit.L10, label %assert.then.L10, !dbg !40, !prof !41
 
 assert.then.L10:                                  ; preds = %2
-  %15 = call i32 (ptr, ...) @printf(ptr @anon.string.0), !dbg !41
-  call void @exit(i32 1), !dbg !41
-  unreachable, !dbg !41
+  %15 = call i32 (ptr, ...) @printf(ptr @anon.string.0), !dbg !40
+  call void @exit(i32 1), !dbg !40
+  unreachable, !dbg !40
 
 assert.exit.L10:                                  ; preds = %2
-  %16 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !43
-    #dbg_declare(ptr %it, !44, !DIExpression(), !50)
-  store %struct.VectorIterator %16, ptr %it, align 8, !dbg !43
-  %17 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !51
-  br i1 %17, label %assert.exit.L14, label %assert.then.L14, !dbg !51, !prof !42
+  %16 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !42
+    #dbg_declare(ptr %it, !43, !DIExpression(), !49)
+  store %struct.VectorIterator %16, ptr %it, align 8, !dbg !42
+  %17 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !50
+  br i1 %17, label %assert.exit.L14, label %assert.then.L14, !dbg !50, !prof !41
 
 assert.then.L14:                                  ; preds = %assert.exit.L10
-  %18 = call i32 (ptr, ...) @printf(ptr @anon.string.1), !dbg !51
-  call void @exit(i32 1), !dbg !51
-  unreachable, !dbg !51
+  %18 = call i32 (ptr, ...) @printf(ptr @anon.string.1), !dbg !50
+  call void @exit(i32 1), !dbg !50
+  unreachable, !dbg !50
 
 assert.exit.L14:                                  ; preds = %assert.exit.L10
-  %19 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !52
-  %20 = load i32, ptr %19, align 4, !dbg !53
-  %21 = icmp eq i32 %20, 123, !dbg !53
-  br i1 %21, label %assert.exit.L15, label %assert.then.L15, !dbg !53, !prof !42
+  %19 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !51
+  %20 = load i32, ptr %19, align 4, !dbg !52
+  %21 = icmp eq i32 %20, 123, !dbg !52
+  br i1 %21, label %assert.exit.L15, label %assert.then.L15, !dbg !52, !prof !41
 
 assert.then.L15:                                  ; preds = %assert.exit.L14
-  %22 = call i32 (ptr, ...) @printf(ptr @anon.string.2), !dbg !53
-  call void @exit(i32 1), !dbg !53
-  unreachable, !dbg !53
+  %22 = call i32 (ptr, ...) @printf(ptr @anon.string.2), !dbg !52
+  call void @exit(i32 1), !dbg !52
+  unreachable, !dbg !52
 
 assert.exit.L15:                                  ; preds = %assert.exit.L14
-  %23 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !54
-  %24 = load i32, ptr %23, align 4, !dbg !55
-  %25 = icmp eq i32 %24, 123, !dbg !55
-  br i1 %25, label %assert.exit.L16, label %assert.then.L16, !dbg !55, !prof !42
+  %23 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !53
+  %24 = load i32, ptr %23, align 4, !dbg !54
+  %25 = icmp eq i32 %24, 123, !dbg !54
+  br i1 %25, label %assert.exit.L16, label %assert.then.L16, !dbg !54, !prof !41
 
 assert.then.L16:                                  ; preds = %assert.exit.L15
-  %26 = call i32 (ptr, ...) @printf(ptr @anon.string.3), !dbg !55
-  call void @exit(i32 1), !dbg !55
-  unreachable, !dbg !55
+  %26 = call i32 (ptr, ...) @printf(ptr @anon.string.3), !dbg !54
+  call void @exit(i32 1), !dbg !54
+  unreachable, !dbg !54
 
 assert.exit.L16:                                  ; preds = %assert.exit.L15
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !56
-  %27 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !57
-  %28 = load i32, ptr %27, align 4, !dbg !58
-  %29 = icmp eq i32 %28, 4321, !dbg !58
-  br i1 %29, label %assert.exit.L18, label %assert.then.L18, !dbg !58, !prof !42
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !55
+  %27 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !56
+  %28 = load i32, ptr %27, align 4, !dbg !57
+  %29 = icmp eq i32 %28, 4321, !dbg !57
+  br i1 %29, label %assert.exit.L18, label %assert.then.L18, !dbg !57, !prof !41
 
 assert.then.L18:                                  ; preds = %assert.exit.L16
-  %30 = call i32 (ptr, ...) @printf(ptr @anon.string.4), !dbg !58
+  %30 = call i32 (ptr, ...) @printf(ptr @anon.string.4), !dbg !57
+  call void @exit(i32 1), !dbg !57
+  unreachable, !dbg !57
+
+assert.exit.L18:                                  ; preds = %assert.exit.L16
+  %31 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !58
+  br i1 %31, label %assert.exit.L19, label %assert.then.L19, !dbg !58, !prof !41
+
+assert.then.L19:                                  ; preds = %assert.exit.L18
+  %32 = call i32 (ptr, ...) @printf(ptr @anon.string.5), !dbg !58
   call void @exit(i32 1), !dbg !58
   unreachable, !dbg !58
 
-assert.exit.L18:                                  ; preds = %assert.exit.L16
-  %31 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !59
-  br i1 %31, label %assert.exit.L19, label %assert.then.L19, !dbg !59, !prof !42
-
-assert.then.L19:                                  ; preds = %assert.exit.L18
-  %32 = call i32 (ptr, ...) @printf(ptr @anon.string.5), !dbg !59
-  call void @exit(i32 1), !dbg !59
-  unreachable, !dbg !59
-
 assert.exit.L19:                                  ; preds = %assert.exit.L18
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !60
-  %33 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !61
-    #dbg_declare(ptr %pair, !62, !DIExpression(), !68)
-  store %struct.Pair %33, ptr %pair, align 8, !dbg !61
-  %34 = call ptr @_ZN4PairImRiE8getFirstEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !69
-  %35 = load i64, ptr %34, align 8, !dbg !70
-  %36 = icmp eq i64 %35, 2, !dbg !70
-  br i1 %36, label %assert.exit.L22, label %assert.then.L22, !dbg !70, !prof !42
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !59
+  %33 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !60
+    #dbg_declare(ptr %pair, !61, !DIExpression(), !67)
+  store %struct.Pair %33, ptr %pair, align 8, !dbg !60
+  %34 = call ptr @_ZN4PairImRiE8getFirstEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !68
+  %35 = load i64, ptr %34, align 8, !dbg !69
+  %36 = icmp eq i64 %35, 2, !dbg !69
+  br i1 %36, label %assert.exit.L22, label %assert.then.L22, !dbg !69, !prof !41
 
 assert.then.L22:                                  ; preds = %assert.exit.L19
-  %37 = call i32 (ptr, ...) @printf(ptr @anon.string.6), !dbg !70
-  call void @exit(i32 1), !dbg !70
-  unreachable, !dbg !70
+  %37 = call i32 (ptr, ...) @printf(ptr @anon.string.6), !dbg !69
+  call void @exit(i32 1), !dbg !69
+  unreachable, !dbg !69
 
 assert.exit.L22:                                  ; preds = %assert.exit.L19
-  %38 = call ptr @_ZN4PairImRiE9getSecondEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !71
-  %39 = load i32, ptr %38, align 4, !dbg !72
-  %40 = icmp eq i32 %39, 9876, !dbg !72
-  br i1 %40, label %assert.exit.L23, label %assert.then.L23, !dbg !72, !prof !42
+  %38 = call ptr @_ZN4PairImRiE9getSecondEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !70
+  %39 = load i32, ptr %38, align 4, !dbg !71
+  %40 = icmp eq i32 %39, 9876, !dbg !71
+  br i1 %40, label %assert.exit.L23, label %assert.then.L23, !dbg !71, !prof !41
 
 assert.then.L23:                                  ; preds = %assert.exit.L22
-  %41 = call i32 (ptr, ...) @printf(ptr @anon.string.7), !dbg !72
-  call void @exit(i32 1), !dbg !72
-  unreachable, !dbg !72
+  %41 = call i32 (ptr, ...) @printf(ptr @anon.string.7), !dbg !71
+  call void @exit(i32 1), !dbg !71
+  unreachable, !dbg !71
 
 assert.exit.L23:                                  ; preds = %assert.exit.L22
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !73
-  %42 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !74
-  %43 = xor i1 %42, true, !dbg !74
-  br i1 %43, label %assert.exit.L25, label %assert.then.L25, !dbg !74, !prof !42
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !72
+  %42 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !73
+  %43 = xor i1 %42, true, !dbg !73
+  br i1 %43, label %assert.exit.L25, label %assert.then.L25, !dbg !73, !prof !41
 
 assert.then.L25:                                  ; preds = %assert.exit.L23
-  %44 = call i32 (ptr, ...) @printf(ptr @anon.string.8), !dbg !74
-  call void @exit(i32 1), !dbg !74
-  unreachable, !dbg !74
+  %44 = call i32 (ptr, ...) @printf(ptr @anon.string.8), !dbg !73
+  call void @exit(i32 1), !dbg !73
+  unreachable, !dbg !73
 
 assert.exit.L25:                                  ; preds = %assert.exit.L23
-  store i32 321, ptr %6, align 4, !dbg !75
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %6), !dbg !75
-  store i32 -99, ptr %7, align 4, !dbg !76
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %7), !dbg !76
-  %45 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !77
-  br i1 %45, label %assert.exit.L30, label %assert.then.L30, !dbg !77, !prof !42
+  store i32 321, ptr %6, align 4, !dbg !74
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %6), !dbg !74
+  store i32 -99, ptr %7, align 4, !dbg !75
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr %7), !dbg !75
+  %45 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !76
+  br i1 %45, label %assert.exit.L30, label %assert.then.L30, !dbg !76, !prof !41
 
 assert.then.L30:                                  ; preds = %assert.exit.L25
-  %46 = call i32 (ptr, ...) @printf(ptr @anon.string.9), !dbg !77
-  call void @exit(i32 1), !dbg !77
-  unreachable, !dbg !77
+  %46 = call i32 (ptr, ...) @printf(ptr @anon.string.9), !dbg !76
+  call void @exit(i32 1), !dbg !76
+  unreachable, !dbg !76
 
 assert.exit.L30:                                  ; preds = %assert.exit.L25
-  call void @_Z13op.minusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 3), !dbg !78
-  %47 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !79
-  %48 = load i32, ptr %47, align 4, !dbg !80
-  %49 = icmp eq i32 %48, 123, !dbg !80
-  br i1 %49, label %assert.exit.L34, label %assert.then.L34, !dbg !80, !prof !42
+  call void @_Z13op.minusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 3), !dbg !77
+  %47 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !78
+  %48 = load i32, ptr %47, align 4, !dbg !79
+  %49 = icmp eq i32 %48, 123, !dbg !79
+  br i1 %49, label %assert.exit.L34, label %assert.then.L34, !dbg !79, !prof !41
 
 assert.then.L34:                                  ; preds = %assert.exit.L30
-  %50 = call i32 (ptr, ...) @printf(ptr @anon.string.10), !dbg !80
+  %50 = call i32 (ptr, ...) @printf(ptr @anon.string.10), !dbg !79
+  call void @exit(i32 1), !dbg !79
+  unreachable, !dbg !79
+
+assert.exit.L34:                                  ; preds = %assert.exit.L30
+  %51 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !80
+  br i1 %51, label %assert.exit.L35, label %assert.then.L35, !dbg !80, !prof !41
+
+assert.then.L35:                                  ; preds = %assert.exit.L34
+  %52 = call i32 (ptr, ...) @printf(ptr @anon.string.11), !dbg !80
   call void @exit(i32 1), !dbg !80
   unreachable, !dbg !80
 
-assert.exit.L34:                                  ; preds = %assert.exit.L30
-  %51 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !81
-  br i1 %51, label %assert.exit.L35, label %assert.then.L35, !dbg !81, !prof !42
-
-assert.then.L35:                                  ; preds = %assert.exit.L34
-  %52 = call i32 (ptr, ...) @printf(ptr @anon.string.11), !dbg !81
-  call void @exit(i32 1), !dbg !81
-  unreachable, !dbg !81
-
 assert.exit.L35:                                  ; preds = %assert.exit.L34
-  %53 = load %struct.VectorIterator, ptr %it, align 8, !dbg !82
-  call void @_Z16op.plusplus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !82
-  %54 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !83
-  %55 = load i32, ptr %54, align 4, !dbg !84
-  %56 = icmp eq i32 %55, 4321, !dbg !84
-  br i1 %56, label %assert.exit.L37, label %assert.then.L37, !dbg !84, !prof !42
+  %53 = load %struct.VectorIterator, ptr %it, align 8, !dbg !81
+  call void @_Z16op.plusplus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !81
+  %54 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !82
+  %55 = load i32, ptr %54, align 4, !dbg !83
+  %56 = icmp eq i32 %55, 4321, !dbg !83
+  br i1 %56, label %assert.exit.L37, label %assert.then.L37, !dbg !83, !prof !41
 
 assert.then.L37:                                  ; preds = %assert.exit.L35
-  %57 = call i32 (ptr, ...) @printf(ptr @anon.string.12), !dbg !84
-  call void @exit(i32 1), !dbg !84
-  unreachable, !dbg !84
+  %57 = call i32 (ptr, ...) @printf(ptr @anon.string.12), !dbg !83
+  call void @exit(i32 1), !dbg !83
+  unreachable, !dbg !83
 
 assert.exit.L37:                                  ; preds = %assert.exit.L35
-  %58 = load %struct.VectorIterator, ptr %it, align 8, !dbg !85
-  call void @_Z18op.minusminus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !85
-  %59 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !86
-  %60 = load i32, ptr %59, align 4, !dbg !87
-  %61 = icmp eq i32 %60, 123, !dbg !87
-  br i1 %61, label %assert.exit.L39, label %assert.then.L39, !dbg !87, !prof !42
+  %58 = load %struct.VectorIterator, ptr %it, align 8, !dbg !84
+  call void @_Z18op.minusminus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !84
+  %59 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !85
+  %60 = load i32, ptr %59, align 4, !dbg !86
+  %61 = icmp eq i32 %60, 123, !dbg !86
+  br i1 %61, label %assert.exit.L39, label %assert.then.L39, !dbg !86, !prof !41
 
 assert.then.L39:                                  ; preds = %assert.exit.L37
-  %62 = call i32 (ptr, ...) @printf(ptr @anon.string.13), !dbg !87
-  call void @exit(i32 1), !dbg !87
-  unreachable, !dbg !87
+  %62 = call i32 (ptr, ...) @printf(ptr @anon.string.13), !dbg !86
+  call void @exit(i32 1), !dbg !86
+  unreachable, !dbg !86
 
 assert.exit.L39:                                  ; preds = %assert.exit.L37
-  call void @_Z12op.plusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 4), !dbg !88
-  %63 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !89
-  %64 = load i32, ptr %63, align 4, !dbg !90
-  %65 = icmp eq i32 %64, -99, !dbg !90
-  br i1 %65, label %assert.exit.L41, label %assert.then.L41, !dbg !90, !prof !42
+  call void @_Z12op.plusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 4), !dbg !87
+  %63 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !88
+  %64 = load i32, ptr %63, align 4, !dbg !89
+  %65 = icmp eq i32 %64, -99, !dbg !89
+  br i1 %65, label %assert.exit.L41, label %assert.then.L41, !dbg !89, !prof !41
 
 assert.then.L41:                                  ; preds = %assert.exit.L39
-  %66 = call i32 (ptr, ...) @printf(ptr @anon.string.14), !dbg !90
-  call void @exit(i32 1), !dbg !90
-  unreachable, !dbg !90
+  %66 = call i32 (ptr, ...) @printf(ptr @anon.string.14), !dbg !89
+  call void @exit(i32 1), !dbg !89
+  unreachable, !dbg !89
 
 assert.exit.L41:                                  ; preds = %assert.exit.L39
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !91
-  %67 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !92
-  %68 = xor i1 %67, true, !dbg !92
-  br i1 %68, label %assert.exit.L43, label %assert.then.L43, !dbg !92, !prof !42
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !90
+  %67 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !91
+  %68 = xor i1 %67, true, !dbg !91
+  br i1 %68, label %assert.exit.L43, label %assert.then.L43, !dbg !91, !prof !41
 
 assert.then.L43:                                  ; preds = %assert.exit.L41
-  %69 = call i32 (ptr, ...) @printf(ptr @anon.string.15), !dbg !92
-  call void @exit(i32 1), !dbg !92
-  unreachable, !dbg !92
+  %69 = call i32 (ptr, ...) @printf(ptr @anon.string.15), !dbg !91
+  call void @exit(i32 1), !dbg !91
+  unreachable, !dbg !91
 
 assert.exit.L43:                                  ; preds = %assert.exit.L41
-  %70 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !93
-    #dbg_declare(ptr %item, !95, !DIExpression(), !96)
-  store %struct.VectorIterator %70, ptr %8, align 8, !dbg !93
-  br label %foreach.head.L46, !dbg !96
+  %70 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !92
+    #dbg_declare(ptr %item, !94, !DIExpression(), !95)
+  store %struct.VectorIterator %70, ptr %8, align 8, !dbg !92
+  br label %foreach.head.L46, !dbg !95
 
 foreach.head.L46:                                 ; preds = %foreach.tail.L46, %assert.exit.L43
-  %71 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %8), !dbg !96
-  br i1 %71, label %foreach.body.L46, label %foreach.exit.L46, !dbg !96
+  %71 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %8), !dbg !95
+  br i1 %71, label %foreach.body.L46, label %foreach.exit.L46, !dbg !95
 
 foreach.body.L46:                                 ; preds = %foreach.head.L46
-  %72 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %8), !dbg !96
-  %73 = load i32, ptr %72, align 4, !dbg !96
-  store i32 %73, ptr %item, align 4, !dbg !96
-  %74 = load i32, ptr %item, align 4, !dbg !97
-  %75 = add nsw i32 %74, 1, !dbg !97
-  store i32 %75, ptr %item, align 4, !dbg !97
-  br label %foreach.tail.L46, !dbg !98
+  %72 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %8), !dbg !95
+  %73 = load i32, ptr %72, align 4, !dbg !95
+  store i32 %73, ptr %item, align 4, !dbg !95
+  %74 = load i32, ptr %item, align 4, !dbg !96
+  %75 = add nsw i32 %74, 1, !dbg !96
+  store i32 %75, ptr %item, align 4, !dbg !96
+  br label %foreach.tail.L46, !dbg !97
 
 foreach.tail.L46:                                 ; preds = %foreach.body.L46
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %8), !dbg !98
-  br label %foreach.head.L46, !dbg !98
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %8), !dbg !97
+  br label %foreach.head.L46, !dbg !97
 
 foreach.exit.L46:                                 ; preds = %foreach.head.L46
-  %76 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !99
-  %77 = load i32, ptr %76, align 4, !dbg !100
-  %78 = icmp eq i32 %77, 123, !dbg !100
-  br i1 %78, label %assert.exit.L49, label %assert.then.L49, !dbg !100, !prof !42
+  %76 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !98
+  %77 = load i32, ptr %76, align 4, !dbg !99
+  %78 = icmp eq i32 %77, 123, !dbg !99
+  br i1 %78, label %assert.exit.L49, label %assert.then.L49, !dbg !99, !prof !41
 
 assert.then.L49:                                  ; preds = %foreach.exit.L46
-  %79 = call i32 (ptr, ...) @printf(ptr @anon.string.16), !dbg !100
-  call void @exit(i32 1), !dbg !100
-  unreachable, !dbg !100
+  %79 = call i32 (ptr, ...) @printf(ptr @anon.string.16), !dbg !99
+  call void @exit(i32 1), !dbg !99
+  unreachable, !dbg !99
 
 assert.exit.L49:                                  ; preds = %foreach.exit.L46
-  %80 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !101
-  %81 = load i32, ptr %80, align 4, !dbg !102
-  %82 = icmp eq i32 %81, 4321, !dbg !102
-  br i1 %82, label %assert.exit.L50, label %assert.then.L50, !dbg !102, !prof !42
+  %80 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !100
+  %81 = load i32, ptr %80, align 4, !dbg !101
+  %82 = icmp eq i32 %81, 4321, !dbg !101
+  br i1 %82, label %assert.exit.L50, label %assert.then.L50, !dbg !101, !prof !41
 
 assert.then.L50:                                  ; preds = %assert.exit.L49
-  %83 = call i32 (ptr, ...) @printf(ptr @anon.string.17), !dbg !102
-  call void @exit(i32 1), !dbg !102
-  unreachable, !dbg !102
+  %83 = call i32 (ptr, ...) @printf(ptr @anon.string.17), !dbg !101
+  call void @exit(i32 1), !dbg !101
+  unreachable, !dbg !101
 
 assert.exit.L50:                                  ; preds = %assert.exit.L49
-  %84 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !103
-  %85 = load i32, ptr %84, align 4, !dbg !104
-  %86 = icmp eq i32 %85, 9876, !dbg !104
-  br i1 %86, label %assert.exit.L51, label %assert.then.L51, !dbg !104, !prof !42
+  %84 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !102
+  %85 = load i32, ptr %84, align 4, !dbg !103
+  %86 = icmp eq i32 %85, 9876, !dbg !103
+  br i1 %86, label %assert.exit.L51, label %assert.then.L51, !dbg !103, !prof !41
 
 assert.then.L51:                                  ; preds = %assert.exit.L50
-  %87 = call i32 (ptr, ...) @printf(ptr @anon.string.18), !dbg !104
-  call void @exit(i32 1), !dbg !104
-  unreachable, !dbg !104
+  %87 = call i32 (ptr, ...) @printf(ptr @anon.string.18), !dbg !103
+  call void @exit(i32 1), !dbg !103
+  unreachable, !dbg !103
 
 assert.exit.L51:                                  ; preds = %assert.exit.L50
-  %88 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !105
-    #dbg_declare(ptr %item1, !107, !DIExpression(), !108)
-  store %struct.VectorIterator %88, ptr %9, align 8, !dbg !105
-  br label %foreach.head.L54, !dbg !108
+  %88 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !104
+    #dbg_declare(ptr %item1, !106, !DIExpression(), !107)
+  store %struct.VectorIterator %88, ptr %9, align 8, !dbg !104
+  br label %foreach.head.L54, !dbg !107
 
 foreach.head.L54:                                 ; preds = %foreach.tail.L54, %assert.exit.L51
-  %89 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %9), !dbg !108
-  br i1 %89, label %foreach.body.L54, label %foreach.exit.L54, !dbg !108
+  %89 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %9), !dbg !107
+  br i1 %89, label %foreach.body.L54, label %foreach.exit.L54, !dbg !107
 
 foreach.body.L54:                                 ; preds = %foreach.head.L54
-  %90 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %9), !dbg !108
-  store ptr %90, ptr %10, align 8, !dbg !108
-  %91 = load ptr, ptr %10, align 8, !dbg !109
-  %92 = load i32, ptr %91, align 4, !dbg !109
-  %93 = add nsw i32 %92, 1, !dbg !109
-  store i32 %93, ptr %91, align 4, !dbg !109
-  br label %foreach.tail.L54, !dbg !110
+  %90 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %9), !dbg !107
+  store ptr %90, ptr %10, align 8, !dbg !107
+  %91 = load ptr, ptr %10, align 8, !dbg !108
+  %92 = load i32, ptr %91, align 4, !dbg !108
+  %93 = add nsw i32 %92, 1, !dbg !108
+  store i32 %93, ptr %91, align 4, !dbg !108
+  br label %foreach.tail.L54, !dbg !109
 
 foreach.tail.L54:                                 ; preds = %foreach.body.L54
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %9), !dbg !110
-  br label %foreach.head.L54, !dbg !110
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %9), !dbg !109
+  br label %foreach.head.L54, !dbg !109
 
 foreach.exit.L54:                                 ; preds = %foreach.head.L54
-  %94 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !111
-  %95 = load i32, ptr %94, align 4, !dbg !112
-  %96 = icmp eq i32 %95, 124, !dbg !112
-  br i1 %96, label %assert.exit.L57, label %assert.then.L57, !dbg !112, !prof !42
+  %94 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !110
+  %95 = load i32, ptr %94, align 4, !dbg !111
+  %96 = icmp eq i32 %95, 124, !dbg !111
+  br i1 %96, label %assert.exit.L57, label %assert.then.L57, !dbg !111, !prof !41
 
 assert.then.L57:                                  ; preds = %foreach.exit.L54
-  %97 = call i32 (ptr, ...) @printf(ptr @anon.string.19), !dbg !112
-  call void @exit(i32 1), !dbg !112
-  unreachable, !dbg !112
+  %97 = call i32 (ptr, ...) @printf(ptr @anon.string.19), !dbg !111
+  call void @exit(i32 1), !dbg !111
+  unreachable, !dbg !111
 
 assert.exit.L57:                                  ; preds = %foreach.exit.L54
-  %98 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !113
-  %99 = load i32, ptr %98, align 4, !dbg !114
-  %100 = icmp eq i32 %99, 4322, !dbg !114
-  br i1 %100, label %assert.exit.L58, label %assert.then.L58, !dbg !114, !prof !42
+  %98 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !112
+  %99 = load i32, ptr %98, align 4, !dbg !113
+  %100 = icmp eq i32 %99, 4322, !dbg !113
+  br i1 %100, label %assert.exit.L58, label %assert.then.L58, !dbg !113, !prof !41
 
 assert.then.L58:                                  ; preds = %assert.exit.L57
-  %101 = call i32 (ptr, ...) @printf(ptr @anon.string.20), !dbg !114
-  call void @exit(i32 1), !dbg !114
-  unreachable, !dbg !114
+  %101 = call i32 (ptr, ...) @printf(ptr @anon.string.20), !dbg !113
+  call void @exit(i32 1), !dbg !113
+  unreachable, !dbg !113
 
 assert.exit.L58:                                  ; preds = %assert.exit.L57
-  %102 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !115
-  %103 = load i32, ptr %102, align 4, !dbg !116
-  %104 = icmp eq i32 %103, 9877, !dbg !116
-  br i1 %104, label %assert.exit.L59, label %assert.then.L59, !dbg !116, !prof !42
+  %102 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !114
+  %103 = load i32, ptr %102, align 4, !dbg !115
+  %104 = icmp eq i32 %103, 9877, !dbg !115
+  br i1 %104, label %assert.exit.L59, label %assert.then.L59, !dbg !115, !prof !41
 
 assert.then.L59:                                  ; preds = %assert.exit.L58
-  %105 = call i32 (ptr, ...) @printf(ptr @anon.string.21), !dbg !116
-  call void @exit(i32 1), !dbg !116
-  unreachable, !dbg !116
+  %105 = call i32 (ptr, ...) @printf(ptr @anon.string.21), !dbg !115
+  call void @exit(i32 1), !dbg !115
+  unreachable, !dbg !115
 
 assert.exit.L59:                                  ; preds = %assert.exit.L58
-  %106 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !117
-  store %struct.VectorIterator %106, ptr %11, align 8, !dbg !117
-    #dbg_declare(ptr %idx, !119, !DIExpression(), !121)
-    #dbg_declare(ptr %item2, !122, !DIExpression(), !123)
-  store i64 0, ptr %idx, align 8, !dbg !121
-  br label %foreach.head.L61, !dbg !123
+  %106 = call %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !116
+  store %struct.VectorIterator %106, ptr %11, align 8, !dbg !116
+    #dbg_declare(ptr %idx, !118, !DIExpression(), !120)
+    #dbg_declare(ptr %item2, !121, !DIExpression(), !122)
+  store i64 0, ptr %idx, align 8, !dbg !120
+  br label %foreach.head.L61, !dbg !122
 
 foreach.head.L61:                                 ; preds = %foreach.tail.L61, %assert.exit.L59
-  %107 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !123
-  br i1 %107, label %foreach.body.L61, label %foreach.exit.L61, !dbg !123
+  %107 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !122
+  br i1 %107, label %foreach.body.L61, label %foreach.exit.L61, !dbg !122
 
 foreach.body.L61:                                 ; preds = %foreach.head.L61
-  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %11), !dbg !123
-  store %struct.Pair %pair3, ptr %pair_addr, align 8, !dbg !123
-  %108 = load i64, ptr %pair_addr, align 8, !dbg !123
-  store i64 %108, ptr %idx, align 8, !dbg !123
-  %item_addr = getelementptr inbounds %struct.Pair, ptr %pair_addr, i32 0, i32 1, !dbg !123
-  %109 = load ptr, ptr %item_addr, align 8, !dbg !123
-  store ptr %109, ptr %12, align 8, !dbg !123
-  %110 = load i64, ptr %idx, align 8, !dbg !124
-  %111 = trunc i64 %110 to i32, !dbg !124
-  %112 = load ptr, ptr %12, align 8, !dbg !124
-  %113 = load i32, ptr %112, align 4, !dbg !124
-  %114 = add nsw i32 %113, %111, !dbg !124
-  store i32 %114, ptr %112, align 4, !dbg !124
-  br label %foreach.tail.L61, !dbg !125
+  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %11), !dbg !122
+  store %struct.Pair %pair3, ptr %pair_addr, align 8, !dbg !122
+  %108 = load i64, ptr %pair_addr, align 8, !dbg !122
+  store i64 %108, ptr %idx, align 8, !dbg !122
+  %item_addr = getelementptr inbounds %struct.Pair, ptr %pair_addr, i32 0, i32 1, !dbg !122
+  %109 = load ptr, ptr %item_addr, align 8, !dbg !122
+  store ptr %109, ptr %12, align 8, !dbg !122
+  %110 = load i64, ptr %idx, align 8, !dbg !123
+  %111 = trunc i64 %110 to i32, !dbg !123
+  %112 = load ptr, ptr %12, align 8, !dbg !123
+  %113 = load i32, ptr %112, align 4, !dbg !123
+  %114 = add nsw i32 %113, %111, !dbg !123
+  store i32 %114, ptr %112, align 4, !dbg !123
+  br label %foreach.tail.L61, !dbg !124
 
 foreach.tail.L61:                                 ; preds = %foreach.body.L61
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !125
-  br label %foreach.head.L61, !dbg !125
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !124
+  br label %foreach.head.L61, !dbg !124
 
 foreach.exit.L61:                                 ; preds = %foreach.head.L61
-  %115 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !126
-  %116 = load i32, ptr %115, align 4, !dbg !127
-  %117 = icmp eq i32 %116, 124, !dbg !127
-  br i1 %117, label %assert.exit.L64, label %assert.then.L64, !dbg !127, !prof !42
+  %115 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 0), !dbg !125
+  %116 = load i32, ptr %115, align 4, !dbg !126
+  %117 = icmp eq i32 %116, 124, !dbg !126
+  br i1 %117, label %assert.exit.L64, label %assert.then.L64, !dbg !126, !prof !41
 
 assert.then.L64:                                  ; preds = %foreach.exit.L61
-  %118 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !127
-  call void @exit(i32 1), !dbg !127
-  unreachable, !dbg !127
+  %118 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !126
+  call void @exit(i32 1), !dbg !126
+  unreachable, !dbg !126
 
 assert.exit.L64:                                  ; preds = %foreach.exit.L61
-  %119 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !128
-  %120 = load i32, ptr %119, align 4, !dbg !129
-  %121 = icmp eq i32 %120, 4323, !dbg !129
-  br i1 %121, label %assert.exit.L65, label %assert.then.L65, !dbg !129, !prof !42
+  %119 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 1), !dbg !127
+  %120 = load i32, ptr %119, align 4, !dbg !128
+  %121 = icmp eq i32 %120, 4323, !dbg !128
+  br i1 %121, label %assert.exit.L65, label %assert.then.L65, !dbg !128, !prof !41
 
 assert.then.L65:                                  ; preds = %assert.exit.L64
-  %122 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !129
-  call void @exit(i32 1), !dbg !129
-  unreachable, !dbg !129
+  %122 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !128
+  call void @exit(i32 1), !dbg !128
+  unreachable, !dbg !128
 
 assert.exit.L65:                                  ; preds = %assert.exit.L64
-  %123 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !130
-  %124 = load i32, ptr %123, align 4, !dbg !131
-  %125 = icmp eq i32 %124, 9879, !dbg !131
-  br i1 %125, label %assert.exit.L66, label %assert.then.L66, !dbg !131, !prof !42
+  %123 = call ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 2), !dbg !129
+  %124 = load i32, ptr %123, align 4, !dbg !130
+  %125 = icmp eq i32 %124, 9879, !dbg !130
+  br i1 %125, label %assert.exit.L66, label %assert.then.L66, !dbg !130, !prof !41
 
 assert.then.L66:                                  ; preds = %assert.exit.L65
-  %126 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !131
-  call void @exit(i32 1), !dbg !131
-  unreachable, !dbg !131
+  %126 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !130
+  call void @exit(i32 1), !dbg !130
+  unreachable, !dbg !130
 
 assert.exit.L66:                                  ; preds = %assert.exit.L65
-  %127 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !132
-  call void @_ZN6VectorIiE4dtorEv(ptr %vi), !dbg !133
-  %128 = load i32, ptr %result, align 4, !dbg !133
-  ret i32 %128, !dbg !133
+  %127 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !131
+  call void @_ZN6VectorIiE4dtorEv(ptr %vi), !dbg !132
+  %128 = load i32, ptr %result, align 4, !dbg !132
+  ret i32 %128, !dbg !132
 }
 
 declare void @_ZN6VectorIiE4ctorEv(ptr)
@@ -481,9 +481,9 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
+!llvm.module.flags = !{!7, !8, !9, !10, !11, !12}
+!llvm.ident = !{!13}
 !llvm.dbg.cu = !{!2}
-!llvm.module.flags = !{!7, !8, !9, !10, !11, !12, !13}
-!llvm.ident = !{!14}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "printf.str.0", linkageName: "printf.str.0", scope: !2, file: !5, line: 68, type: !6, isLocal: true, isDefinition: true)
@@ -492,130 +492,129 @@ attributes #2 = { cold noreturn nounwind }
 !4 = !{!0}
 !5 = !DIFile(filename: "source.spice", directory: "./test-files/irgenerator/debug-info/success-dbg-info-complex")
 !6 = !DIStringType(name: "printf.str.0", size: 192)
-!7 = !{i32 7, !"Dwarf Version", i32 4}
-!8 = !{i32 2, !"Debug Info Version", i32 3}
-!9 = !{i32 1, !"wchar_size", i32 4}
-!10 = !{i32 8, !"PIC Level", i32 2}
-!11 = !{i32 7, !"PIE Level", i32 2}
-!12 = !{i32 7, !"uwtable", i32 2}
-!13 = !{i32 7, !"frame-pointer", i32 2}
-!14 = !{!"spice version dev (https://github.com/spicelang/spice)"}
-!15 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainiPPKc", scope: !5, file: !5, line: 4, type: !16, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !22)
-!16 = !DISubroutineType(types: !17)
-!17 = !{!18, !18, !19}
-!18 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, elements: !22)
-!20 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !21, size: 64)
-!21 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
-!22 = !{}
-!23 = !DILocalVariable(name: "result", scope: !15, file: !5, line: 4, type: !18)
-!24 = !DILocation(line: 4, column: 1, scope: !15)
-!25 = !DILocalVariable(name: "_argc", arg: 1, scope: !15, file: !5, line: 4, type: !18)
-!26 = !DILocalVariable(name: "_argv", arg: 2, scope: !15, file: !5, line: 4, type: !19)
-!27 = !DILocalVariable(name: "vi", scope: !15, file: !5, line: 6, type: !28)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, name: "Vector", scope: !5, file: !5, line: 25, size: 256, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !29, identifier: "struct.Vector")
-!29 = !{!30, !32, !34}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "contents", scope: !28, file: !5, line: 26, baseType: !31, size: 64, offset: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64)
-!32 = !DIDerivedType(tag: DW_TAG_member, name: "capacity", scope: !28, file: !5, line: 27, baseType: !33, size: 64, offset: 128)
-!33 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
-!34 = !DIDerivedType(tag: DW_TAG_member, name: "size", scope: !28, file: !5, line: 28, baseType: !33, size: 64, offset: 192)
-!35 = !DILocation(line: 6, column: 5, scope: !15)
-!36 = !DILocation(line: 6, column: 22, scope: !15)
-!37 = !DILocation(line: 7, column: 17, scope: !15)
-!38 = !DILocation(line: 8, column: 17, scope: !15)
-!39 = !DILocation(line: 9, column: 17, scope: !15)
-!40 = !DILocation(line: 10, column: 12, scope: !15)
-!41 = !DILocation(line: 10, column: 28, scope: !15)
-!42 = !{!"branch_weights", i32 2000, i32 1}
-!43 = !DILocation(line: 13, column: 14, scope: !15)
-!44 = !DILocalVariable(name: "it", scope: !15, file: !5, line: 13, type: !45)
-!45 = !DICompositeType(tag: DW_TAG_structure_type, name: "VectorIterator", scope: !5, file: !5, line: 280, size: 192, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !46, identifier: "struct.VectorIterator")
-!46 = !{!47, !49}
-!47 = !DIDerivedType(tag: DW_TAG_member, name: "vector", scope: !45, file: !5, line: 281, baseType: !48, size: 64, offset: 64)
-!48 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !28, size: 64)
-!49 = !DIDerivedType(tag: DW_TAG_member, name: "cursor", scope: !45, file: !5, line: 282, baseType: !33, size: 64, offset: 128)
-!50 = !DILocation(line: 13, column: 5, scope: !15)
-!51 = !DILocation(line: 14, column: 12, scope: !15)
-!52 = !DILocation(line: 15, column: 12, scope: !15)
-!53 = !DILocation(line: 15, column: 24, scope: !15)
-!54 = !DILocation(line: 16, column: 12, scope: !15)
-!55 = !DILocation(line: 16, column: 24, scope: !15)
-!56 = !DILocation(line: 17, column: 5, scope: !15)
-!57 = !DILocation(line: 18, column: 12, scope: !15)
-!58 = !DILocation(line: 18, column: 24, scope: !15)
-!59 = !DILocation(line: 19, column: 12, scope: !15)
-!60 = !DILocation(line: 20, column: 5, scope: !15)
-!61 = !DILocation(line: 21, column: 16, scope: !15)
-!62 = !DILocalVariable(name: "pair", scope: !15, file: !5, line: 21, type: !63)
-!63 = !DICompositeType(tag: DW_TAG_structure_type, name: "Pair", scope: !5, file: !5, line: 8, size: 128, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !64, identifier: "struct.Pair")
-!64 = !{!65, !66}
-!65 = !DIDerivedType(tag: DW_TAG_member, name: "first", scope: !63, file: !5, line: 9, baseType: !33, size: 64)
-!66 = !DIDerivedType(tag: DW_TAG_member, name: "second", scope: !63, file: !5, line: 10, baseType: !67, size: 64, offset: 64)
-!67 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !18, size: 64)
-!68 = !DILocation(line: 21, column: 5, scope: !15)
-!69 = !DILocation(line: 22, column: 12, scope: !15)
-!70 = !DILocation(line: 22, column: 31, scope: !15)
-!71 = !DILocation(line: 23, column: 12, scope: !15)
-!72 = !DILocation(line: 23, column: 32, scope: !15)
-!73 = !DILocation(line: 24, column: 5, scope: !15)
-!74 = !DILocation(line: 25, column: 13, scope: !15)
-!75 = !DILocation(line: 28, column: 17, scope: !15)
-!76 = !DILocation(line: 29, column: 17, scope: !15)
-!77 = !DILocation(line: 30, column: 12, scope: !15)
-!78 = !DILocation(line: 33, column: 5, scope: !15)
-!79 = !DILocation(line: 34, column: 12, scope: !15)
-!80 = !DILocation(line: 34, column: 24, scope: !15)
-!81 = !DILocation(line: 35, column: 12, scope: !15)
-!82 = !DILocation(line: 36, column: 5, scope: !15)
-!83 = !DILocation(line: 37, column: 12, scope: !15)
-!84 = !DILocation(line: 37, column: 24, scope: !15)
-!85 = !DILocation(line: 38, column: 5, scope: !15)
-!86 = !DILocation(line: 39, column: 12, scope: !15)
-!87 = !DILocation(line: 39, column: 24, scope: !15)
-!88 = !DILocation(line: 40, column: 5, scope: !15)
-!89 = !DILocation(line: 41, column: 12, scope: !15)
-!90 = !DILocation(line: 41, column: 24, scope: !15)
-!91 = !DILocation(line: 42, column: 5, scope: !15)
-!92 = !DILocation(line: 43, column: 13, scope: !15)
-!93 = !DILocation(line: 46, column: 24, scope: !94)
-!94 = distinct !DILexicalBlock(scope: !15, file: !5, line: 46, column: 5)
-!95 = !DILocalVariable(name: "item", scope: !94, file: !5, line: 46, type: !18)
-!96 = !DILocation(line: 46, column: 13, scope: !94)
-!97 = !DILocation(line: 47, column: 9, scope: !94)
-!98 = !DILocation(line: 48, column: 5, scope: !94)
-!99 = !DILocation(line: 49, column: 19, scope: !15)
-!100 = !DILocation(line: 49, column: 25, scope: !15)
-!101 = !DILocation(line: 50, column: 19, scope: !15)
-!102 = !DILocation(line: 50, column: 25, scope: !15)
-!103 = !DILocation(line: 51, column: 19, scope: !15)
-!104 = !DILocation(line: 51, column: 25, scope: !15)
-!105 = !DILocation(line: 54, column: 25, scope: !106)
-!106 = distinct !DILexicalBlock(scope: !15, file: !5, line: 54, column: 5)
-!107 = !DILocalVariable(name: "item", scope: !106, file: !5, line: 54, type: !67)
-!108 = !DILocation(line: 54, column: 13, scope: !106)
-!109 = !DILocation(line: 55, column: 9, scope: !106)
-!110 = !DILocation(line: 56, column: 5, scope: !106)
-!111 = !DILocation(line: 57, column: 19, scope: !15)
-!112 = !DILocation(line: 57, column: 25, scope: !15)
-!113 = !DILocation(line: 58, column: 19, scope: !15)
-!114 = !DILocation(line: 58, column: 25, scope: !15)
-!115 = !DILocation(line: 59, column: 19, scope: !15)
-!116 = !DILocation(line: 59, column: 25, scope: !15)
-!117 = !DILocation(line: 61, column: 35, scope: !118)
-!118 = distinct !DILexicalBlock(scope: !15, file: !5, line: 61, column: 5)
-!119 = !DILocalVariable(name: "idx", scope: !118, file: !5, line: 61, type: !120)
-!120 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!121 = !DILocation(line: 61, column: 13, scope: !118)
-!122 = !DILocalVariable(name: "item", scope: !118, file: !5, line: 61, type: !67)
-!123 = !DILocation(line: 61, column: 23, scope: !118)
-!124 = !DILocation(line: 62, column: 9, scope: !118)
-!125 = !DILocation(line: 63, column: 5, scope: !118)
-!126 = !DILocation(line: 64, column: 19, scope: !15)
-!127 = !DILocation(line: 64, column: 25, scope: !15)
-!128 = !DILocation(line: 65, column: 19, scope: !15)
-!129 = !DILocation(line: 65, column: 25, scope: !15)
-!130 = !DILocation(line: 66, column: 19, scope: !15)
-!131 = !DILocation(line: 66, column: 25, scope: !15)
-!132 = !DILocation(line: 68, column: 5, scope: !15)
-!133 = !DILocation(line: 69, column: 1, scope: !15)
+!7 = !{i32 8, !"PIC Level", i32 2}
+!8 = !{i32 7, !"PIE Level", i32 2}
+!9 = !{i32 7, !"uwtable", i32 2}
+!10 = !{i32 7, !"frame-pointer", i32 2}
+!11 = !{i32 7, !"Dwarf Version", i32 4}
+!12 = !{i32 2, !"Debug Info Version", i32 3}
+!13 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!14 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainiPPKc", scope: !5, file: !5, line: 4, type: !15, scopeLine: 4, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !21)
+!15 = !DISubroutineType(types: !16)
+!16 = !{!17, !17, !18}
+!17 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!18 = !DICompositeType(tag: DW_TAG_array_type, baseType: !19, elements: !21)
+!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
+!20 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+!21 = !{}
+!22 = !DILocalVariable(name: "result", scope: !14, file: !5, line: 4, type: !17)
+!23 = !DILocation(line: 4, column: 1, scope: !14)
+!24 = !DILocalVariable(name: "_argc", arg: 1, scope: !14, file: !5, line: 4, type: !17)
+!25 = !DILocalVariable(name: "_argv", arg: 2, scope: !14, file: !5, line: 4, type: !18)
+!26 = !DILocalVariable(name: "vi", scope: !14, file: !5, line: 6, type: !27)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, name: "Vector", scope: !5, file: !5, line: 25, size: 256, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !28, identifier: "struct.Vector")
+!28 = !{!29, !31, !33}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "contents", scope: !27, file: !5, line: 26, baseType: !30, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !17, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "capacity", scope: !27, file: !5, line: 27, baseType: !32, size: 64, offset: 128)
+!32 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "size", scope: !27, file: !5, line: 28, baseType: !32, size: 64, offset: 192)
+!34 = !DILocation(line: 6, column: 5, scope: !14)
+!35 = !DILocation(line: 6, column: 22, scope: !14)
+!36 = !DILocation(line: 7, column: 17, scope: !14)
+!37 = !DILocation(line: 8, column: 17, scope: !14)
+!38 = !DILocation(line: 9, column: 17, scope: !14)
+!39 = !DILocation(line: 10, column: 12, scope: !14)
+!40 = !DILocation(line: 10, column: 28, scope: !14)
+!41 = !{!"branch_weights", i32 2000, i32 1}
+!42 = !DILocation(line: 13, column: 14, scope: !14)
+!43 = !DILocalVariable(name: "it", scope: !14, file: !5, line: 13, type: !44)
+!44 = !DICompositeType(tag: DW_TAG_structure_type, name: "VectorIterator", scope: !5, file: !5, line: 280, size: 192, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !45, identifier: "struct.VectorIterator")
+!45 = !{!46, !48}
+!46 = !DIDerivedType(tag: DW_TAG_member, name: "vector", scope: !44, file: !5, line: 281, baseType: !47, size: 64, offset: 64)
+!47 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !27, size: 64)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "cursor", scope: !44, file: !5, line: 282, baseType: !32, size: 64, offset: 128)
+!49 = !DILocation(line: 13, column: 5, scope: !14)
+!50 = !DILocation(line: 14, column: 12, scope: !14)
+!51 = !DILocation(line: 15, column: 12, scope: !14)
+!52 = !DILocation(line: 15, column: 24, scope: !14)
+!53 = !DILocation(line: 16, column: 12, scope: !14)
+!54 = !DILocation(line: 16, column: 24, scope: !14)
+!55 = !DILocation(line: 17, column: 5, scope: !14)
+!56 = !DILocation(line: 18, column: 12, scope: !14)
+!57 = !DILocation(line: 18, column: 24, scope: !14)
+!58 = !DILocation(line: 19, column: 12, scope: !14)
+!59 = !DILocation(line: 20, column: 5, scope: !14)
+!60 = !DILocation(line: 21, column: 16, scope: !14)
+!61 = !DILocalVariable(name: "pair", scope: !14, file: !5, line: 21, type: !62)
+!62 = !DICompositeType(tag: DW_TAG_structure_type, name: "Pair", scope: !5, file: !5, line: 8, size: 128, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !63, identifier: "struct.Pair")
+!63 = !{!64, !65}
+!64 = !DIDerivedType(tag: DW_TAG_member, name: "first", scope: !62, file: !5, line: 9, baseType: !32, size: 64)
+!65 = !DIDerivedType(tag: DW_TAG_member, name: "second", scope: !62, file: !5, line: 10, baseType: !66, size: 64, offset: 64)
+!66 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !17, size: 64)
+!67 = !DILocation(line: 21, column: 5, scope: !14)
+!68 = !DILocation(line: 22, column: 12, scope: !14)
+!69 = !DILocation(line: 22, column: 31, scope: !14)
+!70 = !DILocation(line: 23, column: 12, scope: !14)
+!71 = !DILocation(line: 23, column: 32, scope: !14)
+!72 = !DILocation(line: 24, column: 5, scope: !14)
+!73 = !DILocation(line: 25, column: 13, scope: !14)
+!74 = !DILocation(line: 28, column: 17, scope: !14)
+!75 = !DILocation(line: 29, column: 17, scope: !14)
+!76 = !DILocation(line: 30, column: 12, scope: !14)
+!77 = !DILocation(line: 33, column: 5, scope: !14)
+!78 = !DILocation(line: 34, column: 12, scope: !14)
+!79 = !DILocation(line: 34, column: 24, scope: !14)
+!80 = !DILocation(line: 35, column: 12, scope: !14)
+!81 = !DILocation(line: 36, column: 5, scope: !14)
+!82 = !DILocation(line: 37, column: 12, scope: !14)
+!83 = !DILocation(line: 37, column: 24, scope: !14)
+!84 = !DILocation(line: 38, column: 5, scope: !14)
+!85 = !DILocation(line: 39, column: 12, scope: !14)
+!86 = !DILocation(line: 39, column: 24, scope: !14)
+!87 = !DILocation(line: 40, column: 5, scope: !14)
+!88 = !DILocation(line: 41, column: 12, scope: !14)
+!89 = !DILocation(line: 41, column: 24, scope: !14)
+!90 = !DILocation(line: 42, column: 5, scope: !14)
+!91 = !DILocation(line: 43, column: 13, scope: !14)
+!92 = !DILocation(line: 46, column: 24, scope: !93)
+!93 = distinct !DILexicalBlock(scope: !14, file: !5, line: 46, column: 5)
+!94 = !DILocalVariable(name: "item", scope: !93, file: !5, line: 46, type: !17)
+!95 = !DILocation(line: 46, column: 13, scope: !93)
+!96 = !DILocation(line: 47, column: 9, scope: !93)
+!97 = !DILocation(line: 48, column: 5, scope: !93)
+!98 = !DILocation(line: 49, column: 19, scope: !14)
+!99 = !DILocation(line: 49, column: 25, scope: !14)
+!100 = !DILocation(line: 50, column: 19, scope: !14)
+!101 = !DILocation(line: 50, column: 25, scope: !14)
+!102 = !DILocation(line: 51, column: 19, scope: !14)
+!103 = !DILocation(line: 51, column: 25, scope: !14)
+!104 = !DILocation(line: 54, column: 25, scope: !105)
+!105 = distinct !DILexicalBlock(scope: !14, file: !5, line: 54, column: 5)
+!106 = !DILocalVariable(name: "item", scope: !105, file: !5, line: 54, type: !66)
+!107 = !DILocation(line: 54, column: 13, scope: !105)
+!108 = !DILocation(line: 55, column: 9, scope: !105)
+!109 = !DILocation(line: 56, column: 5, scope: !105)
+!110 = !DILocation(line: 57, column: 19, scope: !14)
+!111 = !DILocation(line: 57, column: 25, scope: !14)
+!112 = !DILocation(line: 58, column: 19, scope: !14)
+!113 = !DILocation(line: 58, column: 25, scope: !14)
+!114 = !DILocation(line: 59, column: 19, scope: !14)
+!115 = !DILocation(line: 59, column: 25, scope: !14)
+!116 = !DILocation(line: 61, column: 35, scope: !117)
+!117 = distinct !DILexicalBlock(scope: !14, file: !5, line: 61, column: 5)
+!118 = !DILocalVariable(name: "idx", scope: !117, file: !5, line: 61, type: !119)
+!119 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!120 = !DILocation(line: 61, column: 13, scope: !117)
+!121 = !DILocalVariable(name: "item", scope: !117, file: !5, line: 61, type: !66)
+!122 = !DILocation(line: 61, column: 23, scope: !117)
+!123 = !DILocation(line: 62, column: 9, scope: !117)
+!124 = !DILocation(line: 63, column: 5, scope: !117)
+!125 = !DILocation(line: 64, column: 19, scope: !14)
+!126 = !DILocation(line: 64, column: 25, scope: !14)
+!127 = !DILocation(line: 65, column: 19, scope: !14)
+!128 = !DILocation(line: 65, column: 25, scope: !14)
+!129 = !DILocation(line: 66, column: 19, scope: !14)
+!130 = !DILocation(line: 66, column: 25, scope: !14)
+!131 = !DILocation(line: 68, column: 5, scope: !14)
+!132 = !DILocation(line: 69, column: 1, scope: !14)

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
@@ -10,66 +10,66 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [9 x i8] c"Int: %d\0A\00", align 1, !dbg !12
 
 ; Function Attrs: norecurse
-define void @_ZN10TestStruct4dtorEv(ptr noundef nonnull align 8 dereferenceable(40) %0) #0 !dbg !24 {
+define void @_ZN10TestStruct4dtorEv(ptr noundef nonnull align 8 dereferenceable(40) %0) #0 !dbg !23 {
   %this = alloca ptr, align 8
-    #dbg_declare(ptr %this, !44, !DIExpression(), !46)
-  store ptr %0, ptr %this, align 8, !dbg !46
-  %2 = load ptr, ptr %this, align 8, !dbg !46
-  %3 = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 1, !dbg !46
-  call void @_ZN6String4dtorEv(ptr %3), !dbg !46
-  ret void, !dbg !46
+    #dbg_declare(ptr %this, !43, !DIExpression(), !45)
+  store ptr %0, ptr %this, align 8, !dbg !45
+  %2 = load ptr, ptr %this, align 8, !dbg !45
+  %3 = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 1, !dbg !45
+  call void @_ZN6String4dtorEv(ptr %3), !dbg !45
+  ret void, !dbg !45
 }
 
 declare void @_ZN6String4dtorEv(ptr)
 
-define private %struct.TestStruct @_Z3fctRi(ptr %0) !dbg !47 {
-    #dbg_declare(ptr %result, !51, !DIExpression(), !52)
+define private %struct.TestStruct @_Z3fctRi(ptr %0) !dbg !46 {
+    #dbg_declare(ptr %result, !50, !DIExpression(), !51)
   %result = alloca %struct.TestStruct, align 8
   %ref = alloca ptr, align 8
   %2 = alloca %struct.String, align 8
   %ts = alloca %struct.TestStruct, align 8
-    #dbg_declare(ptr %ref, !53, !DIExpression(), !54)
-  store ptr %0, ptr %ref, align 8, !dbg !54
-  call void @_ZN6String4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(24) %2, ptr @anon.string.0), !dbg !55
-  store i64 6, ptr %ts, align 8, !dbg !56
-  %3 = load %struct.String, ptr %2, align 8, !dbg !56
-  %4 = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 1, !dbg !56
-  store %struct.String %3, ptr %4, align 8, !dbg !56
-  %5 = load ptr, ptr %ref, align 8, !dbg !56
-  %6 = load i32, ptr %5, align 4, !dbg !56
-  %7 = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 2, !dbg !56
-    #dbg_declare(ptr %ts, !57, !DIExpression(), !58)
-  store i32 %6, ptr %7, align 4, !dbg !56
-  %8 = load %struct.TestStruct, ptr %ts, align 8, !dbg !59
-  ret %struct.TestStruct %8, !dbg !60
+    #dbg_declare(ptr %ref, !52, !DIExpression(), !53)
+  store ptr %0, ptr %ref, align 8, !dbg !53
+  call void @_ZN6String4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(24) %2, ptr @anon.string.0), !dbg !54
+  store i64 6, ptr %ts, align 8, !dbg !55
+  %3 = load %struct.String, ptr %2, align 8, !dbg !55
+  %4 = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 1, !dbg !55
+  store %struct.String %3, ptr %4, align 8, !dbg !55
+  %5 = load ptr, ptr %ref, align 8, !dbg !55
+  %6 = load i32, ptr %5, align 4, !dbg !55
+  %7 = getelementptr inbounds %struct.TestStruct, ptr %ts, i32 0, i32 2, !dbg !55
+    #dbg_declare(ptr %ts, !56, !DIExpression(), !57)
+  store i32 %6, ptr %7, align 4, !dbg !55
+  %8 = load %struct.TestStruct, ptr %ts, align 8, !dbg !58
+  ret %struct.TestStruct %8, !dbg !59
 }
 
 declare void @_ZN6String4ctorEPKc(ptr, ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define dso_local i32 @main() #1 !dbg !61 {
-    #dbg_declare(ptr %result, !64, !DIExpression(), !65)
+define dso_local i32 @main() #1 !dbg !60 {
+    #dbg_declare(ptr %result, !63, !DIExpression(), !64)
   %result = alloca i32, align 4
   %test = alloca i32, align 4
   %res = alloca %struct.TestStruct, align 8
-  store i32 0, ptr %result, align 4, !dbg !65
-    #dbg_declare(ptr %test, !66, !DIExpression(), !67)
-  store i32 987654, ptr %test, align 4, !dbg !68
-  %1 = call %struct.TestStruct @_Z3fctRi(ptr %test), !dbg !69
-    #dbg_declare(ptr %res, !70, !DIExpression(), !71)
-  store %struct.TestStruct %1, ptr %res, align 8, !dbg !69
-  %lng_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !72
-  %2 = load i64, ptr %lng_addr, align 8, !dbg !72
-  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 %2), !dbg !72
-  %4 = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 1, !dbg !73
-  %5 = call ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !73
-  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %5), !dbg !73
-  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !74
-  %7 = load i32, ptr %i_addr, align 4, !dbg !74
-  %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %7), !dbg !74
-  call void @_ZN10TestStruct4dtorEv(ptr %res), !dbg !75
-  %9 = load i32, ptr %result, align 4, !dbg !75
-  ret i32 %9, !dbg !75
+  store i32 0, ptr %result, align 4, !dbg !64
+    #dbg_declare(ptr %test, !65, !DIExpression(), !66)
+  store i32 987654, ptr %test, align 4, !dbg !67
+  %1 = call %struct.TestStruct @_Z3fctRi(ptr %test), !dbg !68
+    #dbg_declare(ptr %res, !69, !DIExpression(), !70)
+  store %struct.TestStruct %1, ptr %res, align 8, !dbg !68
+  %lng_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !71
+  %2 = load i64, ptr %lng_addr, align 8, !dbg !71
+  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 %2), !dbg !71
+  %4 = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 1, !dbg !72
+  %5 = call ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !72
+  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %5), !dbg !72
+  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !73
+  %7 = load i32, ptr %i_addr, align 4, !dbg !73
+  %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %7), !dbg !73
+  call void @_ZN10TestStruct4dtorEv(ptr %res), !dbg !74
+  %9 = load i32, ptr %result, align 4, !dbg !74
+  ret i32 %9, !dbg !74
 }
 
 ; Function Attrs: nofree nounwind
@@ -81,9 +81,9 @@ attributes #0 = { norecurse }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
 
+!llvm.module.flags = !{!16, !17, !18, !19, !20, !21}
+!llvm.ident = !{!22}
 !llvm.dbg.cu = !{!2}
-!llvm.module.flags = !{!16, !17, !18, !19, !20, !21, !22}
-!llvm.ident = !{!23}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "anon.string.0", linkageName: "anon.string.0", scope: !2, file: !7, line: 8, type: !15, isLocal: true, isDefinition: true)
@@ -101,63 +101,62 @@ attributes #2 = { nofree nounwind }
 !13 = distinct !DIGlobalVariable(name: "printf.str.2", linkageName: "printf.str.2", scope: !2, file: !7, line: 17, type: !14, isLocal: true, isDefinition: true)
 !14 = !DIStringType(name: "printf.str.2", size: 72)
 !15 = !DIStringType(name: "anon.string.0", size: 96)
-!16 = !{i32 7, !"Dwarf Version", i32 4}
-!17 = !{i32 2, !"Debug Info Version", i32 3}
-!18 = !{i32 1, !"wchar_size", i32 4}
-!19 = !{i32 8, !"PIC Level", i32 2}
-!20 = !{i32 7, !"PIE Level", i32 2}
-!21 = !{i32 7, !"uwtable", i32 2}
-!22 = !{i32 7, !"frame-pointer", i32 2}
-!23 = !{!"spice version dev (https://github.com/spicelang/spice)"}
-!24 = distinct !DISubprogram(name: "dtor", linkageName: "_ZN10TestStruct4dtorEv", scope: !7, file: !7, line: 1, type: !25, scopeLine: 1, flags: DIFlagPublic | DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !43)
-!25 = !DISubroutineType(types: !26)
-!26 = !{!27, !28}
-!27 = !DIBasicType(name: "void", encoding: DW_ATE_unsigned)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, name: "TestStruct", scope: !7, file: !7, line: 1, size: 320, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !29, identifier: "struct.TestStruct")
-!29 = !{!30, !32, !41}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "lng", scope: !28, file: !7, line: 2, baseType: !31, size: 64)
-!31 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!32 = !DIDerivedType(tag: DW_TAG_member, name: "str", scope: !28, file: !7, line: 3, baseType: !33, size: 192, align: 8, offset: 64)
-!33 = !DICompositeType(tag: DW_TAG_structure_type, name: "String", scope: !7, file: !7, line: 21, size: 192, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !34, identifier: "struct.String")
-!34 = !{!35, !38, !40}
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "contents", scope: !33, file: !7, line: 22, baseType: !36, size: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "capacity", scope: !33, file: !7, line: 23, baseType: !39, size: 64, offset: 64)
-!39 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "length", scope: !33, file: !7, line: 24, baseType: !39, size: 64, offset: 128)
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !28, file: !7, line: 4, baseType: !42, size: 32, offset: 256)
-!42 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
-!43 = !{}
-!44 = !DILocalVariable(name: "this", arg: 1, scope: !24, file: !7, line: 1, type: !45)
-!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!46 = !DILocation(line: 1, column: 1, scope: !24)
-!47 = distinct !DISubprogram(name: "fct", linkageName: "_Z3fctRi", scope: !7, file: !7, line: 7, type: !48, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !43)
-!48 = !DISubroutineType(types: !49)
-!49 = !{!28, !50}
-!50 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !42, size: 64)
-!51 = !DILocalVariable(name: "result", scope: !47, file: !7, line: 7, type: !28)
-!52 = !DILocation(line: 7, column: 1, scope: !47)
-!53 = !DILocalVariable(name: "ref", arg: 1, scope: !47, file: !7, line: 7, type: !50)
-!54 = !DILocation(line: 7, column: 19, scope: !47)
-!55 = !DILocation(line: 8, column: 44, scope: !47)
-!56 = !DILocation(line: 8, column: 60, scope: !47)
-!57 = !DILocalVariable(name: "ts", scope: !47, file: !7, line: 8, type: !28)
-!58 = !DILocation(line: 8, column: 5, scope: !47)
-!59 = !DILocation(line: 9, column: 12, scope: !47)
-!60 = !DILocation(line: 10, column: 1, scope: !47)
-!61 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !7, file: !7, line: 12, type: !62, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !43)
-!62 = !DISubroutineType(types: !63)
-!63 = !{!42}
-!64 = !DILocalVariable(name: "result", scope: !61, file: !7, line: 12, type: !42)
-!65 = !DILocation(line: 12, column: 1, scope: !61)
-!66 = !DILocalVariable(name: "test", scope: !61, file: !7, line: 13, type: !42)
-!67 = !DILocation(line: 13, column: 5, scope: !61)
-!68 = !DILocation(line: 13, column: 16, scope: !61)
-!69 = !DILocation(line: 14, column: 32, scope: !61)
-!70 = !DILocalVariable(name: "res", scope: !61, file: !7, line: 14, type: !28)
-!71 = !DILocation(line: 14, column: 5, scope: !61)
-!72 = !DILocation(line: 15, column: 26, scope: !61)
-!73 = !DILocation(line: 16, column: 28, scope: !61)
-!74 = !DILocation(line: 17, column: 25, scope: !61)
-!75 = !DILocation(line: 18, column: 1, scope: !61)
+!16 = !{i32 8, !"PIC Level", i32 2}
+!17 = !{i32 7, !"PIE Level", i32 2}
+!18 = !{i32 7, !"uwtable", i32 2}
+!19 = !{i32 7, !"frame-pointer", i32 2}
+!20 = !{i32 7, !"Dwarf Version", i32 4}
+!21 = !{i32 2, !"Debug Info Version", i32 3}
+!22 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!23 = distinct !DISubprogram(name: "dtor", linkageName: "_ZN10TestStruct4dtorEv", scope: !7, file: !7, line: 1, type: !24, scopeLine: 1, flags: DIFlagPublic | DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
+!24 = !DISubroutineType(types: !25)
+!25 = !{!26, !27}
+!26 = !DIBasicType(name: "void", encoding: DW_ATE_unsigned)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, name: "TestStruct", scope: !7, file: !7, line: 1, size: 320, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !28, identifier: "struct.TestStruct")
+!28 = !{!29, !31, !40}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "lng", scope: !27, file: !7, line: 2, baseType: !30, size: 64)
+!30 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "str", scope: !27, file: !7, line: 3, baseType: !32, size: 192, align: 8, offset: 64)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, name: "String", scope: !7, file: !7, line: 21, size: 192, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !33, identifier: "struct.String")
+!33 = !{!34, !37, !39}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "contents", scope: !32, file: !7, line: 22, baseType: !35, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DIBasicType(name: "char", size: 8, encoding: DW_ATE_unsigned_char)
+!37 = !DIDerivedType(tag: DW_TAG_member, name: "capacity", scope: !32, file: !7, line: 23, baseType: !38, size: 64, offset: 64)
+!38 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "length", scope: !32, file: !7, line: 24, baseType: !38, size: 64, offset: 128)
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !27, file: !7, line: 4, baseType: !41, size: 32, offset: 256)
+!41 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!42 = !{}
+!43 = !DILocalVariable(name: "this", arg: 1, scope: !23, file: !7, line: 1, type: !44)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!45 = !DILocation(line: 1, column: 1, scope: !23)
+!46 = distinct !DISubprogram(name: "fct", linkageName: "_Z3fctRi", scope: !7, file: !7, line: 7, type: !47, scopeLine: 7, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
+!47 = !DISubroutineType(types: !48)
+!48 = !{!27, !49}
+!49 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !41, size: 64)
+!50 = !DILocalVariable(name: "result", scope: !46, file: !7, line: 7, type: !27)
+!51 = !DILocation(line: 7, column: 1, scope: !46)
+!52 = !DILocalVariable(name: "ref", arg: 1, scope: !46, file: !7, line: 7, type: !49)
+!53 = !DILocation(line: 7, column: 19, scope: !46)
+!54 = !DILocation(line: 8, column: 44, scope: !46)
+!55 = !DILocation(line: 8, column: 60, scope: !46)
+!56 = !DILocalVariable(name: "ts", scope: !46, file: !7, line: 8, type: !27)
+!57 = !DILocation(line: 8, column: 5, scope: !46)
+!58 = !DILocation(line: 9, column: 12, scope: !46)
+!59 = !DILocation(line: 10, column: 1, scope: !46)
+!60 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !7, file: !7, line: 12, type: !61, scopeLine: 12, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
+!61 = !DISubroutineType(types: !62)
+!62 = !{!41}
+!63 = !DILocalVariable(name: "result", scope: !60, file: !7, line: 12, type: !41)
+!64 = !DILocation(line: 12, column: 1, scope: !60)
+!65 = !DILocalVariable(name: "test", scope: !60, file: !7, line: 13, type: !41)
+!66 = !DILocation(line: 13, column: 5, scope: !60)
+!67 = !DILocation(line: 13, column: 16, scope: !60)
+!68 = !DILocation(line: 14, column: 32, scope: !60)
+!69 = !DILocalVariable(name: "res", scope: !60, file: !7, line: 14, type: !27)
+!70 = !DILocation(line: 14, column: 5, scope: !60)
+!71 = !DILocation(line: 15, column: 26, scope: !60)
+!72 = !DILocation(line: 16, column: 28, scope: !60)
+!73 = !DILocation(line: 17, column: 25, scope: !60)
+!74 = !DILocation(line: 18, column: 1, scope: !60)

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code-O2.ll
@@ -15,3 +15,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-break/ir-code.ll
@@ -61,3 +61,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code-O2.ll
@@ -34,3 +34,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop-continue/ir-code.ll
@@ -70,3 +70,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/do-while-loops/success-do-while-loop/ir-code.ll
+++ b/test/test-files/irgenerator/do-while-loops/success-do-while-loop/ir-code.ll
@@ -34,3 +34,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/enums/success-enums/ir-code.ll
+++ b/test/test-files/irgenerator/enums/success-enums/ir-code.ll
@@ -25,3 +25,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ext-decl/success-ext-decl-force-substantiate/ir-code.ll
+++ b/test/test-files/irgenerator/ext-decl/success-ext-decl-force-substantiate/ir-code.ll
@@ -80,3 +80,12 @@ define private void @_Z15lambda.L15C39.0v(ptr noundef nonnull dereferenceable(8)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ext-decl/success-ext-decl/ir-code.ll
+++ b/test/test-files/irgenerator/ext-decl/success-ext-decl/ir-code.ll
@@ -21,3 +21,12 @@ define dso_local i32 @main() #0 {
 }
 
 attributes #0 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code-O2.ll
@@ -33,3 +33,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-break/ir-code.ll
@@ -77,3 +77,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code-O2.ll
@@ -42,3 +42,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop-continue/ir-code.ll
@@ -77,3 +77,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/for-loops/success-for-loop/ir-code.ll
+++ b/test/test-files/irgenerator/for-loops/success-for-loop/ir-code.ll
@@ -37,3 +37,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code-O2.ll
@@ -92,3 +92,12 @@ declare void @_ZN14NumberIteratorIsE4nextEv(ptr) local_unnamed_addr
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-break/ir-code.ll
@@ -97,3 +97,12 @@ declare void @_ZN14NumberIteratorIsE4nextEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code-O2.ll
@@ -92,3 +92,12 @@ declare void @_ZN14NumberIteratorIsE4nextEv(ptr) local_unnamed_addr
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-continue/ir-code.ll
@@ -97,3 +97,12 @@ declare void @_ZN14NumberIteratorIsE4nextEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
@@ -62,3 +62,12 @@ declare void @_ZN13ArrayIteratorIiE4nextEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-normal-array/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-normal-array/ir-code.ll
@@ -78,3 +78,12 @@ declare void @_ZN13ArrayIteratorIiE4nextEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-normal/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-normal/ir-code.ll
@@ -82,3 +82,12 @@ declare void @_ZN6VectorIiE4dtorEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/function-pointers/success-basic/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-basic/ir-code.ll
@@ -34,3 +34,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/function-pointers/success-indirect/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-indirect/ir-code.ll
@@ -46,3 +46,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/function-pointers/success-pass-by-non-value/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-pass-by-non-value/ir-code.ll
@@ -60,3 +60,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-default-arg-value-expressions/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-default-arg-value-expressions/ir-code.ll
@@ -33,3 +33,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-default-arg-values/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-default-arg-values/ir-code.ll
@@ -32,3 +32,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-down-call/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-down-call/ir-code.ll
@@ -26,3 +26,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code-O2.ll
+++ b/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code-O2.ll
@@ -14,3 +14,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-explicit-inlining/ir-code.ll
@@ -25,3 +25,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { alwaysinline }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-external-function/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-external-function/ir-code.ll
@@ -21,3 +21,12 @@ declare i1 @_Z6isTruev()
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-overloading/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-overloading/ir-code.ll
@@ -41,3 +41,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-result-variable/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-result-variable/ir-code.ll
@@ -48,3 +48,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/generics/success-external-generic-functions/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-external-generic-functions/ir-code.ll
@@ -24,7 +24,7 @@ define dso_local i32 @main() #0 {
   %2 = load ptr, ptr %iPtr, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 13
-  br i1 %4, label %assert.exit.L12, label %assert.then.L12, !prof !0
+  br i1 %4, label %assert.exit.L12, label %assert.then.L12, !prof !5
 
 assert.then.L12:                                  ; preds = %0
   %5 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -56,4 +56,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/generics/success-generic-functions/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions/ir-code.ll
@@ -77,3 +77,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
@@ -156,3 +156,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
@@ -27,3 +27,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/generics/success-generic-type-ctor-call/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-type-ctor-call/ir-code.ll
@@ -42,3 +42,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/generics/success-nested-generic-structs/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-nested-generic-structs/ir-code.ll
@@ -14,3 +14,12 @@ define dso_local i32 @main() #0 {
 }
 
 attributes #0 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/generics/success-type-hints/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-type-hints/ir-code.ll
@@ -26,3 +26,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/if-stmts/success-if-else-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/if-stmts/success-if-else-stmt/ir-code.ll
@@ -50,3 +50,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/if-stmts/success-if-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/if-stmts/success-if-stmt/ir-code.ll
@@ -28,3 +28,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/imports/success-modules-std/ir-code.ll
+++ b/test/test-files/irgenerator/imports/success-modules-std/ir-code.ll
@@ -20,3 +20,12 @@ declare i32 @_Z5toIntb(i1)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/imports/success-modules/ir-code.ll
+++ b/test/test-files/irgenerator/imports/success-modules/ir-code.ll
@@ -23,3 +23,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/imports/sucess-struct-backwards-dependency/ir-code.ll
+++ b/test/test-files/irgenerator/imports/sucess-struct-backwards-dependency/ir-code.ll
@@ -17,3 +17,12 @@ define dso_local i32 @main() #0 {
 declare void @_ZN10TestStructI5OuterE4ctorEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
@@ -88,3 +88,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
@@ -63,3 +63,12 @@ attributes #1 = { mustprogress nofree norecurse nosync nounwind willreturn memor
 attributes #2 = { noinline nounwind optnone uwtable }
 attributes #3 = { nofree nounwind }
 attributes #4 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
@@ -80,3 +80,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
@@ -120,3 +120,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/interfaces/success-interface-param-struct-match/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-interface-param-struct-match/ir-code.ll
@@ -69,3 +69,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
@@ -76,3 +76,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/lambdas/success-captures/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-captures/ir-code.ll
@@ -48,7 +48,7 @@ define dso_local i32 @main() #0 {
   call void %fct(ptr %captures3, ptr %x)
   %12 = load i32, ptr %x, align 4
   %13 = icmp eq i32 %12, 6
-  br i1 %13, label %assert.exit.L13, label %assert.then.L13, !prof !0
+  br i1 %13, label %assert.exit.L13, label %assert.then.L13, !prof !5
 
 assert.then.L13:                                  ; preds = %0
   %14 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -60,7 +60,7 @@ assert.exit.L13:                                  ; preds = %0
   %captures4 = load ptr, ptr %15, align 8
   %fct5 = load ptr, ptr %foo2, align 8
   %16 = call i1 %fct5(ptr %captures4, ptr %x)
-  br i1 %16, label %assert.exit.L14, label %assert.then.L14, !prof !0
+  br i1 %16, label %assert.exit.L14, label %assert.then.L14, !prof !5
 
 assert.then.L14:                                  ; preds = %assert.exit.L13
   %17 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -70,7 +70,7 @@ assert.then.L14:                                  ; preds = %assert.exit.L13
 assert.exit.L14:                                  ; preds = %assert.exit.L13
   %18 = load i32, ptr %x, align 4
   %19 = icmp eq i32 %18, 11
-  br i1 %19, label %assert.exit.L15, label %assert.then.L15, !prof !0
+  br i1 %19, label %assert.exit.L15, label %assert.then.L15, !prof !5
 
 assert.then.L15:                                  ; preds = %assert.exit.L14
   %20 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -128,4 +128,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
@@ -63,3 +63,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
@@ -166,3 +166,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code.ll
@@ -19,7 +19,7 @@ define private void @_Z4testPFCvRiEPFCbRiE({ ptr, ptr } %0, { ptr, ptr } %1) {
   call void %fct(ptr %captures, ptr %x)
   %4 = load i32, ptr %x, align 4
   %5 = icmp eq i32 %4, 6
-  br i1 %5, label %assert.exit.L4, label %assert.then.L4, !prof !0
+  br i1 %5, label %assert.exit.L4, label %assert.then.L4, !prof !5
 
 assert.then.L4:                                   ; preds = %2
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -31,7 +31,7 @@ assert.exit.L4:                                   ; preds = %2
   %captures1 = load ptr, ptr %7, align 8
   %fct2 = load ptr, ptr %l2, align 8
   %8 = call i1 %fct2(ptr %captures1, ptr %x)
-  br i1 %8, label %assert.exit.L5, label %assert.then.L5, !prof !0
+  br i1 %8, label %assert.exit.L5, label %assert.then.L5, !prof !5
 
 assert.then.L5:                                   ; preds = %assert.exit.L4
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -41,7 +41,7 @@ assert.then.L5:                                   ; preds = %assert.exit.L4
 assert.exit.L5:                                   ; preds = %assert.exit.L4
   %10 = load i32, ptr %x, align 4
   %11 = icmp eq i32 %10, 11
-  br i1 %11, label %assert.exit.L6, label %assert.then.L6, !prof !0
+  br i1 %11, label %assert.exit.L6, label %assert.then.L6, !prof !5
 
 assert.then.L6:                                   ; preds = %assert.exit.L5
   %12 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -139,4 +139,12 @@ attributes #0 = { nofree nounwind }
 attributes #1 = { cold noreturn nounwind }
 attributes #2 = { noinline nounwind optnone uwtable }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/lambdas/success-function-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-function-lambda/ir-code.ll
@@ -126,3 +126,12 @@ declare void @_ZN6String4dtorEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/lambdas/success-multiple-visits/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-multiple-visits/ir-code.ll
@@ -91,3 +91,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/lambdas/success-procedure-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-procedure-lambda/ir-code.ll
@@ -94,3 +94,12 @@ declare void @_ZN6String4dtorEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/lto/success-lto-simple/ir-code-O2.ll
+++ b/test/test-files/irgenerator/lto/success-lto-simple/ir-code-O2.ll
@@ -14,7 +14,7 @@ define dso_local i32 @_Z17functionInModuleBii(i32 %0, i32 %1) local_unnamed_addr
 define dso_local i32 @main() local_unnamed_addr #1 {
   %1 = tail call i32 @_Z17functionInModuleBii(i32 1, i32 2) #4
   %2 = icmp eq i32 %1, 3
-  br i1 %2, label %assert.exit.L4, label %assert.then.L4, !prof !0
+  br i1 %2, label %assert.exit.L4, label %assert.then.L4, !prof !5
 
 assert.then.L4:                                   ; preds = %0
   %3 = tail call i32 (ptr, ...) @printf(ptr nonnull dereferenceable(1) @anon.string.0)
@@ -38,4 +38,12 @@ attributes #2 = { nofree nounwind }
 attributes #3 = { cold noreturn nounwind }
 attributes #4 = { nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.ident = !{!0, !0}
+!llvm.module.flags = !{!1, !2, !3, !4}
+
+!0 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!1 = !{i32 8, !"PIC Level", i32 2}
+!2 = !{i32 7, !"PIE Level", i32 2}
+!3 = !{i32 7, !"uwtable", i32 2}
+!4 = !{i32 7, !"frame-pointer", i32 2}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
@@ -56,3 +56,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
@@ -57,3 +57,12 @@ if.exit.L18:                                      ; preds = %if.then.L18, %1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/methods/success-methods/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-methods/ir-code.ll
@@ -47,3 +47,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
@@ -299,7 +299,7 @@ define dso_local i32 @main() #0 {
   store i64 %48, ptr %res, align 8
   %49 = load i64, ptr %res, align 8
   %50 = icmp eq i64 %49, 14
-  br i1 %50, label %assert.exit.L86, label %assert.then.L86, !prof !0
+  br i1 %50, label %assert.exit.L86, label %assert.then.L86, !prof !5
 
 assert.then.L86:                                  ; preds = %0
   %51 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -323,4 +323,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
@@ -53,7 +53,7 @@ define dso_local i32 @main() #0 {
   %test_addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i64 0, i32 0
   %6 = load i64, ptr %test_addr1, align 8
   %7 = icmp eq i64 %6, 125
-  br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !0
+  br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !5
 
 assert.then.L19:                                  ; preds = %0
   %8 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -64,7 +64,7 @@ assert.exit.L19:                                  ; preds = %0
   %test_addr2 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
   %9 = load i64, ptr %test_addr2, align 8
   %10 = icmp eq i64 %9, 125
-  br i1 %10, label %assert.exit.L20, label %assert.then.L20, !prof !0
+  br i1 %10, label %assert.exit.L20, label %assert.then.L20, !prof !5
 
 assert.then.L20:                                  ; preds = %assert.exit.L19
   %11 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -81,7 +81,7 @@ assert.exit.L20:                                  ; preds = %assert.exit.L19
   %test_addr4 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
   %16 = load i64, ptr %test_addr4, align 8
   %17 = icmp eq i64 %16, 123
-  br i1 %17, label %assert.exit.L23, label %assert.then.L23, !prof !0
+  br i1 %17, label %assert.exit.L23, label %assert.then.L23, !prof !5
 
 assert.then.L23:                                  ; preds = %assert.exit.L20
   %18 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -93,7 +93,7 @@ assert.exit.L23:                                  ; preds = %assert.exit.L20
   %test_addr5 = getelementptr inbounds %struct.TestStruct, ptr %19, i64 0, i32 0
   %20 = load i64, ptr %test_addr5, align 8
   %21 = icmp eq i64 %20, 123
-  br i1 %21, label %assert.exit.L24, label %assert.then.L24, !prof !0
+  br i1 %21, label %assert.exit.L24, label %assert.then.L24, !prof !5
 
 assert.then.L24:                                  ; preds = %assert.exit.L23
   %22 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -116,4 +116,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/operators/success-operators/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operators/ir-code.ll
@@ -19,7 +19,7 @@ define dso_local i32 @main() #0 {
   store i32 %4, ptr %val, align 4
   %5 = load i32, ptr %val, align 4
   %6 = icmp eq i32 %5, 9
-  br i1 %6, label %assert.exit.L4, label %assert.then.L4, !prof !0
+  br i1 %6, label %assert.exit.L4, label %assert.then.L4, !prof !5
 
 assert.then.L4:                                   ; preds = %0
   %7 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -42,4 +42,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/operators/success-operators2/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operators2/ir-code.ll
@@ -34,7 +34,7 @@ define dso_local i32 @main() #0 {
   store i32 %12, ptr %i, align 4
   %13 = load i32, ptr %i, align 4
   %14 = icmp eq i32 %13, 1
-  br i1 %14, label %assert.exit.L9, label %assert.then.L9, !prof !0
+  br i1 %14, label %assert.exit.L9, label %assert.then.L9, !prof !5
 
 assert.then.L9:                                   ; preds = %0
   %15 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -56,7 +56,7 @@ assert.exit.L9:                                   ; preds = %0
   store i32 %23, ptr %i, align 4
   %24 = load i32, ptr %i, align 4
   %25 = icmp eq i32 %24, 1
-  br i1 %25, label %assert.exit.L15, label %assert.then.L15, !prof !0
+  br i1 %25, label %assert.exit.L15, label %assert.then.L15, !prof !5
 
 assert.then.L15:                                  ; preds = %assert.exit.L9
   %26 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -70,7 +70,7 @@ assert.exit.L15:                                  ; preds = %assert.exit.L9
   store i32 %28, ptr %i, align 4
   %29 = load i32, ptr %i, align 4
   %30 = icmp eq i32 %29, 1
-  br i1 %30, label %assert.exit.L19, label %assert.then.L19, !prof !0
+  br i1 %30, label %assert.exit.L19, label %assert.then.L19, !prof !5
 
 assert.then.L19:                                  ; preds = %assert.exit.L15
   %31 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -84,7 +84,7 @@ assert.exit.L19:                                  ; preds = %assert.exit.L15
   store i32 %33, ptr %i, align 4
   %34 = load i32, ptr %i, align 4
   %35 = icmp eq i32 %34, 1
-  br i1 %35, label %assert.exit.L23, label %assert.then.L23, !prof !0
+  br i1 %35, label %assert.exit.L23, label %assert.then.L23, !prof !5
 
 assert.then.L23:                                  ; preds = %assert.exit.L19
   %36 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -98,7 +98,7 @@ assert.exit.L23:                                  ; preds = %assert.exit.L19
   store i32 %38, ptr %i, align 4
   %39 = load i32, ptr %i, align 4
   %40 = icmp eq i32 %39, 127
-  br i1 %40, label %assert.exit.L27, label %assert.then.L27, !prof !0
+  br i1 %40, label %assert.exit.L27, label %assert.then.L27, !prof !5
 
 assert.then.L27:                                  ; preds = %assert.exit.L23
   %41 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
@@ -121,4 +121,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/operators/success-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-short-circuiting/ir-code.ll
@@ -53,3 +53,12 @@ lor.exit.L16C45:                                  ; preds = %lor.1.L16C45, %land
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
@@ -60,3 +60,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/pointers/success-pointer-arithmetic/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer-arithmetic/ir-code.ll
@@ -21,7 +21,7 @@ define dso_local i32 @main() #0 {
   %2 = load ptr, ptr %aPtr, align 8
   %3 = load i32, ptr %2, align 4
   %4 = icmp eq i32 %3, 1
-  br i1 %4, label %assert.exit.L4, label %assert.then.L4, !prof !0
+  br i1 %4, label %assert.exit.L4, label %assert.then.L4, !prof !5
 
 assert.then.L4:                                   ; preds = %0
   %5 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -35,7 +35,7 @@ assert.exit.L4:                                   ; preds = %0
   %8 = load ptr, ptr %aPtr, align 8
   %9 = load i32, ptr %8, align 4
   %10 = icmp eq i32 %9, 2
-  br i1 %10, label %assert.exit.L6, label %assert.then.L6, !prof !0
+  br i1 %10, label %assert.exit.L6, label %assert.then.L6, !prof !5
 
 assert.then.L6:                                   ; preds = %assert.exit.L4
   %11 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -49,7 +49,7 @@ assert.exit.L6:                                   ; preds = %assert.exit.L4
   %14 = load ptr, ptr %aPtr, align 8
   %15 = load i32, ptr %14, align 4
   %16 = icmp eq i32 %15, 1
-  br i1 %16, label %assert.exit.L8, label %assert.then.L8, !prof !0
+  br i1 %16, label %assert.exit.L8, label %assert.then.L8, !prof !5
 
 assert.then.L8:                                   ; preds = %assert.exit.L6
   %17 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -63,7 +63,7 @@ assert.exit.L8:                                   ; preds = %assert.exit.L6
   %20 = load ptr, ptr %aPtr, align 8
   %21 = load i32, ptr %20, align 4
   %22 = icmp eq i32 %21, 3
-  br i1 %22, label %assert.exit.L10, label %assert.then.L10, !prof !0
+  br i1 %22, label %assert.exit.L10, label %assert.then.L10, !prof !5
 
 assert.then.L10:                                  ; preds = %assert.exit.L8
   %23 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -77,7 +77,7 @@ assert.exit.L10:                                  ; preds = %assert.exit.L8
   %26 = load ptr, ptr %aPtr, align 8
   %27 = load i32, ptr %26, align 4
   %28 = icmp eq i32 %27, 1
-  br i1 %28, label %assert.exit.L12, label %assert.then.L12, !prof !0
+  br i1 %28, label %assert.exit.L12, label %assert.then.L12, !prof !5
 
 assert.then.L12:                                  ; preds = %assert.exit.L10
   %29 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
@@ -100,4 +100,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
@@ -51,3 +51,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/pointers/success-pointer/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer/ir-code.ll
@@ -37,3 +37,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/procedures/success-early-return/ir-code.ll
+++ b/test/test-files/irgenerator/procedures/success-early-return/ir-code.ll
@@ -31,3 +31,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code-O2.ll
+++ b/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code-O2.ll
@@ -21,3 +21,12 @@ declare noundef i32 @puts(ptr nocapture noundef readonly) local_unnamed_addr #0
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code.ll
+++ b/test/test-files/irgenerator/procedures/success-explicit-inlining/ir-code.ll
@@ -28,3 +28,12 @@ define dso_local i32 @main() #2 {
 attributes #0 = { alwaysinline }
 attributes #1 = { nofree nounwind }
 attributes #2 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
@@ -26,3 +26,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/references/success-ref-assign/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-assign/ir-code.ll
@@ -19,7 +19,7 @@ define dso_local i32 @main() #0 {
   store ptr %test, ptr %testRef, align 8
   %1 = load ptr, ptr %testRef, align 8
   %2 = icmp eq ptr %test, %1
-  br i1 %2, label %assert.exit.L5, label %assert.then.L5, !prof !0
+  br i1 %2, label %assert.exit.L5, label %assert.then.L5, !prof !5
 
 assert.then.L5:                                   ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -33,7 +33,7 @@ assert.exit.L5:                                   ; preds = %0
   store i32 %6, ptr %4, align 4
   %7 = load i32, ptr %test, align 4
   %8 = icmp eq i32 %7, 135
-  br i1 %8, label %assert.exit.L9, label %assert.then.L9, !prof !0
+  br i1 %8, label %assert.exit.L9, label %assert.then.L9, !prof !5
 
 assert.then.L9:                                   ; preds = %assert.exit.L5
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -47,7 +47,7 @@ assert.exit.L9:                                   ; preds = %assert.exit.L5
   store i32 %12, ptr %10, align 4
   %13 = load i32, ptr %test, align 4
   %14 = icmp eq i32 %13, 124
-  br i1 %14, label %assert.exit.L11, label %assert.then.L11, !prof !0
+  br i1 %14, label %assert.exit.L11, label %assert.then.L11, !prof !5
 
 assert.then.L11:                                  ; preds = %assert.exit.L9
   %15 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -59,7 +59,7 @@ assert.exit.L11:                                  ; preds = %assert.exit.L9
   store i32 123, ptr %16, align 4
   %17 = load i32, ptr %test, align 4
   %18 = icmp eq i32 %17, 123
-  br i1 %18, label %assert.exit.L13, label %assert.then.L13, !prof !0
+  br i1 %18, label %assert.exit.L13, label %assert.then.L13, !prof !5
 
 assert.then.L13:                                  ; preds = %assert.exit.L11
   %19 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -74,7 +74,7 @@ assert.exit.L13:                                  ; preds = %assert.exit.L11
   store i32 %22, ptr %23, align 4
   %24 = load i32, ptr %test, align 4
   %25 = icmp eq i32 %24, 127
-  br i1 %25, label %assert.exit.L15, label %assert.then.L15, !prof !0
+  br i1 %25, label %assert.exit.L15, label %assert.then.L15, !prof !5
 
 assert.then.L15:                                  ; preds = %assert.exit.L13
   %26 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
@@ -89,7 +89,7 @@ assert.exit.L15:                                  ; preds = %assert.exit.L13
   store i32 %29, ptr %30, align 4
   %31 = load i32, ptr %test, align 4
   %32 = icmp eq i32 %31, 123
-  br i1 %32, label %assert.exit.L17, label %assert.then.L17, !prof !0
+  br i1 %32, label %assert.exit.L17, label %assert.then.L17, !prof !5
 
 assert.then.L17:                                  ; preds = %assert.exit.L15
   %33 = call i32 (ptr, ...) @printf(ptr @anon.string.5)
@@ -112,4 +112,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
@@ -62,7 +62,7 @@ define dso_local i32 @main() #1 {
   call void @_Z4procRiRK6Struct(ptr %i, ptr %1)
   %4 = load i32, ptr %i, align 4
   %5 = icmp eq i32 %4, -4309
-  br i1 %5, label %assert.exit.L20, label %assert.then.L20, !prof !0
+  br i1 %5, label %assert.exit.L20, label %assert.then.L20, !prof !5
 
 assert.then.L20:                                  ; preds = %0
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -78,7 +78,7 @@ assert.exit.L20:                                  ; preds = %0
   store i32 %8, ptr %result, align 4
   %9 = load double, ptr %d, align 8
   %10 = fcmp oeq double %9, -1.076400e+02
-  br i1 %10, label %assert.exit.L24, label %assert.then.L24, !prof !0
+  br i1 %10, label %assert.exit.L24, label %assert.then.L24, !prof !5
 
 assert.then.L24:                                  ; preds = %assert.exit.L20
   %11 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -98,4 +98,12 @@ attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
@@ -36,3 +36,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
@@ -36,3 +36,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
@@ -92,3 +92,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
@@ -78,3 +78,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { norecurse }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
@@ -59,3 +59,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { norecurse }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
@@ -54,3 +54,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { norecurse }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -136,3 +136,12 @@ attributes #0 = { norecurse }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nofree nounwind }
 attributes #3 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
@@ -71,3 +71,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { norecurse }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
@@ -41,3 +41,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { norecurse }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
@@ -28,3 +28,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
@@ -41,3 +41,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { norecurse }
 attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
@@ -42,3 +42,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
@@ -20,7 +20,7 @@ define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceab
   store i1 true, ptr %2, align 1
   %5 = call i32 @memcmp(ptr %field1_addr, ptr %2, i64 0)
   %6 = icmp eq i32 %5, 0
-  br i1 %6, label %assert.exit.L8, label %assert.then.L8, !prof !0
+  br i1 %6, label %assert.exit.L8, label %assert.then.L8, !prof !5
 
 assert.then.L8:                                   ; preds = %1
   %7 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -32,7 +32,7 @@ assert.exit.L8:                                   ; preds = %1
   %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
   %9 = load ptr, ptr %field2_addr, align 8
   %10 = call i1 @_Z10isRawEqualPKcPKc(ptr %9, ptr @anon.string.1)
-  br i1 %10, label %assert.exit.L9, label %assert.then.L9, !prof !0
+  br i1 %10, label %assert.exit.L9, label %assert.then.L9, !prof !5
 
 assert.then.L9:                                   ; preds = %assert.exit.L8
   %11 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -76,4 +76,12 @@ attributes #1 = { nounwind }
 attributes #2 = { cold noreturn nounwind }
 attributes #3 = { noinline nounwind optnone uwtable }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
@@ -40,7 +40,7 @@ define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceab
   store i1 true, ptr %2, align 1
   %5 = call i32 @memcmp(ptr %field1_addr, ptr %2, i64 0)
   %6 = icmp eq i32 %5, 0
-  br i1 %6, label %assert.exit.L13, label %assert.then.L13, !prof !0
+  br i1 %6, label %assert.exit.L13, label %assert.then.L13, !prof !5
 
 assert.then.L13:                                  ; preds = %1
   %7 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -52,7 +52,7 @@ assert.exit.L13:                                  ; preds = %1
   %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
   %9 = load ptr, ptr %field2_addr, align 8
   %10 = call i1 @_Z10isRawEqualPKcPKc(ptr %9, ptr @anon.string.2)
-  br i1 %10, label %assert.exit.L14, label %assert.then.L14, !prof !0
+  br i1 %10, label %assert.exit.L14, label %assert.then.L14, !prof !5
 
 assert.then.L14:                                  ; preds = %assert.exit.L13
   %11 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -76,4 +76,12 @@ attributes #1 = { nofree nounwind }
 attributes #2 = { nounwind }
 attributes #3 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/structs/success-destructors3/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors3/ir-code.ll
@@ -51,3 +51,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
@@ -38,3 +38,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-external-structs/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-external-structs/ir-code.ll
@@ -20,3 +20,12 @@ define dso_local i32 @main() #0 {
 declare void @_ZN3Vec5printEv(ptr)
 
 attributes #0 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
@@ -110,7 +110,7 @@ define dso_local i32 @main() #1 {
   %f1_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %1 = load i32, ptr %f1_addr, align 4
   %2 = icmp eq i32 %1, 2
-  br i1 %2, label %assert.exit.L37, label %assert.then.L37, !prof !0
+  br i1 %2, label %assert.exit.L37, label %assert.then.L37, !prof !5
 
 assert.then.L37:                                  ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -120,7 +120,7 @@ assert.then.L37:                                  ; preds = %0
 assert.exit.L37:                                  ; preds = %0
   %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %4 = load i1, ptr %f2_addr, align 1
-  br i1 %4, label %assert.exit.L38, label %assert.then.L38, !prof !0
+  br i1 %4, label %assert.exit.L38, label %assert.then.L38, !prof !5
 
 assert.then.L38:                                  ; preds = %assert.exit.L37
   %5 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -131,7 +131,7 @@ assert.exit.L38:                                  ; preds = %assert.exit.L37
   %f3_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 2
   %6 = load i1, ptr %f3_addr, align 1
   %7 = xor i1 %6, true
-  br i1 %7, label %assert.exit.L39, label %assert.then.L39, !prof !0
+  br i1 %7, label %assert.exit.L39, label %assert.then.L39, !prof !5
 
 assert.then.L39:                                  ; preds = %assert.exit.L38
   %8 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -142,7 +142,7 @@ assert.exit.L39:                                  ; preds = %assert.exit.L38
   %f4_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 3
   %9 = load i32, ptr %f4_addr, align 4
   %10 = icmp eq i32 %9, 11
-  br i1 %10, label %assert.exit.L40, label %assert.then.L40, !prof !0
+  br i1 %10, label %assert.exit.L40, label %assert.then.L40, !prof !5
 
 assert.then.L40:                                  ; preds = %assert.exit.L39
   %11 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -153,7 +153,7 @@ assert.exit.L40:                                  ; preds = %assert.exit.L39
   %f5_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 4
   %12 = load i16, ptr %f5_addr, align 2
   %13 = icmp eq i16 %12, 10
-  br i1 %13, label %assert.exit.L41, label %assert.then.L41, !prof !0
+  br i1 %13, label %assert.exit.L41, label %assert.then.L41, !prof !5
 
 assert.then.L41:                                  ; preds = %assert.exit.L40
   %14 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
@@ -164,7 +164,7 @@ assert.exit.L41:                                  ; preds = %assert.exit.L40
   %f6_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 5
   %15 = load i64, ptr %f6_addr, align 8
   %16 = icmp eq i64 %15, 2
-  br i1 %16, label %assert.exit.L42, label %assert.then.L42, !prof !0
+  br i1 %16, label %assert.exit.L42, label %assert.then.L42, !prof !5
 
 assert.then.L42:                                  ; preds = %assert.exit.L41
   %17 = call i32 (ptr, ...) @printf(ptr @anon.string.5)
@@ -174,7 +174,7 @@ assert.then.L42:                                  ; preds = %assert.exit.L41
 assert.exit.L42:                                  ; preds = %assert.exit.L41
   %f7_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 6
   %18 = load i1, ptr %f7_addr, align 1
-  br i1 %18, label %assert.exit.L43, label %assert.then.L43, !prof !0
+  br i1 %18, label %assert.exit.L43, label %assert.then.L43, !prof !5
 
 assert.then.L43:                                  ; preds = %assert.exit.L42
   %19 = call i32 (ptr, ...) @printf(ptr @anon.string.6)
@@ -184,7 +184,7 @@ assert.then.L43:                                  ; preds = %assert.exit.L42
 assert.exit.L43:                                  ; preds = %assert.exit.L42
   %f8_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 7
   %20 = load i1, ptr %f8_addr, align 1
-  br i1 %20, label %assert.exit.L44, label %assert.then.L44, !prof !0
+  br i1 %20, label %assert.exit.L44, label %assert.then.L44, !prof !5
 
 assert.then.L44:                                  ; preds = %assert.exit.L43
   %21 = call i32 (ptr, ...) @printf(ptr @anon.string.7)
@@ -194,7 +194,7 @@ assert.then.L44:                                  ; preds = %assert.exit.L43
 assert.exit.L44:                                  ; preds = %assert.exit.L43
   %f9_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 8
   %22 = load i1, ptr %f9_addr, align 1
-  br i1 %22, label %assert.exit.L45, label %assert.then.L45, !prof !0
+  br i1 %22, label %assert.exit.L45, label %assert.then.L45, !prof !5
 
 assert.then.L45:                                  ; preds = %assert.exit.L44
   %23 = call i32 (ptr, ...) @printf(ptr @anon.string.8)
@@ -205,7 +205,7 @@ assert.exit.L45:                                  ; preds = %assert.exit.L44
   %f10_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 9
   %24 = load i1, ptr %f10_addr, align 1
   %25 = xor i1 %24, true
-  br i1 %25, label %assert.exit.L46, label %assert.then.L46, !prof !0
+  br i1 %25, label %assert.exit.L46, label %assert.then.L46, !prof !5
 
 assert.then.L46:                                  ; preds = %assert.exit.L45
   %26 = call i32 (ptr, ...) @printf(ptr @anon.string.9)
@@ -215,7 +215,7 @@ assert.then.L46:                                  ; preds = %assert.exit.L45
 assert.exit.L46:                                  ; preds = %assert.exit.L45
   %f11_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 10
   %27 = load i1, ptr %f11_addr, align 1
-  br i1 %27, label %assert.exit.L47, label %assert.then.L47, !prof !0
+  br i1 %27, label %assert.exit.L47, label %assert.then.L47, !prof !5
 
 assert.then.L47:                                  ; preds = %assert.exit.L46
   %28 = call i32 (ptr, ...) @printf(ptr @anon.string.10)
@@ -226,7 +226,7 @@ assert.exit.L47:                                  ; preds = %assert.exit.L46
   %f12_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 11
   %29 = load i1, ptr %f12_addr, align 1
   %30 = xor i1 %29, true
-  br i1 %30, label %assert.exit.L48, label %assert.then.L48, !prof !0
+  br i1 %30, label %assert.exit.L48, label %assert.then.L48, !prof !5
 
 assert.then.L48:                                  ; preds = %assert.exit.L47
   %31 = call i32 (ptr, ...) @printf(ptr @anon.string.11)
@@ -237,7 +237,7 @@ assert.exit.L48:                                  ; preds = %assert.exit.L47
   %f13_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 12
   %32 = load i32, ptr %f13_addr, align 4
   %33 = icmp eq i32 %32, 333
-  br i1 %33, label %assert.exit.L49, label %assert.then.L49, !prof !0
+  br i1 %33, label %assert.exit.L49, label %assert.then.L49, !prof !5
 
 assert.then.L49:                                  ; preds = %assert.exit.L48
   %34 = call i32 (ptr, ...) @printf(ptr @anon.string.12)
@@ -248,7 +248,7 @@ assert.exit.L49:                                  ; preds = %assert.exit.L48
   %f14_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 13
   %35 = load i64, ptr %f14_addr, align 8
   %36 = icmp eq i64 %35, 11
-  br i1 %36, label %assert.exit.L50, label %assert.then.L50, !prof !0
+  br i1 %36, label %assert.exit.L50, label %assert.then.L50, !prof !5
 
 assert.then.L50:                                  ; preds = %assert.exit.L49
   %37 = call i32 (ptr, ...) @printf(ptr @anon.string.13)
@@ -259,7 +259,7 @@ assert.exit.L50:                                  ; preds = %assert.exit.L49
   %f15_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 14
   %38 = load i8, ptr %f15_addr, align 1
   %39 = icmp eq i8 %38, 63
-  br i1 %39, label %assert.exit.L51, label %assert.then.L51, !prof !0
+  br i1 %39, label %assert.exit.L51, label %assert.then.L51, !prof !5
 
 assert.then.L51:                                  ; preds = %assert.exit.L50
   %40 = call i32 (ptr, ...) @printf(ptr @anon.string.14)
@@ -270,7 +270,7 @@ assert.exit.L51:                                  ; preds = %assert.exit.L50
   %f16_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 15
   %41 = load i32, ptr %f16_addr, align 4
   %42 = icmp eq i32 %41, 13
-  br i1 %42, label %assert.exit.L52, label %assert.then.L52, !prof !0
+  br i1 %42, label %assert.exit.L52, label %assert.then.L52, !prof !5
 
 assert.then.L52:                                  ; preds = %assert.exit.L51
   %43 = call i32 (ptr, ...) @printf(ptr @anon.string.15)
@@ -281,7 +281,7 @@ assert.exit.L52:                                  ; preds = %assert.exit.L51
   %f17_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 16
   %44 = load i32, ptr %f17_addr, align 4
   %45 = icmp eq i32 %44, 13
-  br i1 %45, label %assert.exit.L53, label %assert.then.L53, !prof !0
+  br i1 %45, label %assert.exit.L53, label %assert.then.L53, !prof !5
 
 assert.then.L53:                                  ; preds = %assert.exit.L52
   %46 = call i32 (ptr, ...) @printf(ptr @anon.string.16)
@@ -292,7 +292,7 @@ assert.exit.L53:                                  ; preds = %assert.exit.L52
   %f18_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 17
   %47 = load i32, ptr %f18_addr, align 4
   %48 = icmp eq i32 %47, 14
-  br i1 %48, label %assert.exit.L54, label %assert.then.L54, !prof !0
+  br i1 %48, label %assert.exit.L54, label %assert.then.L54, !prof !5
 
 assert.then.L54:                                  ; preds = %assert.exit.L53
   %49 = call i32 (ptr, ...) @printf(ptr @anon.string.17)
@@ -303,7 +303,7 @@ assert.exit.L54:                                  ; preds = %assert.exit.L53
   %f19_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 18
   %50 = load i32, ptr %f19_addr, align 4
   %51 = icmp eq i32 %50, 12
-  br i1 %51, label %assert.exit.L55, label %assert.then.L55, !prof !0
+  br i1 %51, label %assert.exit.L55, label %assert.then.L55, !prof !5
 
 assert.then.L55:                                  ; preds = %assert.exit.L54
   %52 = call i32 (ptr, ...) @printf(ptr @anon.string.18)
@@ -314,7 +314,7 @@ assert.exit.L55:                                  ; preds = %assert.exit.L54
   %f20_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 19
   %53 = load i32, ptr %f20_addr, align 4
   %54 = icmp eq i32 %53, 7
-  br i1 %54, label %assert.exit.L56, label %assert.then.L56, !prof !0
+  br i1 %54, label %assert.exit.L56, label %assert.then.L56, !prof !5
 
 assert.then.L56:                                  ; preds = %assert.exit.L55
   %55 = call i32 (ptr, ...) @printf(ptr @anon.string.19)
@@ -338,4 +338,12 @@ attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { nofree nounwind }
 attributes #3 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
@@ -25,7 +25,7 @@ define dso_local i32 @main() #0 {
   store i32 -2147483647, ptr %f1_addr, align 4
   %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   store i64 9223372036854775807, ptr %f2_addr, align 8
-  br i1 true, label %assert.exit.L16, label %assert.then.L16, !prof !0
+  br i1 true, label %assert.exit.L16, label %assert.then.L16, !prof !5
 
 assert.then.L16:                                  ; preds = %0
   %1 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -33,7 +33,7 @@ assert.then.L16:                                  ; preds = %0
   unreachable
 
 assert.exit.L16:                                  ; preds = %0
-  br i1 true, label %assert.exit.L17, label %assert.then.L17, !prof !0
+  br i1 true, label %assert.exit.L17, label %assert.then.L17, !prof !5
 
 assert.then.L17:                                  ; preds = %assert.exit.L16
   %2 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -44,7 +44,7 @@ assert.exit.L17:                                  ; preds = %assert.exit.L16
   %f1_addr1 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
   %3 = load i32, ptr %f1_addr1, align 4
   %4 = icmp eq i32 %3, -2147483647
-  br i1 %4, label %assert.exit.L18, label %assert.then.L18, !prof !0
+  br i1 %4, label %assert.exit.L18, label %assert.then.L18, !prof !5
 
 assert.then.L18:                                  ; preds = %assert.exit.L17
   %5 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -55,7 +55,7 @@ assert.exit.L18:                                  ; preds = %assert.exit.L17
   %f2_addr2 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   %6 = load i64, ptr %f2_addr2, align 8
   %7 = icmp eq i64 %6, 9223372036854775807
-  br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !0
+  br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !5
 
 assert.then.L19:                                  ; preds = %assert.exit.L18
   %8 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -68,7 +68,7 @@ assert.exit.L19:                                  ; preds = %assert.exit.L18
   store i32 -2147483647, ptr %f1_addr3, align 4
   %f2_addr4 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
   store i64 9223372036854775807, ptr %f2_addr4, align 8
-  br i1 true, label %assert.exit.L25, label %assert.then.L25, !prof !0
+  br i1 true, label %assert.exit.L25, label %assert.then.L25, !prof !5
 
 assert.then.L25:                                  ; preds = %assert.exit.L19
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
@@ -76,7 +76,7 @@ assert.then.L25:                                  ; preds = %assert.exit.L19
   unreachable
 
 assert.exit.L25:                                  ; preds = %assert.exit.L19
-  br i1 true, label %assert.exit.L26, label %assert.then.L26, !prof !0
+  br i1 true, label %assert.exit.L26, label %assert.then.L26, !prof !5
 
 assert.then.L26:                                  ; preds = %assert.exit.L25
   %10 = call i32 (ptr, ...) @printf(ptr @anon.string.5)
@@ -87,7 +87,7 @@ assert.exit.L26:                                  ; preds = %assert.exit.L25
   %f1_addr5 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
   %11 = load i32, ptr %f1_addr5, align 4
   %12 = icmp eq i32 %11, -2147483647
-  br i1 %12, label %assert.exit.L27, label %assert.then.L27, !prof !0
+  br i1 %12, label %assert.exit.L27, label %assert.then.L27, !prof !5
 
 assert.then.L27:                                  ; preds = %assert.exit.L26
   %13 = call i32 (ptr, ...) @printf(ptr @anon.string.6)
@@ -98,7 +98,7 @@ assert.exit.L27:                                  ; preds = %assert.exit.L26
   %f2_addr6 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
   %14 = load i64, ptr %f2_addr6, align 8
   %15 = icmp eq i64 %14, 9223372036854775807
-  br i1 %15, label %assert.exit.L28, label %assert.then.L28, !prof !0
+  br i1 %15, label %assert.exit.L28, label %assert.then.L28, !prof !5
 
 assert.then.L28:                                  ; preds = %assert.exit.L27
   %16 = call i32 (ptr, ...) @printf(ptr @anon.string.7)
@@ -121,4 +121,12 @@ attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold noreturn nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
@@ -27,3 +27,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
@@ -84,3 +84,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
@@ -55,3 +55,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct/ir-code.ll
@@ -55,3 +55,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #2
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
@@ -51,3 +51,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-with-fallthrough/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-with-fallthrough/ir-code.ll
@@ -59,3 +59,12 @@ define dso_local i32 @main() #1 {
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt/ir-code.ll
@@ -115,3 +115,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ternary/success-nested-ternary/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-nested-ternary/ir-code.ll
@@ -62,3 +62,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ternary/success-shortened-ternary/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-shortened-ternary/ir-code.ll
@@ -45,3 +45,12 @@ cond.exit.L12C26:                                 ; preds = %cond.false.L12C26, 
 
 attributes #0 = { nofree nounwind }
 attributes #1 = { noinline nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ternary/success-ternary-cond-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-cond-short-circuiting/ir-code.ll
@@ -37,3 +37,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
@@ -12,7 +12,7 @@ define private i1 @_Z7condFctv() {
 
 define private ptr @_Z7trueFctv() {
   %result = alloca ptr, align 8
-  br i1 false, label %assert.exit.L6, label %assert.then.L6, !prof !0
+  br i1 false, label %assert.exit.L6, label %assert.then.L6, !prof !5
 
 assert.then.L6:                                   ; preds = %0
   %1 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -61,4 +61,12 @@ attributes #0 = { nofree nounwind }
 attributes #1 = { cold noreturn nounwind }
 attributes #2 = { noinline nounwind optnone uwtable }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/ternary/success-ternary-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-stmt/ir-code.ll
@@ -39,3 +39,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code.ll
+++ b/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code.ll
@@ -38,7 +38,7 @@ define dso_local i1 @_Z8testAdd1v() {
   %result = alloca i1, align 1
   %1 = call i32 @_Z3addii(i32 1, i32 2)
   %2 = icmp eq i32 %1, 3
-  br i1 %2, label %assert.exit.L9, label %assert.then.L9, !prof !0
+  br i1 %2, label %assert.exit.L9, label %assert.then.L9, !prof !5
 
 assert.then.L9:                                   ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -48,7 +48,7 @@ assert.then.L9:                                   ; preds = %0
 assert.exit.L9:                                   ; preds = %0
   %4 = call i32 @_Z3addii(i32 2, i32 2)
   %5 = icmp eq i32 %4, 4
-  br i1 %5, label %assert.exit.L10, label %assert.then.L10, !prof !0
+  br i1 %5, label %assert.exit.L10, label %assert.then.L10, !prof !5
 
 assert.then.L10:                                  ; preds = %assert.exit.L9
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -58,7 +58,7 @@ assert.then.L10:                                  ; preds = %assert.exit.L9
 assert.exit.L10:                                  ; preds = %assert.exit.L9
   %7 = call i32 @_Z3addii(i32 3, i32 2)
   %8 = icmp eq i32 %7, 5
-  br i1 %8, label %assert.exit.L11, label %assert.then.L11, !prof !0
+  br i1 %8, label %assert.exit.L11, label %assert.then.L11, !prof !5
 
 assert.then.L11:                                  ; preds = %assert.exit.L10
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -79,7 +79,7 @@ define dso_local i1 @_Z8testAdd2v() {
   %result = alloca i1, align 1
   %1 = call i32 @_Z3addii(i32 5, i32 -4)
   %2 = icmp eq i32 %1, 1
-  br i1 %2, label %assert.exit.L17, label %assert.then.L17, !prof !0
+  br i1 %2, label %assert.exit.L17, label %assert.then.L17, !prof !5
 
 assert.then.L17:                                  ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -89,7 +89,7 @@ assert.then.L17:                                  ; preds = %0
 assert.exit.L17:                                  ; preds = %0
   %4 = call i32 @_Z3addii(i32 2, i32 8)
   %5 = icmp eq i32 %4, 10
-  br i1 %5, label %assert.exit.L18, label %assert.then.L18, !prof !0
+  br i1 %5, label %assert.exit.L18, label %assert.then.L18, !prof !5
 
 assert.then.L18:                                  ; preds = %assert.exit.L17
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
@@ -99,7 +99,7 @@ assert.then.L18:                                  ; preds = %assert.exit.L17
 assert.exit.L18:                                  ; preds = %assert.exit.L17
   %7 = call i32 @_Z3addii(i32 -3, i32 5)
   %8 = icmp eq i32 %7, 2
-  br i1 %8, label %assert.exit.L19, label %assert.then.L19, !prof !0
+  br i1 %8, label %assert.exit.L19, label %assert.then.L19, !prof !5
 
 assert.then.L19:                                  ; preds = %assert.exit.L18
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.5)
@@ -164,4 +164,12 @@ attributes #0 = { nofree nounwind }
 attributes #1 = { cold noreturn nounwind }
 attributes #2 = { norecurse }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/testing/success-testing/ir-code.ll
+++ b/test/test-files/irgenerator/testing/success-testing/ir-code.ll
@@ -55,7 +55,7 @@ define dso_local i1 @_Z8testAdd1v() {
   %result = alloca i1, align 1
   %1 = call i32 @_Z3addii(i32 1, i32 2)
   %2 = icmp eq i32 %1, 3
-  br i1 %2, label %assert.exit.L12, label %assert.then.L12, !prof !0
+  br i1 %2, label %assert.exit.L12, label %assert.then.L12, !prof !5
 
 assert.then.L12:                                  ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
@@ -65,7 +65,7 @@ assert.then.L12:                                  ; preds = %0
 assert.exit.L12:                                  ; preds = %0
   %4 = call i32 @_Z3addii(i32 2, i32 2)
   %5 = icmp eq i32 %4, 4
-  br i1 %5, label %assert.exit.L13, label %assert.then.L13, !prof !0
+  br i1 %5, label %assert.exit.L13, label %assert.then.L13, !prof !5
 
 assert.then.L13:                                  ; preds = %assert.exit.L12
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
@@ -75,7 +75,7 @@ assert.then.L13:                                  ; preds = %assert.exit.L12
 assert.exit.L13:                                  ; preds = %assert.exit.L12
   %7 = call i32 @_Z3addii(i32 3, i32 2)
   %8 = icmp eq i32 %7, 5
-  br i1 %8, label %assert.exit.L14, label %assert.then.L14, !prof !0
+  br i1 %8, label %assert.exit.L14, label %assert.then.L14, !prof !5
 
 assert.then.L14:                                  ; preds = %assert.exit.L13
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
@@ -96,7 +96,7 @@ define dso_local i1 @_Z8testAdd2v() {
   %result = alloca i1, align 1
   %1 = call i32 @_Z3addii(i32 5, i32 -4)
   %2 = icmp eq i32 %1, 1
-  br i1 %2, label %assert.exit.L20, label %assert.then.L20, !prof !0
+  br i1 %2, label %assert.exit.L20, label %assert.then.L20, !prof !5
 
 assert.then.L20:                                  ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
@@ -106,7 +106,7 @@ assert.then.L20:                                  ; preds = %0
 assert.exit.L20:                                  ; preds = %0
   %4 = call i32 @_Z3addii(i32 2, i32 8)
   %5 = icmp eq i32 %4, 10
-  br i1 %5, label %assert.exit.L21, label %assert.then.L21, !prof !0
+  br i1 %5, label %assert.exit.L21, label %assert.then.L21, !prof !5
 
 assert.then.L21:                                  ; preds = %assert.exit.L20
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
@@ -116,7 +116,7 @@ assert.then.L21:                                  ; preds = %assert.exit.L20
 assert.exit.L21:                                  ; preds = %assert.exit.L20
   %7 = call i32 @_Z3addii(i32 -3, i32 5)
   %8 = icmp eq i32 %7, 2
-  br i1 %8, label %assert.exit.L22, label %assert.then.L22, !prof !0
+  br i1 %8, label %assert.exit.L22, label %assert.then.L22, !prof !5
 
 assert.then.L22:                                  ; preds = %assert.exit.L21
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.5)
@@ -131,7 +131,7 @@ define dso_local i1 @_Z8testSub1v() {
   %result = alloca i1, align 1
   %1 = call i32 @_Z3subii(i32 1, i32 2)
   %2 = icmp eq i32 %1, -1
-  br i1 %2, label %assert.exit.L28, label %assert.then.L28, !prof !0
+  br i1 %2, label %assert.exit.L28, label %assert.then.L28, !prof !5
 
 assert.then.L28:                                  ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.6)
@@ -141,7 +141,7 @@ assert.then.L28:                                  ; preds = %0
 assert.exit.L28:                                  ; preds = %0
   %4 = call i32 @_Z3subii(i32 2, i32 2)
   %5 = icmp eq i32 %4, 0
-  br i1 %5, label %assert.exit.L29, label %assert.then.L29, !prof !0
+  br i1 %5, label %assert.exit.L29, label %assert.then.L29, !prof !5
 
 assert.then.L29:                                  ; preds = %assert.exit.L28
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.7)
@@ -151,7 +151,7 @@ assert.then.L29:                                  ; preds = %assert.exit.L28
 assert.exit.L29:                                  ; preds = %assert.exit.L28
   %7 = call i32 @_Z3subii(i32 3, i32 2)
   %8 = icmp eq i32 %7, 1
-  br i1 %8, label %assert.exit.L30, label %assert.then.L30, !prof !0
+  br i1 %8, label %assert.exit.L30, label %assert.then.L30, !prof !5
 
 assert.then.L30:                                  ; preds = %assert.exit.L29
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.8)
@@ -166,7 +166,7 @@ define dso_local i1 @_Z8testSub2v() {
   %result = alloca i1, align 1
   %1 = call i32 @_Z3subii(i32 5, i32 -4)
   %2 = icmp eq i32 %1, 9
-  br i1 %2, label %assert.exit.L36, label %assert.then.L36, !prof !0
+  br i1 %2, label %assert.exit.L36, label %assert.then.L36, !prof !5
 
 assert.then.L36:                                  ; preds = %0
   %3 = call i32 (ptr, ...) @printf(ptr @anon.string.9)
@@ -176,7 +176,7 @@ assert.then.L36:                                  ; preds = %0
 assert.exit.L36:                                  ; preds = %0
   %4 = call i32 @_Z3subii(i32 2, i32 8)
   %5 = icmp eq i32 %4, -6
-  br i1 %5, label %assert.exit.L37, label %assert.then.L37, !prof !0
+  br i1 %5, label %assert.exit.L37, label %assert.then.L37, !prof !5
 
 assert.then.L37:                                  ; preds = %assert.exit.L36
   %6 = call i32 (ptr, ...) @printf(ptr @anon.string.10)
@@ -186,7 +186,7 @@ assert.then.L37:                                  ; preds = %assert.exit.L36
 assert.exit.L37:                                  ; preds = %assert.exit.L36
   %7 = call i32 @_Z3subii(i32 -3, i32 5)
   %8 = icmp eq i32 %7, -8
-  br i1 %8, label %assert.exit.L38, label %assert.then.L38, !prof !0
+  br i1 %8, label %assert.exit.L38, label %assert.then.L38, !prof !5
 
 assert.then.L38:                                  ; preds = %assert.exit.L37
   %9 = call i32 (ptr, ...) @printf(ptr @anon.string.11)
@@ -239,4 +239,12 @@ attributes #0 = { nofree nounwind }
 attributes #1 = { cold noreturn nounwind }
 attributes #2 = { norecurse }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}

--- a/test/test-files/irgenerator/unsafe/success-pointer-cast/ir-code.ll
+++ b/test/test-files/irgenerator/unsafe/success-pointer-cast/ir-code.ll
@@ -27,3 +27,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
@@ -70,3 +70,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/variables/success-external-global-var/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-external-global-var/ir-code.ll
@@ -19,3 +19,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/variables/success-global-variables/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-global-variables/ir-code.ll
@@ -32,3 +32,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code-O2.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code-O2.ll
@@ -15,3 +15,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-break/ir-code.ll
@@ -61,3 +61,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code-O2.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code-O2.ll
@@ -34,3 +34,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) local_unnamed_a
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop-continue/ir-code.ll
@@ -70,3 +70,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/while-loops/success-while-loop/ir-code.ll
+++ b/test/test-files/irgenerator/while-loops/success-while-loop/ir-code.ll
@@ -34,3 +34,12 @@ declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
 
 attributes #0 = { noinline nounwind optnone uwtable }
 attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/std/time/high-res-timer/ir-code-O2.ll
+++ b/test/test-files/std/time/high-res-timer/ir-code-O2.ll
@@ -34,7 +34,7 @@ define dso_local i32 @main() local_unnamed_addr #1 {
   call void @_ZN5Timer4ctorEv(ptr noundef nonnull align 8 dereferenceable(32) %t) #3
   %2 = call i64 @_ZN5Timer11getDurationEv(ptr noundef nonnull align 8 dereferenceable(32) %t) #3
   %3 = icmp eq i64 %2, 0
-  br i1 %3, label %assert.exit.L12, label %assert.then.L12, !prof !0
+  br i1 %3, label %assert.exit.L12, label %assert.then.L12, !prof !5
 
 assert.then.L12:                                  ; preds = %0
   %4 = call i32 (ptr, ...) @printf(ptr nonnull dereferenceable(1) @anon.string.2)
@@ -47,7 +47,7 @@ assert.exit.L12:                                  ; preds = %0
   call void @_ZN5Timer4stopEv(ptr noundef nonnull align 8 dereferenceable(32) %t) #3
   %5 = call i64 @_ZN5Timer11getDurationEv(ptr noundef nonnull align 8 dereferenceable(32) %t) #3
   %6 = call fastcc i1 @_Z9isInRangemmj(i64 %5, i64 10, i32 3) #3
-  br i1 %6, label %assert.exit.L16, label %assert.then.L16, !prof !0
+  br i1 %6, label %assert.exit.L16, label %assert.then.L16, !prof !5
 
 assert.then.L16:                                  ; preds = %assert.exit.L12
   %7 = call i32 (ptr, ...) @printf(ptr nonnull dereferenceable(1) @anon.string.1)
@@ -73,7 +73,7 @@ assert.exit.L16:                                  ; preds = %assert.exit.L12
   store ptr %.fca.3.load, ptr %.fca.3.insert.fca.3.gep, align 8
   %8 = call i64 @_ZN5Timer11getDurationEv(ptr noundef nonnull align 8 dereferenceable(32) %t) #3
   %9 = icmp eq i64 %8, 0
-  br i1 %9, label %assert.exit.L21, label %assert.then.L21, !prof !0
+  br i1 %9, label %assert.exit.L21, label %assert.then.L21, !prof !5
 
 assert.then.L21:                                  ; preds = %assert.exit.L16
   %10 = call i32 (ptr, ...) @printf(ptr nonnull dereferenceable(1) @anon.string.2)
@@ -83,7 +83,7 @@ assert.then.L21:                                  ; preds = %assert.exit.L16
 assert.exit.L21:                                  ; preds = %assert.exit.L16
   %11 = load i64, ptr %duration, align 8
   %12 = icmp eq i64 %11, 0
-  br i1 %12, label %assert.exit.L22, label %assert.then.L22, !prof !0
+  br i1 %12, label %assert.exit.L22, label %assert.then.L22, !prof !5
 
 assert.then.L22:                                  ; preds = %assert.exit.L21
   %13 = call i32 (ptr, ...) @printf(ptr nonnull dereferenceable(1) @anon.string.3)
@@ -100,7 +100,7 @@ assert.exit.L22:                                  ; preds = %assert.exit.L21
   call void @_ZN5Timer4stopEv(ptr noundef nonnull align 8 dereferenceable(32) %t) #3
   %14 = load i64, ptr %duration, align 8
   %15 = call fastcc i1 @_Z9isInRangemmj(i64 %14, i64 20000, i32 5000) #3
-  br i1 %15, label %assert.exit.L30, label %assert.then.L30, !prof !0
+  br i1 %15, label %assert.exit.L30, label %assert.then.L30, !prof !5
 
 assert.then.L30:                                  ; preds = %assert.exit.L22
   %16 = call i32 (ptr, ...) @printf(ptr nonnull dereferenceable(1) @anon.string.4)
@@ -136,4 +136,12 @@ attributes #1 = { noinline nounwind optnone uwtable }
 attributes #2 = { cold noreturn nounwind }
 attributes #3 = { nounwind }
 
-!0 = !{!"branch_weights", i32 2000, i32 1}
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
+!5 = !{!"branch_weights", i32 2000, i32 1}


### PR DESCRIPTION
Module flags like `PIC Level`, `PIE Level`, `uwtable` and `frame-pointer` were not emitted when compiling without debug info enabled before.