### PR TITLE
Don't try to use mold when cross-compiling to Windows

### DIFF
--- a/.run/spice build.run.xml
+++ b/.run/spice build.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O0 -d -ir ../../src-bootstrap/main.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/src-bootstrap/util/file-util.spice
+++ b/src-bootstrap/util/file-util.spice
@@ -11,6 +11,11 @@ public type ExecResult struct {
     int exitCode
 }
 
+public type ExternalBinaryFinderResult struct {
+    public string name
+    public String path
+}
+
 /**
  * Execute external command. Used to execute compiled binaries
  *
@@ -55,19 +60,19 @@ public f<bool> isGraphvizInstalled() {
  *
  * @return Name of path to the linker invoker executable
  */
-public f<String> findLinkerInvoker() {
+public f<ExternalBinaryFinderResult> findLinkerInvoker() {
     foreach const string linkerInvoker : ["clang", "gcc"] {
         if isLinux() {
             foreach const string path : ["/usr/bin/", "/usr/local/bin/", "/bin/"] {
                 const String linkerInvokerPath = path + linkerInvoker;
                 if fileExists(linkerInvokerPath.getRaw()) {
-                    return linkerInvokerPath;
+                    return ExternalBinaryFinderResult{linkerInvoker, linkerInvokerPath};
                 }
             }
         } else if isWindows() {
             String linkerInvokerLookupCommand = linkerInvoker + " -v";
             if isCommandAvailable(linkerInvokerLookupCommand.getRaw()) {
-                return String(linkerInvoker);
+                return ExternalBinaryFinderResult{linkerInvoker, String(linkerInvoker)};
             }
         }
     }
@@ -80,13 +85,13 @@ public f<String> findLinkerInvoker() {
  *
  * @return Name of path to the linker executable
  */
-public f<String> findLinker() {
+public f<ExternalBinaryFinderResult> findLinker() {
     if isLinux() {
         foreach const string linkerName : ["mold", "lld", "gold", "ld"] {
             foreach const string path : ["/usr/bin/", "/usr/local/bin/", "/bin/"] {
-                String linker = path + linkerName;
-                if fileExists(linker.getRaw()) {
-                    return linker;
+                String linkerPath = path + linkerName;
+                if fileExists(linkerPath.getRaw()) {
+                    return ExternalBinaryFinderResult{linkerName, linkerPath};
                 }
             }
         }
@@ -94,7 +99,7 @@ public f<String> findLinker() {
         foreach const string linkerName : ["lld", "ld"] {
             String checkCmd = linkerName + " -v";
             if isCommandAvailable(checkCmd.getRaw()) {
-                return String(linkerName);
+                return ExternalBinaryFinderResult{linkerName, String(linkerName)};
             }
         }
     }

--- a/src/linker/ExternalLinkerInterface.cpp
+++ b/src/linker/ExternalLinkerInterface.cpp
@@ -39,8 +39,10 @@ void ExternalLinkerInterface::link() const {
 
   // Build the linker command
   std::stringstream linkerCommandBuilder;
-  linkerCommandBuilder << FileUtil::findLinkerInvoker();
-  linkerCommandBuilder << " -fuse-ld=" << FileUtil::findLinker(); // Select linker
+  const auto [linkerInvokerName, linkerInvokerPath] = FileUtil::findLinkerInvoker();
+  linkerCommandBuilder << linkerInvokerPath;
+  const auto [linkerName, linkerPath] = FileUtil::findLinker(cliOptions);
+  linkerCommandBuilder << " -fuse-ld=" << linkerPath;
   // Append linker flags
   for (const std::string &linkerFlag : linkerFlags)
     linkerCommandBuilder << " " << linkerFlag;
@@ -51,8 +53,10 @@ void ExternalLinkerInterface::link() const {
     linkerCommandBuilder << " " << objectFilePath;
 
   // Print status message
-  if (cliOptions.printDebugOutput)                                                 // GCOV_EXCL_LINE
-    std::cout << "\nEmitting executable to path: " << outputPath.string() << "\n"; // GCOV_EXCL_LINE
+  if (cliOptions.printDebugOutput) {
+    std::cout << "\nLinking with: " << linkerInvokerName << " (invoker) / " << linkerName << " (linker)"; // GCOV_EXCL_LINE
+    std::cout << "\nEmitting executable to path: " << outputPath.string() << "\n";                        // GCOV_EXCL_LINE
+  }
 
   // Call the linker
   Timer timer;
@@ -98,7 +102,7 @@ void ExternalLinkerInterface::addAdditionalSourcePath(std::filesystem::path addi
   if (!exists(additionalSource)) {                                                                           // GCOV_EXCL_LINE
     const std::string msg = "The additional source file '" + additionalSource.string() + "' does not exist"; // GCOV_EXCL_LINE
     throw CompilerError(IO_ERROR, msg);                                                                      // GCOV_EXCL_LINE
-  }                                                                                                          // GCOV_EXCL_LINE
+  } // GCOV_EXCL_LINE
 
   // Add the file to the linker
   additionalSource.make_preferred();

--- a/src/util/FileUtil.h
+++ b/src/util/FileUtil.h
@@ -7,9 +7,17 @@
 
 namespace spice::compiler {
 
+// Forward declarations
+struct CliOptions;
+
 struct ExecResult {
   std::string output;
   int exitCode;
+};
+
+struct ExternalBinaryFinderResult {
+  const char* name;
+  std::string path;
 };
 
 /**
@@ -23,8 +31,8 @@ public:
   static ExecResult exec(const std::string &command);
   static bool isCommandAvailable(const std::string &cmd);
   static bool isGraphvizInstalled();
-  static std::string findLinkerInvoker();
-  static std::string findLinker();
+  static ExternalBinaryFinderResult findLinkerInvoker();
+  static ExternalBinaryFinderResult findLinker(const CliOptions& cliOptions);
   static std::filesystem::path getStdDir();
   static std::filesystem::path getBootstrapDir();
   static std::filesystem::path getSpiceBinDir();

--- a/test/test-files/bootstrap-compiler/standalone-file-util-test/source.spice
+++ b/test/test-files/bootstrap-compiler/standalone-file-util-test/source.spice
@@ -3,7 +3,7 @@ import "bootstrap/util/file-util";
 f<int> main() {
     printf("GCC installed: %s\n", isCommandAvailable("gcc") ? "yes" : "no");
     printf("Graphviz installed: %s\n", isGraphvizInstalled() ? "yes" : "no");
-    String linkerInvoker = findLinkerInvoker();
-    assert linkerInvoker.endsWith("clang") || linkerInvoker.endsWith("gcc");
+    ExternalBinaryFinderResult linkerInvoker = findLinkerInvoker();
+    assert linkerInvoker.path.contains("clang") || linkerInvoker.path.contains("gcc");
     printf("All assertions passed!");
 }


### PR DESCRIPTION
- Don't try to use mold when cross-compiling to Windows
- Print used linker and linker invoker when debug output is enabled