### PR TITLE
Fix pointer stability bugs

### DIFF
--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -184,7 +184,7 @@ public:
   std::unique_ptr<llvm::Module> llvmModule;
   std::map<std::string, SourceFile *> dependencies; // Has to be an ordered map to keep the compilation order deterministic
   std::vector<const SourceFile *> dependants;
-  std::unordered_map<std::string, NameRegistryEntry> exportedNameRegistry;
+  std::map<std::string, NameRegistryEntry> exportedNameRegistry;
   std::vector<const Function *> testFunctions;
 
 private:

--- a/src/exception/ErrorManager.cpp
+++ b/src/exception/ErrorManager.cpp
@@ -15,10 +15,8 @@ void ErrorManager::addSoftError(const ASTNode *astNode, SemanticErrorType errorT
 
 void ErrorManager::addSoftError(const CodeLoc &codeLoc, const std::string &message) {
   // Avoid duplicate errors
-  for (const auto &[errorLoc, message] : softErrors)
-    if (errorLoc == codeLoc)
-      return;
-  softErrors.emplace_back(SoftError{codeLoc, message});
+  if (std::ranges::none_of(softErrors, [&](const SoftError &err) { return err.codeLoc == codeLoc; }))
+    softErrors.emplace_back(SoftError{codeLoc, message});
 }
 
 } // namespace spice::compiler

--- a/src/global/GlobalResourceManager.h
+++ b/src/global/GlobalResourceManager.h
@@ -49,7 +49,7 @@ public:
   std::unordered_map<std::string, std::unique_ptr<SourceFile>> sourceFiles; // The GlobalResourceManager owns all source files
   const CliOptions &cliOptions;
   ExternalLinkerInterface linker;
-  CacheManager cacheManager;
+  CacheManager  cacheManager;
   RuntimeModuleManager runtimeModuleManager;
   Timer totalTimer;
   ErrorManager errorManager;

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -167,8 +167,8 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
             generateCtorOrDtorCall(valueCopyPtr, copyCtor, {originalPtr});
             llvm::Value *newValue = insertLoad(valueType, valueCopyPtr);
 
-            // Attach address of copy to anonymous symbol (+1 because return value is 0)
-            SymbolTableEntry *anonymousSymbol = currentScope->symbolTable.lookupAnonymous(node->codeLoc, i + 1);
+            // Attach address of copy to anonymous symbol
+            SymbolTableEntry *anonymousSymbol = currentScope->symbolTable.lookupAnonymous(argNode->codeLoc, SIZE_MAX);
             anonymousSymbol->updateAddress(valueCopyPtr);
 
             argValues.push_back(newValue);

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -118,7 +118,7 @@ private:
   FunctionRegistry functions;
   StructRegistry structs;
   InterfaceRegistry interfaces;
-  std::unordered_map<std::string, GenericType> genericTypes;
+  std::map<std::string, GenericType> genericTypes;
 };
 
 } // namespace spice::compiler

--- a/src/symboltablebuilder/SymbolTable.cpp
+++ b/src/symboltablebuilder/SymbolTable.cpp
@@ -57,7 +57,7 @@ SymbolTableEntry *SymbolTable::insertAnonymous(const QualType &qualType, ASTNode
   std::stringstream name;
   name << "anon." << declNode->codeLoc.toString();
   if (numericSuffix > 0)
-    name << "." << std::to_string(numericSuffix);
+    name << '.' << std::to_string(numericSuffix);
   SymbolTableEntry *anonSymbol = insert(name.str(), declNode, true);
   anonSymbol->updateType(qualType, false);
   anonSymbol->updateState(DECLARED, declNode);
@@ -139,18 +139,18 @@ std::pair<SymbolTableEntry *, bool> SymbolTable::lookupWithAliasResolution(const
 /**
  * Check if a symbol exists in the current scope and return it if possible
  *
- * @param name Name of the desired symbol
+ * @param symbolName Name of the desired symbol
  * @return Desired symbol / nullptr if the symbol was not found
  */
-SymbolTableEntry *SymbolTable::lookupStrict(const std::string &name) {
-  if (name.empty())
+SymbolTableEntry *SymbolTable::lookupStrict(const std::string &symbolName) {
+  if (symbolName.empty())
     return nullptr;
   // Check if a symbol with this name exists in this scope
-  if (symbols.contains(name))
-    return &symbols.at(name);
+  if (symbols.contains(symbolName))
+    return &symbols.at(symbolName);
   // Check if a capture with this name exists in this scope
-  if (captures.contains(name))
-    return captures.at(name).capturedSymbol;
+  if (captures.contains(symbolName))
+    return captures.at(symbolName).capturedSymbol;
   // Otherwise, return a nullptr
   return nullptr;
 }
@@ -291,13 +291,13 @@ nlohmann::json SymbolTable::toJSON() const {
   // Collect all symbols
   std::vector<nlohmann::json> jsonSymbols;
   jsonSymbols.reserve(symbols.size());
-  for (const auto &symbol : symbols | std::views::values)
+  for (const SymbolTableEntry &symbol : symbols | std::views::values)
     jsonSymbols.emplace_back(symbol.toJSON());
 
   // Collect all captures
   std::vector<nlohmann::json> jsonCaptures;
   jsonCaptures.reserve(captures.size());
-  for (const auto &capture : captures | std::views::values)
+  for (const Capture &capture : captures | std::views::values)
     jsonCaptures.emplace_back(capture.toJSON());
 
   // Generate json

--- a/src/symboltablebuilder/SymbolTable.h
+++ b/src/symboltablebuilder/SymbolTable.h
@@ -19,8 +19,8 @@ class Scope;
 class Type;
 struct CodeLoc;
 
-using CaptureMap = std::unordered_map<std::string /*name*/, Capture /*capture*/>;
-using SymbolMap = std::unordered_map<std::string /*name*/, SymbolTableEntry /*entry*/>;
+using CaptureMap = std::map<std::string /*name*/, Capture /*capture*/>;
+using SymbolMap = std::map<std::string /*name*/, SymbolTableEntry /*entry*/>;
 
 /**
  * Class for storing information about symbols of the program.

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -23,7 +23,7 @@ class GenericType;
 class TypeChecker;
 
 // Typedefs
-using FunctionManifestationList = std::unordered_map</*mangledName=*/std::string, Function>;
+using FunctionManifestationList = std::map</*mangledName=*/std::string, Function>;
 using FunctionRegistry = std::map</*fctId=*/std::string, /*manifestationList=*/FunctionManifestationList>;
 using Arg = std::pair</*type=*/QualType, /*isTemporary=*/bool>;
 using ArgList = std::vector<Arg>;
@@ -45,9 +45,8 @@ public:
   [[nodiscard]] static Function createMainFunction(SymbolTableEntry *entry, const QualTypeList &paramTypes, ASTNode *declNode);
   [[nodiscard]] static const Function *lookup(Scope *matchScope, const std::string &reqName, const QualType &reqThisType,
                                               const ArgList &reqArgs, bool strictQualifierMatching);
-  static Function *match(const TypeChecker *typeChecker, Scope *matchScope, const std::string &reqName, const QualType &reqThisType,
-                         const ArgList &reqArgs, const QualTypeList &templateTypeHints, bool strictQualifierMatching,
-                         const ASTNode *callNode);
+  static Function *match(Scope *matchScope, const std::string &reqName, const QualType &reqThisType, const ArgList &reqArgs,
+                         const QualTypeList &templateTypeHints, bool strictQualifierMatching, const ASTNode *callNode);
   static void cleanup();
   [[nodiscard]] static std::string dumpLookupCacheStatistics();
 

--- a/src/typechecker/InterfaceManager.h
+++ b/src/typechecker/InterfaceManager.h
@@ -17,7 +17,7 @@ class Interface;
 class Scope;
 
 // Typedefs
-using InterfaceManifestationList = std::unordered_map</*mangledName=*/std::string, Interface>;
+using InterfaceManifestationList = std::map</*mangledName=*/std::string, Interface>;
 using InterfaceRegistry = std::map<CodeLoc, InterfaceManifestationList>;
 
 class InterfaceManager {

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -697,7 +697,7 @@ ExprResult OpRuleManager::isOperatorOverloadingFctAvailable(ASTNode *node, const
     args[0] = {typeChecker->mapLocalTypeToImportedScopeType(calleeParentScope, op[0].type), op[0].isTemporary()};
     if constexpr (N == 2)
       args[1] = {typeChecker->mapLocalTypeToImportedScopeType(calleeParentScope, op[1].type), op[1].isTemporary()};
-    callee = FunctionManager::match(typeChecker, calleeParentScope, fctName, thisType, args, {}, false, node);
+    callee = FunctionManager::match(calleeParentScope, fctName, thisType, args, {}, false, node);
     if (callee)
       break;
   }

--- a/src/typechecker/StructManager.h
+++ b/src/typechecker/StructManager.h
@@ -20,7 +20,7 @@ class ASTNode;
 class GenericType;
 
 // Typedefs
-using StructManifestationList = std::unordered_map</*mangledName=*/std::string, Struct>;
+using StructManifestationList = std::map</*mangledName=*/std::string, Struct>;
 using StructRegistry = std::map</*structId=*/std::string, /*manifestationList=*/StructManifestationList>;
 
 class StructManager {

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -76,7 +76,7 @@ Function *TypeChecker::matchCopyCtor(const QualType &thisType, const ASTNode *no
   Scope *matchScope = thisType.getBodyScope();
   assert(matchScope != nullptr);
   const ArgList args = {{thisType.toConstRef(node), false}};
-  return FunctionManager::match(this, matchScope, CTOR_FUNCTION_NAME, thisType, args, {}, true, node);
+  return FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType, args, {}, true, node);
 }
 
 QualType TypeChecker::mapLocalTypeToImportedScopeType(const Scope *targetScope, const QualType &symbolType) const {

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -137,9 +137,9 @@ private:
   bool typeCheckedMainFct = false;
 
   // Private methods
-  bool visitOrdinaryFctCall(FctCallNode *node, std::string fqFunctionName);
+  bool visitOrdinaryFctCall(FctCallNode *node, std::string fqFunctionName) const;
   bool visitFctPtrCall(const FctCallNode *node, const QualType &functionType) const;
-  bool visitMethodCall(FctCallNode *node, Scope *structScope);
+  bool visitMethodCall(FctCallNode *node, Scope *structScope) const;
   bool checkAsyncLambdaCaptureRules(const LambdaBaseNode *node, const LambdaAttrNode *attrs) const;
   [[nodiscard]] Function *matchCopyCtor(const QualType &thisType, const ASTNode *node) const;
   [[nodiscard]] QualType mapLocalTypeToImportedScopeType(const Scope *targetScope, const QualType &symbolType) const;
@@ -153,20 +153,20 @@ private:
   // Implicit code generation
   void createDefaultStructMethod(const Struct &spiceStruct, const std::string &entryName, const std::string &name,
                                  const ParamList &params) const;
-  void createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
-  void createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
-  void createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope);
-  void createCtorBodyPreamble(const Scope *bodyScope);
-  void createCopyCtorBodyPreamble(const Scope *bodyScope);
-  void createDtorBodyPreamble(const Scope *bodyScope);
+  void createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
+  void createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
+  void createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
+  void createCtorBodyPreamble(const Scope *bodyScope) const;
+  void createCopyCtorBodyPreamble(const Scope *bodyScope) const;
+  void createDtorBodyPreamble(const Scope *bodyScope) const;
   Function *implicitlyCallStructMethod(const SymbolTableEntry *entry, const std::string &methodName, const ArgList &args,
                                        const ASTNode *node);
   Function *implicitlyCallStructMethod(QualType thisType, const std::string &methodName, const ArgList &args,
-                                       const ASTNode *node);
-  Function *implicitlyCallStructCopyCtor(const SymbolTableEntry *entry, const ASTNode *node);
-  Function *implicitlyCallStructCopyCtor(const QualType &thisType, const ASTNode *node);
+                                       const ASTNode *node) const;
+  Function *implicitlyCallStructCopyCtor(const SymbolTableEntry *entry, const ASTNode *node) const;
+  Function *implicitlyCallStructCopyCtor(const QualType &thisType, const ASTNode *node) const;
   void implicitlyCallStructDtor(SymbolTableEntry *entry, StmtLstNode *node);
-  void implicitlyCallDeallocate(const ASTNode *node);
+  void implicitlyCallDeallocate(const ASTNode *node) const;
   void doScopeCleanup(StmtLstNode *node);
 };
 

--- a/src/typechecker/TypeCheckerControlStructures.cpp
+++ b/src/typechecker/TypeCheckerControlStructures.cpp
@@ -67,10 +67,10 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
       unsignedLongType.makeUnsigned(true);
       const ArgList argTypes = {Arg(iterableType, false), Arg(unsignedLongType, false)};
       const QualType thisType(TY_DYN);
-      node->getIteratorFct = FunctionManager::match(this, matchScope, "iterate", thisType, argTypes, {}, true, iteratorNode);
+      node->getIteratorFct = FunctionManager::match(matchScope, "iterate", thisType, argTypes, {}, true, iteratorNode);
     } else { // Struct, implementing Iterator interface
       Scope *matchScope = iterableType.getBodyScope();
-      node->getIteratorFct = FunctionManager::match(this, matchScope, "getIterator", iterableType, {}, {}, true, iteratorNode);
+      node->getIteratorFct = FunctionManager::match(matchScope, "getIterator", iterableType, {}, {}, true, iteratorNode);
     }
     if (node->getIteratorFct == nullptr)
       throw SemanticError(iteratorNode, INVALID_ITERATOR, "No getIterator() function found for the given iterable type");
@@ -112,17 +112,17 @@ std::any TypeChecker::visitForeachLoop(ForeachLoopNode *node) {
   Scope *matchScope = iteratorType.getBodyScope();
   QualType iteratorItemType;
   if (hasIdx) {
-    node->getIdxFct = FunctionManager::match(this, matchScope, "getIdx", iteratorType, {}, {}, false, node);
+    node->getIdxFct = FunctionManager::match(matchScope, "getIdx", iteratorType, {}, {}, false, node);
     assert(node->getIdxFct != nullptr);
     iteratorItemType = node->getIdxFct->returnType.getTemplateTypes().back();
   } else {
-    node->getFct = FunctionManager::match(this, matchScope, "get", iteratorType, {}, {}, false, node);
+    node->getFct = FunctionManager::match(matchScope, "get", iteratorType, {}, {}, false, node);
     assert(node->getFct != nullptr);
     iteratorItemType = node->getFct->returnType;
   }
-  node->isValidFct = FunctionManager::match(this, matchScope, "isValid", iteratorType, {}, {}, false, node);
+  node->isValidFct = FunctionManager::match(matchScope, "isValid", iteratorType, {}, {}, false, node);
   assert(node->isValidFct != nullptr);
-  node->nextFct = FunctionManager::match(this, matchScope, "next", iteratorType, {}, {}, false, node);
+  node->nextFct = FunctionManager::match(matchScope, "next", iteratorType, {}, {}, false, node);
   assert(node->nextFct != nullptr);
 
   // Retrieve item variable entry

--- a/src/typechecker/TypeCheckerStatements.cpp
+++ b/src/typechecker/TypeCheckerStatements.cpp
@@ -84,7 +84,7 @@ std::any TypeChecker::visitDeclStmt(DeclStmtNode *node) {
       // Check if we have a no-args ctor to call
       const std::string &structName = localVarType.getSubType();
       const QualType &thisType = localVarType;
-      node->calledInitCtor = FunctionManager::match(this, matchScope, CTOR_FUNCTION_NAME, thisType, {}, {}, false, node);
+      node->calledInitCtor = FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType, {}, {}, false, node);
       if (!node->calledInitCtor && node->isCtorCallRequired)
         SOFT_ERROR_QT(node, MISSING_NO_ARGS_CTOR, "Struct '" + structName + "' misses a no-args constructor")
     }

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -143,7 +143,7 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
   manIdx = 0; // Reset the manifestation index
 
   // Get all manifestations for this procedure definition
-  for (Struct *manifestation : node->structManifestations) {
+  for (const Struct *manifestation : node->structManifestations) {
     // Skip non-substantiated or already checked procedures
     if (!manifestation->isFullySubstantiated()) {
       manIdx++; // Increase the manifestation index
@@ -185,7 +185,7 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
           args.emplace_back(param, nullptr);
 
         // Search for method that has the required signature
-        Function *spiceFunction = FunctionManager::match(this, currentScope, methodName, structType, args, {}, true, node);
+        Function *spiceFunction = FunctionManager::match(currentScope, methodName, structType, args, {}, true, node);
         if (spiceFunction == nullptr) {
           softError(node, INTERFACE_METHOD_NOT_IMPLEMENTED,
                     "The struct '" + node->structName + "' does not implement method '" + expMethod->getSignature() +
@@ -196,6 +196,9 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
         // Check return type
         if (spiceFunction->returnType != returnType &&
             !returnType.matchesInterfaceImplementedByStruct(spiceFunction->returnType)) {
+          std::cout << "Expected: " << returnType.getName() << std::endl;
+          std::cout << "Actual: " << spiceFunction->returnType.getName() << std::endl;
+          std::cout << "Signature: " << spiceFunction->getSignature(true, true) << std::endl;
           softError(node, INTERFACE_METHOD_NOT_IMPLEMENTED,
                     "The struct '" + node->structName + "' does not implement method '" + expMethod->getSignature() +
                         "'. The return type does not match.");

--- a/test/test-files/benchmark/success-ackermann/symbol-table.json
+++ b/test/test-files/benchmark/success-ackermann/symbol-table.json
@@ -20,20 +20,20 @@
       "name": "f<int> ack(int,int)",
       "symbols": [
         {
-          "codeLoc": "L1C19",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "n",
-          "orderIndex": 2,
-          "state": "initialized",
-          "type": "int"
-        },
-        {
           "codeLoc": "L1C12",
           "isGlobal": false,
           "isVolatile": false,
           "name": "m",
           "orderIndex": 1,
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "codeLoc": "L1C19",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "n",
+          "orderIndex": 2,
           "state": "initialized",
           "type": "int"
         },
@@ -54,20 +54,20 @@
       "name": "fct:main",
       "symbols": [
         {
-          "codeLoc": "L9C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "baseN",
-          "orderIndex": 2,
-          "state": "initialized",
-          "type": "int"
-        },
-        {
           "codeLoc": "L8C5",
           "isGlobal": false,
           "isVolatile": false,
           "name": "baseM",
           "orderIndex": 1,
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "codeLoc": "L9C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "baseN",
+          "orderIndex": 2,
           "state": "initialized",
           "type": "int"
         },
@@ -85,15 +85,6 @@
   ],
   "symbols": [
     {
-      "codeLoc": "L7C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "main",
-      "orderIndex": 1,
-      "state": "declared",
-      "type": "f<int>()"
-    },
-    {
       "codeLoc": "L1C1",
       "isGlobal": true,
       "isVolatile": false,
@@ -101,6 +92,15 @@
       "orderIndex": 0,
       "state": "declared",
       "type": "f<int>(int,int)"
+    },
+    {
+      "codeLoc": "L7C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "main",
+      "orderIndex": 1,
+      "state": "declared",
+      "type": "f<int>()"
     }
   ]
 }

--- a/test/test-files/benchmark/success-faculty/symbol-table.json
+++ b/test/test-files/benchmark/success-faculty/symbol-table.json
@@ -39,20 +39,20 @@
       "name": "fct:main",
       "symbols": [
         {
-          "codeLoc": "L9C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "input",
-          "orderIndex": 1,
-          "state": "initialized",
-          "type": "int"
-        },
-        {
           "codeLoc": "L10C5",
           "isGlobal": false,
           "isVolatile": false,
           "name": "faculty",
           "orderIndex": 2,
+          "state": "initialized",
+          "type": "int"
+        },
+        {
+          "codeLoc": "L9C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "input",
+          "orderIndex": 1,
           "state": "initialized",
           "type": "int"
         },
@@ -70,15 +70,6 @@
   ],
   "symbols": [
     {
-      "codeLoc": "L8C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "main",
-      "orderIndex": 1,
-      "state": "declared",
-      "type": "f<int>()"
-    },
-    {
       "codeLoc": "L1C1",
       "isGlobal": true,
       "isVolatile": false,
@@ -86,6 +77,15 @@
       "orderIndex": 0,
       "state": "declared",
       "type": "f<int>(int)"
+    },
+    {
+      "codeLoc": "L8C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "main",
+      "orderIndex": 1,
+      "state": "declared",
+      "type": "f<int>()"
     }
   ]
 }

--- a/test/test-files/benchmark/success-fibonacci-threaded/symbol-table.json
+++ b/test/test-files/benchmark/success-fibonacci-threaded/symbol-table.json
@@ -42,15 +42,6 @@
           "name": "for:L20C5",
           "symbols": [
             {
-              "codeLoc": "L21C9",
-              "isGlobal": false,
-              "isVolatile": false,
-              "name": "thread",
-              "orderIndex": 1,
-              "state": "initialized",
-              "type": "public Thread&"
-            },
-            {
               "codeLoc": "L20C9",
               "isGlobal": false,
               "isVolatile": false,
@@ -58,6 +49,15 @@
               "orderIndex": 0,
               "state": "initialized",
               "type": "unsigned int"
+            },
+            {
+              "codeLoc": "L21C9",
+              "isGlobal": false,
+              "isVolatile": false,
+              "name": "thread",
+              "orderIndex": 1,
+              "state": "initialized",
+              "type": "public Thread&"
             }
           ]
         },
@@ -84,15 +84,6 @@
           "name": "for:L11C5",
           "symbols": [
             {
-              "codeLoc": "L16C9",
-              "isGlobal": false,
-              "isVolatile": false,
-              "name": "thread",
-              "orderIndex": 1,
-              "state": "initialized",
-              "type": "public Thread&"
-            },
-            {
               "codeLoc": "L11C9",
               "isGlobal": false,
               "isVolatile": false,
@@ -100,6 +91,15 @@
               "orderIndex": 0,
               "state": "initialized",
               "type": "unsigned int"
+            },
+            {
+              "codeLoc": "L16C9",
+              "isGlobal": false,
+              "isVolatile": false,
+              "name": "thread",
+              "orderIndex": 1,
+              "state": "initialized",
+              "type": "public Thread&"
             }
           ]
         }
@@ -107,13 +107,13 @@
       "name": "fct:main",
       "symbols": [
         {
-          "codeLoc": "L10C5",
+          "codeLoc": "L8C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "threads",
-          "orderIndex": 2,
-          "state": "initialized",
-          "type": "public Thread[8]"
+          "name": "result",
+          "orderIndex": 0,
+          "state": "declared",
+          "type": "int"
         },
         {
           "codeLoc": "L9C5",
@@ -125,27 +125,18 @@
           "type": "int"
         },
         {
-          "codeLoc": "L8C1",
+          "codeLoc": "L10C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "result",
-          "orderIndex": 0,
-          "state": "declared",
-          "type": "int"
+          "name": "threads",
+          "orderIndex": 2,
+          "state": "initialized",
+          "type": "public Thread[8]"
         }
       ]
     }
   ],
   "symbols": [
-    {
-      "codeLoc": "L8C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "main",
-      "orderIndex": 2,
-      "state": "declared",
-      "type": "f<int>()"
-    },
     {
       "codeLoc": "L3C1",
       "isGlobal": true,
@@ -154,6 +145,15 @@
       "orderIndex": 1,
       "state": "declared",
       "type": "f<int>(int)"
+    },
+    {
+      "codeLoc": "L8C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "main",
+      "orderIndex": 2,
+      "state": "declared",
+      "type": "f<int>()"
     },
     {
       "codeLoc": "L1C1",

--- a/test/test-files/benchmark/success-fibonacci/symbol-table.json
+++ b/test/test-files/benchmark/success-fibonacci/symbol-table.json
@@ -52,15 +52,6 @@
   ],
   "symbols": [
     {
-      "codeLoc": "L6C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "main",
-      "orderIndex": 1,
-      "state": "declared",
-      "type": "f<int>()"
-    },
-    {
       "codeLoc": "L1C1",
       "isGlobal": true,
       "isVolatile": false,
@@ -68,6 +59,15 @@
       "orderIndex": 0,
       "state": "declared",
       "type": "f<int>(int)"
+    },
+    {
+      "codeLoc": "L6C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "main",
+      "orderIndex": 1,
+      "state": "declared",
+      "type": "f<int>()"
     }
   ]
 }

--- a/test/test-files/benchmark/success-pidigits/symbol-table.json
+++ b/test/test-files/benchmark/success-pidigits/symbol-table.json
@@ -44,31 +44,13 @@
       "name": "fct:main",
       "symbols": [
         {
-          "codeLoc": "L13C5",
+          "codeLoc": "L16C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "m",
-          "orderIndex": 9,
+          "name": "iterations",
+          "orderIndex": 11,
           "state": "initialized",
-          "type": "long"
-        },
-        {
-          "codeLoc": "L14C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "x",
-          "orderIndex": 10,
-          "state": "initialized",
-          "type": "long"
-        },
-        {
-          "codeLoc": "L10C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "t_new",
-          "orderIndex": 6,
-          "state": "initialized",
-          "type": "long"
+          "type": "int"
         },
         {
           "codeLoc": "L11C5",
@@ -80,38 +62,20 @@
           "type": "long"
         },
         {
-          "codeLoc": "L9C5",
+          "codeLoc": "L12C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "t",
-          "orderIndex": 5,
+          "name": "k_new",
+          "orderIndex": 8,
           "state": "initialized",
           "type": "long"
         },
         {
-          "codeLoc": "L8C5",
+          "codeLoc": "L13C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "r_new",
-          "orderIndex": 4,
-          "state": "initialized",
-          "type": "long"
-        },
-        {
-          "codeLoc": "L16C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "iterations",
-          "orderIndex": 11,
-          "state": "initialized",
-          "type": "int"
-        },
-        {
-          "codeLoc": "L7C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "r",
-          "orderIndex": 3,
+          "name": "m",
+          "orderIndex": 9,
           "state": "initialized",
           "type": "long"
         },
@@ -125,11 +89,11 @@
           "type": "int"
         },
         {
-          "codeLoc": "L12C5",
+          "codeLoc": "L5C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "k_new",
-          "orderIndex": 8,
+          "name": "q",
+          "orderIndex": 1,
           "state": "initialized",
           "type": "long"
         },
@@ -143,11 +107,20 @@
           "type": "long"
         },
         {
-          "codeLoc": "L5C5",
+          "codeLoc": "L7C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "q",
-          "orderIndex": 1,
+          "name": "r",
+          "orderIndex": 3,
+          "state": "initialized",
+          "type": "long"
+        },
+        {
+          "codeLoc": "L8C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "r_new",
+          "orderIndex": 4,
           "state": "initialized",
           "type": "long"
         },
@@ -159,6 +132,33 @@
           "orderIndex": 0,
           "state": "declared",
           "type": "int"
+        },
+        {
+          "codeLoc": "L9C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "t",
+          "orderIndex": 5,
+          "state": "initialized",
+          "type": "long"
+        },
+        {
+          "codeLoc": "L10C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "t_new",
+          "orderIndex": 6,
+          "state": "initialized",
+          "type": "long"
+        },
+        {
+          "codeLoc": "L14C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "x",
+          "orderIndex": 10,
+          "state": "initialized",
+          "type": "long"
         }
       ]
     }

--- a/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
@@ -10,16 +10,16 @@ define dso_local i32 @main() #0 {
   %result = alloca i32, align 4
   %i = alloca i32, align 4
   %j = alloca i32, align 4
-  %captures = alloca { i32, ptr }, align 8
+  %captures = alloca { ptr, i32 }, align 8
   %fat.ptr = alloca { ptr, ptr }, align 8
   %lambda = alloca { ptr, ptr }, align 8
   store i32 0, ptr %result, align 4
   store i32 123, ptr %i, align 4
   store i32 321, ptr %j, align 4
+  store ptr %i, ptr %captures, align 8
   %1 = load i32, ptr %j, align 4
-  store i32 %1, ptr %captures, align 4
-  %2 = getelementptr inbounds nuw { i32, ptr }, ptr %captures, i32 0, i32 1
-  store ptr %i, ptr %2, align 8
+  %2 = getelementptr inbounds nuw { ptr, i32 }, ptr %captures, i32 0, i32 1
+  store i32 %1, ptr %2, align 4
   store ptr @_Z14lambda.L4C18.0v, ptr %fat.ptr, align 8
   %3 = getelementptr inbounds nuw { ptr, ptr }, ptr %fat.ptr, i32 0, i32 1
   store ptr %captures, ptr %3, align 8
@@ -39,20 +39,20 @@ define private void @_Z14lambda.L4C18.0v(ptr noundef nonnull dereferenceable(8) 
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = load ptr, ptr %captures, align 8
-  %i.addr = getelementptr inbounds nuw { i32, ptr }, ptr %2, i32 0, i32 1
-  %3 = load ptr, ptr %i.addr, align 8
+  %j = getelementptr inbounds nuw { ptr, i32 }, ptr %2, i32 0, i32 1
+  %3 = load ptr, ptr %2, align 8
   %4 = load i32, ptr %3, align 4
   %5 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 %4)
-  %6 = load ptr, ptr %i.addr, align 8
+  %6 = load ptr, ptr %2, align 8
   %7 = load i32, ptr %6, align 4
   %8 = add nsw i32 %7, 1
   store i32 %8, ptr %6, align 4
-  %9 = load i32, ptr %2, align 4
-  %10 = load ptr, ptr %i.addr, align 8
+  %9 = load i32, ptr %j, align 4
+  %10 = load ptr, ptr %2, align 8
   %11 = load i32, ptr %10, align 4
   %12 = add nsw i32 %11, %9
   store i32 %12, ptr %10, align 4
-  %13 = load ptr, ptr %i.addr, align 8
+  %13 = load ptr, ptr %2, align 8
   %14 = load i32, ptr %13, align 4
   %15 = call i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 %14)
   ret void

--- a/test/test-files/irgenerator/lambdas/success-different-capture-modes/symbol-table.json
+++ b/test/test-files/irgenerator/lambdas/success-different-capture-modes/symbol-table.json
@@ -7,14 +7,14 @@
         {
           "captures": [
             {
-              "accessType": "READ_ONLY",
-              "mode": "BY_VALUE",
-              "name": "j"
-            },
-            {
               "accessType": "READ_WRITE",
               "mode": "BY_REFERENCE",
               "name": "i"
+            },
+            {
+              "accessType": "READ_ONLY",
+              "mode": "BY_VALUE",
+              "name": "j"
             }
           ],
           "children": [],
@@ -25,13 +25,13 @@
       "name": "fct:main",
       "symbols": [
         {
-          "codeLoc": "L4C5",
+          "codeLoc": "L2C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "lambda",
-          "orderIndex": 3,
+          "name": "i",
+          "orderIndex": 1,
           "state": "initialized",
-          "type": "p[]()"
+          "type": "int"
         },
         {
           "codeLoc": "L3C5",
@@ -43,13 +43,13 @@
           "type": "int"
         },
         {
-          "codeLoc": "L2C5",
+          "codeLoc": "L4C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "i",
-          "orderIndex": 1,
+          "name": "lambda",
+          "orderIndex": 3,
           "state": "initialized",
-          "type": "int"
+          "type": "p[]()"
         },
         {
           "codeLoc": "L1C1",

--- a/test/test-files/typechecker/aliases/success-complex-alias/symbol-table.json
+++ b/test/test-files/typechecker/aliases/success-complex-alias/symbol-table.json
@@ -90,31 +90,13 @@
       "name": "struct:TestStruct<long>",
       "symbols": [
         {
-          "codeLoc": "L8C1",
+          "codeLoc": "L4C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "ctor:L8C1",
-          "orderIndex": 2,
+          "name": "_f1",
+          "orderIndex": 0,
           "state": "declared",
-          "type": "p(unsigned long)"
-        },
-        {
-          "codeLoc": "L12C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "printLength:L12C1",
-          "orderIndex": 3,
-          "state": "declared",
-          "type": "p()"
-        },
-        {
-          "codeLoc": "L12C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "printLength:L12C1",
-          "orderIndex": 3,
-          "state": "declared",
-          "type": "p()"
+          "type": "long"
         },
         {
           "codeLoc": "L8C1",
@@ -135,13 +117,31 @@
           "type": "unsigned long"
         },
         {
-          "codeLoc": "L4C5",
+          "codeLoc": "L8C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "_f1",
-          "orderIndex": 0,
+          "name": "ctor:L8C1",
+          "orderIndex": 2,
           "state": "declared",
-          "type": "long"
+          "type": "p(unsigned long)"
+        },
+        {
+          "codeLoc": "L12C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "printLength:L12C1",
+          "orderIndex": 3,
+          "state": "declared",
+          "type": "p()"
+        },
+        {
+          "codeLoc": "L12C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "printLength:L12C1",
+          "orderIndex": 3,
+          "state": "declared",
+          "type": "p()"
         }
       ]
     },
@@ -151,20 +151,20 @@
       "name": "fct:main",
       "symbols": [
         {
-          "codeLoc": "L21C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "b",
-          "orderIndex": 2,
-          "state": "initialized",
-          "type": "TestStruct<long>"
-        },
-        {
           "codeLoc": "L19C5",
           "isGlobal": false,
           "isVolatile": false,
           "name": "a",
           "orderIndex": 1,
+          "state": "initialized",
+          "type": "TestStruct<long>"
+        },
+        {
+          "codeLoc": "L21C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "b",
+          "orderIndex": 2,
           "state": "initialized",
           "type": "TestStruct<long>"
         },
@@ -227,13 +227,13 @@
       "name": "struct:TestStruct",
       "symbols": [
         {
-          "codeLoc": "L12C1",
+          "codeLoc": "L4C5",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "printLength:L12C1",
-          "orderIndex": 3,
+          "name": "_f1",
+          "orderIndex": 0,
           "state": "declared",
-          "type": "p()"
+          "type": "T"
         },
         {
           "codeLoc": "L8C1",
@@ -254,18 +254,54 @@
           "type": "unsigned long"
         },
         {
-          "codeLoc": "L4C5",
+          "codeLoc": "L12C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "_f1",
-          "orderIndex": 0,
+          "name": "printLength:L12C1",
+          "orderIndex": 3,
           "state": "declared",
-          "type": "T"
+          "type": "p()"
         }
       ]
     }
   ],
   "symbols": [
+    {
+      "codeLoc": "L16C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "Alias",
+      "orderIndex": 2,
+      "state": "declared",
+      "type": "Alias"
+    },
+    {
+      "codeLoc": "L16C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "Alias.container",
+      "orderIndex": 3,
+      "state": "declared",
+      "type": "TestStruct<long>"
+    },
+    {
+      "codeLoc": "L1C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "T",
+      "orderIndex": 0,
+      "state": "declared",
+      "type": "invalid"
+    },
+    {
+      "codeLoc": "L3C1",
+      "isGlobal": true,
+      "isVolatile": false,
+      "name": "TestStruct",
+      "orderIndex": 1,
+      "state": "declared",
+      "type": "TestStruct<long>"
+    },
     {
       "codeLoc": "L3C1",
       "isGlobal": true,
@@ -283,42 +319,6 @@
       "orderIndex": 4,
       "state": "declared",
       "type": "f<int>()"
-    },
-    {
-      "codeLoc": "L16C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "Alias.container",
-      "orderIndex": 3,
-      "state": "declared",
-      "type": "TestStruct<long>"
-    },
-    {
-      "codeLoc": "L16C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "Alias",
-      "orderIndex": 2,
-      "state": "declared",
-      "type": "Alias"
-    },
-    {
-      "codeLoc": "L3C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "TestStruct",
-      "orderIndex": 1,
-      "state": "declared",
-      "type": "TestStruct<long>"
-    },
-    {
-      "codeLoc": "L1C1",
-      "isGlobal": true,
-      "isVolatile": false,
-      "name": "T",
-      "orderIndex": 0,
-      "state": "declared",
-      "type": "invalid"
     }
   ]
 }

--- a/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
+++ b/test/test-files/typechecker/foreach-loops/success-foreach-item-type-inference/symbol-table.json
@@ -238,31 +238,13 @@
       "name": "struct:MockIterator<short>",
       "symbols": [
         {
-          "codeLoc": "L19C1",
+          "codeLoc": "L11C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "getIdx:L19C1",
-          "orderIndex": 5,
+          "name": "ctor:L11C1",
+          "orderIndex": 3,
           "state": "declared",
-          "type": "f<public Pair<unsigned long,T&>>()"
-        },
-        {
-          "codeLoc": "L23C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "isValid:L23C1",
-          "orderIndex": 6,
-          "state": "declared",
-          "type": "f<bool>()"
-        },
-        {
-          "codeLoc": "L6C31",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "this.IIterator",
-          "orderIndex": 0,
-          "state": "declared",
-          "type": "public IIterator<short>"
+          "type": "p()"
         },
         {
           "codeLoc": "L8C5",
@@ -274,6 +256,24 @@
           "type": "unsigned long"
         },
         {
+          "codeLoc": "L6C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "default_copyctor:L6C1",
+          "orderIndex": 8,
+          "state": "declared",
+          "type": "public p()"
+        },
+        {
+          "codeLoc": "L19C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "getIdx:L19C1",
+          "orderIndex": 5,
+          "state": "declared",
+          "type": "f<public Pair<unsigned long,T&>>()"
+        },
+        {
           "codeLoc": "L23C1",
           "isGlobal": false,
           "isVolatile": false,
@@ -281,6 +281,15 @@
           "orderIndex": 6,
           "state": "declared",
           "type": "f<bool>()"
+        },
+        {
+          "codeLoc": "L15C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "get:L15C1",
+          "orderIndex": 4,
+          "state": "declared",
+          "type": "f<T&>()"
         },
         {
           "codeLoc": "L15C1",
@@ -301,40 +310,13 @@
           "type": "f<public Pair<unsigned long,T&>>()"
         },
         {
-          "codeLoc": "L6C1",
+          "codeLoc": "L23C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "default_copyctor:L6C1",
-          "orderIndex": 8,
+          "name": "isValid:L23C1",
+          "orderIndex": 6,
           "state": "declared",
-          "type": "public p()"
-        },
-        {
-          "codeLoc": "L11C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "ctor:L11C1",
-          "orderIndex": 3,
-          "state": "declared",
-          "type": "p()"
-        },
-        {
-          "codeLoc": "L27C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "next:L27C1",
-          "orderIndex": 7,
-          "state": "declared",
-          "type": "p()"
-        },
-        {
-          "codeLoc": "L11C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "ctor:L11C1",
-          "orderIndex": 3,
-          "state": "declared",
-          "type": "p()"
+          "type": "f<bool>()"
         },
         {
           "codeLoc": "L7C5",
@@ -346,13 +328,22 @@
           "type": "short"
         },
         {
-          "codeLoc": "L15C1",
+          "codeLoc": "L27C1",
           "isGlobal": false,
           "isVolatile": false,
-          "name": "get:L15C1",
-          "orderIndex": 4,
+          "name": "next:L27C1",
+          "orderIndex": 7,
           "state": "declared",
-          "type": "f<T&>()"
+          "type": "p()"
+        },
+        {
+          "codeLoc": "L11C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "ctor:L11C1",
+          "orderIndex": 3,
+          "state": "declared",
+          "type": "p()"
         },
         {
           "codeLoc": "L27C1",
@@ -362,6 +353,15 @@
           "orderIndex": 7,
           "state": "declared",
           "type": "p()"
+        },
+        {
+          "codeLoc": "L6C31",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "this.IIterator",
+          "orderIndex": 0,
+          "state": "declared",
+          "type": "public IIterator<short>"
         }
       ]
     },
@@ -528,6 +528,24 @@
       "name": "struct:MockIterator",
       "symbols": [
         {
+          "codeLoc": "L11C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "ctor:L11C1",
+          "orderIndex": 3,
+          "state": "declared",
+          "type": "p()"
+        },
+        {
+          "codeLoc": "L8C5",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "cursor",
+          "orderIndex": 2,
+          "state": "declared",
+          "type": "unsigned long"
+        },
+        {
           "codeLoc": "L6C1",
           "isGlobal": false,
           "isVolatile": false,
@@ -535,15 +553,6 @@
           "orderIndex": 8,
           "state": "declared",
           "type": "public p()"
-        },
-        {
-          "codeLoc": "L27C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "next:L27C1",
-          "orderIndex": 7,
-          "state": "declared",
-          "type": "p()"
         },
         {
           "codeLoc": "L15C1",
@@ -564,15 +573,6 @@
           "type": "f<public Pair<unsigned long,T&>>()"
         },
         {
-          "codeLoc": "L8C5",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "cursor",
-          "orderIndex": 2,
-          "state": "declared",
-          "type": "unsigned long"
-        },
-        {
           "codeLoc": "L23C1",
           "isGlobal": false,
           "isVolatile": false,
@@ -582,15 +582,6 @@
           "type": "f<bool>()"
         },
         {
-          "codeLoc": "L11C1",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "ctor:L11C1",
-          "orderIndex": 3,
-          "state": "declared",
-          "type": "p()"
-        },
-        {
           "codeLoc": "L7C5",
           "isGlobal": false,
           "isVolatile": false,
@@ -598,6 +589,15 @@
           "orderIndex": 1,
           "state": "declared",
           "type": "T"
+        },
+        {
+          "codeLoc": "L27C1",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "next:L27C1",
+          "orderIndex": 7,
+          "state": "declared",
+          "type": "p()"
         },
         {
           "codeLoc": "L6C31",
@@ -619,16 +619,16 @@
       "name": "MockIterator",
       "orderIndex": 3,
       "state": "declared",
-      "type": "MockIterator<short>"
+      "type": "MockIterator<T>"
     },
     {
-      "codeLoc": "L29C1",
+      "codeLoc": "L6C1",
       "isGlobal": true,
       "isVolatile": false,
-      "name": "main",
-      "orderIndex": 4,
+      "name": "MockIterator",
+      "orderIndex": 3,
       "state": "declared",
-      "type": "f<int>()"
+      "type": "MockIterator<short>"
     },
     {
       "codeLoc": "L4C1",
@@ -640,13 +640,13 @@
       "type": "invalid"
     },
     {
-      "codeLoc": "L6C1",
+      "codeLoc": "L29C1",
       "isGlobal": true,
       "isVolatile": false,
-      "name": "MockIterator",
-      "orderIndex": 3,
+      "name": "main",
+      "orderIndex": 4,
       "state": "declared",
-      "type": "MockIterator<T>"
+      "type": "f<int>()"
     },
     {
       "codeLoc": "L2C1",

--- a/test/test-files/typechecker/functions/success-function-overloading1/symbol-table.json
+++ b/test/test-files/typechecker/functions/success-function-overloading1/symbol-table.json
@@ -7,15 +7,6 @@
       "name": "f<double> calledFunction(int)",
       "symbols": [
         {
-          "codeLoc": "L1C44",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "optionalArg",
-          "orderIndex": 2,
-          "state": "initialized",
-          "type": "bool"
-        },
-        {
           "codeLoc": "L1C26",
           "isGlobal": false,
           "isVolatile": false,
@@ -23,6 +14,15 @@
           "orderIndex": 1,
           "state": "initialized",
           "type": "int"
+        },
+        {
+          "codeLoc": "L1C44",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "optionalArg",
+          "orderIndex": 2,
+          "state": "initialized",
+          "type": "bool"
         },
         {
           "codeLoc": "L1C1",
@@ -41,15 +41,6 @@
       "name": "f<double> calledFunction(int,bool)",
       "symbols": [
         {
-          "codeLoc": "L1C44",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "optionalArg",
-          "orderIndex": 2,
-          "state": "initialized",
-          "type": "bool"
-        },
-        {
           "codeLoc": "L1C26",
           "isGlobal": false,
           "isVolatile": false,
@@ -57,6 +48,15 @@
           "orderIndex": 1,
           "state": "initialized",
           "type": "int"
+        },
+        {
+          "codeLoc": "L1C44",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "optionalArg",
+          "orderIndex": 2,
+          "state": "initialized",
+          "type": "bool"
         },
         {
           "codeLoc": "L1C1",
@@ -75,15 +75,6 @@
       "name": "f<double> calledFunction(string)",
       "symbols": [
         {
-          "codeLoc": "L7C26",
-          "isGlobal": false,
-          "isVolatile": false,
-          "name": "testString",
-          "orderIndex": 1,
-          "state": "initialized",
-          "type": "string"
-        },
-        {
           "codeLoc": "L7C1",
           "isGlobal": false,
           "isVolatile": false,
@@ -91,6 +82,15 @@
           "orderIndex": 0,
           "state": "declared",
           "type": "double"
+        },
+        {
+          "codeLoc": "L7C26",
+          "isGlobal": false,
+          "isVolatile": false,
+          "name": "testString",
+          "orderIndex": 1,
+          "state": "initialized",
+          "type": "string"
         }
       ]
     },
@@ -122,13 +122,13 @@
   ],
   "symbols": [
     {
-      "codeLoc": "L12C1",
+      "codeLoc": "L1C1",
       "isGlobal": true,
       "isVolatile": false,
-      "name": "main",
-      "orderIndex": 2,
+      "name": "calledFunction:L1C1",
+      "orderIndex": 0,
       "state": "declared",
-      "type": "f<int>()"
+      "type": "f<double>(int,bool)"
     },
     {
       "codeLoc": "L7C1",
@@ -140,13 +140,13 @@
       "type": "f<double>(string)"
     },
     {
-      "codeLoc": "L1C1",
+      "codeLoc": "L12C1",
       "isGlobal": true,
       "isVolatile": false,
-      "name": "calledFunction:L1C1",
-      "orderIndex": 0,
+      "name": "main",
+      "orderIndex": 2,
       "state": "declared",
-      "type": "f<double>(int,bool)"
+      "type": "f<int>()"
     }
   ]
 }


### PR DESCRIPTION
- Use ` std::map` instead of `std::unordered_map` to fix pointer instability problems. This affects function, symbol, capture order, etc.
- Improve argument copy anonymous symbol naming, by using arg node instead of call node with suffix