### PR TITLE
Fix bug on result var assign

### DIFF
--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -422,7 +422,10 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
     }
 
     // Reference to reference assignment (only for struct fields that are not initialized yet)
-    if (rhsSType.isRef() && rhs.entry && lhsEntry->isField()) {
+    const bool isFieldRefAssign = rhsSType.isRef() && rhs.entry && lhsEntry->isField();
+    // Assigning the result variable
+    const bool isReturnValAssign = lhsEntry->name == RETURN_VARIABLE_NAME;
+    if (isFieldRefAssign || isReturnValAssign) {
       // Get address of right side
       llvm::Value *referencedAddress = resolveAddress(rhs);
       assert(referencedAddress != nullptr);

--- a/test/test-files/irgenerator/functions/success-result-variable-ref/cout.out
+++ b/test/test-files/irgenerator/functions/success-result-variable-ref/cout.out
@@ -1,0 +1,1 @@
+Field value: 12

--- a/test/test-files/irgenerator/functions/success-result-variable-ref/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-result-variable-ref/ir-code.ll
@@ -1,0 +1,48 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+
+%struct.Test = type { i32 }
+
+@printf.str.0 = private unnamed_addr constant [16 x i8] c"Field value: %d\00", align 1
+
+define private ptr @_ZN4Test8getFieldEv(ptr noundef nonnull align 4 dereferenceable(4) %0) {
+  %result = alloca ptr, align 8
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = load ptr, ptr %this, align 8
+  %field_addr = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 0
+  store ptr %field_addr, ptr %result, align 8
+  %3 = load ptr, ptr %result, align 8
+  ret ptr %3
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define dso_local i32 @main() #0 {
+  %result = alloca i32, align 4
+  %t = alloca %struct.Test, align 8
+  %res = alloca i32, align 4
+  store i32 0, ptr %result, align 4
+  store %struct.Test { i32 12 }, ptr %t, align 4
+  %1 = call ptr @_ZN4Test8getFieldEv(ptr noundef nonnull align 4 dereferenceable(4) %t)
+  %2 = load i32, ptr %1, align 4
+  store i32 %2, ptr %res, align 4
+  %3 = load i32, ptr %res, align 4
+  %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3)
+  %5 = load i32, ptr %result, align 4
+  ret i32 %5
+}
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(ptr nocapture noundef readonly, ...) #1
+
+attributes #0 = { noinline nounwind optnone uwtable }
+attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/functions/success-result-variable-ref/source.spice
+++ b/test/test-files/irgenerator/functions/success-result-variable-ref/source.spice
@@ -1,0 +1,13 @@
+type Test struct {
+    int field
+}
+
+f<int&> Test.getField() {
+    result = this.field;
+}
+
+f<int> main() {
+    Test t = Test{12};
+    int res = t.getField();
+    printf("Field value: %d", res);
+}


### PR DESCRIPTION
- Fix miscompile when assigning a result variable of reference type. This produced an additional load instruction, which led to a segfault.
- Add test