### PR TITLE
Upgrade to CMake 4.x

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -48,20 +48,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build graphviz pipx uuid-dev
 
-      # Temporary necessary until ANTLR supports CMake 4.0.0
-      - name: Downgrade CMake
-        run: |
-          CMAKE_VERSION=3.31.6
-          CMAKE_FOLDER=cmake-$CMAKE_VERSION-linux-x86_64
-          wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/$CMAKE_FOLDER.tar.gz
-          tar -xzvf $CMAKE_FOLDER.tar.gz
-          sudo mv $CMAKE_FOLDER /opt/cmake
-          sudo ln -f -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-          sudo ln -f -s /opt/cmake/bin/ctest /usr/local/bin/ctest
-          sudo ln -f -s /opt/cmake/bin/cpack /usr/local/bin/cpack
-          sudo ln -f -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake || true
-          cmake --version
-
 #      - name: Setup Valgrind
 #        if: github.event_name == 'pull_request'
 #        run: sudo apt-get install valgrind

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,20 +35,6 @@ jobs:
       - name: Setup Dependencies
         run: sudo apt-get install ninja-build graphviz pipx uuid-dev
 
-      # Temporary necessary until ANTLR supports CMake 4.0.0
-      - name: Downgrade CMake
-        run: |
-          CMAKE_VERSION=3.31.6
-          CMAKE_FOLDER=cmake-$CMAKE_VERSION-linux-x86_64
-          wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/$CMAKE_FOLDER.tar.gz
-          tar -xzvf $CMAKE_FOLDER.tar.gz
-          sudo mv $CMAKE_FOLDER /opt/cmake
-          sudo ln -f -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-          sudo ln -f -s /opt/cmake/bin/ctest /usr/local/bin/ctest
-          sudo ln -f -s /opt/cmake/bin/cpack /usr/local/bin/cpack
-          sudo ln -f -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake || true
-          cmake --version
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,20 +38,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build pipx uuid-dev checksec jq
 
-      # Temporary necessary until ANTLR supports CMake 4.0.0
-      - name: Downgrade CMake
-        run: |
-          CMAKE_VERSION=3.31.6
-          CMAKE_FOLDER=cmake-$CMAKE_VERSION-linux-x86_64
-          wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/$CMAKE_FOLDER.tar.gz
-          tar -xzvf $CMAKE_FOLDER.tar.gz
-          sudo mv $CMAKE_FOLDER /opt/cmake
-          sudo ln -f -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-          sudo ln -f -s /opt/cmake/bin/ctest /usr/local/bin/ctest
-          sudo ln -f -s /opt/cmake/bin/cpack /usr/local/bin/cpack
-          sudo ln -f -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake || true
-          cmake --version
-
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
@@ -128,20 +114,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install ninja-build pipx uuid-dev checksec jq
-
-      # Temporary necessary until ANTLR supports CMake 4.0.0
-      - name: Downgrade CMake
-        run: |
-          CMAKE_VERSION=3.31.6
-          CMAKE_FOLDER=cmake-$CMAKE_VERSION-linux-aarch64
-          wget https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/$CMAKE_FOLDER.tar.gz
-          tar -xzvf $CMAKE_FOLDER.tar.gz
-          sudo mv $CMAKE_FOLDER /opt/cmake
-          sudo ln -f -s /opt/cmake/bin/cmake /usr/local/bin/cmake
-          sudo ln -f -s /opt/cmake/bin/ctest /usr/local/bin/ctest
-          sudo ln -f -s /opt/cmake/bin/cpack /usr/local/bin/cpack
-          sudo ln -f -s /opt/cmake/bin/ccmake /usr/local/bin/ccmake || true
-          cmake --version
 
       - name: Cache LLVM
         id: cache-llvm

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(Spice)
 
 # Set constants

--- a/setup-libs.bat
+++ b/setup-libs.bat
@@ -7,7 +7,7 @@ if not exist lib (
 pushd lib
 
 :: Download ANTLR4
-git clone --quiet --depth 1 --branch 4.13.2 https://github.com/antlr/antlr4.git
+git clone --quiet --depth 1 --branch dev https://github.com/spicelang/antlr4.git
 
 :: Download Google Test
 git clone --quiet --depth 1 --branch v1.17.0 https://github.com/google/googletest.git

--- a/setup-libs.sh
+++ b/setup-libs.sh
@@ -6,7 +6,7 @@ fi
 cd lib || exit
 
 # Download ANTLR4
-git clone --quiet --depth 1 --branch 4.13.2 https://github.com/antlr/antlr4.git
+git clone --quiet --depth 1 --branch dev https://github.com/spicelang/antlr4.git
 
 # Download Google Test
 git clone --quiet --depth 1 --branch v1.17.0 https://github.com/google/googletest.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set ANTLR grammar
-antlr_target(Spice ${CMAKE_CURRENT_SOURCE_DIR}/Spice.g4 VISITOR)
+antlr_target(Spice Spice.g4 VISITOR PACKAGE spice::compiler)
 
 set(SOURCES
         # Global source files
@@ -176,8 +176,10 @@ add_executable(spice ${SOURCES} ${ANTLR_Spice_CXX_OUTPUTS})
 target_compile_options(spice PRIVATE -Wpedantic -Wall -Wno-unknown-pragmas)
 
 # Include Antlr components
-include_directories(../lib/antlr4/runtime/Cpp/runtime/src)
-include_directories(${ANTLR_Spice_OUTPUT_DIR})
+include_directories(
+        ${ANTLR_Spice_OUTPUT_DIR}
+        ../lib/antlr4/runtime/Cpp/runtime/src
+)
 
 target_link_libraries(spice antlr4_static ${LLVM_LIBS})
 add_library(spicecore STATIC ${SOURCES} ${ANTLR_Spice_CXX_OUTPUTS})

--- a/src/cmake/FindANTLR.cmake
+++ b/src/cmake/FindANTLR.cmake
@@ -2,7 +2,7 @@ find_package(Java QUIET COMPONENTS Runtime)
 
 if (NOT ANTLR_EXECUTABLE)
     find_program(ANTLR_EXECUTABLE
-            NAMES antlr.jar antlr4.jar antlr-4.jar antlr-4.10-complete.jar)
+            NAMES antlr.jar antlr4.jar antlr-4.jar antlr-4.13.2-complete.jar)
 endif ()
 
 if (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)

--- a/src/cmake/FindANTLR.cmake
+++ b/src/cmake/FindANTLR.cmake
@@ -1,11 +1,11 @@
 find_package(Java QUIET COMPONENTS Runtime)
 
-if (NOT ANTLR_EXECUTABLE)
+if(NOT ANTLR_EXECUTABLE)
     find_program(ANTLR_EXECUTABLE
             NAMES antlr.jar antlr4.jar antlr-4.jar antlr-4.13.2-complete.jar)
-endif ()
+endif()
 
-if (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
+if(ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
     execute_process(
             COMMAND ${Java_JAVA_EXECUTABLE} -jar ${ANTLR_EXECUTABLE}
             OUTPUT_VARIABLE ANTLR_COMMAND_OUTPUT
@@ -13,15 +13,15 @@ if (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
             RESULT_VARIABLE ANTLR_COMMAND_RESULT
             OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-    if (ANTLR_COMMAND_RESULT EQUAL 0)
-        string(REGEX MATCH "Version [0-9]+(\\.[0-9])*" ANTLR_VERSION ${ANTLR_COMMAND_OUTPUT})
+    if(ANTLR_COMMAND_RESULT EQUAL 0)
+        string(REGEX MATCH "Version [0-9]+(\\.[0-9]+)*" ANTLR_VERSION ${ANTLR_COMMAND_OUTPUT})
         string(REPLACE "Version " "" ANTLR_VERSION ${ANTLR_VERSION})
-    else ()
+    else()
         message(
                 SEND_ERROR
                 "Command '${Java_JAVA_EXECUTABLE} -jar ${ANTLR_EXECUTABLE}' "
                 "failed with the output '${ANTLR_COMMAND_ERROR}'")
-    endif ()
+    endif()
 
     macro(ANTLR_TARGET Name InputFile)
         set(ANTLR_OPTIONS LEXER PARSER LISTENER VISITOR)
@@ -37,16 +37,16 @@ if (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
 
         get_filename_component(ANTLR_INPUT ${InputFile} NAME_WE)
 
-        if (ANTLR_TARGET_OUTPUT_DIRECTORY)
+        if(ANTLR_TARGET_OUTPUT_DIRECTORY)
             set(ANTLR_${Name}_OUTPUT_DIR ${ANTLR_TARGET_OUTPUT_DIRECTORY})
-        else ()
+        else()
             set(ANTLR_${Name}_OUTPUT_DIR
                     ${CMAKE_CURRENT_BINARY_DIR}/antlr4cpp_generated_src/${ANTLR_INPUT})
-        endif ()
+        endif()
 
         unset(ANTLR_${Name}_CXX_OUTPUTS)
 
-        if ((ANTLR_TARGET_LEXER AND NOT ANTLR_TARGET_PARSER) OR
+        if((ANTLR_TARGET_LEXER AND NOT ANTLR_TARGET_PARSER) OR
         (ANTLR_TARGET_PARSER AND NOT ANTLR_TARGET_LEXER))
             list(APPEND ANTLR_${Name}_CXX_OUTPUTS
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}.h
@@ -54,7 +54,7 @@ if (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
             set(ANTLR_${Name}_OUTPUTS
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}.interp
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}.tokens)
-        else ()
+        else()
             list(APPEND ANTLR_${Name}_CXX_OUTPUTS
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Lexer.h
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Lexer.cpp
@@ -63,43 +63,43 @@ if (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
             list(APPEND ANTLR_${Name}_OUTPUTS
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Lexer.interp
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Lexer.tokens)
-        endif ()
+        endif()
 
-        if (ANTLR_TARGET_LISTENER)
+        if(ANTLR_TARGET_LISTENER)
             list(APPEND ANTLR_${Name}_CXX_OUTPUTS
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}BaseListener.h
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}BaseListener.cpp
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Listener.h
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Listener.cpp)
             list(APPEND ANTLR_TARGET_COMPILE_FLAGS -listener)
-        endif ()
+        endif()
 
-        if (ANTLR_TARGET_VISITOR)
+        if(ANTLR_TARGET_VISITOR)
             list(APPEND ANTLR_${Name}_CXX_OUTPUTS
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}BaseVisitor.h
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}BaseVisitor.cpp
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Visitor.h
                     ${ANTLR_${Name}_OUTPUT_DIR}/${ANTLR_INPUT}Visitor.cpp)
             list(APPEND ANTLR_TARGET_COMPILE_FLAGS -visitor)
-        endif ()
+        endif()
 
-        if (ANTLR_TARGET_PACKAGE)
+        if(ANTLR_TARGET_PACKAGE)
             list(APPEND ANTLR_TARGET_COMPILE_FLAGS -package ${ANTLR_TARGET_PACKAGE})
-        endif ()
+        endif()
 
         list(APPEND ANTLR_${Name}_OUTPUTS ${ANTLR_${Name}_CXX_OUTPUTS})
 
-        if (ANTLR_TARGET_DEPENDS_ANTLR)
-            if (ANTLR_${ANTLR_TARGET_DEPENDS_ANTLR}_INPUT)
+        if(ANTLR_TARGET_DEPENDS_ANTLR)
+            if(ANTLR_${ANTLR_TARGET_DEPENDS_ANTLR}_INPUT)
                 list(APPEND ANTLR_TARGET_DEPENDS
                         ${ANTLR_${ANTLR_TARGET_DEPENDS_ANTLR}_INPUT})
                 list(APPEND ANTLR_TARGET_DEPENDS
                         ${ANTLR_${ANTLR_TARGET_DEPENDS_ANTLR}_OUTPUTS})
-            else ()
+            else()
                 message(SEND_ERROR
                         "ANTLR target '${ANTLR_TARGET_DEPENDS_ANTLR}' not found")
-            endif ()
-        endif ()
+            endif()
+        endif()
 
         add_custom_command(
                 OUTPUT ${ANTLR_${Name}_OUTPUTS}
@@ -115,7 +115,7 @@ if (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
                 COMMENT "Building ${Name} with ANTLR ${ANTLR_VERSION}")
     endmacro(ANTLR_TARGET)
 
-endif (ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
+endif(ANTLR_EXECUTABLE AND Java_JAVA_EXECUTABLE)
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Set ANTLR grammar
-antlr_target(Spice ${CMAKE_CURRENT_SOURCE_DIR}/../src/Spice.g4 VISITOR)
+antlr_target(Spice ${CMAKE_CURRENT_SOURCE_DIR}/../src/Spice.g4 VISITOR PACKAGE spice::compiler)
 
 set(SOURCES
         main.cpp
@@ -18,8 +18,10 @@ add_executable(spicetest ${SOURCES} ${ANTLR_Spice_CXX_OUTPUTS})
 target_compile_options(spicetest PRIVATE -Wpedantic -Wall)
 
 # Include Antlr components
-include_directories(${ANTLR_Spice_OUTPUT_DIR})
-include_directories(../lib/antlr4/runtime/Cpp/runtime/src)
+include_directories(
+        ${ANTLR_Spice_OUTPUT_DIR}
+        ../lib/antlr4/runtime/Cpp/runtime/src
+)
 
 add_test(NAME spicetest COMMAND spicetest)
 target_link_libraries(spicetest PUBLIC spicecore gtest gmock antlr4_static ${LLVM_LIBS})


### PR DESCRIPTION
- Upgrade to CMake 4.x
- Remove CMake downgrade steps in CI workflows
- Using CMake 4.x requires the use of the latest upstream ANTLR (dev branch)
- Optimizations in the usage of ANTLR