### PR TITLE
Treat struct with no-arg ctor as non-trivially-constructible

### DIFF
--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -338,8 +338,7 @@ bool QualType::isTriviallyConstructible(const ASTNode *node) const {
   if (is(TY_STRUCT)) {
     // If the struct has a ctor, it is a non-trivially constructible one
     const Struct *spiceStruct = getStruct(node);
-    const Function *ctor = FunctionManager::lookup(spiceStruct->scope, CTOR_FUNCTION_NAME, *this, {}, true);
-    if (ctor != nullptr)
+    if (FunctionManager::hasAnyNonCopyCtor(spiceStruct->scope))
       return false;
 
     // If the struct emits a vtable, it is non-trivially constructible, because the vtable needs to be initialized in the ctor
@@ -384,9 +383,7 @@ bool QualType::isTriviallyCopyable(const ASTNode *node) const { // NOLINT(*-no-r
   if (is(TY_STRUCT)) {
     // If the struct has a copy ctor, it is a non-trivially copyable one
     const Struct *spiceStruct = getStruct(node);
-    const std::vector args = {Arg(toConstRef(node), false)};
-    const Function *copyCtor = FunctionManager::lookup(spiceStruct->scope, CTOR_FUNCTION_NAME, *this, args, true);
-    if (copyCtor != nullptr)
+    if (FunctionManager::hasCopyCtor(spiceStruct->scope))
       return false;
 
     // Check if all member types are trivially copyable
@@ -417,8 +414,7 @@ bool QualType::isTriviallyDestructible(const ASTNode *node) const {
   if (is(TY_STRUCT)) {
     // If the struct has a dtor, it is a non-trivially destructible one
     const Struct *spiceStruct = getStruct(node);
-    const Function *dtor = FunctionManager::lookup(spiceStruct->scope, DTOR_FUNCTION_NAME, *this, {}, true);
-    if (dtor != nullptr)
+    if (FunctionManager::hasDtor(spiceStruct->scope))
       return false;
 
     // Check if all member types are trivially destructible

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -219,7 +219,7 @@ Function *FunctionManager::match(Scope *matchScope, const std::string &reqName, 
 
   // Loop over function registry to find functions, that match the requirements of the call
   std::vector<Function *> matches;
-  for (auto &[fctId, manifestations] :  matchScope->functions) {
+  for (auto &[fctId, manifestations] : matchScope->functions) {
     for (const auto &[signature, presetFunction] : manifestations) {
       assert(presetFunction.hasSubstantiatedParams()); // No optional params are allowed at this point
 
@@ -531,6 +531,34 @@ uint64_t FunctionManager::getCacheKey(const Scope *scope, const std::string &nam
   }
   hashCombine64(hash, hashVector(templateTypes));
   return hash;
+}
+
+bool FunctionManager::hasCtor(const Scope *matchScope, bool lookForCopyCtor) {
+  for (const auto &manifestations : matchScope->functions | std::views::values) {
+    for (const auto &function : manifestations | std::views::values) {
+      // If it is no ctor, skip it
+      if (function.name != CTOR_FUNCTION_NAME)
+        continue;
+      // If we don't search for a copy ctor and got none -> we found one
+      // If we search for a copy ctor and got one -> we found one
+      const bool isCopyCtor = function.paramList.size() == 1 && function.paramList.at(0).qualType.isConstRef();
+      if (isCopyCtor == lookForCopyCtor)
+        return true;
+    }
+  }
+  return false;
+}
+
+bool FunctionManager::hasAnyNonCopyCtor(const Scope *matchScope) { return hasCtor(matchScope, false); }
+
+bool FunctionManager::hasCopyCtor(const Scope *matchScope) { return hasCtor(matchScope, true); }
+
+bool FunctionManager::hasDtor(const Scope *matchScope) {
+  for (const auto &manifestations : matchScope->functions | std::views::values)
+    for (const auto &function : manifestations | std::views::values)
+      if (function.name == DTOR_FUNCTION_NAME)
+        return true;
+  return false;
 }
 
 /**

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -541,7 +541,8 @@ bool FunctionManager::hasCtor(const Scope *matchScope, bool lookForCopyCtor) {
         continue;
       // If we don't search for a copy ctor and got none -> we found one
       // If we search for a copy ctor and got one -> we found one
-      const bool isCopyCtor = function.paramList.size() == 1 && function.paramList.at(0).qualType.isConstRef();
+      const bool isCopyCtor = function.paramList.size() == 1 && function.paramList.at(0).qualType.isConstRef() &&
+                              function.paramList.at(0).qualType.getBase() == function.thisType;
       if (isCopyCtor == lookForCopyCtor)
         return true;
     }

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -44,6 +44,9 @@ public:
                                               const ArgList &reqArgs, bool strictQualifierMatching);
   static Function *match(Scope *matchScope, const std::string &reqName, const QualType &reqThisType, const ArgList &reqArgs,
                          const QualTypeList &templateTypeHints, bool strictQualifierMatching, const ASTNode *callNode);
+  [[nodiscard]] static bool hasAnyNonCopyCtor(const Scope *matchScope);
+  [[nodiscard]] static bool hasCopyCtor(const Scope *matchScope);
+  [[nodiscard]] static bool hasDtor(const Scope *matchScope);
   static void cleanup();
   [[nodiscard]] static std::string dumpLookupCacheStatistics();
 
@@ -70,6 +73,7 @@ private:
                                                                           const std::string &templateTypeName);
   [[nodiscard]] static uint64_t getCacheKey(const Scope *scope, const std::string &name, const QualType &thisType, const ArgList &args,
                                             const QualTypeList &templateTypes);
+  [[nodiscard]] static bool hasCtor(const Scope *matchScope, bool lookForCopyCtor);
 };
 
 } // namespace spice::compiler

--- a/test/test-files/std/time/high-res-timer/cache-stats-linux.out
+++ b/test/test-files/std/time/high-res-timer/cache-stats-linux.out
@@ -1,7 +1,7 @@
 FunctionManager lookup cache statistics:
   lookup cache entries: 18
   lookup cache hits: 20
-  lookup cache misses: 50
+  lookup cache misses: 44
 
 StructManager lookup cache statistics:
   lookup cache entries: 3


### PR DESCRIPTION
Previously a struct was considered trivially-constructible if it does not have a no-args constructor.
This is wrong, since a struct with no no-args, but another non-copy constructor is non-trivially-constructible as well.