### PR TITLE
Undefine conflicting macros

### DIFF
--- a/src/driver/Driver.h
+++ b/src/driver/Driver.h
@@ -4,6 +4,11 @@
 
 #include "../../lib/cli11/CLI11.hpp"
 
+// Undef conflicting macros (only problematic on Windows)
+#undef TRUE
+#undef FALSE
+#undef CONST
+
 namespace spice::compiler {
 
 const char *const TARGET_UNKNOWN = "unknown";

--- a/test/driver/Driver.h
+++ b/test/driver/Driver.h
@@ -4,6 +4,11 @@
 
 #include "../../lib/cli11/CLI11.hpp"
 
+// Undef conflicting macros (only problematic on Windows)
+#undef TRUE
+#undef FALSE
+#undef CONST
+
 // GCOV_EXCL_START
 namespace spice::testing {
 


### PR DESCRIPTION
This fixes a build issue on Windows/MinGW