### PR TITLE
Minimize cache size of CI runs

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -57,19 +57,22 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: sudo pipx install gcovr
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/llvm
+          path: ${{ github.workspace }}/llvm/build
           key: llvm-21.1.5-linux-x64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
-          git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;X86" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
           cmake --build .
 
@@ -169,6 +172,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install ninja-build graphviz uuid-dev
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
@@ -176,12 +182,12 @@ jobs:
           path: ${{ github.workspace }}/llvm
           key: llvm-21.1.5-linux-aarch64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
-          git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;X86" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
           cmake --build .
 
@@ -230,22 +236,25 @@ jobs:
       - name: Setup CCache
         uses: hendrikmuhs/ccache-action@v1
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/llvm
+          path: ${{ github.workspace }}/llvm/build
           key: llvm-21.1.5-win-x64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
-          git clone --depth 1 --branch llvmorg-21.1.5  https://github.com/llvm/llvm-project.git llvm
           setx /M PATH "%PATH%;C:\mingw64\bin"
           $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
           echo "Adding MinGW to path done."
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;X86" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
           cmake --build .
 
@@ -310,19 +319,22 @@ jobs:
           brew update
           brew install graphviz
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/llvm
+          path: ${{ github.workspace }}/llvm/build
           key: llvm-21.1.5-macos-aarch64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
-          git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;X86" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
           cmake --build .
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,21 +41,23 @@ jobs:
         with:
           languages: cpp
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/llvm
+          path: ${{ github.workspace }}/llvm/build
           key: llvm-21.1.5-linux-x64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
           echo "/usr/lib/ccache:/usr/local/opt/ccache/libexec" >> $GITHUB_PATH
-          cd ..
-          git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;X86" -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
           cmake --build .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,21 +37,24 @@ jobs:
       - name: Setup Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build pipx uuid-dev checksec jq
+          sudo apt-get install ninja-build uuid-dev checksec jq
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
 
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/llvm
+          path: ${{ github.workspace }}/llvm/build
           key: llvm-21.1.5-linux-x64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
-          git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project.git llvm
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" -DLLVM_ENABLE_RTTI=ON -Wno-dev -Wattributes ../llvm
           cmake --build .
 
@@ -60,7 +63,7 @@ jobs:
           chmod +x setup-libs.sh
           ./setup-libs.sh
 
-      - name: Configure & compile project
+      - name: Build compiler
         env:
           LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
         run: |
@@ -115,21 +118,24 @@ jobs:
       - name: Setup Dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install ninja-build pipx uuid-dev checksec jq
+          sudo apt-get install ninja-build uuid-dev checksec jq
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
 
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/llvm
+          path: ${{ github.workspace }}/llvm/build
           key: llvm-21.1.5-linux-aarch64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
-          git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project.git llvm
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" -DLLVM_ENABLE_RTTI=ON -Wno-dev -Wattributes ../llvm
           cmake --build .
 
@@ -138,7 +144,7 @@ jobs:
           chmod +x setup-libs.sh
           ./setup-libs.sh
 
-      - name: Configure & compile project
+      - name: Build compiler
         env:
           LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
         run: |
@@ -196,29 +202,32 @@ jobs:
       - name: Setup CCache
         uses: hendrikmuhs/ccache-action@v1
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/llvm
+          path: ${{ github.workspace }}/llvm/build
           key: llvm-21.1.5-win-x64
 
-      - name: Setup LLVM
+      - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
         run: |
-          git clone --depth 1 --branch llvmorg-21.1.5  https://github.com/llvm/llvm-project.git llvm
           setx /M PATH "%PATH%;C:\mingw64\mingw64\bin"
           $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
           echo "Adding MinGW to path done."
-          mkdir ./llvm/build
-          cd ./llvm/build
+          mkdir ./build
+          cd ./build
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" -DLLVM_ENABLE_RTTI=ON -GNinja -Wno-dev -Wattributes ../llvm
           cmake --build .
 
       - name: Download Libs
         run: .\setup-libs.bat
 
-      - name: Configure & compile project
+      - name: Build compiler
         env:
           LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
         run: |
@@ -240,9 +249,80 @@ jobs:
           name: spice-windows-static-x64
           path: ./build/spice**
 
+  build-compiler-macos-aarch64:
+    name: Build compiler - MacOS/AArch64
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 21
+          java-package: jre
+
+      - name: Setup Mold
+        uses: rui314/setup-mold@v1
+
+      - name: Setup CCache
+        uses: hendrikmuhs/ccache-action@v1
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch llvmorg-21.1.5 https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-21.1.5-macos-aarch64
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" -DLLVM_ENABLE_RTTI=ON -Wno-dev -Wattributes ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: |
+          chmod +x setup-libs.sh
+          ./setup-libs.sh
+
+      - name: Build compiler
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++ -DSPICE_ALL_TARGETS=ON -DSPICE_LINK_STATIC=ON -DSPICE_LTO=ON -DSPICE_VERSION="${{ github.ref_name }}" -DSPICE_BUILT_BY="ghactions" ..
+          cmake --build . --target spice
+
+      - name: Process build output
+        working-directory: build
+        run: |
+          mv ./src/spice spice
+          chmod +x spice
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: spice-macos-arm64
+          path: ./build/spice**
+
   build-artifacts:
     name: Build artifacts
-    needs: [ build-compiler-linux-x86, build-compiler-linux-aarch64, build-compiler-windows-x86 ]
+    needs: [
+      build-compiler-linux-x86,
+      build-compiler-linux-aarch64,
+      build-compiler-windows-x86,
+      build-compiler-macos-aarch64
+    ]
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: enabled

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -72,6 +72,8 @@ nfpms:
       - build-essential
       - clang
       - lld
+    suggests:
+      - mold
     contents:
       - src: std
         dst: /usr/lib/spice/std


### PR DESCRIPTION
- Only cache the LLVM build directory and not the entire llvm subdirectory
- Add macOS release step in the publish workflow