### PR TITLE
Strip public qualifier from types in error messages

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,11 +1,15 @@
-import "std/io/dir" as dir;
+import "std/data/queue";
+
+f<Queue<String>> getStringQueue() {
+    Queue<String> queue;
+    queue.push(String("Hello"));
+    queue.push(String("World"));
+    return queue;
+}
 
 f<int> main() {
-    printf("Existing before create: %d\n", dirExists("./test"));
-    dyn mkReturnCode = mkDir("./test", dir::MODE_ALL_RWX);
-    printf("mkDir return code: %d\n", mkReturnCode);
-    printf("Existing after create: %d\n", dirExists("./test"));
-    dyn rmReturnCode = rmDir("./test");
-    printf("rmDir return code: %d\n", rmReturnCode);
-    printf("Existing after delete: %d\n", dirExists("./test"));
+    const Queue<String> args = getStringQueue();
+    foreach unsigned long i, const String& arg : args {
+        printf("Arg %d: %s\n", i, arg);
+    }
 }

--- a/src/global/TypeRegistry.cpp
+++ b/src/global/TypeRegistry.cpp
@@ -86,8 +86,8 @@ size_t TypeRegistry::getTypeCount() { return types.size(); }
 std::string TypeRegistry::dump() {
   std::vector<std::string> typeStrings;
   typeStrings.reserve(types.size());
-  for (const std::unique_ptr<Type>& type : types | std::views::values)
-    typeStrings.push_back(type->getName(false));
+  for (const std::unique_ptr<Type> &type : types | std::views::values)
+    typeStrings.push_back(type->getName(false, true));
   // Sort to ensure deterministic output
   std::ranges::sort(typeStrings);
   // Serialize type registry

--- a/src/irgenerator/NameMangling.cpp
+++ b/src/irgenerator/NameMangling.cpp
@@ -249,8 +249,8 @@ void NameMangling::mangleTypeChainElement(std::stringstream &out, const TypeChai
     out << "E";
     break;
   }
-  default:                                                                                             // GCOV_EXCL_LINE
-    throw CompilerError(INTERNAL_ERROR, "Type " + chainElement.getName(false) + " cannot be mangled"); // GCOV_EXCL_LINE
+  default:                                                                                                   // GCOV_EXCL_LINE
+    throw CompilerError(INTERNAL_ERROR, "Type " + chainElement.getName(false, true) + " cannot be mangled"); // GCOV_EXCL_LINE
   }
 }
 

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -377,13 +377,14 @@ bool QualType::isTriviallyDestructible(const ASTNode *node) const {
       return false;
 
     // Check if all member types are trivially destructible
-    const auto pred = [&](const QualType &fieldType) { return fieldType.isTriviallyDestructible(node); }; // NOLINT(*-no-recursion)
+    const auto pred = [&](const QualType &fieldType) {
+      return fieldType.isTriviallyDestructible(node);
+    }; // NOLINT(*-no-recursion)
     return std::ranges::all_of(spiceStruct->fieldTypes, pred);
   }
 
   return true;
 }
-
 
 /**
  * Check if the current type implements the given interface type
@@ -565,7 +566,7 @@ void QualType::getName(std::stringstream &name, bool withSize, bool ignorePublic
     name << "unsigned ";
 
   // Loop through all chain elements
-  type->getName(name, withSize);
+  type->getName(name, withSize, ignorePublic);
 }
 
 /**

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -273,7 +273,7 @@ llvm::Type *Type::toLLVMType(SourceFile *sourceFile) const { // NOLINT(misc-no-r
     return llvm::StructType::get(context, {ptrTy, ptrTy});
   }
 
-  throw CompilerError(UNHANDLED_BRANCH, "Cannot determine LLVM type of " + getName(true)); // GCOVR_EXCL_LINE
+  throw CompilerError(UNHANDLED_BRANCH, "Cannot determine LLVM type of " + getName(true, true)); // GCOVR_EXCL_LINE
 }
 
 /**
@@ -303,9 +303,7 @@ bool Type::isPrimitive() const { return isOneOf({TY_DOUBLE, TY_INT, TY_SHORT, TY
  *
  * @return Extended primitive or not
  */
-bool Type::isExtendedPrimitive() const {
-  return isPrimitive() || isOneOf({TY_STRUCT, TY_INTERFACE, TY_FUNCTION, TY_PROCEDURE});
-}
+bool Type::isExtendedPrimitive() const { return isPrimitive() || isOneOf({TY_STRUCT, TY_INTERFACE, TY_FUNCTION, TY_PROCEDURE}); }
 
 /**
  * Check if the current type is a pointer type
@@ -486,23 +484,25 @@ bool Type::isOneOf(const std::initializer_list<SuperType> &superTypes) const {
  *
  * @param name Get name of type
  * @param withSize Include the array size for sized types
+ * @param ignorePublic Ignore any potential public qualifier
  * @return Symbol type name
  */
-void Type::getName(std::stringstream &name, bool withSize) const { // NOLINT(misc-no-recursion)
+void Type::getName(std::stringstream &name, bool withSize, bool ignorePublic) const { // NOLINT(misc-no-recursion)
   // Loop through all chain elements
   for (const TypeChainElement &chainElement : typeChain)
-    name << chainElement.getName(withSize);
+    name << chainElement.getName(withSize, ignorePublic);
 }
 
 /**
  * Get the name of the symbol type as a string
  *
  * @param withSize Include the array size for sized types
+ * @param ignorePublic Ignore any potential public qualifier
  * @return Symbol type name
  */
-std::string Type::getName(bool withSize) const {
+std::string Type::getName(bool withSize, bool ignorePublic) const {
   std::stringstream name;
-  getName(name, withSize);
+  getName(name, withSize, ignorePublic);
   return name.str();
 }
 

--- a/src/symboltablebuilder/Type.h
+++ b/src/symboltablebuilder/Type.h
@@ -60,8 +60,8 @@ public:
   [[nodiscard]] bool matches(const Type *otherType, bool ignoreArraySize) const;
 
   // Serialization
-  void getName(std::stringstream &name, bool withSize) const;
-  [[nodiscard]] std::string getName(bool withSize) const;
+  void getName(std::stringstream &name, bool withSize, bool ignorePublic) const;
+  [[nodiscard]] std::string getName(bool withSize, bool ignorePublic) const;
 
   // Get new type, based on this one
   [[nodiscard]] const Type *toPtr(const ASTNode *node) const;

--- a/src/symboltablebuilder/TypeChain.cpp
+++ b/src/symboltablebuilder/TypeChain.cpp
@@ -40,7 +40,7 @@ bool operator==(const TypeChainElement &lhs, const TypeChainElement &rhs) {
 
 bool operator!=(const TypeChainElement &lhs, const TypeChainElement &rhs) { return !(lhs == rhs); }
 
-void TypeChainElement::getName(std::stringstream &name, bool withSize) const {
+void TypeChainElement::getName(std::stringstream &name, bool withSize, bool ignorePublic) const {
   switch (superType) {
   case TY_PTR:
     name << "*";
@@ -83,7 +83,7 @@ void TypeChainElement::getName(std::stringstream &name, bool withSize) const {
       for (size_t i = 0; i < templateTypes.size(); i++) {
         if (i > 0)
           name << ",";
-        templateTypes.at(i).getName(name, withSize);
+        templateTypes.at(i).getName(name, withSize, ignorePublic);
       }
       name << ">";
     }
@@ -102,13 +102,16 @@ void TypeChainElement::getName(std::stringstream &name, bool withSize) const {
     name << "f";
     if (data.hasCaptures)
       name << "[]";
-    if (!paramTypes.empty())
-      name << "<" << paramTypes.front().getName(true) << ">";
+    if (!paramTypes.empty()) {
+      name << "<";
+      paramTypes.front().getName(name, true, ignorePublic);
+      name << ">";
+    }
     name << "(";
     for (size_t i = 1; i < paramTypes.size(); i++) {
       if (i > 1)
         name << ",";
-      paramTypes.at(i).getName(name, true);
+      paramTypes.at(i).getName(name, true, ignorePublic);
     }
     name << ")";
     break;
@@ -121,7 +124,7 @@ void TypeChainElement::getName(std::stringstream &name, bool withSize) const {
     for (size_t i = 1; i < paramTypes.size(); i++) {
       if (i > 1)
         name << ",";
-      paramTypes.at(i).getName(name, true);
+      paramTypes.at(i).getName(name, true, ignorePublic);
     }
     name << ")";
     break;
@@ -141,11 +144,12 @@ void TypeChainElement::getName(std::stringstream &name, bool withSize) const {
  * Return the type name as string
  *
  * @param withSize Also encode array sizes
+ * @param ignorePublic Ignore public qualifier
  * @return Name as string
  */
-std::string TypeChainElement::getName(bool withSize) const {
+std::string TypeChainElement::getName(bool withSize, bool ignorePublic) const {
   std::stringstream name;
-  getName(name, withSize);
+  getName(name, withSize, ignorePublic);
   return name.str();
 }
 

--- a/src/symboltablebuilder/TypeChain.h
+++ b/src/symboltablebuilder/TypeChain.h
@@ -62,8 +62,8 @@ public:
   // Overloaded operators
   friend bool operator==(const TypeChainElement &lhs, const TypeChainElement &rhs);
   friend bool operator!=(const TypeChainElement &lhs, const TypeChainElement &rhs);
-  void getName(std::stringstream &name, bool withSize) const;
-  [[nodiscard]] std::string getName(bool withSize) const;
+  void getName(std::stringstream &name, bool withSize, bool ignorePublic) const;
+  [[nodiscard]] std::string getName(bool withSize, bool ignorePublic) const;
 
   // Public members
   SuperType superType = TY_INVALID;

--- a/src/typechecker/TypeCheckerControlStructures.cpp
+++ b/src/typechecker/TypeCheckerControlStructures.cpp
@@ -88,7 +88,7 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
   if (!iteratorType.isIterator(node)) {
     const std::string errMsg =
         "Can only iterate over arrays or data structures, inheriting from IIterator or IIterable. You provided " +
-        iteratorType.getName(false);
+        iteratorType.getName(false, true);
     softError(node->iteratorAssign, OPERATOR_WRONG_DATA_TYPE, errMsg);
     return nullptr;
   }


### PR DESCRIPTION
Pass information about ignoring the public modifier to nested types to ensure that no public modifier is printed.