### PR TITLE
Avoid unnecessary typechecker post runs

### DIFF
--- a/.run/spice build.run.xml
+++ b/.run/spice build.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O2 -d -g ../../src-bootstrap/main.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,24 +1,22 @@
-import "std/os/thread-pool";
-import "std/time/delay";
-import "std/net/socket";
+type Visitor struct {}
+
+type SymbolTable struct {}
+
+type Visitable interface {
+    f<bool> accept(Visitor*);
+}
+
+type AstNode struct : Visitable {}
+
+p AstNode.accept(Visitor* v) {}
+
+type AstEntryNode struct : Visitable {
+    AstNode astNode
+    SymbolTable* extFunctionScope
+    bool takesArgs
+}
 
 f<int> main() {
-    ThreadPool tp = ThreadPool(3s);
-    // Server thread
-    tp.enqueue(p() [[async]] {
-        printf("Opening server socket ...\n");
-        Result<Socket> socketRes = openServerSocket(8080s);
-        Socket socket = socketRes.unwrap();
-        printf("Server socket open.\n");
-    });
-    // Client thread
-    tp.enqueue(p() [[async]] {
-        delay(50); // Wait for server to become available
-        printf("Opening client socket ...\n");
-        Result<Socket> socketRes = openClientSocket("127.0.0.1", 8080s);
-        Socket socket = socketRes.unwrap();
-        printf("Client socket open.\n");
-    });
-    tp.start();
-    tp.join();
+    AstEntryNode entryNode;
+    printf("%d", entryNode.takesArgs);
 }

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -274,7 +274,7 @@ void SourceFile::runTypeCheckerPost() { // NOLINT(misc-no-recursion)
   // Start type-checking loop. The type-checker can request a re-execution. The max number of type-checker runs is limited
   TypeChecker typeChecker(resourceManager, this, TC_MODE_POST);
   unsigned short typeCheckerRuns = 0;
-  do {
+  while (reVisitRequested) {
     typeCheckerRuns++;
     totalTypeCheckerRuns++;
     reVisitRequested = false;
@@ -287,7 +287,7 @@ void SourceFile::runTypeCheckerPost() { // NOLINT(misc-no-recursion)
     // Then type-check all dependencies
     for (SourceFile *sourceFile : dependencies | std::views::values)
       sourceFile->runTypeCheckerPost();
-  } while (reVisitRequested);
+  }
 
   checkForSoftErrors();
 

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -166,7 +166,7 @@ public:
   bool alwaysKeepSymbolsOnNameCollision = false;
   bool ignoreWarnings = false;
   bool restoredFromCache = false;
-  bool reVisitRequested = false;
+  bool reVisitRequested = true;
   CompileStageType previousStage = NONE;
   SourceFileAntlrCtx antlrCtx;
   CompilerOutput compilerOutput;

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -2739,8 +2739,8 @@ std::vector<const Function *> &TypeChecker::getOpFctPointers(ASTNode *node) cons
  *
  * @param fct Function to check
  */
-void TypeChecker::requestRevisitIfRequired(const Function *fct) const {
-  if (fct && !fct->alreadyTypeChecked && !fct->entry->scope->isImportedBy(rootScope))
+void TypeChecker::requestRevisitIfRequired(const Function *fct) {
+  if (fct && !fct->alreadyTypeChecked)
     fct->entry->scope->sourceFile->reVisitRequested = true;
 }
 

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -146,7 +146,7 @@ private:
   [[nodiscard]] QualType mapImportedScopeTypeToLocalType(const Scope *sourceScope, const QualType &symbolType) const;
   static void autoDeReference(QualType &symbolType);
   std::vector<const Function *> &getOpFctPointers(ASTNode *node) const;
-  void requestRevisitIfRequired(const Function *fct) const;
+  static void requestRevisitIfRequired(const Function *fct);
   void softError(const ASTNode *node, SemanticErrorType errorType, const std::string &message) const;
 
   // Implicit code generation


### PR DESCRIPTION
Previously, whenever a parent source file was invalidated by `revisitRequested` all the imported source files were revisited as well. This is a huge load of work when dealing with larger Spice projects.

Example for the bootstrap compiler:
```
Successfully compiled 34 source file(s) or 5406 lines in total.
Total number of blocks allocated via BlockAllocator: 8.39 MB in 61611 allocations.
Total number of types: 821
```

Before:
```
- 645 runs of typechecker post
- O0 compile time (average out of 5 runs): 746ms
```

After:
```
- 80 runs of typechecker post
- O0 compile time (average out of 5 runs): 665ms
```

This is a solid ~11% improvement in O0 compile time. Continuing efforts in this area ...