### PR TITLE
Fix trivially copyability of ref field structs

### DIFF
--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -371,10 +371,6 @@ bool QualType::isTriviallyCopyable(const ASTNode *node) const { // NOLINT(*-no-r
   if (qualifiers.isHeap)
     return false;
 
-  // References can't be copied at all
-  if (isRef())
-    return false;
-
   // In case of an array, the item type is determining the copy triviality
   if (isArray())
     return getBase().isTriviallyCopyable(node);

--- a/test/test-files/irgenerator/builtins/success-is-trivially-constructible/cout.out
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-constructible/cout.out
@@ -1,2 +1,4 @@
 Trivially constructible: 1
 Trivially constructible: 0
+Trivially constructible: 0
+Trivially constructible: 0

--- a/test/test-files/irgenerator/builtins/success-is-trivially-constructible/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-constructible/ir-code.ll
@@ -3,6 +3,8 @@ source_filename = "source.spice"
 
 @printf.str.0 = private unnamed_addr constant [29 x i8] c"Trivially constructible: %d\0A\00", align 4
 @printf.str.1 = private unnamed_addr constant [29 x i8] c"Trivially constructible: %d\0A\00", align 4
+@printf.str.2 = private unnamed_addr constant [29 x i8] c"Trivially constructible: %d\0A\00", align 4
+@printf.str.3 = private unnamed_addr constant [29 x i8] c"Trivially constructible: %d\0A\00", align 4
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
 define dso_local noundef i32 @main() #0 {
@@ -10,8 +12,10 @@ define dso_local noundef i32 @main() #0 {
   store i32 0, ptr %result, align 4
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 noundef 1)
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 noundef 0)
-  %3 = load i32, ptr %result, align 4
-  ret i32 %3
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 noundef 0)
+  %4 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 noundef 0)
+  %5 = load i32, ptr %result, align 4
+  ret i32 %5
 }
 
 ; Function Attrs: nofree nounwind

--- a/test/test-files/irgenerator/builtins/success-is-trivially-constructible/source.spice
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-constructible/source.spice
@@ -1,4 +1,14 @@
+type Test struct {
+    int& a
+}
+
+type TestHeap struct {
+    heap int* a
+}
+
 f<int> main() {
     printf("Trivially constructible: %d\n", __is_trivially_constructible<int>());
     printf("Trivially constructible: %d\n", __is_trivially_constructible<String>());
+    printf("Trivially constructible: %d\n", __is_trivially_constructible<Test>());
+    printf("Trivially constructible: %d\n", __is_trivially_constructible<TestHeap>());
 }

--- a/test/test-files/irgenerator/builtins/success-is-trivially-copyable/cout.out
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-copyable/cout.out
@@ -1,2 +1,4 @@
 Trivially copyable: 1
 Trivially copyable: 0
+Trivially copyable: 1
+Trivially copyable: 0

--- a/test/test-files/irgenerator/builtins/success-is-trivially-copyable/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-copyable/ir-code.ll
@@ -3,6 +3,8 @@ source_filename = "source.spice"
 
 @printf.str.0 = private unnamed_addr constant [24 x i8] c"Trivially copyable: %d\0A\00", align 4
 @printf.str.1 = private unnamed_addr constant [24 x i8] c"Trivially copyable: %d\0A\00", align 4
+@printf.str.2 = private unnamed_addr constant [24 x i8] c"Trivially copyable: %d\0A\00", align 4
+@printf.str.3 = private unnamed_addr constant [24 x i8] c"Trivially copyable: %d\0A\00", align 4
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
 define dso_local noundef i32 @main() #0 {
@@ -10,8 +12,10 @@ define dso_local noundef i32 @main() #0 {
   store i32 0, ptr %result, align 4
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 noundef 1)
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 noundef 0)
-  %3 = load i32, ptr %result, align 4
-  ret i32 %3
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 noundef 1)
+  %4 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 noundef 0)
+  %5 = load i32, ptr %result, align 4
+  ret i32 %5
 }
 
 ; Function Attrs: nofree nounwind

--- a/test/test-files/irgenerator/builtins/success-is-trivially-copyable/source.spice
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-copyable/source.spice
@@ -1,4 +1,14 @@
+type Test struct {
+    int& a
+}
+
+type TestHeap struct {
+    heap int* a
+}
+
 f<int> main() {
     printf("Trivially copyable: %d\n", __is_trivially_copyable<int>());
     printf("Trivially copyable: %d\n", __is_trivially_copyable<String>());
+    printf("Trivially copyable: %d\n", __is_trivially_copyable<Test>());
+    printf("Trivially copyable: %d\n", __is_trivially_copyable<TestHeap>());
 }

--- a/test/test-files/irgenerator/builtins/success-is-trivially-destructible/cout.out
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-destructible/cout.out
@@ -1,2 +1,4 @@
 Trivially destructible: 1
 Trivially destructible: 0
+Trivially destructible: 1
+Trivially destructible: 0

--- a/test/test-files/irgenerator/builtins/success-is-trivially-destructible/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-destructible/ir-code.ll
@@ -3,6 +3,8 @@ source_filename = "source.spice"
 
 @printf.str.0 = private unnamed_addr constant [28 x i8] c"Trivially destructible: %d\0A\00", align 4
 @printf.str.1 = private unnamed_addr constant [28 x i8] c"Trivially destructible: %d\0A\00", align 4
+@printf.str.2 = private unnamed_addr constant [28 x i8] c"Trivially destructible: %d\0A\00", align 4
+@printf.str.3 = private unnamed_addr constant [28 x i8] c"Trivially destructible: %d\0A\00", align 4
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
 define dso_local noundef i32 @main() #0 {
@@ -10,8 +12,10 @@ define dso_local noundef i32 @main() #0 {
   store i32 0, ptr %result, align 4
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 noundef 1)
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 noundef 0)
-  %3 = load i32, ptr %result, align 4
-  ret i32 %3
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 noundef 1)
+  %4 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 noundef 0)
+  %5 = load i32, ptr %result, align 4
+  ret i32 %5
 }
 
 ; Function Attrs: nofree nounwind

--- a/test/test-files/irgenerator/builtins/success-is-trivially-destructible/source.spice
+++ b/test/test-files/irgenerator/builtins/success-is-trivially-destructible/source.spice
@@ -1,4 +1,14 @@
+type Test struct {
+    int& a
+}
+
+type TestHeap struct {
+    heap int* a
+}
+
 f<int> main() {
     printf("Trivially destructible: %d\n", __is_trivially_destructible<int>());
     printf("Trivially destructible: %d\n", __is_trivially_destructible<String>());
+    printf("Trivially destructible: %d\n", __is_trivially_destructible<Test>());
+    printf("Trivially destructible: %d\n", __is_trivially_destructible<TestHeap>());
 }

--- a/test/test-files/irgenerator/instrumentation/success-dbg-info-complex/debug.out
+++ b/test/test-files/irgenerator/instrumentation/success-dbg-info-complex/debug.out
@@ -1,4 +1,4 @@
-GNU gdb (Ubuntu 15.0.50.20240403-0ubuntu1) 15.0.50.20240403-git
+GNU gdb (Ubuntu 15.1-1ubuntu1~24.04.1) 15.1
 Copyright (C) 2024 Free Software Foundation, Inc.
 License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
 This is free software: you are free to change and redistribute it.
@@ -28,4 +28,4 @@ pair = {first = 2, second = }
 $1 = {contents = , capacity = 5, size = 5}
 $2 = 5
 All assertions passed!
-[Inferior 1 (process 172651) exited normally]
+[Inferior 1 (process 189391) exited normally]


### PR DESCRIPTION
- Structs with reference fields were mistakenly considered non-trivially-copyable, they are only non-trivially-constructible
- Add tests