### PR TITLE
Disable threadpool test on Windows

### DIFF
--- a/test/test-files/std/os/thread-pool/skip-windows
+++ b/test/test-files/std/os/thread-pool/skip-windows
@@ -1,0 +1,1 @@
+Test behaves flakey on Windows


### PR DESCRIPTION
Disable threadpool test on Windows due to flakiness