### PR TITLE
Properly handle unresolved param type

### DIFF
--- a/src/typechecker/TypeCheckMeta.cpp
+++ b/src/typechecker/TypeCheckMeta.cpp
@@ -16,8 +16,6 @@ std::any TypeChecker::visitParamLst(ParamLstNode *node) {
   for (DeclStmtNode *param : node->params) {
     // Visit param
     const auto paramType = std::any_cast<QualType>(visit(param));
-    if (paramType.is(TY_UNRESOLVED))
-      throw SemanticError(param, UNKNOWN_DATATYPE, "Unknown data type for parameter '" + param->varName + "'");
 
     // Check if the type could be inferred. Dyn without a default value is forbidden
     if (paramType.is(TY_DYN)) {

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsPrepare.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsPrepare.cpp
@@ -117,6 +117,7 @@ std::any TypeChecker::visitFctDefPrepare(FctDefNode *node) {
     auto namedParamList = std::any_cast<NamedParamList>(visit(node->paramLst));
     for (const auto &[name, qualType, isOptional] : namedParamList) {
       paramNames.push_back(name);
+      HANDLE_UNRESOLVED_TYPE_PTR(qualType);
       paramTypes.push_back(qualType);
       paramList.push_back({qualType, isOptional});
       // Check if the type is present in the template for generic types
@@ -256,6 +257,7 @@ std::any TypeChecker::visitProcDefPrepare(ProcDefNode *node) {
     for (const auto &[name, qualType, isOptional] : namedParamList) {
       paramNames.push_back(name);
       paramTypes.push_back(qualType);
+      HANDLE_UNRESOLVED_TYPE_PTR(qualType);
       paramList.push_back({qualType, isOptional});
       // Check if the type is present in the template for generic types
       if (!qualType.isCoveredByGenericTypeList(usedGenericTypes))


### PR DESCRIPTION
Properly handle unresolved param type using a hard error to prevent following misleading error messages