### PR TITLE
Fix duplicate symbol name bug

### DIFF
--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
+  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_CLASS="BootstrapCompilerTests" TEST_MODE="SUITE_TEST">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/src/global/TypeRegistry.cpp
+++ b/src/global/TypeRegistry.cpp
@@ -87,7 +87,7 @@ std::string TypeRegistry::dump() {
   std::vector<std::string> typeStrings;
   typeStrings.reserve(types.size());
   for (const std::unique_ptr<Type>& type : types | std::views::values)
-    typeStrings.push_back(type->getName());
+    typeStrings.push_back(type->getName(false));
   // Sort to ensure deterministic output
   std::ranges::sort(typeStrings);
   // Serialize type registry

--- a/src/model/Function.cpp
+++ b/src/model/Function.cpp
@@ -2,6 +2,8 @@
 
 #include "Function.h"
 
+#include "symboltablebuilder/SymbolTableBuilder.h"
+
 #include <ast/ASTBuilder.h>
 #include <ast/ASTNodes.h>
 #include <irgenerator/NameMangling.h>
@@ -132,6 +134,18 @@ std::string Function::getMangledName() const {
 
 std::string Function::getSymbolTableEntryName(const std::string &functionName, const CodeLoc &codeLoc) {
   return functionName + ":" + codeLoc.toString();
+}
+
+std::string Function::getSymbolTableEntryNameDefaultCtor(const CodeLoc &structCodeLoc) {
+  return "default_" + std::string(CTOR_FUNCTION_NAME) + ":" + structCodeLoc.toString();
+}
+
+std::string Function::getSymbolTableEntryNameDefaultCopyCtor(const CodeLoc &structCodeLoc) {
+  return "default_copy" + std::string(CTOR_FUNCTION_NAME) + ":" + structCodeLoc.toString();
+}
+
+std::string Function::getSymbolTableEntryNameDefaultDtor(const CodeLoc &structCodeLoc) {
+  return "default_" + std::string(DTOR_FUNCTION_NAME) + ":" + structCodeLoc.toString();
 }
 
 /**

--- a/src/model/Function.h
+++ b/src/model/Function.h
@@ -46,6 +46,9 @@ public:
                                                 bool withReturnType = true, bool withThisType = true, bool ignorePublic = true);
   [[nodiscard]] std::string getMangledName() const;
   [[nodiscard]] static std::string getSymbolTableEntryName(const std::string &functionName, const CodeLoc &codeLoc);
+  [[nodiscard]] static std::string getSymbolTableEntryNameDefaultCtor(const CodeLoc &structCodeLoc);
+  [[nodiscard]] static std::string getSymbolTableEntryNameDefaultCopyCtor(const CodeLoc &structCodeLoc);
+  [[nodiscard]] static std::string getSymbolTableEntryNameDefaultDtor(const CodeLoc &structCodeLoc);
   [[nodiscard]] ALWAYS_INLINE bool isMethod() const { return !thisType.is(TY_DYN); }
   [[nodiscard]] ALWAYS_INLINE bool isFunction() const { return !returnType.is(TY_DYN); }
   [[nodiscard]] ALWAYS_INLINE bool isProcedure() const { return returnType.is(TY_DYN); }

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -401,13 +401,14 @@ bool QualType::isSelfReferencingStructType(const QualType *typeToCompareWith) co
   Scope *baseTypeBodyScope = getBodyScope();
   for (size_t i = 0; i < baseTypeBodyScope->getFieldCount(); i++) {
     const SymbolTableEntry *field = baseTypeBodyScope->lookupField(i);
+    const QualType &fieldType = field->getQualType();
     // Check if the base type of the field matches with the current type, which is also a base type
     // If yes, this is a self-referencing struct type
-    if (field->getQualType().getBase() == *typeToCompareWith)
+    if (fieldType.getBase() == *typeToCompareWith)
       return true;
 
     // If the field is a struct, check if it is a self-referencing struct type
-    if (field->getQualType().isSelfReferencingStructType(typeToCompareWith))
+    if (fieldType.isSelfReferencingStructType(typeToCompareWith))
       return true;
   }
   return false;
@@ -545,9 +546,9 @@ QualType QualType::toRef(const ASTNode *node) const {
  * @return New type
  */
 QualType QualType::toConstRef(const ASTNode *node) const {
-  QualType qualType = toRef(node);
-  qualType.makeConst();
-  return qualType;
+  QualType newType = toRef(node);
+  newType.makeConst();
+  return newType;
 }
 
 /**
@@ -558,7 +559,7 @@ QualType QualType::toConstRef(const ASTNode *node) const {
  * @param skipDynCheck Skip dynamic check
  * @return New type
  */
-QualType QualType::toArray(const ASTNode *node, size_t size, bool skipDynCheck /*=false*/) const {
+QualType QualType::toArr(const ASTNode *node, size_t size, bool skipDynCheck /*=false*/) const {
   QualType newType = *this;
   newType.type = type->toArr(node, size, skipDynCheck);
   return newType;
@@ -570,9 +571,9 @@ QualType QualType::toArray(const ASTNode *node, size_t size, bool skipDynCheck /
  * @return New type
  */
 QualType QualType::toNonConst() const {
-  QualType qualType = *this;
-  qualType.qualifiers.isConst = false;
-  return qualType;
+  QualType newType = *this;
+  newType.qualifiers.isConst = false;
+  return newType;
 }
 
 /**
@@ -582,10 +583,10 @@ QualType QualType::toNonConst() const {
  * @return New type
  */
 QualType QualType::getContained() const {
-  assert(isOneOf({TY_PTR, TY_ARRAY, TY_REF, TY_STRING}));
-  QualType qualType = *this;
-  qualType.type = type->getContained();
-  return qualType;
+  assert(isOneOf({TY_PTR, TY_REF, TY_ARRAY, TY_STRING}));
+  QualType newType = *this;
+  newType.type = type->getContained();
+  return newType;
 }
 
 /**
@@ -594,9 +595,9 @@ QualType QualType::getContained() const {
  * @return New type
  */
 QualType QualType::getBase() const {
-  QualType qualType = *this;
-  qualType.type = type->getBase();
-  return qualType;
+  QualType newType = *this;
+  newType.type = type->getBase();
+  return newType;
 }
 
 /**

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -101,7 +101,7 @@ public:
   [[nodiscard]] QualType toPtr(const ASTNode *node) const;
   [[nodiscard]] QualType toRef(const ASTNode *node) const;
   [[nodiscard]] QualType toConstRef(const ASTNode *node) const;
-  [[nodiscard]] QualType toArray(const ASTNode *node, size_t size, bool skipDynCheck = false) const;
+  [[nodiscard]] QualType toArr(const ASTNode *node, size_t size, bool skipDynCheck = false) const;
   [[nodiscard]] QualType toNonConst() const;
   [[nodiscard]] QualType getContained() const;
   [[nodiscard]] QualType getBase() const;

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -8,6 +8,7 @@
 #include <typechecker/FunctionManager.h>
 #include <typechecker/InterfaceManager.h>
 #include <typechecker/StructManager.h>
+#include <util/CompilerWarning.h>
 
 namespace spice::compiler {
 

--- a/src/symboltablebuilder/SymbolTable.cpp
+++ b/src/symboltablebuilder/SymbolTable.cpp
@@ -24,6 +24,7 @@ SymbolTableEntry *SymbolTable::insert(const std::string &name, ASTNode *declNode
   if (!isAnonymousSymbol)
     orderIndex = std::ranges::count_if(symbols, [](const auto &entry) { return !entry.second.anonymous; });
   // Insert into symbols map. The type is 'dyn', because concrete types are determined by the type checker later on
+  assert(!symbols.contains(name));
   symbols.insert({name, SymbolTableEntry(name, QualType(TY_INVALID), scope, declNode, orderIndex, isGlobal)});
   // Set entry to declared
   SymbolTableEntry *entry = &symbols.at(name);

--- a/src/symboltablebuilder/SymbolTable.h
+++ b/src/symboltablebuilder/SymbolTable.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <queue>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -10,7 +9,6 @@
 #include <model/GenericType.h>
 #include <symboltablebuilder/Capture.h>
 #include <symboltablebuilder/SymbolTableEntry.h>
-#include <util/CompilerWarning.h>
 
 #include "../../lib/json/json.hpp"
 

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -121,7 +121,7 @@ const Type *Type::toRef(const ASTNode *node) const {
  * @param skipDynCheck Skip check if array base type is dyn
  * @return Array type of the current type
  */
-const Type *Type::toArr(const ASTNode *node, unsigned int size, bool skipDynCheck /*=false*/) const {
+const Type *Type::toArr(const ASTNode *node, unsigned int size, bool skipDynCheck) const {
   // Do not allow arrays of dyn
   if (!skipDynCheck && typeChain.back().superType == TY_DYN)
     throw SemanticError(node, DYN_ARRAYS_NOT_ALLOWED, "Just use the dyn type without '[]' instead");

--- a/src/symboltablebuilder/Type.h
+++ b/src/symboltablebuilder/Type.h
@@ -60,13 +60,13 @@ public:
   [[nodiscard]] bool matches(const Type *otherType, bool ignoreArraySize) const;
 
   // Serialization
-  void getName(std::stringstream &name, bool withSize = false) const;
-  [[nodiscard]] std::string getName(bool withSize = false) const;
+  void getName(std::stringstream &name, bool withSize) const;
+  [[nodiscard]] std::string getName(bool withSize) const;
 
   // Get new type, based on this one
   [[nodiscard]] const Type *toPtr(const ASTNode *node) const;
   [[nodiscard]] const Type *toRef(const ASTNode *node) const;
-  [[nodiscard]] const Type *toArr(const ASTNode *node, unsigned int size = 0, bool skipDynCheck = false) const;
+  [[nodiscard]] const Type *toArr(const ASTNode *node, unsigned int size, bool skipDynCheck) const;
   [[nodiscard]] const Type *getContained() const;
   [[nodiscard]] const Type *replaceBase(const Type *newBaseType) const;
   [[nodiscard]] const Type *removeReferenceWrapper() const;

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -57,7 +57,7 @@ std::pair<QualType, Function *> OpRuleManager::getAssignResultType(const ASTNode
     const bool supportsNRVO = isReturn && !rhs.isTemporary();
     Function *copyCtor = nullptr;
     if (rhs.entry != nullptr && !supportsNRVO && !isReturn && !rhs.isTemporary())
-      copyCtor = typeChecker->implicitlyCallStructCopyCtor(rhs.entry, rhs.entry->declNode);
+      copyCtor = typeChecker->implicitlyCallStructCopyCtor(rhsType, rhs.entry->declNode);
     return {rhsType, copyCtor};
   }
 

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -583,7 +583,9 @@ std::any TypeChecker::visitDeclStmt(DeclStmtNode *node) {
       Scope *matchScope = localVarType.getBodyScope();
       assert(matchScope != nullptr);
       // Check if we are required to call a ctor
-      auto structDeclNode = spice_pointer_cast<StructDefNode *>(localVarType.getStruct(node)->declNode);
+      const Struct *spiceStruct = localVarType.getStruct(node);
+      assert(spiceStruct != nullptr);
+      auto structDeclNode = spice_pointer_cast<StructDefNode *>(spiceStruct->declNode);
       node->isCtorCallRequired = matchScope->hasRefFields() || structDeclNode->emitVTable;
       // Check if we have a no-args ctor to call
       const std::string &structName = localVarType.getSubType();
@@ -2063,7 +2065,7 @@ std::any TypeChecker::visitArrayInitialization(ArrayInitializationNode *node) {
   }
   assert(!actualItemType.is(TY_DYN));
 
-  const QualType arrayType = actualItemType.toArray(node, node->actualSize, true);
+  const QualType arrayType = actualItemType.toArr(node, node->actualSize, true);
   return ExprResult{node->setEvaluatedSymbolType(arrayType, manIdx)};
 }
 
@@ -2383,7 +2385,7 @@ std::any TypeChecker::visitDataType(DataTypeNode *node) {
 
       if (hasSize && hardcodedSize <= 1)
         SOFT_ERROR_QT(node, ARRAY_SIZE_INVALID, "The size of an array must be > 1 and explicitly stated")
-      type = type.toArray(node, hardcodedSize);
+      type = type.toArr(node, hardcodedSize);
       break;
     }
     default:                                                               // GCOV_EXCL_LINE

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -150,7 +150,8 @@ private:
   void softError(const ASTNode *node, SemanticErrorType errorType, const std::string &message) const;
 
   // Implicit code generation
-  void createDefaultStructMethod(const Struct &spiceStruct, const std::string &name, const ParamList &params) const;
+  void createDefaultStructMethod(const Struct &spiceStruct, const std::string &entryName, const std::string &name,
+                                 const ParamList &params) const;
   void createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
   void createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
   void createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope);

--- a/src/typechecker/TypeCheckerPrepare.cpp
+++ b/src/typechecker/TypeCheckerPrepare.cpp
@@ -434,7 +434,7 @@ std::any TypeChecker::visitInterfaceDefPrepare(InterfaceDefNode *node) {
         continue;
       }
       // Convert generic symbol type to generic type
-      GenericType *genericType = currentScope->lookupGenericType(templateType.getSubType());
+      const GenericType *genericType = currentScope->lookupGenericType(templateType.getSubType());
       assert(genericType != nullptr);
       usedTemplateTypes.push_back(*genericType);
       templateTypesGeneric.push_back(*genericType);

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -72,7 +72,7 @@ bool TypeMatcher::matchRequestedToCandidateType(QualType candidateType, QualType
 
       // Add to type mapping
       const QualType newMappingType = requestedType.hasAnyGenericParts() ? candidateType : requestedType;
-      assert(newMappingType.is(TY_GENERIC) ||
+      assert(newMappingType.is(TY_GENERIC) || newMappingType.is(TY_INVALID) ||
              newMappingType.getQualifiers().isSigned != newMappingType.getQualifiers().isUnsigned);
       typeMapping.insert({genericTypeName, newMappingType});
 

--- a/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
+++ b/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
@@ -265,15 +265,6 @@
           "type": "f<bool>()"
         },
         {
-          "codeLoc": "L19C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "getIdx:L19C1",
-          "orderIndex": 5,
-          "state": "declared",
-          "type": "f<public Pair<unsigned long,T&>>()"
-        },
-        {
           "codeLoc": "L15C1",
           "isGlobal": false,
           "isVolatile": false,
@@ -310,10 +301,19 @@
           "type": "p()"
         },
         {
+          "codeLoc": "L19C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "getIdx:L19C1",
+          "orderIndex": 5,
+          "state": "declared",
+          "type": "f<public Pair<unsigned long,T&>>()"
+        },
+        {
           "codeLoc": "L6C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "ctor:L6C1",
+          "name": "default_copyctor:L6C1",
           "orderIndex": 8,
           "state": "declared",
           "type": "public p()"
@@ -540,7 +540,7 @@
           "codeLoc": "L6C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "ctor:L6C1",
+          "name": "default_copyctor:L6C1",
           "orderIndex": 8,
           "state": "declared",
           "type": "public p()"


### PR DESCRIPTION
- Fix bug, where two symbols of the same name were created (e,g default ctor and default copy ctor of the same struct, because the code location is the same).
- Minor code improvements