### PR TITLE
Unify IR variable names

### DIFF
--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -166,7 +166,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
   if (hasIdx) {
     // Allocate space to save pair
     llvm::Type *pairTy = node->getIdxFct->returnType.toLLVMType(sourceFile);
-    llvm::Value *pairPtr = insertAlloca(pairTy, "pair_addr");
+    llvm::Value *pairPtr = insertAlloca(pairTy, "pair.addr");
     // Call .getIdx() on iterator
     assert(node->getIdxFct);
     llvm::Function *getIdxFct = stdFunctionManager.getIteratorGetIdxFct(node->getIdxFct);
@@ -174,12 +174,12 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
     pair->setName("pair");
     insertStore(pair, pairPtr);
     // Store idx to idx var
-    llvm::Value *idxAddrInPair = insertStructGEP(pairTy, pairPtr, 0, "idx_addr");
+    llvm::Value *idxAddrInPair = insertStructGEP(pairTy, pairPtr, 0, "idx.addr");
     LLVMExprResult idxResult = {.ptr = idxAddrInPair};
     assert(idxAddress != nullptr && idxEntry != nullptr);
     doAssignment(idxAddress, idxEntry, idxResult, QualType(TY_LONG), node, true);
     // Store item to item var
-    llvm::Value *itemAddrInPair = insertStructGEP(pairTy, pairPtr, 1, "item_addr");
+    llvm::Value *itemAddrInPair = insertStructGEP(pairTy, pairPtr, 1, "item.addr");
     LLVMExprResult itemResult = {.refPtr = itemAddrInPair};
     doAssignment(itemAddress, itemEntry, itemResult, itemRefSTy, node, true);
   } else {

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -799,7 +799,7 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
     std::vector<llvm::Value *> indices = {builder.getInt64(0)};
     for (const size_t index : indexPath)
       indices.push_back(builder.getInt32(index));
-    const std::string name = fieldName + "_addr";
+    const std::string name = fieldName + ".addr";
     llvm::Value *memberAddr = insertInBoundsGEP(lhsSTy.toLLVMType(sourceFile), lhs.ptr, indices, name);
 
     // Set as ptr or refPtr, depending on the type

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-complex/ir-code.ll
@@ -56,7 +56,7 @@ define dso_local i32 @main(i32 %0, ptr %1) #0 !dbg !14 {
   %11 = alloca %struct.VectorIterator, align 8
   %idx = alloca i64, align 8
   %item2 = alloca ptr, align 8
-  %pair_addr = alloca %struct.Pair, align 8
+  %pair.addr = alloca %struct.Pair, align 8
   %12 = alloca ptr, align 8
   store i32 0, ptr %result, align 4, !dbg !23
     #dbg_declare(ptr %_argc, !24, !DIExpression(), !23)
@@ -381,11 +381,11 @@ foreach.head.L61:                                 ; preds = %foreach.tail.L61, %
 
 foreach.body.L61:                                 ; preds = %foreach.head.L61
   %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %11), !dbg !122
-  store %struct.Pair %pair3, ptr %pair_addr, align 8, !dbg !122
-  %108 = load i64, ptr %pair_addr, align 8, !dbg !122
+  store %struct.Pair %pair3, ptr %pair.addr, align 8, !dbg !122
+  %108 = load i64, ptr %pair.addr, align 8, !dbg !122
   store i64 %108, ptr %idx, align 8, !dbg !122
-  %item_addr = getelementptr inbounds nuw %struct.Pair, ptr %pair_addr, i32 0, i32 1, !dbg !122
-  %109 = load ptr, ptr %item_addr, align 8, !dbg !122
+  %item.addr = getelementptr inbounds nuw %struct.Pair, ptr %pair.addr, i32 0, i32 1, !dbg !122
+  %109 = load ptr, ptr %item.addr, align 8, !dbg !122
   store ptr %109, ptr %12, align 8, !dbg !122
   %110 = load i64, ptr %idx, align 8, !dbg !123
   %111 = trunc i64 %110 to i32, !dbg !123

--- a/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
+++ b/test/test-files/irgenerator/debug-info/success-dbg-info-simple/ir-code.ll
@@ -58,14 +58,14 @@ define dso_local i32 @main() #1 !dbg !60 {
   %1 = call %struct.TestStruct @_Z3fctRi(ptr %test), !dbg !68
     #dbg_declare(ptr %res, !69, !DIExpression(), !70)
   store %struct.TestStruct %1, ptr %res, align 8, !dbg !68
-  %lng_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !71
-  %2 = load i64, ptr %lng_addr, align 8, !dbg !71
+  %lng.addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !71
+  %2 = load i64, ptr %lng.addr, align 8, !dbg !71
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 %2), !dbg !71
   %4 = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 1, !dbg !72
   %5 = call ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !72
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %5), !dbg !72
-  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !73
-  %7 = load i32, ptr %i_addr, align 4, !dbg !73
+  %i.addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !73
+  %7 = load i32, ptr %i.addr, align 4, !dbg !73
   %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %7), !dbg !73
   call void @_ZN10TestStruct4dtorEv(ptr %res), !dbg !74
   %9 = load i32, ptr %result, align 4, !dbg !74

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-loop-indexed/ir-code.ll
@@ -15,7 +15,7 @@ define dso_local i32 @main() #0 {
   %1 = alloca %struct.ArrayIterator, align 8
   %index = alloca i64, align 8
   %item = alloca i32, align 4
-  %pair_addr = alloca %struct.Pair, align 8
+  %pair.addr = alloca %struct.Pair, align 8
   store i32 0, ptr %result, align 4
   store [7 x i32] [i32 1, i32 5, i32 4, i32 0, i32 12, i32 12345, i32 9], ptr %intArray, align 4
   %2 = getelementptr inbounds [7 x i32], ptr %intArray, i64 0, i32 0
@@ -30,11 +30,11 @@ foreach.head.L5:                                  ; preds = %foreach.tail.L5, %0
 
 foreach.body.L5:                                  ; preds = %foreach.head.L5
   %pair = call %struct.Pair @_ZN13ArrayIteratorIiE6getIdxEv(ptr %1)
-  store %struct.Pair %pair, ptr %pair_addr, align 8
-  %5 = load i64, ptr %pair_addr, align 8
+  store %struct.Pair %pair, ptr %pair.addr, align 8
+  %5 = load i64, ptr %pair.addr, align 8
   store i64 %5, ptr %index, align 8
-  %item_addr = getelementptr inbounds nuw %struct.Pair, ptr %pair_addr, i32 0, i32 1
-  %6 = load ptr, ptr %item_addr, align 8
+  %item.addr = getelementptr inbounds nuw %struct.Pair, ptr %pair.addr, i32 0, i32 1
+  %6 = load ptr, ptr %item.addr, align 8
   %7 = load i64, ptr %index, align 8
   %8 = load i32, ptr %6, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 %7, i32 %8)

--- a/test/test-files/irgenerator/functions/success-result-variable-ref/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-result-variable-ref/ir-code.ll
@@ -10,8 +10,8 @@ define private ptr @_ZN4Test8getFieldEv(ptr noundef nonnull align 4 dereferencea
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %field_addr = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 0
-  store ptr %field_addr, ptr %result, align 8
+  %field.addr = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 0
+  store ptr %field.addr, ptr %result, align 8
   %3 = load ptr, ptr %result, align 8
   ret ptr %3
 }

--- a/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-structs/ir-code.ll
@@ -15,8 +15,8 @@ define dso_local i32 @main() #0 {
   store ptr %dbl, ptr %doubleVec, align 8
   %1 = getelementptr inbounds nuw %struct.Vector, ptr %doubleVec, i32 0, i32 1
   store i32 1, ptr %1, align 4
-  %cap_addr = getelementptr inbounds %struct.Vector, ptr %doubleVec, i64 0, i32 1
-  %2 = load i32, ptr %cap_addr, align 4
+  %cap.addr = getelementptr inbounds %struct.Vector, ptr %doubleVec, i64 0, i32 1
+  %2 = load i32, ptr %cap.addr, align 4
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
   %4 = load i32, ptr %result, align 4
   ret i32 %4

--- a/test/test-files/irgenerator/generics/success-generic-type-ctor-call/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-type-ctor-call/ir-code.ll
@@ -20,8 +20,8 @@ define private void @_ZN4TestI6NestedE8testFuncEv(ptr noundef nonnull align 1 %0
   %t = alloca %struct.Nested, align 8
   store ptr %0, ptr %this, align 8
   call void @_ZN6Nested4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %t)
-  %i_addr = getelementptr inbounds %struct.Nested, ptr %t, i64 0, i32 0
-  %2 = load i32, ptr %i_addr, align 4
+  %i.addr = getelementptr inbounds %struct.Nested, ptr %t, i64 0, i32 0
+  %2 = load i32, ptr %i.addr, align 4
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
   ret void
 }

--- a/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
@@ -33,8 +33,8 @@ define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(
   %3 = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
   store i1 false, ptr %3, align 1
   %4 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %4, i64 0, i32 1
-  store i1 false, ptr %driving_addr, align 1
+  %driving.addr = getelementptr inbounds %struct.Car, ptr %4, i64 0, i32 1
+  store i1 false, ptr %driving.addr, align 1
   ret void
 }
 
@@ -44,8 +44,8 @@ define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable
   store ptr %0, ptr %this, align 8
   store i32 %1, ptr %param, align 4
   %3 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %3, i64 0, i32 1
-  store i1 true, ptr %driving_addr, align 1
+  %driving.addr = getelementptr inbounds %struct.Car, ptr %3, i64 0, i32 1
+  store i1 true, ptr %driving.addr, align 1
   ret void
 }
 
@@ -54,8 +54,8 @@ define private i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
-  %3 = load i1, ptr %driving_addr, align 1
+  %driving.addr = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
+  %3 = load i1, ptr %driving.addr, align 1
   ret i1 %3
 }
 

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
@@ -27,15 +27,15 @@ define private fastcc void @_ZN3Car4ctorEv(ptr nocapture noundef nonnull writeon
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write)
 define private void @_ZN3Car5driveEi(ptr nocapture noundef nonnull writeonly align 8 dereferenceable(16) initializes((8, 9)) %0, i32 %1) #0 {
-  %driving_addr = getelementptr inbounds nuw i8, ptr %0, i64 8
-  store i1 true, ptr %driving_addr, align 8
+  %driving.addr = getelementptr inbounds nuw i8, ptr %0, i64 8
+  store i1 true, ptr %driving.addr, align 8
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read)
 define private i1 @_ZN3Car9isDrivingEv(ptr nocapture noundef nonnull readonly align 8 dereferenceable(16) %0) #1 {
-  %driving_addr = getelementptr inbounds nuw i8, ptr %0, i64 8
-  %2 = load i1, ptr %driving_addr, align 8
+  %driving.addr = getelementptr inbounds nuw i8, ptr %0, i64 8
+  %2 = load i1, ptr %driving.addr, align 8
   ret i1 %2
 }
 

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
@@ -25,8 +25,8 @@ define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(
   %3 = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
   store i1 false, ptr %3, align 1
   %4 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %4, i64 0, i32 1
-  store i1 false, ptr %driving_addr, align 1
+  %driving.addr = getelementptr inbounds %struct.Car, ptr %4, i64 0, i32 1
+  store i1 false, ptr %driving.addr, align 1
   ret void
 }
 
@@ -36,8 +36,8 @@ define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable
   store ptr %0, ptr %this, align 8
   store i32 %1, ptr %param, align 4
   %3 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %3, i64 0, i32 1
-  store i1 true, ptr %driving_addr, align 1
+  %driving.addr = getelementptr inbounds %struct.Car, ptr %3, i64 0, i32 1
+  store i1 true, ptr %driving.addr, align 1
   ret void
 }
 
@@ -46,8 +46,8 @@ define private i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %driving_addr = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
-  %3 = load i1, ptr %driving_addr, align 1
+  %driving.addr = getelementptr inbounds %struct.Car, ptr %2, i64 0, i32 1
+  %3 = load i1, ptr %driving.addr, align 1
   ret i1 %3
 }
 

--- a/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
@@ -47,17 +47,17 @@ define private void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 derefer
   %8 = getelementptr inbounds %struct.Person, ptr %5, i64 0, i32 3
   store i32 0, ptr %8, align 4
   %9 = load ptr, ptr %this, align 8
-  %firstName_addr = getelementptr inbounds %struct.Person, ptr %9, i64 0, i32 1
+  %firstName.addr = getelementptr inbounds %struct.Person, ptr %9, i64 0, i32 1
   %10 = load ptr, ptr %firstName, align 8
-  store ptr %10, ptr %firstName_addr, align 8
+  store ptr %10, ptr %firstName.addr, align 8
   %11 = load ptr, ptr %this, align 8
-  %lastName_addr = getelementptr inbounds %struct.Person, ptr %11, i64 0, i32 2
+  %lastName.addr = getelementptr inbounds %struct.Person, ptr %11, i64 0, i32 2
   %12 = load ptr, ptr %lastName, align 8
-  store ptr %12, ptr %lastName_addr, align 8
+  store ptr %12, ptr %lastName.addr, align 8
   %13 = load ptr, ptr %this, align 8
-  %age_addr = getelementptr inbounds %struct.Person, ptr %13, i64 0, i32 3
+  %age.addr = getelementptr inbounds %struct.Person, ptr %13, i64 0, i32 3
   %14 = load i32, ptr %age, align 4
-  store i32 %14, ptr %age_addr, align 4
+  store i32 %14, ptr %age.addr, align 4
   ret void
 }
 

--- a/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
@@ -34,8 +34,8 @@ define private void @_ZN9InnerTest4ctorEv(ptr noundef nonnull align 8 dereferenc
   %3 = getelementptr inbounds %struct.InnerTest, ptr %2, i64 0, i32 1
   store i32 0, ptr %3, align 4
   %4 = load ptr, ptr %this, align 8
-  %a_addr = getelementptr inbounds %struct.InnerTest, ptr %4, i64 0, i32 1
-  store i32 0, ptr %a_addr, align 4
+  %a.addr = getelementptr inbounds %struct.InnerTest, ptr %4, i64 0, i32 1
+  store i32 0, ptr %a.addr, align 4
   ret void
 }
 

--- a/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
@@ -12,11 +12,11 @@ define private void @_ZN5Stamp5printEv(ptr noundef nonnull align 8 dereferenceab
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %value_addr = getelementptr inbounds %struct.Stamp, ptr %2, i64 0, i32 0
-  %3 = load double, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Stamp, ptr %2, i64 0, i32 0
+  %3 = load double, ptr %value.addr, align 8
   %4 = load ptr, ptr %this, align 8
-  %glued_addr = getelementptr inbounds %struct.Stamp, ptr %4, i64 0, i32 1
-  %5 = load i1, ptr %glued_addr, align 1
+  %glued.addr = getelementptr inbounds %struct.Stamp, ptr %4, i64 0, i32 1
+  %5 = load i1, ptr %glued.addr, align 1
   %6 = zext i1 %5 to i32
   %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, double %3, i32 %6)
   ret void
@@ -30,8 +30,8 @@ define private %struct.Stamp @_ZN6Letter8getStampEv(ptr noundef nonnull align 8 
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %stamp_addr = getelementptr inbounds %struct.Letter, ptr %2, i64 0, i32 1
-  %3 = load %struct.Stamp, ptr %stamp_addr, align 8
+  %stamp.addr = getelementptr inbounds %struct.Letter, ptr %2, i64 0, i32 1
+  %3 = load %struct.Stamp, ptr %stamp.addr, align 8
   ret %struct.Stamp %3
 }
 
@@ -42,9 +42,9 @@ define dso_local i32 @main() #1 {
   %stamp = alloca %struct.Stamp, align 8
   store i32 0, ptr %result, align 4
   store %struct.Letter { ptr @anon.string.0, %struct.Stamp { double 3.400000e+00, i1 true } }, ptr %letter, align 8
-  %stamp_addr = getelementptr inbounds %struct.Letter, ptr %letter, i64 0, i32 1
-  %glued_addr = getelementptr inbounds %struct.Stamp, ptr %stamp_addr, i64 0, i32 1
-  %1 = load i1, ptr %glued_addr, align 1
+  %stamp.addr = getelementptr inbounds %struct.Letter, ptr %letter, i64 0, i32 1
+  %glued.addr = getelementptr inbounds %struct.Stamp, ptr %stamp.addr, i64 0, i32 1
+  %1 = load i1, ptr %glued.addr, align 1
   %2 = zext i1 %1 to i32
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %2)
   %4 = call %struct.Stamp @_ZN6Letter8getStampEv(ptr noundef nonnull align 8 dereferenceable(24) %letter)

--- a/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
@@ -33,25 +33,25 @@ define private i32 @_ZN10TestStructIhE7getTestEv(ptr noundef nonnull align 4 der
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 1
-  %3 = load i32, ptr %test_addr, align 4
+  %test.addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 1
+  %3 = load i32, ptr %test.addr, align 4
   %4 = icmp eq i32 %3, 1
   br i1 %4, label %if.then.L18, label %if.exit.L18
 
 if.then.L18:                                      ; preds = %1
   %5 = load ptr, ptr %this, align 8
-  %test_addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i64 0, i32 1
-  %6 = load i32, ptr %test_addr1, align 4
+  %test.addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i64 0, i32 1
+  %6 = load i32, ptr %test.addr1, align 4
   %7 = add nsw i32 %6, 1
-  store i32 %7, ptr %test_addr1, align 4
+  store i32 %7, ptr %test.addr1, align 4
   %8 = load ptr, ptr %this, align 8
   call void @_ZN10TestStructIhE9printTestEv(ptr noundef nonnull align 8 dereferenceable(8) %8)
   br label %if.exit.L18
 
 if.exit.L18:                                      ; preds = %if.then.L18, %1
   %9 = load ptr, ptr %this, align 8
-  %test_addr2 = getelementptr inbounds %struct.TestStruct, ptr %9, i64 0, i32 1
-  %10 = load i32, ptr %test_addr2, align 4
+  %test.addr2 = getelementptr inbounds %struct.TestStruct, ptr %9, i64 0, i32 1
+  %10 = load i32, ptr %test.addr2, align 4
   ret i32 %10
 }
 

--- a/test/test-files/irgenerator/methods/success-methods/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-methods/ir-code.ll
@@ -12,8 +12,8 @@ define private ptr @_ZN6Letter10getContentEv(ptr noundef nonnull align 8 derefer
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %content_addr = getelementptr inbounds %struct.Letter, ptr %2, i64 0, i32 0
-  %3 = load ptr, ptr %content_addr, align 8
+  %content.addr = getelementptr inbounds %struct.Letter, ptr %2, i64 0, i32 0
+  %3 = load ptr, ptr %content.addr, align 8
   ret ptr %3
 }
 
@@ -23,9 +23,9 @@ define private void @_ZN6Letter10setContentEPKc(ptr noundef nonnull align 8 dere
   store ptr %0, ptr %this, align 8
   store ptr %1, ptr %text, align 8
   %3 = load ptr, ptr %this, align 8
-  %content_addr = getelementptr inbounds %struct.Letter, ptr %3, i64 0, i32 0
+  %content.addr = getelementptr inbounds %struct.Letter, ptr %3, i64 0, i32 0
   %4 = load ptr, ptr %text, align 8
-  store ptr %4, ptr %content_addr, align 8
+  store ptr %4, ptr %content.addr, align 8
   ret void
 }
 

--- a/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
@@ -27,9 +27,9 @@ define private void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferencea
   %4 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
   store i64 0, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %5, i64 0, i32 0
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %5, i64 0, i32 0
   %6 = load i64, ptr %initialValue, align 8
-  store i64 %6, ptr %value_addr, align 8
+  store i64 %6, ptr %value.addr, align 8
   ret void
 }
 
@@ -38,8 +38,8 @@ define private i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 dereferen
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %2, i64 0, i32 0
-  %3 = load i64, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %2, i64 0, i32 0
+  %3 = load i64, ptr %value.addr, align 8
   ret i64 %3
 }
 
@@ -50,10 +50,10 @@ define private %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Counter %0, %
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
-  %4 = load i64, ptr %value_addr1, align 8
-  %5 = load i64, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %4 = load i64, ptr %value.addr1, align 8
+  %5 = load i64, ptr %value.addr, align 8
   %6 = add nsw i64 %5, %4
   call void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %3, i64 %6)
   %7 = load %struct.Counter, ptr %3, align 8
@@ -67,10 +67,10 @@ define private %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Counter %0, 
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
-  %4 = load i64, ptr %value_addr1, align 8
-  %5 = load i64, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %4 = load i64, ptr %value.addr1, align 8
+  %5 = load i64, ptr %value.addr, align 8
   %6 = sub nsw i64 %5, %4
   call void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %3, i64 %6)
   %7 = load %struct.Counter, ptr %3, align 8
@@ -84,10 +84,10 @@ define private %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
-  %4 = load i64, ptr %value_addr1, align 8
-  %5 = load i64, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %4 = load i64, ptr %value.addr1, align 8
+  %5 = load i64, ptr %value.addr, align 8
   %6 = mul nsw i64 %5, %4
   call void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %3, i64 %6)
   %7 = load %struct.Counter, ptr %3, align 8
@@ -101,10 +101,10 @@ define private %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
-  %4 = load i64, ptr %value_addr1, align 8
-  %5 = load i64, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %4 = load i64, ptr %value.addr1, align 8
+  %5 = load i64, ptr %value.addr, align 8
   %6 = sdiv i64 %5, %4
   call void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %3, i64 %6)
   %7 = load %struct.Counter, ptr %3, align 8
@@ -118,10 +118,10 @@ define private %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
-  %4 = load i64, ptr %value_addr1, align 8
-  %5 = load i64, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %4 = load i64, ptr %value.addr1, align 8
+  %5 = load i64, ptr %value.addr, align 8
   %6 = shl i64 %5, %4
   call void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %3, i64 %6)
   %7 = load %struct.Counter, ptr %3, align 8
@@ -135,10 +135,10 @@ define private %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counter %0, %s
   %3 = alloca %struct.Counter, align 8
   store %struct.Counter %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
-  %4 = load i64, ptr %value_addr1, align 8
-  %5 = load i64, ptr %value_addr, align 8
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c1, i64 0, i32 0
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %4 = load i64, ptr %value.addr1, align 8
+  %5 = load i64, ptr %value.addr, align 8
   %6 = ashr i64 %5, %4
   call void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %3, i64 %6)
   %7 = load %struct.Counter, ptr %3, align 8
@@ -150,13 +150,13 @@ define private void @_Z12op.plusequalR7Counter7Counter(ptr %0, %struct.Counter %
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
-  %4 = load i64, ptr %value_addr, align 8
-  %5 = load i64, ptr %value_addr1, align 8
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
+  %4 = load i64, ptr %value.addr, align 8
+  %5 = load i64, ptr %value.addr1, align 8
   %6 = add nsw i64 %5, %4
-  store i64 %6, ptr %value_addr1, align 8
+  store i64 %6, ptr %value.addr1, align 8
   ret void
 }
 
@@ -165,13 +165,13 @@ define private void @_Z13op.minusequalR7Counter7Counter(ptr %0, %struct.Counter 
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
-  %4 = load i64, ptr %value_addr, align 8
-  %5 = load i64, ptr %value_addr1, align 8
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
+  %4 = load i64, ptr %value.addr, align 8
+  %5 = load i64, ptr %value.addr1, align 8
   %6 = sub nsw i64 %5, %4
-  store i64 %6, ptr %value_addr1, align 8
+  store i64 %6, ptr %value.addr1, align 8
   ret void
 }
 
@@ -180,13 +180,13 @@ define private void @_Z11op.mulequalR7Counter7Counter(ptr %0, %struct.Counter %1
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
-  %4 = load i64, ptr %value_addr, align 8
-  %5 = load i64, ptr %value_addr1, align 8
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
+  %4 = load i64, ptr %value.addr, align 8
+  %5 = load i64, ptr %value.addr1, align 8
   %6 = mul nsw i64 %5, %4
-  store i64 %6, ptr %value_addr1, align 8
+  store i64 %6, ptr %value.addr1, align 8
   ret void
 }
 
@@ -195,13 +195,13 @@ define private void @_Z11op.divequalR7Counter7Counter(ptr %0, %struct.Counter %1
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
   store %struct.Counter %1, ptr %c2, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %c2, i64 0, i32 0
   %3 = load ptr, ptr %c1, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
-  %4 = load i64, ptr %value_addr, align 8
-  %5 = load i64, ptr %value_addr1, align 8
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
+  %4 = load i64, ptr %value.addr, align 8
+  %5 = load i64, ptr %value.addr1, align 8
   %6 = sdiv i64 %5, %4
-  store i64 %6, ptr %value_addr1, align 8
+  store i64 %6, ptr %value.addr1, align 8
   ret void
 }
 
@@ -212,15 +212,15 @@ define private ptr @_Z12op.subscriptR7Counterj(ptr %0, i32 %1) {
   store ptr %0, ptr %c, align 8
   store i32 %1, ptr %summand, align 4
   %3 = load ptr, ptr %c, align 8
-  %value_addr = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
+  %value.addr = getelementptr inbounds %struct.Counter, ptr %3, i64 0, i32 0
   %4 = load i32, ptr %summand, align 4
   %5 = sext i32 %4 to i64
-  %6 = load i64, ptr %value_addr, align 8
+  %6 = load i64, ptr %value.addr, align 8
   %7 = add i64 %6, %5
-  store i64 %7, ptr %value_addr, align 8
+  store i64 %7, ptr %value.addr, align 8
   %8 = load ptr, ptr %c, align 8
-  %value_addr1 = getelementptr inbounds %struct.Counter, ptr %8, i64 0, i32 0
-  ret ptr %value_addr1
+  %value.addr1 = getelementptr inbounds %struct.Counter, ptr %8, i64 0, i32 0
+  ret ptr %value.addr1
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable

--- a/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
@@ -14,10 +14,10 @@ define private ptr @_Z16op.plusplus.postR10TestStruct(ptr %0) {
   %ts = alloca ptr, align 8
   store ptr %0, ptr %ts, align 8
   %2 = load ptr, ptr %ts, align 8
-  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 0
-  %3 = load i64, ptr %test_addr, align 8
+  %test.addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 0
+  %3 = load i64, ptr %test.addr, align 8
   %4 = add nsw i64 %3, 1
-  store i64 %4, ptr %test_addr, align 8
+  store i64 %4, ptr %test.addr, align 8
   %5 = load ptr, ptr %ts, align 8
   ret ptr %5
 }
@@ -27,10 +27,10 @@ define private ptr @_Z18op.minusminus.postR10TestStruct(ptr %0) {
   %ts = alloca ptr, align 8
   store ptr %0, ptr %ts, align 8
   %2 = load ptr, ptr %ts, align 8
-  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 0
-  %3 = load i64, ptr %test_addr, align 8
+  %test.addr = getelementptr inbounds %struct.TestStruct, ptr %2, i64 0, i32 0
+  %3 = load i64, ptr %test.addr, align 8
   %4 = sub nsw i64 %3, 1
-  store i64 %4, ptr %test_addr, align 8
+  store i64 %4, ptr %test.addr, align 8
   %5 = load ptr, ptr %ts, align 8
   ret ptr %5
 }
@@ -45,13 +45,13 @@ define dso_local i32 @main() #0 {
   %1 = load %struct.TestStruct, ptr %ts, align 8
   %2 = call ptr @_Z16op.plusplus.postR10TestStruct(ptr %ts)
   store ptr %2, ptr %output, align 8
-  %test_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
-  %3 = load i64, ptr %test_addr, align 8
+  %test.addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
+  %3 = load i64, ptr %test.addr, align 8
   %4 = add nsw i64 %3, 1
-  store i64 %4, ptr %test_addr, align 8
+  store i64 %4, ptr %test.addr, align 8
   %5 = load ptr, ptr %output, align 8
-  %test_addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i64 0, i32 0
-  %6 = load i64, ptr %test_addr1, align 8
+  %test.addr1 = getelementptr inbounds %struct.TestStruct, ptr %5, i64 0, i32 0
+  %6 = load i64, ptr %test.addr1, align 8
   %7 = icmp eq i64 %6, 125
   br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !5
 
@@ -61,8 +61,8 @@ assert.then.L19:                                  ; preds = %0
   unreachable
 
 assert.exit.L19:                                  ; preds = %0
-  %test_addr2 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
-  %9 = load i64, ptr %test_addr2, align 8
+  %test.addr2 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
+  %9 = load i64, ptr %test.addr2, align 8
   %10 = icmp eq i64 %9, 125
   br i1 %10, label %assert.exit.L20, label %assert.then.L20, !prof !5
 
@@ -72,14 +72,14 @@ assert.then.L20:                                  ; preds = %assert.exit.L19
   unreachable
 
 assert.exit.L20:                                  ; preds = %assert.exit.L19
-  %test_addr3 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
-  %12 = load i64, ptr %test_addr3, align 8
+  %test.addr3 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
+  %12 = load i64, ptr %test.addr3, align 8
   %13 = sub nsw i64 %12, 1
-  store i64 %13, ptr %test_addr3, align 8
+  store i64 %13, ptr %test.addr3, align 8
   %14 = load %struct.TestStruct, ptr %ts, align 8
   %15 = call ptr @_Z18op.minusminus.postR10TestStruct(ptr %ts)
-  %test_addr4 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
-  %16 = load i64, ptr %test_addr4, align 8
+  %test.addr4 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
+  %16 = load i64, ptr %test.addr4, align 8
   %17 = icmp eq i64 %16, 123
   br i1 %17, label %assert.exit.L23, label %assert.then.L23, !prof !5
 
@@ -90,8 +90,8 @@ assert.then.L23:                                  ; preds = %assert.exit.L20
 
 assert.exit.L23:                                  ; preds = %assert.exit.L20
   %19 = load ptr, ptr %output, align 8
-  %test_addr5 = getelementptr inbounds %struct.TestStruct, ptr %19, i64 0, i32 0
-  %20 = load i64, ptr %test_addr5, align 8
+  %test.addr5 = getelementptr inbounds %struct.TestStruct, ptr %19, i64 0, i32 0
+  %20 = load i64, ptr %test.addr5, align 8
   %21 = icmp eq i64 %20, 123
   br i1 %21, label %assert.exit.L24, label %assert.then.L24, !prof !5
 

--- a/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
@@ -13,10 +13,10 @@ define private void @_Z8birthdayP6Person(ptr %0) {
   %person = alloca ptr, align 8
   store ptr %0, ptr %person, align 8
   %2 = load ptr, ptr %person, align 8
-  %age_addr = getelementptr inbounds %struct.Person, ptr %2, i64 0, i32 2
-  %3 = load i32, ptr %age_addr, align 4
+  %age.addr = getelementptr inbounds %struct.Person, ptr %2, i64 0, i32 2
+  %3 = load i32, ptr %age.addr, align 4
   %4 = add i32 %3, 1
-  store i32 %4, ptr %age_addr, align 4
+  store i32 %4, ptr %age.addr, align 4
   ret void
 }
 
@@ -26,17 +26,17 @@ define dso_local i32 @main() #0 {
   %mike = alloca %struct.Person, align 8
   store i32 0, ptr %result, align 4
   store %struct.Person { ptr @anon.string.0, ptr @anon.string.1, i32 32 }, ptr %mike, align 8
-  %lastName_addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 1
-  %1 = load ptr, ptr %lastName_addr, align 8
-  %firstName_addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 0
-  %2 = load ptr, ptr %firstName_addr, align 8
+  %lastName.addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 1
+  %1 = load ptr, ptr %lastName.addr, align 8
+  %firstName.addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 0
+  %2 = load ptr, ptr %firstName.addr, align 8
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %1, ptr %2)
-  %age_addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 2
-  %4 = load i32, ptr %age_addr, align 4
+  %age.addr = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 2
+  %4 = load i32, ptr %age.addr, align 4
   %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %4)
   call void @_Z8birthdayP6Person(ptr %mike)
-  %age_addr1 = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 2
-  %6 = load i32, ptr %age_addr1, align 4
+  %age.addr1 = getelementptr inbounds %struct.Person, ptr %mike, i64 0, i32 2
+  %6 = load i32, ptr %age.addr1, align 4
   %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 %6)
   %8 = load i32, ptr %result, align 4
   ret i32 %8

--- a/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-const-ref-immediate/ir-code.ll
@@ -13,8 +13,8 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   store i32 123, ptr %1, align 4
   store ptr %1, ptr %str, align 8
-  %ref_addr = getelementptr inbounds %struct.Struct, ptr %str, i64 0, i32 0
-  %2 = load ptr, ptr %ref_addr, align 8
+  %ref.addr = getelementptr inbounds %struct.Struct, ptr %str, i64 0, i32 0
+  %2 = load ptr, ptr %ref.addr, align 8
   %3 = load i32, ptr %2, align 4
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3)
   %5 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
@@ -19,8 +19,8 @@ define private void @_Z4procRiRK6Struct(ptr %0, ptr %1) {
   %5 = add nsw i32 %4, 12
   store i32 %5, ptr %3, align 4
   %6 = load ptr, ptr %structRef, align 8
-  %ref_addr = getelementptr inbounds %struct.Struct, ptr %6, i64 0, i32 0
-  %7 = load ptr, ptr %ref_addr, align 8
+  %ref.addr = getelementptr inbounds %struct.Struct, ptr %6, i64 0, i32 0
+  %7 = load ptr, ptr %ref.addr, align 8
   %8 = load i32, ptr %7, align 4
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %8)
   ret void
@@ -40,8 +40,8 @@ define private i32 @_Z4funcRdRK6Struct(ptr %0, ptr %1) {
   %5 = fmul double %4, -1.560000e+00
   store double %5, ptr %3, align 8
   %6 = load ptr, ptr %structRef, align 8
-  %b_addr = getelementptr inbounds %struct.Struct, ptr %6, i64 0, i32 1
-  %7 = load i1, ptr %b_addr, align 1
+  %b.addr = getelementptr inbounds %struct.Struct, ptr %6, i64 0, i32 1
+  %7 = load i1, ptr %b.addr, align 1
   %8 = zext i1 %7 to i32
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %8)
   ret i32 0

--- a/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-struct-fields/ir-code.ll
@@ -16,12 +16,12 @@ define dso_local i32 @main() #0 {
   store i1 true, ptr %ts, align 1
   %1 = getelementptr inbounds nuw %struct.TestStruct, ptr %ts, i32 0, i32 1
   store ptr %t, ptr %1, align 8
-  %f2_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
-  %2 = load ptr, ptr %f2_addr, align 8
+  %f2.addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
+  %2 = load ptr, ptr %f2.addr, align 8
   %3 = load i32, ptr %2, align 4
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3)
-  %f2_addr1 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
-  %5 = load ptr, ptr %f2_addr1, align 8
+  %f2.addr1 = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
+  %5 = load ptr, ptr %f2.addr1, align 8
   %6 = load i32, ptr %5, align 4
   %7 = add nsw i32 %6, 1
   store i32 %7, ptr %5, align 4

--- a/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-access-composed-fields/ir-code.ll
@@ -14,18 +14,18 @@ define dso_local i32 @main() #0 {
   %d = alloca %struct.D, align 8
   store i32 0, ptr %result, align 4
   store %struct.D zeroinitializer, ptr %d, align 4
-  %f1_addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 0, i32 0
-  store i32 1, ptr %f1_addr, align 4
-  %f2_addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 2
-  store i32 2, ptr %f2_addr, align 4
-  %f3_addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 1, i32 1, i32 0
-  store i32 3, ptr %f3_addr, align 4
-  %f1_addr1 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 0, i32 0
-  %1 = load i32, ptr %f1_addr1, align 4
-  %f2_addr2 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 2
-  %2 = load i32, ptr %f2_addr2, align 4
-  %f3_addr3 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 1, i32 1, i32 0
-  %3 = load i32, ptr %f3_addr3, align 4
+  %f1.addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 0, i32 0
+  store i32 1, ptr %f1.addr, align 4
+  %f2.addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 2
+  store i32 2, ptr %f2.addr, align 4
+  %f3.addr = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 1, i32 1, i32 0
+  store i32 3, ptr %f3.addr, align 4
+  %f1.addr1 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 0, i32 0
+  %1 = load i32, ptr %f1.addr1, align 4
+  %f2.addr2 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 2
+  %2 = load i32, ptr %f2.addr2, align 4
+  %f3.addr3 = getelementptr inbounds %struct.D, ptr %d, i64 0, i32 1, i32 1, i32 0
+  %3 = load i32, ptr %f3.addr3, align 4
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1, i32 %2, i32 %3)
   %5 = load i32, ptr %result, align 4
   ret i32 %5

--- a/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
@@ -23,12 +23,12 @@ define private void @_ZN6Vector4ctorEv(ptr noundef nonnull align 8 dereferenceab
   %4 = getelementptr inbounds %struct.Vector, ptr %2, i64 0, i32 1
   store ptr @0, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %5, i64 0, i32 0
-  store i1 false, ptr %field1_addr, align 1
+  %field1.addr = getelementptr inbounds %struct.Vector, ptr %5, i64 0, i32 0
+  store i1 false, ptr %field1.addr, align 1
   %6 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %6, i64 0, i32 1
+  %field2.addr = getelementptr inbounds %struct.Vector, ptr %6, i64 0, i32 1
   %7 = load ptr, ptr %msg, align 8
-  store ptr %7, ptr %field2_addr, align 8
+  store ptr %7, ptr %field2.addr, align 8
   ret void
 }
 
@@ -43,12 +43,12 @@ define private void @_ZN6Vector4ctorEPKc(ptr noundef nonnull align 8 dereference
   %5 = getelementptr inbounds %struct.Vector, ptr %3, i64 0, i32 1
   store ptr @1, ptr %5, align 8
   %6 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %6, i64 0, i32 0
-  store i1 false, ptr %field1_addr, align 1
+  %field1.addr = getelementptr inbounds %struct.Vector, ptr %6, i64 0, i32 0
+  store i1 false, ptr %field1.addr, align 1
   %7 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %7, i64 0, i32 1
+  %field2.addr = getelementptr inbounds %struct.Vector, ptr %7, i64 0, i32 1
   %8 = load ptr, ptr %msg, align 8
-  store ptr %8, ptr %field2_addr, align 8
+  store ptr %8, ptr %field2.addr, align 8
   ret void
 }
 
@@ -66,20 +66,20 @@ define dso_local i32 @main() #0 {
   %1 = alloca %struct.Vector, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN6Vector4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %vec)
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
-  %2 = load i1, ptr %field1_addr, align 1
+  %field1.addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
+  %2 = load i1, ptr %field1.addr, align 1
   %3 = zext i1 %2 to i32
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
-  %4 = load ptr, ptr %field2_addr, align 8
+  %field2.addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
+  %4 = load ptr, ptr %field2.addr, align 8
   %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3, ptr %4)
   call void @_ZN6Vector4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr @anon.string.2)
   %6 = load %struct.Vector, ptr %1, align 8
   store %struct.Vector %6, ptr %vec, align 8
-  %field1_addr1 = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
-  %7 = load i1, ptr %field1_addr1, align 1
+  %field1.addr1 = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
+  %7 = load i1, ptr %field1.addr1, align 1
   %8 = zext i1 %7 to i32
-  %field2_addr2 = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
-  %9 = load ptr, ptr %field2_addr2, align 8
+  %field2.addr2 = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
+  %9 = load ptr, ptr %field2.addr2, align 8
   %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %8, ptr %9)
   %11 = call ptr @_ZN6Vector4testEv(ptr noundef nonnull align 8 dereferenceable(16) %vec)
   %12 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, ptr %11)

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
@@ -17,12 +17,12 @@ define private void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 2 derefer
   %4 = getelementptr inbounds %struct.Inner, ptr %3, i64 0, i32 0
   store i16 -43, ptr %4, align 2
   %5 = load ptr, ptr %this, align 8
-  %x_addr = getelementptr inbounds %struct.Inner, ptr %5, i64 0, i32 0
+  %x.addr = getelementptr inbounds %struct.Inner, ptr %5, i64 0, i32 0
   %6 = load ptr, ptr %other, align 8
-  %x_addr1 = getelementptr inbounds %struct.Inner, ptr %6, i64 0, i32 0
-  %7 = load i16, ptr %x_addr1, align 2
+  %x.addr1 = getelementptr inbounds %struct.Inner, ptr %6, i64 0, i32 0
+  %7 = load i16, ptr %x.addr1, align 2
   %8 = add nsw i16 %7, 5
-  store i16 %8, ptr %x_addr, align 2
+  store i16 %8, ptr %x.addr, align 2
   ret void
 }
 
@@ -55,17 +55,17 @@ define dso_local i32 @main() #1 {
   %outer2 = alloca %struct.Outer, align 8
   store i32 0, ptr %result, align 4
   store %struct.Outer { %struct.Middle { %struct.Inner { i16 -43 } } }, ptr %outer, align 2
-  %middle_addr = getelementptr inbounds %struct.Outer, ptr %outer, i64 0, i32 0
-  %inner_addr = getelementptr inbounds %struct.Middle, ptr %middle_addr, i64 0, i32 0
-  %x_addr = getelementptr inbounds %struct.Inner, ptr %inner_addr, i64 0, i32 0
-  %1 = load i16, ptr %x_addr, align 2
+  %middle.addr = getelementptr inbounds %struct.Outer, ptr %outer, i64 0, i32 0
+  %inner.addr = getelementptr inbounds %struct.Middle, ptr %middle.addr, i64 0, i32 0
+  %x.addr = getelementptr inbounds %struct.Inner, ptr %inner.addr, i64 0, i32 0
+  %1 = load i16, ptr %x.addr, align 2
   %2 = sext i16 %1 to i32
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2)
   call void @_ZN5Outer4ctorERK5Outer(ptr %outer2, ptr %outer)
-  %middle_addr1 = getelementptr inbounds %struct.Outer, ptr %outer2, i64 0, i32 0
-  %inner_addr2 = getelementptr inbounds %struct.Middle, ptr %middle_addr1, i64 0, i32 0
-  %x_addr3 = getelementptr inbounds %struct.Inner, ptr %inner_addr2, i64 0, i32 0
-  %4 = load i16, ptr %x_addr3, align 2
+  %middle.addr1 = getelementptr inbounds %struct.Outer, ptr %outer2, i64 0, i32 0
+  %inner.addr2 = getelementptr inbounds %struct.Middle, ptr %middle.addr1, i64 0, i32 0
+  %x.addr3 = getelementptr inbounds %struct.Inner, ptr %inner.addr2, i64 0, i32 0
+  %4 = load i16, ptr %x.addr3, align 2
   %5 = sext i16 %4 to i32
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %5)
   %7 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor-nested/ir-code.ll
@@ -44,10 +44,10 @@ define dso_local i32 @main() #1 {
   %outer = alloca %struct.Outer, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN5Outer4ctorEv(ptr %outer)
-  %middle_addr = getelementptr inbounds %struct.Outer, ptr %outer, i64 0, i32 0
-  %inner_addr = getelementptr inbounds %struct.Middle, ptr %middle_addr, i64 0, i32 0
-  %message_addr = getelementptr inbounds %struct.Inner, ptr %inner_addr, i64 0, i32 0
-  %1 = load ptr, ptr %message_addr, align 8
+  %middle.addr = getelementptr inbounds %struct.Outer, ptr %outer, i64 0, i32 0
+  %inner.addr = getelementptr inbounds %struct.Middle, ptr %middle.addr, i64 0, i32 0
+  %message.addr = getelementptr inbounds %struct.Inner, ptr %inner.addr, i64 0, i32 0
+  %1 = load ptr, ptr %message.addr, align 8
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %1)
   %3 = load i32, ptr %result, align 4
   ret i32 %3

--- a/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-ctor/ir-code.ll
@@ -31,17 +31,17 @@ define dso_local i32 @main() #1 {
   %ts = alloca %struct.TestStruct, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN10TestStruct4ctorEv(ptr %ts)
-  %i_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
-  %1 = load i32, ptr %i_addr, align 4
+  %i.addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 0
+  %1 = load i32, ptr %i.addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
-  %3 = load ptr, ptr %s_addr, align 8
+  %s.addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 1
+  %3 = load ptr, ptr %s.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
-  %d_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 2
-  %5 = load double, ptr %d_addr, align 8
+  %d.addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 2
+  %5 = load double, ptr %d.addr, align 8
   %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, double %5)
-  %b_addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 3
-  %7 = load i1, ptr %b_addr, align 1
+  %b.addr = getelementptr inbounds %struct.TestStruct, ptr %ts, i64 0, i32 3
+  %7 = load i1, ptr %b.addr, align 1
   %8 = zext i1 %7 to i32
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 %8)
   %10 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -50,9 +50,9 @@ define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceabl
   %4 = getelementptr inbounds %struct.Inner, ptr %2, i64 0, i32 1
   store ptr null, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %data_addr = getelementptr inbounds %struct.Inner, ptr %5, i64 0, i32 1
+  %data.addr = getelementptr inbounds %struct.Inner, ptr %5, i64 0, i32 1
   %6 = call ptr @malloc(i64 10)
-  store ptr %6, ptr %data_addr, align 8
+  store ptr %6, ptr %data.addr, align 8
   ret void
 }
 
@@ -60,8 +60,8 @@ define private void @_ZN5Inner4dtorEv(ptr noundef nonnull align 8 dereferenceabl
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
-  %data_addr = getelementptr inbounds %struct.Inner, ptr %2, i64 0, i32 1
-  %3 = load ptr, ptr %data_addr, align 8
+  %data.addr = getelementptr inbounds %struct.Inner, ptr %2, i64 0, i32 1
+  %3 = load ptr, ptr %data.addr, align 8
   call void @free(ptr %3)
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
   ret void

--- a/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
@@ -30,10 +30,10 @@ define private void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align 
   %4 = call %struct.Result @_Z6sAllocm(i64 10)
   store %struct.Result %4, ptr %res, align 8
   %5 = load ptr, ptr %this, align 8
-  %data_addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i64 0, i32 0
+  %data.addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i64 0, i32 0
   %6 = call ptr @_ZN6ResultIPhE6unwrapEv(ptr noundef nonnull align 8 dereferenceable(24) %res)
   %7 = load ptr, ptr %6, align 8
-  store ptr %7, ptr %data_addr, align 8
+  store ptr %7, ptr %data.addr, align 8
   ret void
 }
 
@@ -50,15 +50,15 @@ define dso_local i32 @main() #1 {
   store ptr null, ptr %sPtr, align 8
   call void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %s)
   store ptr %s, ptr %sPtr, align 8
-  %data_addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %s, i64 0, i32 0
-  %1 = load ptr, ptr %data_addr, align 8
+  %data.addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %s, i64 0, i32 0
+  %1 = load ptr, ptr %data.addr, align 8
   %2 = icmp eq ptr %1, null
   %3 = zext i1 %2 to i32
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %3)
   call void @_ZN20StructWithHeapFields4dtorEv(ptr %s)
   %5 = load ptr, ptr %sPtr, align 8
-  %data_addr1 = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i64 0, i32 0
-  %6 = load ptr, ptr %data_addr1, align 8
+  %data.addr1 = getelementptr inbounds %struct.StructWithHeapFields, ptr %5, i64 0, i32 0
+  %6 = load ptr, ptr %data.addr1, align 8
   %7 = icmp eq ptr %6, null
   %8 = zext i1 %7 to i32
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %8)

--- a/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values1/ir-code.ll
@@ -25,11 +25,11 @@ define dso_local i32 @main() #1 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr %t)
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  %1 = load i32, ptr %i_addr, align 4
+  %i.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
+  %1 = load i32, ptr %i.addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  %3 = load ptr, ptr %s_addr, align 8
+  %s.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
+  %3 = load ptr, ptr %s.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4
   ret i32 %5

--- a/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values2/ir-code.ll
@@ -13,11 +13,11 @@ define dso_local i32 @main() #0 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   store %struct.Test { i32 12, ptr @anon.string.0 }, ptr %t, align 8
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  %1 = load i32, ptr %i_addr, align 4
+  %i.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
+  %1 = load i32, ptr %i.addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  %3 = load ptr, ptr %s_addr, align 8
+  %s.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
+  %3 = load ptr, ptr %s.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4
   ret i32 %5

--- a/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values3/ir-code.ll
@@ -25,11 +25,11 @@ define dso_local i32 @main() #1 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr %t)
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  %1 = load i32, ptr %i_addr, align 4
+  %i.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
+  %1 = load i32, ptr %i.addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  %3 = load ptr, ptr %s_addr, align 8
+  %s.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
+  %3 = load ptr, ptr %s.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4
   ret i32 %5

--- a/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
@@ -16,8 +16,8 @@ define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable
   %4 = getelementptr inbounds %struct.Test, ptr %2, i64 0, i32 1
   store ptr @0, ptr %4, align 8
   %5 = load ptr, ptr %this, align 8
-  %i_addr = getelementptr inbounds %struct.Test, ptr %5, i64 0, i32 0
-  store i32 14, ptr %i_addr, align 4
+  %i.addr = getelementptr inbounds %struct.Test, ptr %5, i64 0, i32 0
+  store i32 14, ptr %i.addr, align 4
   ret void
 }
 
@@ -27,11 +27,11 @@ define dso_local i32 @main() #0 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %t)
-  %i_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  %1 = load i32, ptr %i_addr, align 4
+  %i.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
+  %1 = load i32, ptr %i.addr, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
-  %s_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  %3 = load ptr, ptr %s_addr, align 8
+  %s.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
+  %3 = load ptr, ptr %s.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %3)
   %5 = load i32, ptr %result, align 4
   ret i32 %5

--- a/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
@@ -16,9 +16,9 @@ define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceab
   store ptr %0, ptr %this, align 8
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
   %4 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %4, i64 0, i32 0
+  %field1.addr = getelementptr inbounds %struct.Vector, ptr %4, i64 0, i32 0
   store i1 true, ptr %2, align 1
-  %5 = call i32 @memcmp(ptr %field1_addr, ptr %2, i64 0)
+  %5 = call i32 @memcmp(ptr %field1.addr, ptr %2, i64 0)
   %6 = icmp eq i32 %5, 0
   br i1 %6, label %assert.exit.L8, label %assert.then.L8, !prof !5
 
@@ -29,8 +29,8 @@ assert.then.L8:                                   ; preds = %1
 
 assert.exit.L8:                                   ; preds = %1
   %8 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
-  %9 = load ptr, ptr %field2_addr, align 8
+  %field2.addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
+  %9 = load ptr, ptr %field2.addr, align 8
   %10 = call i1 @_Z10isRawEqualPKcPKc(ptr %9, ptr @anon.string.1)
   br i1 %10, label %assert.exit.L9, label %assert.then.L9, !prof !5
 
@@ -60,11 +60,11 @@ define dso_local i32 @main() #3 {
   %vec = alloca %struct.Vector, align 8
   store i32 0, ptr %result, align 4
   store %struct.Vector { i1 true, ptr @anon.string.3 }, ptr %vec, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
-  %1 = load i1, ptr %field1_addr, align 1
+  %field1.addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
+  %1 = load i1, ptr %field1.addr, align 1
   %2 = zext i1 %1 to i32
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
-  %3 = load ptr, ptr %field2_addr, align 8
+  %field2.addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
+  %3 = load ptr, ptr %field2.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %2, ptr %3)
   call void @_ZN6Vector4dtorEv(ptr %vec)
   %5 = load i32, ptr %result, align 4

--- a/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
@@ -16,11 +16,11 @@ define dso_local i32 @main() #0 {
   %vec = alloca %struct.Vector, align 8
   store i32 0, ptr %result, align 4
   store %struct.Vector { i1 true, ptr @anon.string.0 }, ptr %vec, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
-  %1 = load i1, ptr %field1_addr, align 1
+  %field1.addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 0
+  %1 = load i1, ptr %field1.addr, align 1
   %2 = zext i1 %1 to i32
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
-  %3 = load ptr, ptr %field2_addr, align 8
+  %field2.addr = getelementptr inbounds %struct.Vector, ptr %vec, i64 0, i32 1
+  %3 = load ptr, ptr %field2.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %2, ptr %3)
   call void @_ZN6Vector4dtorEv(ptr %vec)
   %5 = load i32, ptr %result, align 4
@@ -36,9 +36,9 @@ define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceab
   store ptr %0, ptr %this, align 8
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1)
   %4 = load ptr, ptr %this, align 8
-  %field1_addr = getelementptr inbounds %struct.Vector, ptr %4, i64 0, i32 0
+  %field1.addr = getelementptr inbounds %struct.Vector, ptr %4, i64 0, i32 0
   store i1 true, ptr %2, align 1
-  %5 = call i32 @memcmp(ptr %field1_addr, ptr %2, i64 0)
+  %5 = call i32 @memcmp(ptr %field1.addr, ptr %2, i64 0)
   %6 = icmp eq i32 %5, 0
   br i1 %6, label %assert.exit.L13, label %assert.then.L13, !prof !5
 
@@ -49,8 +49,8 @@ assert.then.L13:                                  ; preds = %1
 
 assert.exit.L13:                                  ; preds = %1
   %8 = load ptr, ptr %this, align 8
-  %field2_addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
-  %9 = load ptr, ptr %field2_addr, align 8
+  %field2.addr = getelementptr inbounds %struct.Vector, ptr %8, i64 0, i32 1
+  %9 = load ptr, ptr %field2.addr, align 8
   %10 = call i1 @_Z10isRawEqualPKcPKc(ptr %9, ptr @anon.string.2)
   br i1 %10, label %assert.exit.L14, label %assert.then.L14, !prof !5
 

--- a/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-external-nested-struct/ir-code.ll
@@ -15,13 +15,13 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   %1 = call %struct.Socket @_Z16openServerSockett(i16 8080)
   store %struct.Socket %1, ptr %s, align 8
-  %nested_addr = getelementptr inbounds %struct.Socket, ptr %s, i64 0, i32 2
-  call void @llvm.memcpy.p0.p0.i64(ptr %n, ptr %nested_addr, i64 16, i1 false)
-  %testString_addr = getelementptr inbounds %struct.NestedSocket, ptr %n, i64 0, i32 0
-  %2 = load ptr, ptr %testString_addr, align 8
+  %nested.addr = getelementptr inbounds %struct.Socket, ptr %s, i64 0, i32 2
+  call void @llvm.memcpy.p0.p0.i64(ptr %n, ptr %nested.addr, i64 16, i1 false)
+  %testString.addr = getelementptr inbounds %struct.NestedSocket, ptr %n, i64 0, i32 0
+  %2 = load ptr, ptr %testString.addr, align 8
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %2)
-  %sock_addr = getelementptr inbounds %struct.Socket, ptr %s, i64 0, i32 0
-  %4 = load i32, ptr %sock_addr, align 4
+  %sock.addr = getelementptr inbounds %struct.Socket, ptr %s, i64 0, i32 0
+  %4 = load i32, ptr %sock.addr, align 4
   %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %4)
   %6 = load i32, ptr %result, align 4
   ret i32 %6

--- a/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-field-default-value-folding/ir-code.ll
@@ -107,8 +107,8 @@ define dso_local i32 @main() #1 {
   %t = alloca %struct.Test, align 8
   store i32 0, ptr %result, align 4
   call void @_ZN4Test4ctorEv(ptr %t)
-  %f1_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  %1 = load i32, ptr %f1_addr, align 4
+  %f1.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
+  %1 = load i32, ptr %f1.addr, align 4
   %2 = icmp eq i32 %1, 2
   br i1 %2, label %assert.exit.L37, label %assert.then.L37, !prof !5
 
@@ -118,8 +118,8 @@ assert.then.L37:                                  ; preds = %0
   unreachable
 
 assert.exit.L37:                                  ; preds = %0
-  %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  %4 = load i1, ptr %f2_addr, align 1
+  %f2.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
+  %4 = load i1, ptr %f2.addr, align 1
   br i1 %4, label %assert.exit.L38, label %assert.then.L38, !prof !5
 
 assert.then.L38:                                  ; preds = %assert.exit.L37
@@ -128,8 +128,8 @@ assert.then.L38:                                  ; preds = %assert.exit.L37
   unreachable
 
 assert.exit.L38:                                  ; preds = %assert.exit.L37
-  %f3_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 2
-  %6 = load i1, ptr %f3_addr, align 1
+  %f3.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 2
+  %6 = load i1, ptr %f3.addr, align 1
   %7 = xor i1 %6, true
   br i1 %7, label %assert.exit.L39, label %assert.then.L39, !prof !5
 
@@ -139,8 +139,8 @@ assert.then.L39:                                  ; preds = %assert.exit.L38
   unreachable
 
 assert.exit.L39:                                  ; preds = %assert.exit.L38
-  %f4_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 3
-  %9 = load i32, ptr %f4_addr, align 4
+  %f4.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 3
+  %9 = load i32, ptr %f4.addr, align 4
   %10 = icmp eq i32 %9, 11
   br i1 %10, label %assert.exit.L40, label %assert.then.L40, !prof !5
 
@@ -150,8 +150,8 @@ assert.then.L40:                                  ; preds = %assert.exit.L39
   unreachable
 
 assert.exit.L40:                                  ; preds = %assert.exit.L39
-  %f5_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 4
-  %12 = load i16, ptr %f5_addr, align 2
+  %f5.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 4
+  %12 = load i16, ptr %f5.addr, align 2
   %13 = icmp eq i16 %12, 10
   br i1 %13, label %assert.exit.L41, label %assert.then.L41, !prof !5
 
@@ -161,8 +161,8 @@ assert.then.L41:                                  ; preds = %assert.exit.L40
   unreachable
 
 assert.exit.L41:                                  ; preds = %assert.exit.L40
-  %f6_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 5
-  %15 = load i64, ptr %f6_addr, align 8
+  %f6.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 5
+  %15 = load i64, ptr %f6.addr, align 8
   %16 = icmp eq i64 %15, 2
   br i1 %16, label %assert.exit.L42, label %assert.then.L42, !prof !5
 
@@ -172,8 +172,8 @@ assert.then.L42:                                  ; preds = %assert.exit.L41
   unreachable
 
 assert.exit.L42:                                  ; preds = %assert.exit.L41
-  %f7_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 6
-  %18 = load i1, ptr %f7_addr, align 1
+  %f7.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 6
+  %18 = load i1, ptr %f7.addr, align 1
   br i1 %18, label %assert.exit.L43, label %assert.then.L43, !prof !5
 
 assert.then.L43:                                  ; preds = %assert.exit.L42
@@ -182,8 +182,8 @@ assert.then.L43:                                  ; preds = %assert.exit.L42
   unreachable
 
 assert.exit.L43:                                  ; preds = %assert.exit.L42
-  %f8_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 7
-  %20 = load i1, ptr %f8_addr, align 1
+  %f8.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 7
+  %20 = load i1, ptr %f8.addr, align 1
   br i1 %20, label %assert.exit.L44, label %assert.then.L44, !prof !5
 
 assert.then.L44:                                  ; preds = %assert.exit.L43
@@ -192,8 +192,8 @@ assert.then.L44:                                  ; preds = %assert.exit.L43
   unreachable
 
 assert.exit.L44:                                  ; preds = %assert.exit.L43
-  %f9_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 8
-  %22 = load i1, ptr %f9_addr, align 1
+  %f9.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 8
+  %22 = load i1, ptr %f9.addr, align 1
   br i1 %22, label %assert.exit.L45, label %assert.then.L45, !prof !5
 
 assert.then.L45:                                  ; preds = %assert.exit.L44
@@ -202,8 +202,8 @@ assert.then.L45:                                  ; preds = %assert.exit.L44
   unreachable
 
 assert.exit.L45:                                  ; preds = %assert.exit.L44
-  %f10_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 9
-  %24 = load i1, ptr %f10_addr, align 1
+  %f10.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 9
+  %24 = load i1, ptr %f10.addr, align 1
   %25 = xor i1 %24, true
   br i1 %25, label %assert.exit.L46, label %assert.then.L46, !prof !5
 
@@ -213,8 +213,8 @@ assert.then.L46:                                  ; preds = %assert.exit.L45
   unreachable
 
 assert.exit.L46:                                  ; preds = %assert.exit.L45
-  %f11_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 10
-  %27 = load i1, ptr %f11_addr, align 1
+  %f11.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 10
+  %27 = load i1, ptr %f11.addr, align 1
   br i1 %27, label %assert.exit.L47, label %assert.then.L47, !prof !5
 
 assert.then.L47:                                  ; preds = %assert.exit.L46
@@ -223,8 +223,8 @@ assert.then.L47:                                  ; preds = %assert.exit.L46
   unreachable
 
 assert.exit.L47:                                  ; preds = %assert.exit.L46
-  %f12_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 11
-  %29 = load i1, ptr %f12_addr, align 1
+  %f12.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 11
+  %29 = load i1, ptr %f12.addr, align 1
   %30 = xor i1 %29, true
   br i1 %30, label %assert.exit.L48, label %assert.then.L48, !prof !5
 
@@ -234,8 +234,8 @@ assert.then.L48:                                  ; preds = %assert.exit.L47
   unreachable
 
 assert.exit.L48:                                  ; preds = %assert.exit.L47
-  %f13_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 12
-  %32 = load i32, ptr %f13_addr, align 4
+  %f13.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 12
+  %32 = load i32, ptr %f13.addr, align 4
   %33 = icmp eq i32 %32, 333
   br i1 %33, label %assert.exit.L49, label %assert.then.L49, !prof !5
 
@@ -245,8 +245,8 @@ assert.then.L49:                                  ; preds = %assert.exit.L48
   unreachable
 
 assert.exit.L49:                                  ; preds = %assert.exit.L48
-  %f14_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 13
-  %35 = load i64, ptr %f14_addr, align 8
+  %f14.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 13
+  %35 = load i64, ptr %f14.addr, align 8
   %36 = icmp eq i64 %35, 11
   br i1 %36, label %assert.exit.L50, label %assert.then.L50, !prof !5
 
@@ -256,8 +256,8 @@ assert.then.L50:                                  ; preds = %assert.exit.L49
   unreachable
 
 assert.exit.L50:                                  ; preds = %assert.exit.L49
-  %f15_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 14
-  %38 = load i8, ptr %f15_addr, align 1
+  %f15.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 14
+  %38 = load i8, ptr %f15.addr, align 1
   %39 = icmp eq i8 %38, 63
   br i1 %39, label %assert.exit.L51, label %assert.then.L51, !prof !5
 
@@ -267,8 +267,8 @@ assert.then.L51:                                  ; preds = %assert.exit.L50
   unreachable
 
 assert.exit.L51:                                  ; preds = %assert.exit.L50
-  %f16_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 15
-  %41 = load i32, ptr %f16_addr, align 4
+  %f16.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 15
+  %41 = load i32, ptr %f16.addr, align 4
   %42 = icmp eq i32 %41, 13
   br i1 %42, label %assert.exit.L52, label %assert.then.L52, !prof !5
 
@@ -278,8 +278,8 @@ assert.then.L52:                                  ; preds = %assert.exit.L51
   unreachable
 
 assert.exit.L52:                                  ; preds = %assert.exit.L51
-  %f17_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 16
-  %44 = load i32, ptr %f17_addr, align 4
+  %f17.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 16
+  %44 = load i32, ptr %f17.addr, align 4
   %45 = icmp eq i32 %44, 13
   br i1 %45, label %assert.exit.L53, label %assert.then.L53, !prof !5
 
@@ -289,8 +289,8 @@ assert.then.L53:                                  ; preds = %assert.exit.L52
   unreachable
 
 assert.exit.L53:                                  ; preds = %assert.exit.L52
-  %f18_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 17
-  %47 = load i32, ptr %f18_addr, align 4
+  %f18.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 17
+  %47 = load i32, ptr %f18.addr, align 4
   %48 = icmp eq i32 %47, 14
   br i1 %48, label %assert.exit.L54, label %assert.then.L54, !prof !5
 
@@ -300,8 +300,8 @@ assert.then.L54:                                  ; preds = %assert.exit.L53
   unreachable
 
 assert.exit.L54:                                  ; preds = %assert.exit.L53
-  %f19_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 18
-  %50 = load i32, ptr %f19_addr, align 4
+  %f19.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 18
+  %50 = load i32, ptr %f19.addr, align 4
   %51 = icmp eq i32 %50, 12
   br i1 %51, label %assert.exit.L55, label %assert.then.L55, !prof !5
 
@@ -311,8 +311,8 @@ assert.then.L55:                                  ; preds = %assert.exit.L54
   unreachable
 
 assert.exit.L55:                                  ; preds = %assert.exit.L54
-  %f20_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 19
-  %53 = load i32, ptr %f20_addr, align 4
+  %f20.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 19
+  %53 = load i32, ptr %f20.addr, align 4
   %54 = icmp eq i32 %53, 7
   br i1 %54, label %assert.exit.L56, label %assert.then.L56, !prof !5
 

--- a/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
@@ -21,10 +21,10 @@ define dso_local i32 @main() #0 {
   %tp = alloca %struct.TestPacked, align 8
   store i32 0, ptr %result, align 4
   store %struct.Test zeroinitializer, ptr %t, align 8
-  %f1_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  store i32 -2147483647, ptr %f1_addr, align 4
-  %f2_addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  store i64 9223372036854775807, ptr %f2_addr, align 8
+  %f1.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
+  store i32 -2147483647, ptr %f1.addr, align 4
+  %f2.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
+  store i64 9223372036854775807, ptr %f2.addr, align 8
   br i1 true, label %assert.exit.L16, label %assert.then.L16, !prof !5
 
 assert.then.L16:                                  ; preds = %0
@@ -41,8 +41,8 @@ assert.then.L17:                                  ; preds = %assert.exit.L16
   unreachable
 
 assert.exit.L17:                                  ; preds = %assert.exit.L16
-  %f1_addr1 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  %3 = load i32, ptr %f1_addr1, align 4
+  %f1.addr1 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
+  %3 = load i32, ptr %f1.addr1, align 4
   %4 = icmp eq i32 %3, -2147483647
   br i1 %4, label %assert.exit.L18, label %assert.then.L18, !prof !5
 
@@ -52,8 +52,8 @@ assert.then.L18:                                  ; preds = %assert.exit.L17
   unreachable
 
 assert.exit.L18:                                  ; preds = %assert.exit.L17
-  %f2_addr2 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  %6 = load i64, ptr %f2_addr2, align 8
+  %f2.addr2 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
+  %6 = load i64, ptr %f2.addr2, align 8
   %7 = icmp eq i64 %6, 9223372036854775807
   br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !5
 
@@ -64,10 +64,10 @@ assert.then.L19:                                  ; preds = %assert.exit.L18
 
 assert.exit.L19:                                  ; preds = %assert.exit.L18
   store %struct.TestPacked zeroinitializer, ptr %tp, align 1
-  %f1_addr3 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
-  store i32 -2147483647, ptr %f1_addr3, align 4
-  %f2_addr4 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
-  store i64 9223372036854775807, ptr %f2_addr4, align 8
+  %f1.addr3 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
+  store i32 -2147483647, ptr %f1.addr3, align 4
+  %f2.addr4 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
+  store i64 9223372036854775807, ptr %f2.addr4, align 8
   br i1 true, label %assert.exit.L25, label %assert.then.L25, !prof !5
 
 assert.then.L25:                                  ; preds = %assert.exit.L19
@@ -84,8 +84,8 @@ assert.then.L26:                                  ; preds = %assert.exit.L25
   unreachable
 
 assert.exit.L26:                                  ; preds = %assert.exit.L25
-  %f1_addr5 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
-  %11 = load i32, ptr %f1_addr5, align 4
+  %f1.addr5 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
+  %11 = load i32, ptr %f1.addr5, align 4
   %12 = icmp eq i32 %11, -2147483647
   br i1 %12, label %assert.exit.L27, label %assert.then.L27, !prof !5
 
@@ -95,8 +95,8 @@ assert.then.L27:                                  ; preds = %assert.exit.L26
   unreachable
 
 assert.exit.L27:                                  ; preds = %assert.exit.L26
-  %f2_addr6 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
-  %14 = load i64, ptr %f2_addr6, align 8
+  %f2.addr6 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
+  %14 = load i64, ptr %f2.addr6, align 8
   %15 = icmp eq i64 %14, 9223372036854775807
   br i1 %15, label %assert.exit.L28, label %assert.then.L28, !prof !5
 

--- a/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-field-access/ir-code.ll
@@ -13,10 +13,10 @@ define dso_local i32 @main() #0 {
   %john = alloca %struct.Person, align 8
   store i32 0, ptr %result, align 4
   store %struct.Person { ptr @anon.string.0, ptr @anon.string.1, i32 46 }, ptr %john, align 8
-  %age_addr = getelementptr inbounds %struct.Person, ptr %john, i64 0, i32 2
-  store i32 47, ptr %age_addr, align 4
-  %age_addr1 = getelementptr inbounds %struct.Person, ptr %john, i64 0, i32 2
-  %1 = load i32, ptr %age_addr1, align 4
+  %age.addr = getelementptr inbounds %struct.Person, ptr %john, i64 0, i32 2
+  store i32 47, ptr %age.addr, align 4
+  %age.addr1 = getelementptr inbounds %struct.Person, ptr %john, i64 0, i32 2
+  %1 = load i32, ptr %age.addr1, align 4
   %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %1)
   %3 = load i32, ptr %result, align 4
   ret i32 %3

--- a/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
@@ -63,17 +63,17 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   %1 = call %struct.ShoppingCart @_Z15newShoppingCartv()
   store %struct.ShoppingCart %1, ptr %shoppingCart, align 8
-  %items_addr = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i64 0, i32 1
-  %2 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items_addr, i64 0, i32 1
-  %name_addr = getelementptr inbounds %struct.ShoppingItem, ptr %2, i64 0, i32 0
-  %3 = load ptr, ptr %name_addr, align 8
+  %items.addr = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i64 0, i32 1
+  %2 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items.addr, i64 0, i32 1
+  %name.addr = getelementptr inbounds %struct.ShoppingItem, ptr %2, i64 0, i32 0
+  %3 = load ptr, ptr %name.addr, align 8
   %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr %3)
   %5 = call %struct.ShoppingCart @_Z19anotherShoppingCartv()
   store %struct.ShoppingCart %5, ptr %shoppingCart, align 8
-  %items_addr1 = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i64 0, i32 1
-  %6 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items_addr1, i64 0, i32 2
-  %unit_addr = getelementptr inbounds %struct.ShoppingItem, ptr %6, i64 0, i32 2
-  %7 = load ptr, ptr %unit_addr, align 8
+  %items.addr1 = getelementptr inbounds %struct.ShoppingCart, ptr %shoppingCart, i64 0, i32 1
+  %6 = getelementptr inbounds [3 x %struct.ShoppingItem], ptr %items.addr1, i64 0, i32 2
+  %unit.addr = getelementptr inbounds %struct.ShoppingItem, ptr %6, i64 0, i32 2
+  %7 = load ptr, ptr %unit.addr, align 8
   %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %7)
   %9 = load i32, ptr %result, align 4
   ret i32 %9

--- a/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-self-ref/ir-code.ll
@@ -29,22 +29,22 @@ define dso_local i32 @main() #0 {
 
 while.head.L21:                                   ; preds = %while.body.L21, %0
   %4 = load ptr, ptr %curNode, align 8
-  %parent_addr = getelementptr inbounds %struct.TreeNode, ptr %4, i64 0, i32 0
-  %5 = load ptr, ptr %parent_addr, align 8
+  %parent.addr = getelementptr inbounds %struct.TreeNode, ptr %4, i64 0, i32 0
+  %5 = load ptr, ptr %parent.addr, align 8
   %6 = icmp ne ptr %5, null
   br i1 %6, label %while.body.L21, label %while.exit.L21
 
 while.body.L21:                                   ; preds = %while.head.L21
   %7 = load ptr, ptr %curNode, align 8
-  %parent_addr1 = getelementptr inbounds %struct.TreeNode, ptr %7, i64 0, i32 0
-  %8 = load ptr, ptr %parent_addr1, align 8
+  %parent.addr1 = getelementptr inbounds %struct.TreeNode, ptr %7, i64 0, i32 0
+  %8 = load ptr, ptr %parent.addr1, align 8
   store ptr %8, ptr %curNode, align 8
   br label %while.head.L21
 
 while.exit.L21:                                   ; preds = %while.head.L21
   %9 = load ptr, ptr %curNode, align 8
-  %value_addr = getelementptr inbounds %struct.TreeNode, ptr %9, i64 0, i32 1
-  %10 = load i32, ptr %value_addr, align 4
+  %value.addr = getelementptr inbounds %struct.TreeNode, ptr %9, i64 0, i32 1
+  %10 = load i32, ptr %value.addr, align 4
   %11 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %10)
   %12 = load i32, ptr %result, align 4
   ret i32 %12

--- a/test/test-files/irgenerator/structs/success-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct/ir-code.ll
@@ -28,19 +28,19 @@ define dso_local i32 @main() #0 {
   %3 = getelementptr inbounds nuw %struct.TestStruct, ptr %instance, i32 0, i32 2
   store ptr %nestedInstance, ptr %3, align 8
   call void @llvm.memcpy.p0.p0.i64(ptr %instance1, ptr %instance, i64 24, i1 false)
-  %nested_addr = getelementptr inbounds %struct.TestStruct, ptr %instance, i64 0, i32 2
-  %4 = load ptr, ptr %nested_addr, align 8
-  %nested2_addr = getelementptr inbounds %struct.Nested, ptr %4, i64 0, i32 1
-  %5 = load ptr, ptr %nested2_addr, align 8
+  %nested.addr = getelementptr inbounds %struct.TestStruct, ptr %instance, i64 0, i32 2
+  %4 = load ptr, ptr %nested.addr, align 8
+  %nested2.addr = getelementptr inbounds %struct.Nested, ptr %4, i64 0, i32 1
+  %5 = load ptr, ptr %nested2.addr, align 8
   %6 = load i1, ptr %5, align 1
   %7 = zext i1 %6 to i32
-  %field2_addr = getelementptr inbounds %struct.TestStruct, ptr %instance1, i64 0, i32 1
-  %8 = load double, ptr %field2_addr, align 8
+  %field2.addr = getelementptr inbounds %struct.TestStruct, ptr %instance1, i64 0, i32 1
+  %8 = load double, ptr %field2.addr, align 8
   %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %7, double %8)
-  %nested_addr1 = getelementptr inbounds %struct.TestStruct, ptr %instance1, i64 0, i32 2
-  %10 = load ptr, ptr %nested_addr1, align 8
-  %nested1_addr = getelementptr inbounds %struct.Nested, ptr %10, i64 0, i32 0
-  %11 = load ptr, ptr %nested1_addr, align 8
+  %nested.addr1 = getelementptr inbounds %struct.TestStruct, ptr %instance1, i64 0, i32 2
+  %10 = load ptr, ptr %nested.addr1, align 8
+  %nested1.addr = getelementptr inbounds %struct.Nested, ptr %10, i64 0, i32 0
+  %11 = load ptr, ptr %nested1.addr, align 8
   %12 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr %11)
   %13 = load i32, ptr %result, align 4
   ret i32 %13

--- a/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-decl-default-value/ir-code.ll
@@ -58,8 +58,8 @@ define dso_local i32 @main() #0 {
   %20 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.7, i32 %19)
   store [4 x %struct.NestedStruct] [%struct.NestedStruct { i32 0, ptr @1 }, %struct.NestedStruct { i32 0, ptr @1 }, %struct.NestedStruct { i32 0, ptr @1 }, %struct.NestedStruct { i32 0, ptr @1 }], ptr %structArrayVar, align 8
   %21 = getelementptr inbounds [4 x %struct.NestedStruct], ptr %structArrayVar, i64 0, i32 2
-  %field2_addr = getelementptr inbounds %struct.NestedStruct, ptr %21, i64 0, i32 1
-  %22 = load ptr, ptr %field2_addr, align 8
+  %field2.addr = getelementptr inbounds %struct.NestedStruct, ptr %21, i64 0, i32 1
+  %22 = load ptr, ptr %field2.addr, align 8
   %23 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.8, ptr %22)
   %24 = load i32, ptr %result, align 4
   ret i32 %24


### PR DESCRIPTION
Always use `<var-name>.addr` for field address allocas, etc.