### PR TITLE
Add support for more casts to double

### DIFF
--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -1627,33 +1627,26 @@ LLVMExprResult OpRuleConversionManager::getCastInst(const ASTNode *node, QualTyp
   case COMB(TY_BOOL, TY_BOOL):     // fallthrough
   case COMB(TY_PTR, TY_PTR):
     return rhs; // Identity cast
+  case COMB(TY_DOUBLE, TY_INT):
+  case COMB(TY_DOUBLE, TY_SHORT):
+  case COMB(TY_DOUBLE, TY_LONG):
+    return {.value = rhsSTy.isSigned() ? builder.CreateSIToFP(rhsV(), lhsT) : builder.CreateUIToFP(rhsV(), lhsT)};
   case COMB(TY_INT, TY_DOUBLE):
-    if (lhsSTy.isSigned())
-      return {.value = builder.CreateFPToSI(rhsV(), lhsT)};
-    else
-      return {.value = builder.CreateFPToUI(rhsV(), lhsT)};
+    return {.value = lhsSTy.isSigned() ? builder.CreateFPToSI(rhsV(), lhsT) : builder.CreateFPToUI(rhsV(), lhsT)};
   case COMB(TY_INT, TY_SHORT): // fallthrough
   case COMB(TY_INT, TY_LONG):  // fallthrough
   case COMB(TY_INT, TY_BYTE):  // fallthrough
   case COMB(TY_INT, TY_CHAR):
     return {.value = builder.CreateIntCast(rhsV(), lhsT, lhsSTy.isSigned())};
   case COMB(TY_SHORT, TY_DOUBLE):
-    if (lhsSTy.isSigned())
-      return {.value = builder.CreateFPToSI(rhsV(), lhsT)};
-    else
-      return {.value = builder.CreateFPToUI(rhsV(), lhsT)};
-  case COMB(TY_SHORT, TY_INT):
-    return {.value = builder.CreateIntCast(rhsV(), lhsT, lhsSTy.isSigned())};
+    return {.value = lhsSTy.isSigned() ? builder.CreateFPToSI(rhsV(), lhsT) : builder.CreateFPToUI(rhsV(), lhsT)};
+  case COMB(TY_SHORT, TY_INT): // fallthrough
   case COMB(TY_SHORT, TY_LONG):
     return {.value = builder.CreateIntCast(rhsV(), lhsT, lhsSTy.isSigned())};
   case COMB(TY_LONG, TY_DOUBLE):
-    if (lhsSTy.isSigned())
-      return {.value = builder.CreateFPToSI(rhsV(), lhsT)};
-    else
-      return {.value = builder.CreateFPToUI(rhsV(), lhsT)};
-  case COMB(TY_LONG, TY_INT): // fallthrough
-  case COMB(TY_LONG, TY_SHORT):
-    return {.value = builder.CreateIntCast(rhsV(), lhsT, lhsSTy.isSigned())};
+    return {.value = lhsSTy.isSigned() ? builder.CreateFPToSI(rhsV(), lhsT) : builder.CreateFPToUI(rhsV(), lhsT)};
+  case COMB(TY_LONG, TY_INT):   // fallthrough
+  case COMB(TY_LONG, TY_SHORT): // fallthrough
   case COMB(TY_BYTE, TY_INT):   // fallthrough
   case COMB(TY_BYTE, TY_SHORT): // fallthrough
   case COMB(TY_BYTE, TY_LONG):

--- a/src/typechecker/OpRuleManager.h
+++ b/src/typechecker/OpRuleManager.h
@@ -559,6 +559,9 @@ static constexpr UnaryOpRule POSTFIX_MINUS_MINUS_OP_RULES[] = {
 // Cast op rules
 static constexpr BinaryOpRule CAST_OP_RULES[] = {
     BinaryOpRule(TY_DOUBLE, TY_DOUBLE, TY_DOUBLE, false), // (double) double -> double
+    BinaryOpRule(TY_DOUBLE, TY_INT, TY_DOUBLE, false),    // (double) int -> double
+    BinaryOpRule(TY_DOUBLE, TY_SHORT, TY_DOUBLE, false),  // (double) short -> double
+    BinaryOpRule(TY_DOUBLE, TY_LONG, TY_DOUBLE, false),   // (double) long -> double
     BinaryOpRule(TY_INT, TY_DOUBLE, TY_INT, false),       // (int) double -> int
     BinaryOpRule(TY_INT, TY_INT, TY_INT, false),          // (int) int -> int
     BinaryOpRule(TY_INT, TY_SHORT, TY_INT, false),        // (int) short -> int
@@ -595,8 +598,9 @@ public:
   explicit OpRuleManager(TypeChecker *typeChecker);
 
   // Public methods
-  std::pair<QualType, Function*> getAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool isDecl = false,
-                               bool isReturn = false, const char *errMsgPrefix = "") const;
+  std::pair<QualType, Function *> getAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs,
+                                                      bool isDecl = false, bool isReturn = false,
+                                                      const char *errMsgPrefix = "") const;
   QualType getFieldAssignResultType(const ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, bool imm,
                                     bool isDecl = false) const;
   ExprResult getPlusEqualResultType(ASTNode *node, const ExprResult &lhs, const ExprResult &rhs, size_t opIdx);


### PR DESCRIPTION
Add support for the following new casts:

- `cast<double>(12)`
- `cast<double>(12s)`
- `cast<double>(12l)`