### PR TITLE
Avoid redundant loads in implicit codegen

### DIFF
--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -396,9 +396,12 @@ void IRGenerator::generateCtorBodyPreamble(Scope *bodyScope) {
     if (fieldType.is(TY_STRUCT)) {
       // Lookup ctor function and call if available
       Scope *matchScope = fieldType.getBodyScope();
-      if (const Function *ctorFunction = FunctionManager::lookup(matchScope, CTOR_FUNCTION_NAME, fieldType, {}, false))
-        generateCtorOrDtorCall(fieldSymbol, ctorFunction, {});
-
+      if (const Function *ctorFunction = FunctionManager::lookup(matchScope, CTOR_FUNCTION_NAME, fieldType, {}, false)) {
+        if (!thisPtr)
+          thisPtr = insertLoad(builder.getPtrTy(), thisPtrPtr);
+        llvm::Value *fieldAddress = insertStructGEP(structType, thisPtr, i);
+        generateCtorOrDtorCall(fieldAddress, ctorFunction, {});
+      }
       continue;
     }
 

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -191,7 +191,10 @@ void Scope::collectWarnings(std::vector<CompilerWarning> &warnings) const { // N
     }
     case ScopeType::STRUCT: // fall-through
     case ScopeType::INTERFACE: {
-      if (entryType.isOneOf({TY_FUNCTION, TY_PROCEDURE})) {
+      if (entry.isField()) {
+        warningType = UNUSED_FIELD;
+        warningMessage = "The field '" + entry.name + "' is unused";
+      } else if (entryType.isOneOf({TY_FUNCTION, TY_PROCEDURE})) {
         // Skip implicit method entries and generic templates
         const std::vector<Function *> *fctManifestations = entry.declNode->getFctManifestations(name);
         if (fctManifestations->empty() || fctManifestations->front()->implicitDefault)
@@ -199,9 +202,6 @@ void Scope::collectWarnings(std::vector<CompilerWarning> &warnings) const { // N
 
         warningType = UNUSED_METHOD;
         warningMessage = "The method '" + fctManifestations->front()->getSignature() + "' is unused";
-      } else {
-        warningType = UNUSED_FIELD;
-        warningMessage = "The field '" + entry.name + "' is unused";
       }
       break;
     }


### PR DESCRIPTION
- Avoid redundant loads in implicit codegen
- Fix assertion error when having unused lambda struct fields