### PR TITLE
Make sizeof return size in bytes instead of bits

### DIFF
--- a/docs/docs/language/builtins.md
+++ b/docs/docs/language/builtins.md
@@ -44,7 +44,7 @@ printf("Here is a string: %s.\nAnd here is a double: %f", "Demo", 1.123);
 ```
 
 ## The `sizeof` builtin
-Sizeof returns the internal size of a variable, constant or type in bits. To get the size in bytes, simply divide the result by 8.
+Sizeof returns the internal size of a variable, constant or type in bytes. To get the size in bits, simply multiply the result by 8.
 
 ### Signature
 `int sizeof(<any variable>)` or `int sizeof<any type>()`
@@ -53,13 +53,13 @@ Sizeof returns the internal size of a variable, constant or type in bits. To get
 
 ### Usage example
 ```spice
-sizeof(12); // 32
-sizeof<int>() // 32
+sizeof(12); // 4
+sizeof<int>() // 4
 
 int[9] intArray = [];
-sizeof(intArray); // 9 * 32 = 288
+sizeof(intArray); // 9 * 4 = 36
 
-sizeof("Hello World!"); // 64 (Strings are Char pointers internally)
+sizeof("Hello World!"); // 8 (Strings are Char pointers internally)
 ```
 
 ## The `alignof` builtin

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,24 +1,7 @@
-import "std/data/red-black-tree";
-import "std/data/pair";
-
 f<int> main() {
-    RedBlackTree<int, int> tree;
-    {
-        foreach Pair<int&, int&> item : tree {
-            int& first = item.getFirst();
-            int& second = item.getSecond();
-            printf("%d: %d\n", first, second);
-        }
-    }
-
-    tree.insert(1, 2);
-    tree.insert(2, 3);
-    tree.insert(3, 4);
-    tree.insert(4, 5);
-    tree.insert(5, 6);
-    foreach Pair<int&, int&> item : tree {
-        int& first = item.getFirst();
-        int& second = item.getSecond();
-        printf("%d: %d\n", first, second);
-    }
+    int i = cast<int>(1s);
+    int i = (int) 1s;
+    int i = 1s as int;
+    int i as<int>(1s);
+    int i = int(1s);
 }

--- a/src/irgenerator/GenBuiltinFunctions.cpp
+++ b/src/irgenerator/GenBuiltinFunctions.cpp
@@ -80,10 +80,10 @@ std::any IRGenerator::visitSizeofCall(const SizeofCallNode *node) {
     type = node->assignExpr->getEvaluatedSymbolType(manIdx).toLLVMType(sourceFile);
   }
   // Calculate size at compile-time
-  const llvm::TypeSize sizeInBits = module->getDataLayout().getTypeSizeInBits(type);
+  const llvm::TypeSize sizeInBytes = module->getDataLayout().getTypeAllocSize(type);
 
   // Return size value
-  llvm::Value *sizeValue = builder.getInt64(sizeInBits);
+  llvm::Value *sizeValue = builder.getInt64(sizeInBytes);
   return LLVMExprResult{.value = sizeValue};
 }
 
@@ -95,11 +95,11 @@ std::any IRGenerator::visitAlignofCall(const AlignofCallNode *node) {
     type = node->assignExpr->getEvaluatedSymbolType(manIdx).toLLVMType(sourceFile);
   }
   // Calculate size at compile-time
-  const llvm::Align align = module->getDataLayout().getABITypeAlign(type);
+  const llvm::Align alignmentInBytes = module->getDataLayout().getABITypeAlign(type);
 
   // Return align value
-  llvm::Value *sizeValue = builder.getInt64(align.value());
-  return LLVMExprResult{.value = sizeValue};
+  llvm::Value *alignValue = builder.getInt64(alignmentInBytes.value());
+  return LLVMExprResult{.value = alignValue};
 }
 
 std::any IRGenerator::visitLenCall(const LenCallNode *node) {

--- a/std/data/deque.spice
+++ b/std/data/deque.spice
@@ -46,7 +46,7 @@ public p Deque.ctor(unsigned int initAllocItems) {
 
 public p Deque.ctor(unsigned long initAllocItems = INITIAL_ALLOC_COUNT) {
     // Allocate space for the initial number of elements
-    const long itemSize = sizeof<T>() / 8l;
+    const long itemSize = sizeof<T>();
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
         this.contents = (heap T*) allocResult.unwrap();
@@ -248,7 +248,7 @@ public f<bool> operator!=<T>(const Deque<T>& lhs, const Deque<T>& rhs) {
  */
 p Deque.resize(unsigned long itemCount) {
     // Allocate the new memory
-    const unsigned long itemSize = sizeof<T>() / 8l;
+    const unsigned long itemSize = sizeof<T>();
     unsafe {
         // Allocate a new chunk of memory with the requested size
         unsigned long newSize = itemSize * itemCount;

--- a/std/data/queue.spice
+++ b/std/data/queue.spice
@@ -43,7 +43,7 @@ public p Queue.ctor(unsigned int initAllocItems) {
 
 public p Queue.ctor(unsigned long initAllocItems = INITIAL_CAPACITY) {
     // Allocate space for the initial number of elements
-    const long itemSize = sizeof<T>() / 8l;
+    const long itemSize = sizeof<T>();
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
         this.contents = (heap T*) allocResult.unwrap();
@@ -196,7 +196,7 @@ public f<bool> operator!=<T>(const Queue<T>& lhs, const Queue<T>& rhs) {
  */
 p Queue.resize(unsigned long itemCount) {
     // Allocate the new memory
-    const unsigned long itemSize = sizeof<T>() / 8l;
+    const unsigned long itemSize = sizeof<T>();
     unsafe {
         // Allocate a new chunk of memory with the requested size
         heap byte*& oldAddress = (heap byte*) this.contents;

--- a/std/data/stack.spice
+++ b/std/data/stack.spice
@@ -40,7 +40,7 @@ public p Stack.ctor(unsigned int initAllocItems) {
 
 public p Stack.ctor(unsigned long initAllocItems = INITIAL_CAPACITY) {
     // Allocate space for the initial number of elements
-    const unsigned long itemSize = sizeof<T>() / 8l;
+    const unsigned long itemSize = sizeof<T>();
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
         this.contents = (heap T*) allocResult.unwrap();
@@ -144,7 +144,7 @@ public f<bool> operator==<T>(const Stack<T>& lhs, const Stack<T>& rhs) {
     // Compare the sizes
     if lhs.size != rhs.size { return false; }
     // Compare the contents
-    const unsigned long itemSize = sizeof<T>() / 8l;
+    const unsigned long itemSize = sizeof<T>();
     return sCompare(lhs.contents, rhs.contents, itemSize * lhs.size);
 }
 
@@ -157,7 +157,7 @@ public f<bool> operator!=<T>(const Stack<T>& lhs, const Stack<T>& rhs) {
  */
 p Stack.resize(unsigned long itemCount) {
     // Allocate the new memory
-    const unsigned long itemSize = sizeof<T>() / 8l;
+    const unsigned long itemSize = sizeof<T>();
     unsafe {
         heap byte*& oldAddress = (heap byte*) this.contents;
         unsigned long newSize = (unsigned long) (itemSize * itemCount);

--- a/std/data/vector.spice
+++ b/std/data/vector.spice
@@ -30,7 +30,7 @@ public type Vector<T> struct : IIterable<T> {
 
 public p Vector.ctor(unsigned long initialCapacity = INITIAL_CAPACITY) {
     // Allocate space for the initial number of elements
-    const long itemSize = sizeof<T>() / 8l;
+    const long itemSize = sizeof<T>();
     assert itemSize != 0l;
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initialCapacity);
@@ -249,7 +249,7 @@ public f<bool> operator==<T>(const Vector<T>& lhs, const Vector<T>& rhs) {
     // Compare the sizes
     if lhs.size != rhs.size { return false; }
     // Compare the contents
-    const unsigned long itemSize = sizeof<T>() / 8l;
+    const unsigned long itemSize = sizeof<T>();
     return sCompare(lhs.contents, rhs.contents, itemSize * lhs.size);
 }
 
@@ -262,7 +262,7 @@ public f<bool> operator!=<T>(const Vector<T>& lhs, const Vector<T>& rhs) {
  */
 p Vector.resize(unsigned long itemCount) {
     // Allocate the new memory
-    const long itemSize = sizeof<T>() / 8l;
+    const long itemSize = sizeof<T>();
     assert itemSize != 0l;
     unsafe {
         heap byte*& oldAddress = (heap byte*) this.contents;

--- a/std/os/thread-pool.spice
+++ b/std/os/thread-pool.spice
@@ -62,7 +62,6 @@ public p ThreadPool.start() {
         Thread& workerThread = this.workerThreads.back();
         workerThread.run();
     }
-    sizeof(0);
 }
 
 /**

--- a/test/test-files/irgenerator/builtins/success-sizeof/cout.out
+++ b/test/test-files/irgenerator/builtins/success-sizeof/cout.out
@@ -1,11 +1,11 @@
-Size of double: 64
-Size of int: 32
-Size of short: 16
-Size of long: 64
-Size of byte: 8
-Size of char: 8
-Size of string: 64
+Size of double: 8
+Size of int: 4
+Size of short: 2
+Size of long: 8
+Size of byte: 1
+Size of char: 1
+Size of string: 8
 Size of bool: 1
-Size of int[]: 224
-Size of int*: 64
-Size of struct type: 128
+Size of int[7]: 28
+Size of int*: 8
+Size of struct type: 16

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code-O2.ll
@@ -9,23 +9,23 @@ source_filename = "source.spice"
 @printf.str.5 = private unnamed_addr constant [18 x i8] c"Size of char: %d\0A\00", align 1
 @printf.str.6 = private unnamed_addr constant [20 x i8] c"Size of string: %d\0A\00", align 1
 @printf.str.7 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
-@printf.str.8 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
+@printf.str.8 = private unnamed_addr constant [20 x i8] c"Size of int[7]: %d\0A\00", align 1
 @printf.str.9 = private unnamed_addr constant [18 x i8] c"Size of int*: %d\0A\00", align 1
 @printf.str.10 = private unnamed_addr constant [25 x i8] c"Size of struct type: %d\0A\00", align 1
 
 ; Function Attrs: noinline nounwind optnone uwtable
 define dso_local i32 @main() local_unnamed_addr #0 {
-  %1 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i64 64)
-  %2 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.1, i64 32)
-  %3 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.2, i64 16)
-  %4 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.3, i64 64)
-  %5 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.4, i64 8)
-  %6 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.5, i64 8)
-  %7 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.6, i64 64)
+  %1 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i64 8)
+  %2 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.1, i64 4)
+  %3 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.2, i64 2)
+  %4 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.3, i64 8)
+  %5 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.4, i64 1)
+  %6 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.5, i64 1)
+  %7 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.6, i64 8)
   %8 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.7, i64 1)
-  %9 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.8, i64 224)
-  %10 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.9, i64 64)
-  %11 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.10, i64 128)
+  %9 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.8, i64 28)
+  %10 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.9, i64 8)
+  %11 = tail call i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.10, i64 16)
   ret i32 0
 }
 

--- a/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-sizeof/ir-code.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 @printf.str.5 = private unnamed_addr constant [18 x i8] c"Size of char: %d\0A\00", align 1
 @printf.str.6 = private unnamed_addr constant [20 x i8] c"Size of string: %d\0A\00", align 1
 @printf.str.7 = private unnamed_addr constant [18 x i8] c"Size of bool: %d\0A\00", align 1
-@printf.str.8 = private unnamed_addr constant [19 x i8] c"Size of int[]: %d\0A\00", align 1
+@printf.str.8 = private unnamed_addr constant [20 x i8] c"Size of int[7]: %d\0A\00", align 1
 @printf.str.9 = private unnamed_addr constant [18 x i8] c"Size of int*: %d\0A\00", align 1
 @printf.str.10 = private unnamed_addr constant [25 x i8] c"Size of struct type: %d\0A\00", align 1
 
@@ -18,18 +18,18 @@ define dso_local i32 @main() #0 {
   %result = alloca i32, align 4
   %intVariable = alloca i32, align 4
   store i32 0, ptr %result, align 4
-  %1 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 64)
-  %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i64 32)
-  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i64 16)
-  %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i64 64)
-  %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.4, i64 8)
-  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.5, i64 8)
-  %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.6, i64 64)
+  %1 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 8)
+  %2 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i64 4)
+  %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i64 2)
+  %4 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i64 8)
+  %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.4, i64 1)
+  %6 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.5, i64 1)
+  %7 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.6, i64 8)
   %8 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.7, i64 1)
-  %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.8, i64 224)
+  %9 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.8, i64 28)
   store i32 123, ptr %intVariable, align 4
-  %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.9, i64 64)
-  %11 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.10, i64 128)
+  %10 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.9, i64 8)
+  %11 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.10, i64 16)
   %12 = load i32, ptr %result, align 4
   ret i32 %12
 }

--- a/test/test-files/irgenerator/builtins/success-sizeof/source.spice
+++ b/test/test-files/irgenerator/builtins/success-sizeof/source.spice
@@ -13,7 +13,7 @@ f<int> main() {
     printf("Size of char: %d\n", sizeof((char) 65));
     printf("Size of string: %d\n", sizeof("Hello Spice!"));
     printf("Size of bool: %d\n", sizeof(false));
-    printf("Size of int[]: %d\n", sizeof([1, 2, 3, 4, 5, 6, 7]));
+    printf("Size of int[7]: %d\n", sizeof([1, 2, 3, 4, 5, 6, 7]));
     int intVariable = 123;
     printf("Size of int*: %d\n", sizeof(&intVariable));
     printf("Size of struct type: %d\n", sizeof<Struct>());

--- a/test/test-files/irgenerator/generics/success-external-generic-functions/cout.out
+++ b/test/test-files/irgenerator/generics/success-external-generic-functions/cout.out
@@ -1,4 +1,4 @@
-Sizeof output: 64
-Sizeof output: 32
-Sizeof output: 128
-Sizeof output: 64
+Sizeof output: 8
+Sizeof output: 4
+Sizeof output: 16
+Sizeof output: 8

--- a/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
@@ -4,12 +4,12 @@ source_filename = "source.spice"
 %struct.Test = type { i32, i64 }
 %struct.TestPacked = type <{ i32, i64 }>
 
-@anon.string.0 = private unnamed_addr constant [76 x i8] c"Assertion failed: Condition 'sizeof<Test>() == 16 * 8' evaluated to false.\0A\00", align 1
-@anon.string.1 = private unnamed_addr constant [71 x i8] c"Assertion failed: Condition 'sizeof(t) == 16 * 8' evaluated to false.\0A\00", align 1
+@anon.string.0 = private unnamed_addr constant [72 x i8] c"Assertion failed: Condition 'sizeof<Test>() == 16' evaluated to false.\0A\00", align 1
+@anon.string.1 = private unnamed_addr constant [67 x i8] c"Assertion failed: Condition 'sizeof(t) == 16' evaluated to false.\0A\00", align 1
 @anon.string.2 = private unnamed_addr constant [71 x i8] c"Assertion failed: Condition 't.f1 == -2147483647' evaluated to false.\0A\00", align 1
 @anon.string.3 = private unnamed_addr constant [80 x i8] c"Assertion failed: Condition 't.f2 == 9223372036854775807l' evaluated to false.\0A\00", align 1
-@anon.string.4 = private unnamed_addr constant [82 x i8] c"Assertion failed: Condition 'sizeof<TestPacked>() == 12 * 8' evaluated to false.\0A\00", align 1
-@anon.string.5 = private unnamed_addr constant [72 x i8] c"Assertion failed: Condition 'sizeof(tp) == 12 * 8' evaluated to false.\0A\00", align 1
+@anon.string.4 = private unnamed_addr constant [78 x i8] c"Assertion failed: Condition 'sizeof<TestPacked>() == 12' evaluated to false.\0A\00", align 1
+@anon.string.5 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'sizeof(tp) == 12' evaluated to false.\0A\00", align 1
 @anon.string.6 = private unnamed_addr constant [72 x i8] c"Assertion failed: Condition 'tp.f1 == -2147483647' evaluated to false.\0A\00", align 1
 @anon.string.7 = private unnamed_addr constant [81 x i8] c"Assertion failed: Condition 'tp.f2 == 9223372036854775807l' evaluated to false.\0A\00", align 1
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 1

--- a/test/test-files/irgenerator/structs/success-packed-struct/source.spice
+++ b/test/test-files/irgenerator/structs/success-packed-struct/source.spice
@@ -13,8 +13,8 @@ f<int> main() {
     Test t;
     t.f1 = -2147483647;
     t.f2 = 9223372036854775807l;
-    assert sizeof<Test>() == 16 * 8;
-    assert sizeof(t) == 16 * 8;
+    assert sizeof<Test>() == 16;
+    assert sizeof(t) == 16;
     assert t.f1 == -2147483647;
     assert t.f2 == 9223372036854775807l;
 
@@ -22,8 +22,8 @@ f<int> main() {
     tp.f1 = -2147483647;
     tp.f2 = 9223372036854775807l;
 
-    assert sizeof<TestPacked>() == 12 * 8;
-    assert sizeof(tp) == 12 * 8;
+    assert sizeof<TestPacked>() == 12;
+    assert sizeof(tp) == 12;
     assert tp.f1 == -2147483647;
     assert tp.f2 == 9223372036854775807l;
 


### PR DESCRIPTION
Make sizeof return size in bytes instead of bits.
This makes it more consistent with alignof and to the C builtin.
Furthermore, it is much more often required to obtain the size of a type/value in bytes, than in bits. This resulted in many divisions by 8 inside the std lib.