### PR TITLE
Move more logic to helper functions in QualType

### DIFF
--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=true" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
+  <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,11 +1,17 @@
-import "test2" as s1;
+import "std/data/vector";
 
 f<int> main() {
-    dyn v = s1::Vector<int>{};
-    v.setData(12);
-    printf("Data: %d\n", v.data);
-    v.setData(1.5);
-    printf("Data: %d\n", v.data);
+    Vector<int> intVector;
+    intVector.pushBack(1);
+    intVector.pushBack(5);
+    intVector.pushBack(4);
+    intVector.pushBack(0);
+    intVector.pushBack(12);
+    intVector.pushBack(12345);
+    intVector.pushBack(9);
+    foreach const int item : intVector {
+        printf("Item: %d\n", item);
+    }
 }
 
 /*import "bootstrap/util/block-allocator";

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,18 +1,28 @@
-import "std/data/vector";
+import "std/data/red-black-tree";
+import "std/data/pair";
 
 f<int> main() {
-    Vector<int> intVector;
-    intVector.pushBack(1);
-    intVector.pushBack(5);
-    intVector.pushBack(4);
-    intVector.pushBack(0);
-    intVector.pushBack(12);
-    intVector.pushBack(12345);
-    intVector.pushBack(9);
-    foreach const int item : intVector {
-        printf("Item: %d\n", item);
+    RedBlackTree<int, int> tree;
+    {
+        foreach Pair<int&, int&> item : tree {
+            int& first = item.getFirst();
+            int& second = item.getSecond();
+            printf("%d: %d\n", first, second);
+        }
+    }
+
+    tree.insert(1, 2);
+    tree.insert(2, 3);
+    tree.insert(3, 4);
+    tree.insert(4, 5);
+    tree.insert(5, 6);
+    foreach Pair<int&, int&> item : tree {
+        int& first = item.getFirst();
+        int& second = item.getSecond();
+        printf("%d: %d\n", first, second);
     }
 }
+
 
 /*import "bootstrap/util/block-allocator";
 import "bootstrap/util/memory";

--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -114,10 +114,9 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
     LLVMExprResult callResult = {.value = iterator, .node = iteratorAssignNode};
     iteratorPtr = resolveAddress(callResult);
 
-    // Attach address to anonymous symbol to keep track of de-allocation
-    SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(iteratorAssignNode->codeLoc);
-    assert(returnSymbol != nullptr);
-    returnSymbol->updateAddress(iteratorPtr);
+    // If an anonymous symbol exists, set its address
+    if (SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(iteratorAssignNode->codeLoc))
+      returnSymbol->updateAddress(iteratorPtr);
   } else { // The iteratorAssignExpr is of type Iterator
     iteratorPtr = resolveAddress(iteratorAssignNode);
   }

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -106,6 +106,29 @@ Struct *QualType::getStruct(const ASTNode *node, const QualTypeList &templateTyp
 Struct *QualType::getStruct(const ASTNode *node) const { return getStruct(node, type->getTemplateTypes()); }
 
 /**
+ * Get the struct instance for a struct type
+ * Adopt information from the struct to this type.
+ *
+ * @param node Accessing AST node
+ * @param templateTypes Custom set of template types
+ * @return Struct instance
+ */
+Struct *QualType::getStructAndAdjustType(const ASTNode *node, const QualTypeList &templateTypes) {
+  Struct *spiceStruct = getStruct(node, templateTypes);
+  type = type->getWithBodyScope(spiceStruct->scope)->getWithTemplateTypes(spiceStruct->getTemplateTypes());
+  return spiceStruct;
+}
+
+/**
+ * Get the struct instance for a struct type
+ * Adopt information from the struct to this type.
+ *
+ * @param node Accessing AST node
+ * @return Struct instance
+ */
+Struct *QualType::getStructAndAdjustType(const ASTNode *node) { return getStructAndAdjustType(node, type->getTemplateTypes()); }
+
+/**
  * Get the interface instance for an interface type
  *
  * @param node Accessing AST node

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -87,14 +87,36 @@ const QualTypeList &QualType::getTemplateTypes() const { return type->getTemplat
  * Get the struct instance for a struct type
  *
  * @param node Accessing AST node
+ * @param templateTypes Custom set of template types
  * @return Struct instance
  */
-Struct *QualType::getStruct(const ASTNode *node) const {
+Struct *QualType::getStruct(const ASTNode *node, const QualTypeList &templateTypes) const {
   assert(is(TY_STRUCT));
   Scope *structDefScope = getBodyScope()->parent;
   const std::string &structName = getSubType();
-  const QualTypeList &templateTypes = getTemplateTypes();
   return StructManager::match(structDefScope, structName, templateTypes, node);
+}
+
+/**
+ * Get the struct instance for a struct type
+ *
+ * @param node Accessing AST node
+ * @return Struct instance
+ */
+Struct *QualType::getStruct(const ASTNode *node) const { return getStruct(node, type->getTemplateTypes()); }
+
+/**
+ * Get the interface instance for an interface type
+ *
+ * @param node Accessing AST node
+ * @param templateTypes Custom set of template types
+ * @return Interface instance
+ */
+Interface *QualType::getInterface(const ASTNode *node, const QualTypeList &templateTypes) const {
+  assert(is(TY_INTERFACE));
+  Scope *interfaceDefScope = getBodyScope()->parent;
+  const std::string structName = getSubType();
+  return InterfaceManager::match(interfaceDefScope, structName, templateTypes, node);
 }
 
 /**
@@ -103,13 +125,7 @@ Struct *QualType::getStruct(const ASTNode *node) const {
  * @param node Accessing AST node
  * @return Interface instance
  */
-Interface *QualType::getInterface(const ASTNode *node) const {
-  assert(is(TY_INTERFACE));
-  Scope *interfaceDefScope = getBodyScope()->parent;
-  const std::string structName = getSubType();
-  const QualTypeList &templateTypes = getTemplateTypes();
-  return InterfaceManager::match(interfaceDefScope, structName, templateTypes, node);
-}
+Interface *QualType::getInterface(const ASTNode *node) const { return getInterface(node, type->getTemplateTypes()); }
 
 /**
  * Check if the underlying type is of a certain super type
@@ -634,7 +650,6 @@ QualType QualType::autoDeReference() const {
     newType = newType.getContained();
   return newType;
 }
-
 
 /**
  * Replace the base type with another one

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -86,6 +86,7 @@ public:
 
   // Complex queries on the type
   [[nodiscard]] bool isTriviallyCopyable(const ASTNode *node) const;
+  [[nodiscard]] bool isTriviallyDestructible(const ASTNode *node) const;
   [[nodiscard]] bool doesImplement(const QualType &implementedInterfaceType, const ASTNode *node) const;
   [[nodiscard]] bool canBind(const QualType &inputType, bool isTemporary) const;
   [[nodiscard]] bool matches(const QualType &otherType, bool ignoreArraySize, bool ignoreQualifiers, bool allowConstify) const;

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -60,6 +60,8 @@ public:
   [[nodiscard]] const QualTypeList &getTemplateTypes() const;
   [[nodiscard]] Struct *getStruct(const ASTNode *node, const QualTypeList &templateTypes) const;
   [[nodiscard]] Struct *getStruct(const ASTNode *node) const;
+  [[nodiscard]] Struct *getStructAndAdjustType(const ASTNode *node, const QualTypeList &templateTypes);
+  [[nodiscard]] Struct *getStructAndAdjustType(const ASTNode *node);
   [[nodiscard]] Interface *getInterface(const ASTNode *node, const QualTypeList &templateTypes) const;
   [[nodiscard]] Interface *getInterface(const ASTNode *node) const;
 

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -58,7 +58,9 @@ public:
   [[nodiscard]] const QualTypeList &getFunctionParamAndReturnTypes() const;
   [[nodiscard]] bool hasLambdaCaptures() const;
   [[nodiscard]] const QualTypeList &getTemplateTypes() const;
-  Struct *getStruct(const ASTNode *node) const;
+  [[nodiscard]] Struct *getStruct(const ASTNode *node, const QualTypeList &templateTypes) const;
+  [[nodiscard]] Struct *getStruct(const ASTNode *node) const;
+  [[nodiscard]] Interface *getInterface(const ASTNode *node, const QualTypeList &templateTypes) const;
   [[nodiscard]] Interface *getInterface(const ASTNode *node) const;
 
   // Queries on the type

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -353,13 +353,12 @@ MatchResult FunctionManager::matchManifestation(Function &candidate, Scope *&mat
   // Substantiate return type
   substantiateReturnType(candidate, typeMapping, callNode);
 
+  // Set the match scope to the scope of the concrete substantiation
   const QualType &thisType = candidate.thisType;
   if (!thisType.is(TY_DYN)) {
     // If we only have the generic struct scope, lookup the concrete manifestation scope
     if (matchScope->isGenericScope) {
-      const std::string &structName = thisType.getSubType();
-      Scope *scope = thisType.getBodyScope()->parent;
-      Struct *spiceStruct = StructManager::match(scope, structName, thisType.getTemplateTypes(), candidate.declNode);
+      const Struct *spiceStruct = thisType.getStruct(candidate.declNode);
       assert(spiceStruct != nullptr);
       matchScope = spiceStruct->scope;
     }

--- a/src/typechecker/InterfaceManager.cpp
+++ b/src/typechecker/InterfaceManager.cpp
@@ -204,7 +204,7 @@ bool InterfaceManager::matchTemplateTypes(Interface &candidate, const QualTypeLi
  * @param typeMapping Generic type mapping
  * @param node Instantiation AST node for printing error messages
  */
-void InterfaceManager::substantiateSignatures(Interface &candidate, TypeMapping &typeMapping, const ASTNode *node) {
+void InterfaceManager::substantiateSignatures(Interface &candidate, const TypeMapping &typeMapping, const ASTNode *node) {
   // Loop over all signatures and substantiate the generic ones
   for (Function *method : candidate.methods) {
     // Skip methods, that are already fully substantiated

--- a/src/typechecker/InterfaceManager.h
+++ b/src/typechecker/InterfaceManager.h
@@ -37,7 +37,7 @@ private:
   [[nodiscard]] static bool matchName(const Interface &candidate, const std::string &reqName);
   [[nodiscard]] static bool matchTemplateTypes(Interface &candidate, const QualTypeList &reqTemplateTypes,
                                                TypeMapping &typeMapping, const ASTNode *node);
-  static void substantiateSignatures(Interface &candidate, TypeMapping &typeMapping, const ASTNode *node);
+  static void substantiateSignatures(Interface &candidate, const TypeMapping &typeMapping, const ASTNode *node);
   [[nodiscard]] static const GenericType *getGenericTypeOfCandidateByName(const Interface &candidate,
                                                                           const std::string &templateTypeName);
   [[nodiscard]] static uint64_t getCacheKey(Scope *scope, const std::string &name, const QualTypeList &templateTypes);

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -726,13 +726,14 @@ ExprResult OpRuleManager::isOperatorOverloadingFctAvailable(ASTNode *node, const
   // Procedures always have the return type 'bool'
   if (callee->isProcedure())
     return ExprResult(QualType(TY_BOOL));
+  const QualType &returnType = callee->returnType;
 
-  // Add anonymous symbol to keep track of de-allocation
+  // Add anonymous symbol to keep track of dtor call, if non-trivially destructible
   SymbolTableEntry *anonymousSymbol = nullptr;
-  if (callee->returnType.is(TY_STRUCT))
-    anonymousSymbol = typeChecker->currentScope->symbolTable.insertAnonymous(callee->returnType, node, opIdx);
+  if (returnType.is(TY_STRUCT) && !returnType.isTriviallyDestructible(node))
+    anonymousSymbol = typeChecker->currentScope->symbolTable.insertAnonymous(returnType, node, opIdx);
 
-  return {typeChecker->mapImportedScopeTypeToLocalType(calleeParentScope, callee->returnType), anonymousSymbol};
+  return {typeChecker->mapImportedScopeTypeToLocalType(calleeParentScope, returnType), anonymousSymbol};
 }
 
 QualType OpRuleManager::validateUnaryOperation(const ASTNode *node, const UnaryOpRule opRules[], size_t opRulesSize,

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -156,7 +156,7 @@ Struct *StructManager::match(Scope *matchScope, const std::string &qt, const Qua
 
         // Instantiate structs
         if (baseType.is(TY_STRUCT))
-          baseType.getStruct(node);
+          (void)baseType.getStruct(node);
       }
 
       // Instantiate implemented interfaces if required
@@ -170,10 +170,8 @@ Struct *StructManager::match(Scope *matchScope, const std::string &qt, const Qua
         TypeMatcher::substantiateTypesWithTypeMapping(templateTypes, typeMapping, node);
 
         // Instantiate interface
-        Scope *interfaceMatchScope = interfaceType.getBodyScope()->parent;
-        Interface *spiceInterface = InterfaceManager::match(interfaceMatchScope, interfaceType.getSubType(), templateTypes, node);
+        Interface *spiceInterface = interfaceType.getInterface(node, templateTypes);
         assert(spiceInterface != nullptr);
-
         interfaceType = spiceInterface->entry->getQualType();
       }
 

--- a/src/typechecker/TypeCheckMeta.cpp
+++ b/src/typechecker/TypeCheckMeta.cpp
@@ -342,7 +342,7 @@ std::any TypeChecker::visitCustomDataType(CustomDataTypeNode *node) {
       // Here, it is allowed to accept, that the struct/interface cannot be found, because there are self-referencing ones
       if (entryType.is(TY_STRUCT)) {
         const std::string structName = node->typeNameFragments.back();
-        if (Struct *spiceStruct = StructManager::match(localAccessScope, structName, templateTypes, node))
+        if (const Struct *spiceStruct = StructManager::match(localAccessScope, structName, templateTypes, node))
           entryType = entryType.getWithBodyScope(spiceStruct->scope);
       } else {
         assert(entryType.is(TY_INTERFACE));

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -113,7 +113,7 @@ QualType TypeChecker::mapImportedScopeTypeToLocalType(const Scope *sourceScope, 
   if (!symbolType.isBase(TY_STRUCT))
     return symbolType;
 
-  // If the source scope is in the current source file, we can return the symbol type as is
+  // If the given source file is in the current one, we can return the symbol type as is
   const SourceFile *sourceSourceFile = sourceScope->sourceFile;
   if (sourceSourceFile == sourceFile)
     return symbolType;

--- a/src/typechecker/TypeCheckerControlStructures.cpp
+++ b/src/typechecker/TypeCheckerControlStructures.cpp
@@ -76,8 +76,9 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
       throw SemanticError(iteratorNode, INVALID_ITERATOR, "No getIterator() function found for the given iterable type");
 
     iteratorType = QualType(node->getIteratorFct->returnType);
-    // Create anonymous entry for the iterator
-    currentScope->symbolTable.insertAnonymous(iteratorType, iteratorNode);
+    // Add anonymous symbol to keep track of dtor call, if non-trivially destructible
+    if (!iteratorType.isTriviallyDestructible(iteratorNode))
+      currentScope->symbolTable.insertAnonymous(iteratorType, iteratorNode);
   }
 
   // Change to foreach body scope

--- a/src/typechecker/TypeCheckerExpressions.cpp
+++ b/src/typechecker/TypeCheckerExpressions.cpp
@@ -552,8 +552,7 @@ std::any TypeChecker::visitPostfixUnaryExpr(PostfixUnaryExprNode *node) {
 
     // If we only have the generic struct scope, lookup the concrete manifestation scope
     if (structScope->isGenericScope) {
-      Scope *matchScope = structScope->parent;
-      Struct *spiceStruct = StructManager::match(matchScope, structName, lhsBaseTy.getTemplateTypes(), node);
+      const Struct *spiceStruct = lhsBaseTy.getStruct(node);
       assert(spiceStruct != nullptr);
       structScope = spiceStruct->scope;
     }

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -164,10 +164,7 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
     // Check if the struct implements all methods of all attached interfaces
     size_t vtableIndex = 0;
     for (const QualType &interfaceType : manifestation->interfaceTypes) {
-      // Retrieve interface instance
-      const std::string interfaceName = interfaceType.getSubType();
-      Scope *matchScope = interfaceType.getBodyScope()->parent;
-      const Interface *interface = InterfaceManager::match(matchScope, interfaceName, interfaceType.getTemplateTypes(), node);
+      const Interface *interface = interfaceType.getInterface(node);
       assert(interface != nullptr);
 
       // Check for all methods, that it is implemented by the struct

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -146,7 +146,7 @@ void TypeMatcher::substantiateTypeWithTypeMapping(QualType &type, const TypeMapp
     if (!baseType.isSelfReferencingStructType()) {
       Scope *matchScope = baseType.getBodyScope()->parent;
       if (baseType.is(TY_STRUCT)) { // Struct
-        const Struct *spiceStruct = StructManager::match(matchScope, baseType.getSubType(), templateTypes, node);
+        const Struct *spiceStruct = baseType.getStruct(node, templateTypes);
         if (!spiceStruct) {
           assert(node != nullptr);
           const std::string signature = Struct::getSignature(baseType.getSubType(), templateTypes);
@@ -154,7 +154,7 @@ void TypeMatcher::substantiateTypeWithTypeMapping(QualType &type, const TypeMapp
         }
         type = type.getWithBodyScope(spiceStruct->scope);
       } else { // Interface
-        const Interface *spiceInterface = InterfaceManager::match(matchScope, baseType.getSubType(), templateTypes, node);
+        const Interface *spiceInterface = baseType.getInterface(node, templateTypes);
         if (!spiceInterface) {
           assert(node != nullptr);
           const std::string signature = Interface::getSignature(baseType.getSubType(), templateTypes);

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -144,7 +144,6 @@ void TypeMatcher::substantiateTypeWithTypeMapping(QualType &type, const TypeMapp
     // Lookup the scope of the concrete struct or interface type
     // Only do this, if the struct or interface is not self-referencing, because in that case we'd end up in an infinite recursion
     if (!baseType.isSelfReferencingStructType()) {
-      Scope *matchScope = baseType.getBodyScope()->parent;
       if (baseType.is(TY_STRUCT)) { // Struct
         const Struct *spiceStruct = baseType.getStruct(node, templateTypes);
         if (!spiceStruct) {

--- a/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
+++ b/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
@@ -388,15 +388,6 @@
       "name": "fct:main",
       "symbols": [
         {
-          "codeLoc": "L30C24",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "anon.L30C24",
-          "orderIndex": 18446744073709551615,
-          "state": "initialized",
-          "type": "MockIterator<short>"
-        },
-        {
           "codeLoc": "L29C1",
           "isGlobal": false,
           "isVolatile": false,


### PR DESCRIPTION
- Move more logic to helper functions in QualType
- Avoid creating unnecessary anonymous symbols for tracking deallocation of structs
- Simplify logic / reduce redundant work