### PR TITLE
Fix array name mangling

### DIFF
--- a/src/irgenerator/NameMangling.cpp
+++ b/src/irgenerator/NameMangling.cpp
@@ -181,9 +181,14 @@ void NameMangling::mangleType(std::stringstream &out, QualType qualType) { // NO
  */
 void NameMangling::mangleTypeChainElement(std::stringstream &out, const TypeChainElement &chainElement, bool signedness) {
   switch (chainElement.superType) {
-  case TY_PTR: // fall-through
-  case TY_ARRAY:
+  case TY_PTR:
     out << "P";
+    break;
+  case TY_ARRAY:
+    if (chainElement.data.arraySize == ARRAY_SIZE_UNKNOWN)
+      out << "P";
+    else
+      out << "A" << chainElement.data.arraySize << "_";
     break;
   case TY_REF:
     out << "R";

--- a/test/test-files/irgenerator/generics/success-external-generic-functions/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-external-generic-functions/ir-code.ll
@@ -15,7 +15,7 @@ define dso_local i32 @main() #0 {
   store i32 0, ptr %result, align 4
   call void @_Z11printFormatIdEvd(double 1.123000e+00)
   call void @_Z11printFormatIiEvi(i32 543)
-  call void @_Z11printFormatIPPKcEvPPKc([2 x ptr] [ptr @anon.string.0, ptr @anon.string.1])
+  call void @_Z11printFormatIA2_PKcEvA2_PKc([2 x ptr] [ptr @anon.string.0, ptr @anon.string.1])
   store i32 1234, ptr %test, align 4
   call void @_Z11printFormatIPiEvPi(ptr %test)
   store i32 12, ptr %i, align 4
@@ -40,7 +40,7 @@ declare void @_Z11printFormatIdEvd(double)
 
 declare void @_Z11printFormatIiEvi(i32)
 
-declare void @_Z11printFormatIPPKcEvPPKc([2 x ptr])
+declare void @_Z11printFormatIA2_PKcEvA2_PKc([2 x ptr])
 
 declare void @_Z11printFormatIPiEvPi(ptr)
 

--- a/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
@@ -24,7 +24,7 @@ define private void @_Z4swapRiRi(ptr %0, ptr %1) {
   ret void
 }
 
-define private void @_Z4sortRPiPFbiiE(ptr %0, { ptr, ptr } %1) {
+define private void @_Z4sortRA10_iPFbiiE(ptr %0, { ptr, ptr } %1) {
   %array = alloca ptr, align 8
   %sortFct = alloca { ptr, ptr }, align 8
   %i = alloca i32, align 4
@@ -112,8 +112,8 @@ define dso_local i32 @main() #0 {
   %1 = getelementptr inbounds nuw { ptr, ptr }, ptr %fat.ptr, i32 0, i32 1
   store ptr poison, ptr %1, align 8
   %2 = load { ptr, ptr }, ptr %fat.ptr, align 8
-  call void @_Z4sortRPiPFbiiE(ptr %array, { ptr, ptr } %2)
-  call void @_Z10printArrayRPi(ptr %array)
+  call void @_Z4sortRA10_iPFbiiE(ptr %array, { ptr, ptr } %2)
+  call void @_Z10printArrayRA10_i(ptr %array)
   %3 = load i32, ptr %result, align 4
   ret i32 %3
 }
@@ -129,7 +129,7 @@ define private i1 @_Z15lambda.L19C17.0ii(i32 %0, i32 %1) {
   ret i1 %5
 }
 
-define private void @_Z10printArrayRPi(ptr %0) {
+define private void @_Z10printArrayRA10_i(ptr %0) {
   %array = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %0, ptr %array, align 8

--- a/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
@@ -8,7 +8,7 @@ source_filename = "source.spice"
 @anon.array.0 = private unnamed_addr constant [4 x i32] [i32 1, i32 2, i32 3, i32 4]
 @printf.str.4 = private unnamed_addr constant [7 x i8] c"1: %d\0A\00", align 1
 
-define private void @_Z8testProcPPPPi(ptr %0) {
+define private void @_Z8testProcPPPA4_i(ptr %0) {
   %nums = alloca ptr, align 8
   %nums1 = alloca ptr, align 8
   %nums2 = alloca [4 x i32], align 4
@@ -53,7 +53,7 @@ define dso_local i32 @main() #1 {
   %3 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.4, i32 %2)
   store ptr %intArray, ptr %intArray1, align 8
   store ptr %intArray1, ptr %intArray2, align 8
-  call void @_Z8testProcPPPPi(ptr %intArray2)
+  call void @_Z8testProcPPPA4_i(ptr %intArray2)
   %4 = load i32, ptr %result, align 4
   ret i32 %4
 }


### PR DESCRIPTION
Arrays were mangled as pointers before, now fixed-size arrays match the C++ mangling scheme