### PR TITLE
Cleanup std

### DIFF
--- a/src-bootstrap/lexer/lexer.spice
+++ b/src-bootstrap/lexer/lexer.spice
@@ -35,7 +35,7 @@ public f<const Token&> Lexer.getToken() {
 
 public p Lexer.advance() {
     // Skip any whitespaces
-    while (isWhitespace(this.reader.getChar()) && !this.reader.isEOF()) {
+    while isWhitespace(this.reader.getChar()) && !this.reader.isEOF() {
         this.reader.advance();
     }
 
@@ -44,7 +44,7 @@ public p Lexer.advance() {
 }
 
 public p Lexer.expect(TokenType expectedType) {
-    if (this.curTok.tokenType != expectedType) {
+    if this.curTok.tokenType != expectedType {
         panic(Error("The type of the current token does not match the expected type"));
     }
     this.advance();
@@ -52,7 +52,7 @@ public p Lexer.expect(TokenType expectedType) {
 
 public p Lexer.expectOneOf(Vector<TokenType> expectedTypes) {
     foreach TokenType expectedType : expectedTypes.getIterator() {
-        if (this.curTok.tokenType == expectedType) {
+        if this.curTok.tokenType == expectedType {
             return;
         }
     }

--- a/src-bootstrap/symboltablebuilder/lifecycle.spice
+++ b/src-bootstrap/symboltablebuilder/lifecycle.spice
@@ -47,7 +47,7 @@ public p Lifecycle.addEvent(const LifecycleEvent& event) {
  * @return Current state
  */
 public f<LifecycleState> Lifecycle.getCurrentState() {
-    if (this.events.isEmpty()) { return LifecycleState::DEAD; }
+    if this.events.isEmpty() { return LifecycleState::DEAD; }
     return this.events.back().state;
 }
 
@@ -57,7 +57,7 @@ public f<LifecycleState> Lifecycle.getCurrentState() {
  * @return Current state name
  */
 public f<string> Lifecycle.getCurrentStateName() {
-    switch (this.getCurrentState()) {
+    switch this.getCurrentState() {
         case LifecycleState::DECLARED: { return "declared"; }
         case LifecycleState::INITIALIZED: { return "initialized"; }
         default: { return "dead"; }

--- a/std/bindings/llvm/llvm.spice
+++ b/std/bindings/llvm/llvm.spice
@@ -1190,8 +1190,8 @@ public p PassBuilder.clearPasses() {
 
 public p PassBuilder.buildCustomPipeline() {
     this.pipelineDescription.clear();
-    for (unsigned int i = 0; i < this.passes.getSize(); i++) {
-        if (i > 0) { this.pipelineDescription += ','; }
+    for unsigned int i = 0; i < this.passes.getSize(); i++ {
+        if i > 0 { this.pipelineDescription += ','; }
         this.pipelineDescription += this.passes.get(i);
     }
 }

--- a/std/io/dir.spice
+++ b/std/io/dir.spice
@@ -152,7 +152,7 @@ public f<bool> dirExists(string path) {
     DirStream* dirStream = opendir(path);
 
     // Return empty array if stream result is nil
-    if (dirStream == nil<DirStream*>) { return; }
+    if dirStream == nil<DirStream*> { return; }
 
     dyn dirEntry = &DirEntry{};
     while (dirEntry = readdir(dirStream)) != nil<DirEntry*> {

--- a/std/math/fct.spice
+++ b/std/math/fct.spice
@@ -136,7 +136,7 @@ public f<double> sin<Numeric>(Numeric x) {
     double res = 0.0;
     double term = 0.0 + xRad;
     double k = 1.0;
-    while (res + term != res) {
+    while res + term != res {
         res += term;
         k += 2.0;
         term *= -xRad * xRad / k / (k - 1);
@@ -159,7 +159,7 @@ public f<double> cos<Numeric>(Numeric x) {
     double res = 0.0;
     double term = 1.0;
     double k = 0.0;
-    while (res + term != res) {
+    while res + term != res {
         res += term;
         k += 2.0;
         term *= -xRad * xRad / k / (k - 1);
@@ -175,7 +175,7 @@ public f<double> cos<Numeric>(Numeric x) {
  */
 public inline f<WholeNumber> factorial<WholeNumber>(WholeNumber input) {
     Numeric fac = cast<Numeric>(1);
-    for (int i = 1; i <= input; i++) {
+    for int i = 1; i <= input; i++ {
         fac *= i;
     }
     return fac;

--- a/std/math/hash.spice
+++ b/std/math/hash.spice
@@ -105,7 +105,7 @@ public f<Hash> hash(string input) {
     result = 1469598103934665603ul;
     const char* c = cast<const char*>(input);
     unsafe {
-        while (c != nil<string>) {
+        while c != nil<string> {
             result ^= cast<unsigned long>(cast<unsigned int>(*c++));
             result *= 1099511628211ul; // FNV prime
         }

--- a/std/os/system_windows.spice
+++ b/std/os/system_windows.spice
@@ -50,15 +50,15 @@ public f<int> getCPUCoreCount() {
 public f<string> getArchName() {
     SystemInfo info = SystemInfo{};
     GetSystemInfo(&info);
-    if (info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64) {
+    if info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_AMD64 {
         return "amd64";
-    } else if (info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM) {
+    } else if info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM {
         return "arm";
-    } else if (info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64) {
+    } else if info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_ARM64 {
         return "arm64";
-    } else if (info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64) {
+    } else if info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_IA64 {
         return "ia64";
-    } else if (info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL) {
+    } else if info.wProcessorArchitecture == PROCESSOR_ARCHITECTURE_INTEL {
         return "intel";
     }
     return "unknown";

--- a/std/os/thread-pool.spice
+++ b/std/os/thread-pool.spice
@@ -53,7 +53,7 @@ public p ThreadPool.start() {
             }
             // Yield to other threads
             yield();
-        } while (!this.stopRequested);
+        } while !this.stopRequested;
     };
 
     // Create worker threads

--- a/std/runtime/memory_rt.spice
+++ b/std/runtime/memory_rt.spice
@@ -30,8 +30,8 @@ public f<Result<heap byte*>> sAlloc(unsigned long size) {
   */
 public f<heap byte*> sAllocUnsafe(unsigned long size) {
     heap byte* ptr = malloc(size);
-    if ptr != nil<heap byte*> { return ptr; }
-    panic(Error("OOM occurred in sAllocUnsafe!"));
+    if ptr == nil<heap byte*> { panic(Error("OOM occurred in sAllocUnsafe!")); }
+    return ptr;
 }
 
 /**
@@ -43,7 +43,6 @@ public f<heap byte*> sAllocUnsafe(unsigned long size) {
   * @return A pointer to the reallocated block, or an error if the reallocation failed.
   */
 public f<Result<heap byte*>> sRealloc(heap byte* ptr, unsigned long size) {
-    if ptr == nil<heap byte*> { return err<heap byte*>("Original pointer is nil!"); }
     if size == 0l { return err<heap byte*>("Size is 0!"); }
     heap byte* newPtr = realloc(ptr, size);
     return newPtr != nil<heap byte*> ? ok(newPtr) : err<heap byte*>("OOM occurred in sRealloc!");
@@ -59,12 +58,9 @@ public f<Result<heap byte*>> sRealloc(heap byte* ptr, unsigned long size) {
   * @return A pointer to the reallocated block, or an error if the reallocation failed.
   */
 public f<heap byte*> sReallocUnsafe(heap byte* ptr, unsigned long size) {
-    if ptr == nil<heap byte*> { panic(Error("Original pointer is nil!")); }
     if size == 0l { panic(Error("Size is 0!")); }
     heap byte* newPtr = realloc(ptr, size);
-    if newPtr == nil<heap byte*> {
-        panic(Error("OOM occurred in sReallocUnsafe!"));
-    }
+    if newPtr == nil<heap byte*> { panic(Error("OOM occurred in sReallocUnsafe!")); }
     return newPtr;
 }
 
@@ -164,7 +160,9 @@ public f<T*> sPlacementNew<T>(heap byte* ptr, const T& val) {
  * @param obj The object to destroy
  */
 public p sDestruct<T>(T& obj) {
-    obj.dtor();
+    if !__is_trivially_destructible<T>() {
+        obj.dtor();
+    }
 }
 
 /**

--- a/std/text/print.spice
+++ b/std/text/print.spice
@@ -28,21 +28,21 @@ public p printColumn(string text, unsigned int width) {
     const unsigned long length = len(text);
     unsigned long i = 0l;
 
-    while (i < length) {
+    while i < length {
         // Find the last word that fits within the width
         unsigned long j = i + width;
-        while (j > i & j < length && !isWhitespace(text[j])) {
+        while j > i & j < length && !isWhitespace(text[j]) {
             j--;
         }
         // Print the word
-        for (unsigned long k = i; k < j & k < length; k++) {
+        for unsigned long k = i; k < j & k < length; k++ {
             printf("%c", text[k]);
         }
         // Move to the next line
         printf("\n");
         // Move to the next word
         i = j;
-        while (i < length && isWhitespace(text[i])) {
+        while i < length && isWhitespace(text[i]) {
             i++;
         }
     }
@@ -56,10 +56,10 @@ public p printFixedWidth(string text, unsigned int width, bool ellipsis = false)
     unsigned long length = len(text);
     const bool printEllipsis = ellipsis & length > width;
 
-    for (unsigned long i = 0l; i < width; i++) {
-        if (i < (printEllipsis ? cast<unsigned long>(width) - 3ul : length)) {
+    for unsigned long i = 0l; i < width; i++ {
+        if i < (printEllipsis ? cast<unsigned long>(width) - 3ul : length) {
             printf("%c", text[i]);
-        } else if (printEllipsis) {
+        } else if printEllipsis {
             printf("...");
             break;
         } else {

--- a/std/time/time.spice
+++ b/std/time/time.spice
@@ -70,7 +70,7 @@ public f<int> getCurrentYear() {
     // Subtract full years until remaining days fit into the current year
     while true {
         const int daysInYear = isLeapYear(year) ? 366 : 365;
-        if (days < daysInYear) {
+        if days < daysInYear {
             break;
         }
         days -= daysInYear;


### PR DESCRIPTION
- Remove unnecessary parentheses in std
- Only destruct object with `sDestruct` if it is not trivially destructible