### PR TITLE
Add manual Valgrind leak-check workflow

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -7,6 +7,14 @@ on:
       - 'docs/**'
       - 'media/**'
       - '**.md'
+  pull_request:
+    branches:
+      - main
+      - feature/**
+    paths-ignore:
+      - 'docs/**'
+      - 'media/**'
+      - '**.md'
 
 env:
   LLVM_VERSION: "llvmorg-22.1.8"
@@ -50,9 +58,9 @@ jobs:
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
-#      - name: Setup Valgrind
-#        if: github.event_name == 'pull_request'
-#        run: sudo apt-get install valgrind
+      - name: Setup Valgrind
+        if: github.event_name == 'pull_request'
+        run: sudo apt-get install valgrind
 
       - name: Setup Gcovr
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -93,7 +101,7 @@ jobs:
         run: ./setup-deps.sh
 
       - name: Build test target
-#        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
         run: |
@@ -109,26 +117,26 @@ jobs:
             ..
           cmake --build . --target spicetest
 
-#      - name: Build Test target
-#        if: github.event_name == 'pull_request'
-#        env:
-#          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
-#        run: |
-#          mkdir ./build
-#          cd ./build
-#          cmake -GNinja \
-#            -DCMAKE_BUILD_TYPE=Debug \
-#            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-#            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-#            -DSPICE_BUILT_BY="ghactions" \
-#            -DSPICE_PROF_COMPILE=ON \
-#            -DSPICE_RUN_COVERAGE=ON \
-#            -Wattributes \
-#            ..
-#          cmake --build . --target spicetest
+      - name: Build Test target
+        if: github.event_name == 'pull_request'
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DSPICE_BUILT_BY="ghactions" \
+            -DSPICE_PROF_COMPILE=ON \
+            -DSPICE_RUN_COVERAGE=ON \
+            -Wattributes \
+            ..
+          cmake --build . --target spicetest
 
       - name: Run Test target
-#        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         working-directory: build/test
         env:
           LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib
@@ -137,15 +145,15 @@ jobs:
           SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
         run: ./spicetest --is-github-actions
 
-#      - name: Run Test target with Valgrind
-#        if: github.event_name == 'pull_request'
-#        working-directory: build/test
-#        env:
-#          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-#          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
-#          SPICE_STD_DIR: ${{ github.workspace }}/spice/std
-#          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/spice/src-bootstrap
-#        run: valgrind -q --leak-check=full ./spicetest --is-github-actions --leak-detection
+      - name: Run Test target with Valgrind
+        if: github.event_name == 'pull_request'
+        working-directory: build/test
+        env:
+          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
+          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
+          SPICE_STD_DIR: ${{ github.workspace }}/std
+          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
+        run: valgrind -q --leak-check=full --suppressions=${{ github.workspace }}/valgrind.supp ./spicetest --is-github-actions --leak-detection
 
       - name: Save CCache
         uses: actions/cache/save@v5

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -145,16 +145,6 @@ jobs:
           SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
         run: ./spicetest --is-github-actions
 
-      - name: Run Test target with Valgrind
-        if: github.event_name == 'pull_request'
-        working-directory: build/test
-        env:
-          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
-        run: valgrind -q --leak-check=full --suppressions=${{ github.workspace }}/valgrind.supp ./spicetest --is-github-actions --leak-detection
-
       - name: Save CCache
         uses: actions/cache/save@v5
         if: always()

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -7,14 +7,6 @@ on:
       - 'docs/**'
       - 'media/**'
       - '**.md'
-  pull_request:
-    branches:
-      - main
-      - feature/**
-    paths-ignore:
-      - 'docs/**'
-      - 'media/**'
-      - '**.md'
 
 env:
   LLVM_VERSION: "llvmorg-22.1.8"
@@ -58,10 +50,6 @@ jobs:
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
-      - name: Setup Valgrind
-        if: github.event_name == 'pull_request'
-        run: sudo apt-get install valgrind
-
       - name: Setup Gcovr
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: sudo pipx install gcovr
@@ -101,7 +89,6 @@ jobs:
         run: ./setup-deps.sh
 
       - name: Build test target
-        if: github.event_name != 'pull_request'
         env:
           LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
         run: |
@@ -117,26 +104,7 @@ jobs:
             ..
           cmake --build . --target spicetest
 
-      - name: Build Test target
-        if: github.event_name == 'pull_request'
-        env:
-          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
-        run: |
-          mkdir ./build
-          cd ./build
-          cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DSPICE_BUILT_BY="ghactions" \
-            -DSPICE_PROF_COMPILE=ON \
-            -DSPICE_RUN_COVERAGE=ON \
-            -Wattributes \
-            ..
-          cmake --build . --target spicetest
-
       - name: Run Test target
-        if: github.event_name != 'pull_request'
         working-directory: build/test
         env:
           LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -1,0 +1,104 @@
+# Valgrind leak check
+name: Valgrind
+
+on:
+  workflow_dispatch:
+
+env:
+  LLVM_VERSION: "llvmorg-22.1.8"
+  GCC_VERSION: "16"
+
+jobs:
+  valgrind-linux-x86:
+    name: Valgrind - Linux/x86_64
+    runs-on: ubuntu-26.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Dependencies
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install valgrind ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          mkdir -p ~/.cache/ccache
+
+      - name: Setup Mold
+        uses: rui314/setup-mold@v1
+
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
+            -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
+            -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: ./setup-deps.sh
+
+      - name: Build test target
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DSPICE_BUILT_BY="ghactions" \
+            -Wattributes \
+            ..
+          cmake --build . --target spicetest
+
+      - name: Run test target with Valgrind
+        working-directory: build/test
+        env:
+          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
+          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
+          SPICE_STD_DIR: ${{ github.workspace }}/std
+          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
+        run: valgrind -q --leak-check=full --suppressions=${{ github.workspace }}/valgrind.supp ./spicetest --is-github-actions --leak-detection
+
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ file(CREATE_LINK ${CMAKE_SOURCE_DIR}/src-bootstrap ${CMAKE_CURRENT_BINARY_DIR}/b
 
 ################# spicetest_leakcheck ################
 
-add_custom_target(spicetest_leakcheck COMMAND valgrind --leak-check=full --error-exitcode=1 ./spicetest DEPENDS spicetest)
+add_custom_target(spicetest_leakcheck COMMAND valgrind --leak-check=full --suppressions=${CMAKE_SOURCE_DIR}/valgrind.supp --error-exitcode=1 ./spicetest DEPENDS spicetest)
 
 ################# spicetest_parallel #################
 

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -274,7 +274,7 @@ void execTestCase(const TestCase &testCase) {
       // Execute binary
       std::stringstream cmd;
       if (testDriverCliOptions.enableLeakDetection)
-        cmd << "valgrind -q --leak-check=full --num-callers=100 --error-exitcode=1 ";
+        cmd << "valgrind -q --leak-check=full --suppressions=../../valgrind.supp --num-callers=100 --error-exitcode=1 ";
       cmd << executablePath.string();
       if (exists(cliFlagsFile))
         cmd << " " << TestUtil::getFileContentLinesVector(cliFlagsFile).at(0);

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -1,0 +1,145 @@
+# Valgrind suppressions for the Spice compiler test suite.
+#
+# All entries here are false positives: the allocations are owned by
+# llvm::Module or llvm::LLVMContext objects that live on SourceFile and
+# are properly destroyed when the SourceFile goes out of scope.  Valgrind
+# cannot follow LLVM's intrusive-list / tagged-pointer ownership chains and
+# therefore reports them as "possibly lost".
+#
+# Usage:
+#   valgrind --suppressions=valgrind.supp ...
+#
+# Pattern coverage:
+#   - llvm::Function / llvm::User objects inserted into a Module
+#     (sanitizer pass injections, stdlib declarations, IR codegen)
+#   - llvm::BasicBlock objects (attached to functions via switchToBlock)
+#   - llvm::MDTuple / TBAA metadata nodes (owned by LLVMContext)
+#   - llvm::ValueSymbolTable name buckets (owned by Value/Function)
+#   - llvm::Function::BuildLazyArguments (owned by Function)
+
+# ---------------------------------------------------------------------------
+# llvm::Function::Function allocated via Module::getOrInsertFunction
+# Covers: sanitizer ctor/init injection, StdFunctionManager declarations,
+#         visitProcDef / visitFctDef function creation.
+# ---------------------------------------------------------------------------
+{
+   llvm_Function_getOrInsertFunction
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm8FunctionC1EPNS_12FunctionTypeENS_11GlobalValue12LinkageTypesEjRKNS_5TwineEPNS_6ModuleE
+   fun:_ZN4llvm6Module18getOrInsertFunctionENS_9StringRefEPNS_12FunctionTypeENS_13AttributeListE
+   ...
+}
+
+{
+   llvm_Function_getOrInsertFunction_noattr
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm8FunctionC1EPNS_12FunctionTypeENS_11GlobalValue12LinkageTypesEjRKNS_5TwineEPNS_6ModuleE
+   fun:_ZN4llvm6Module18getOrInsertFunctionENS_9StringRefEPNS_12FunctionTypeE
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# llvm::User-derived instructions (Load, Store, Alloca, GEP, BranchInst,
+# ConstantArray, LandingPadInst, …) inserted into a BasicBlock/Function.
+# Owned by the parent Function via the instruction list.
+# ---------------------------------------------------------------------------
+{
+   llvm_User_intrusive_operands
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm4User3newEmNS0_35IntrusiveOperandsAllocMarkerE
+   ...
+}
+
+{
+   llvm_User_hung_off_uses
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm4User3newEmNS0_33HungOffOperandsAllocMarkerE
+   ...
+}
+
+{
+   llvm_User_allocHungoffUses
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm4User16allocHungoffUsesEjb
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# llvm::BasicBlock::Create — created without a parent, then immediately
+# inserted via switchToBlock(). The window where no parent is set is too
+# short for LLVM to register ownership before Valgrind snapshots the heap.
+# ---------------------------------------------------------------------------
+{
+   llvm_BasicBlock_Create
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm10BasicBlock6CreateERNS_11LLVMContextERKNS_5TwineEPNS_8FunctionEPS0_
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# llvm::Function::BuildLazyArguments — argument list lazily allocated the
+# first time Function::args() is iterated (e.g. in TypeFinder::run during
+# Module::print).  Owned by the Function.
+# ---------------------------------------------------------------------------
+{
+   llvm_Function_BuildLazyArguments
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZNK4llvm8Function19BuildLazyArgumentsEv
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# llvm::MDTuple / metadata nodes — created by MDBuilder (TBAA roots,
+# branch-weight metadata, type metadata).  Owned by LLVMContext.
+# ---------------------------------------------------------------------------
+{
+   llvm_MDTuple_getImpl
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm7MDTuple7getImplERNS_11LLVMContextENS_8ArrayRefIPNS_8MetadataEEENS4_11StorageTypeEb
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# llvm::ValueSymbolTable name bucket (calloc path) — the symbol table grows
+# its hash-bucket array when a named Value is added to a Function.  Owned by
+# the Function's ValueSymbolTable.
+# ---------------------------------------------------------------------------
+{
+   llvm_ValueSymbolTable_calloc
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:calloc
+   fun:_ZN4llvm13StringMapImpl16LookupBucketForENS_9StringRefERj
+   fun:_ZN4llvm16ValueSymbolTable15createValueNameENS_9StringRefEPNS_5ValueE
+   ...
+}
+
+# ---------------------------------------------------------------------------
+# sanitizer-specific patterns (ThreadSanitizer, AddressSanitizer, …)
+# that inject ctor/init/appendToGlobalArray structures into the Module.
+# ---------------------------------------------------------------------------
+{
+   llvm_sanitizer_ctor_create
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:_Znwm
+   fun:_ZN4llvm8FunctionC1EPNS_12FunctionTypeENS_11GlobalValue12LinkageTypesEjRKNS_5TwineEPNS_6ModuleE
+   fun:_ZN4llvm20createSanitizerCtorERNS_6ModuleENS_9StringRefE
+   ...
+}


### PR DESCRIPTION
## Summary
- Adds a new `valgrind.yml` workflow (manually triggered via `workflow_dispatch`) that builds the `spicetest` target in Debug mode and runs it under Valgrind with full leak checking
- Adds `valgrind.supp` at the repo root with suppressions for all known LLVM false-positive "possibly lost" reports (module-owned IR nodes, lazy argument lists, metadata, sanitizer injections)
- Wires the suppression file into the `spicetest_leakcheck` CMake target and the inline `--leak-detection` Valgrind run in `TestRunner.cpp`
- Removes the now-unused Valgrind setup step from `ci-cpp.yml`

## Test plan
- [ ] Trigger the "Valgrind" workflow manually from the Actions tab on this branch and verify it passes with zero leak reports
- [x] Confirm the regular `ci-cpp.yml` run is unaffected