### PR TITLE
Add insert method for String type

### DIFF
--- a/std/runtime/string_rt.spice
+++ b/std/runtime/string_rt.spice
@@ -145,6 +145,45 @@ public p String.append(const char c) {
     }
 }
 
+p String.prepareInsert<IntLong>(unsigned IntLong position, unsigned long strLength) {
+    // Check if the position is out of bounds
+    if position > this.length {
+        panic(Error("Insert index out of bounds"));
+    }
+    // Check if we need to re-allocate memory
+    while this.capacity < this.length + strLength {
+        this.resize(this.capacity * RESIZE_FACTOR);
+    }
+    this.length += strLength;
+    unsafe {
+        // Shift all chars, starting from the back
+        for unsigned long i = this.length; i > position; i-- {
+            this.contents[i] = this.contents[i - strLength];
+        }
+    }
+}
+
+public p String.insert<IntLong>(unsigned IntLong position, string str) {
+    const unsigned long strLength = len(str);
+    this.prepareInsert(position, strLength);
+    unsafe {
+        for unsigned long i = 0l; i < strLength; i++ {
+            this.contents[position + i] = str[i];
+        }
+    }
+}
+
+public p String.insert<IntLong>(unsigned IntLong position, const String& str) {
+    this.insert(position, str.getRaw());
+}
+
+public p String.insert<IntLong>(unsigned IntLong position, char c) {
+    this.prepareInsert(position, 1l);
+    unsafe {
+        this.contents[position] = c;
+    }
+}
+
 /**
  * Concatenates two strings and returns the result
  *

--- a/test/test-files/std/runtime/string-basic-methods-modifying/source.spice
+++ b/test/test-files/std/runtime/string-basic-methods-modifying/source.spice
@@ -39,6 +39,11 @@ f<int> main() {
     assert s.getRaw() == "This was a demo. And because this was a d, it was a demonstration.";
     assert s.replaceAll('t', 'y') == 4;
     assert s.getRaw() == "This was a demo. And because yhis was a d, iy was a demonsyrayion.";
+    String test = String("Test");
+    test.insert(4, '.');
+    test.insert(2, "--");
+    test.insert(4, String("foo"));
+    assert test.getRaw() == "Te--foost.";
 
     printf("All assertions passed!");
 }


### PR DESCRIPTION
Add insert method for String type. It can be used to insert a char/string/String in the middle of an existing String object at a given index.