### PR TITLE
Improve env std

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -299,7 +299,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
-          version: v2.12.0
+          version: v2.12.7
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 -ir --sanitizer=thread ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O1 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
       <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />

--- a/src-bootstrap/util/file-util.spice
+++ b/src-bootstrap/util/file-util.spice
@@ -117,9 +117,9 @@ public f<FilePath> getStdDir() {
         result = FilePath("/usr/lib/spice/std/");
         if result.exists() { return; }
     }
-    string value = getEnv("SPICE_STD_DIR");
-    if value != "" {
-        result = FilePath(value);
+    Result<string> value = getEnv("SPICE_STD_DIR");
+    if value.isOk() {
+        result = FilePath(value.unwrap());
         if result.exists() { return; }
     }
     return FilePath();
@@ -132,9 +132,9 @@ public f<FilePath> getStdDir() {
  * @return
  */
 public f<FilePath> getBootstrapCompilerDir() {
-    string value = getEnv("SPICE_BOOTSTRAP_DIR");
-    if value != "" {
-        result = FilePath(value);
+    Result<string> value = getEnv("SPICE_BOOTSTRAP_DIR");
+    if value.isOk() {
+        result = FilePath(value.unwrap());
         if result.exists() { return; }
     }
     return FilePath();
@@ -147,9 +147,8 @@ public f<FilePath> getBootstrapCompilerDir() {
  */
 public f<FilePath> getSpiceBinDir() {
     if isWindows() {
-        string userprofile = getEnv("USERPROFILE");
-        assert userprofile != "";
-        return FilePath(userprofile) / "spice" / "bin";
+        Result<string> userprofile = getEnv("USERPROFILE");
+        return FilePath(userprofile.unwrap()) / "spice" / "bin";
     } else if isLinux() {
         return FilePath("/usr/local/bin");
     } else {

--- a/std/os/env.spice
+++ b/std/os/env.spice
@@ -1,23 +1,25 @@
+// Link external functions
 ext f<string> getenv(string);
 ext f<int> putenv(string);
 
 /**
  * Returns the content of an environment variable as string.
  *
- * @return Env variable content
+ * @return Env variable content or error
  */
-public f<string> getEnv(string name) {
-    return getenv(name);
+public f<Result<string>> getEnv(string name) {
+    string value = getenv(name);
+    return value != nil<string> ? ok(value) : err<string>(Error("Env var not found"));
 }
 
 /**
  * Sets the content of an environment variable to the given value.
  *
- * @return Result code: 0 = successful, -1 = failed
+ * @return Successful or not
  */
-public f<int> setEnv(string name, string value) {
+public f<bool> setEnv(string name, string value) {
     String str = String(name);
     str += "=";
     str += value;
-    return putenv(str.getRaw());
+    return putenv(str.getRaw()) == 0;
 }

--- a/std/os/filesystem_linux.spice
+++ b/std/os/filesystem_linux.spice
@@ -1,6 +1,6 @@
 import "std/os/env";
 
 public f<string> getTempDir() {
-    string dir = getEnv("TMPDIR");
-    return dir != nil<string> ? dir : "/tmp";
+    Result<string> dir = getEnv("TMPDIR");
+    return dir.isOk() ? dir.unwrap() : "/tmp";
 }

--- a/test/test-files/bootstrap-compiler/standalone-lexer-test/source.spice
+++ b/test/test-files/bootstrap-compiler/standalone-lexer-test/source.spice
@@ -3,7 +3,8 @@ import "std/io/filepath";
 import "bootstrap/lexer/lexer";
 
 f<int> main() {
-    String filePathString = getEnv("SPICE_STD_DIR") + "/../test/test-files/bootstrap-compiler/standalone-lexer-test/test-file.spice";
+    Result<string> spiceStdDir = getEnv("SPICE_STD_DIR");
+    String filePathString = spiceStdDir.unwrap() + "/../test/test-files/bootstrap-compiler/standalone-lexer-test/test-file.spice";
     FilePath filePath = FilePath(filePathString);
     Lexer lexer = Lexer(filePath);
     unsigned long tokenCount = 0l;

--- a/test/test-files/bootstrap-compiler/standalone-reader-test/source.spice
+++ b/test/test-files/bootstrap-compiler/standalone-reader-test/source.spice
@@ -3,7 +3,8 @@ import "std/io/filepath";
 import "bootstrap/reader/reader";
 
 f<int> main() {
-    String filePathString = getEnv("SPICE_STD_DIR") + "/../test/test-files/bootstrap-compiler/standalone-reader-test/test-file.spice";
+    Result<string> spiceStdDir = getEnv("SPICE_STD_DIR");
+    String filePathString = spiceStdDir.unwrap() + "/../test/test-files/bootstrap-compiler/standalone-reader-test/test-file.spice";
     FilePath filePath = FilePath(filePathString);
     Reader reader = Reader(filePath);
     assert !reader.isEOF();


### PR DESCRIPTION
- Use `Result<string>` instead of string with nil compare to be consistent with the safe std interface used elsewhere