### PR TITLE
Fix various bugs in std container types

### DIFF
--- a/std/data/deque.spice
+++ b/std/data/deque.spice
@@ -150,14 +150,14 @@ public f<T&> Deque.popFront() {
 public f<T&> Deque.popBack() {
     if this.isEmpty() { panic(Error("Deque is empty")); }
 
+    // Adjust indices and size
+    this.idxBack = this.idxBack - 1 + this.capacity;
+    this.idxBack %= this.capacity;
+
     // Get item value
     unsafe {
         result = this.contents[this.idxBack];
     }
-
-    // Adjust indices and size
-    this.idxBack = this.idxBack - 1 + this.capacity;
-    this.idxBack %= this.capacity;
     this.size--;
 }
 
@@ -181,7 +181,7 @@ public f<T&> Deque.front() {
 public f<T&> Deque.back() {
     if this.isEmpty() { panic(Error("Access index out of bounds")); }
     unsafe {
-        return this.contents[this.idxBack - 1];
+        return this.contents[(this.idxBack - 1 + this.capacity) % this.capacity];
     }
 }
 

--- a/std/data/doubly-linked-list.spice
+++ b/std/data/doubly-linked-list.spice
@@ -51,38 +51,45 @@ public p DoublyLinkedList.insertAt(unsigned long idx, const T& value) {
     // Abort if the index is out of bounds
     if idx < 0 || idx > this.size { panic(Error("Access index out of bound")); }
 
-    heap Node<T>* newNode = this.createNode(value);
     if idx == 0 {
         this.pushFront(value);
-    } else if idx == this.size {
-        this.pushBack(value);
-    } else {
-        heap Node<T>* curr = this.tail;
-        for unsigned long i = 0l; i < idx - 1l; i++ {
-            curr = curr.next;
-        }
-        newNode.next = curr.next;
-        newNode.prev = curr;
-        curr.next.prev = newNode;
-        curr.next = newNode;
-        this.size++;
+        return;
     }
+    if idx == this.size {
+        this.pushBack(value);
+        return;
+    }
+    heap Node<T>* newNode = this.createNode(value);
+    heap Node<T>* curr = this.tail;
+    for unsigned long i = 0l; i < idx - 1l; i++ {
+        curr = curr.next;
+    }
+    newNode.next = curr.next;
+    newNode.prev = curr;
+    curr.next.prev = newNode;
+    curr.next = newNode;
+    this.size++;
 }
 
 public p DoublyLinkedList.remove(const T& valueToRemove) {
     Node<T>* curr = this.tail;
     while curr != nil<Node<T>*> {
         if curr.value == valueToRemove {
-            if curr == this.tail {
-                this.tail = curr.next;
+            if curr == this.tail && curr == this.head {
+                this.tail = nil<heap Node<T>*>;
+                this.head = nil<Node<T>*>;
+            } else if curr == this.tail {
+                this.tail = sMove(curr.next);
                 this.tail.prev = nil<Node<T>*>;
             } else if curr == this.head {
                 this.head = curr.prev;
                 this.head.next = nil<heap Node<T>*>;
+                curr.next = nil<heap Node<T>*>;
             } else {
                 curr.next.prev = curr.prev;
-                curr.prev.next = curr.next;
+                curr.prev.next = sMove(curr.next);
             }
+            sDelete(curr);
             this.size--;
             break;
         }
@@ -98,16 +105,21 @@ public p DoublyLinkedList.removeAt(unsigned long idx) {
     for unsigned long i = 0l; i < idx; i++ {
         curr = curr.next;
     }
-    if curr == this.tail {
-        this.tail = curr.next;
+    if curr == this.tail && curr == this.head {
+        this.tail = nil<heap Node<T>*>;
+        this.head = nil<Node<T>*>;
+    } else if curr == this.tail {
+        this.tail = sMove(curr.next);
         this.tail.prev = nil<Node<T>*>;
     } else if curr == this.head {
         this.head = curr.prev;
         this.head.next = nil<heap Node<T>*>;
+        curr.next = nil<heap Node<T>*>;
     } else {
         curr.next.prev = curr.prev;
-        curr.prev.next = curr.next;
+        curr.prev.next = sMove(curr.next);
     }
+    sDelete(curr);
     this.size--;
 }
 

--- a/std/data/linked-list.spice
+++ b/std/data/linked-list.spice
@@ -83,7 +83,7 @@ public p LinkedList.pushFront(const T& value) {
  */
 public p LinkedList.insertAt(unsigned long idx, const T& value) {
     // Abort if the index is out of bounds
-    if idx < 0l || idx >= this.size { return; }
+    if idx > this.size { return; }
 
     // Create new node
     heap Node<T>* newNode = this.createNode(value);
@@ -100,6 +100,9 @@ public p LinkedList.insertAt(unsigned long idx, const T& value) {
         }
         newNode.next = curr.next; // Link the next node to the new one
         curr.next = newNode; // Link the new node to the previous one
+        if idx == this.size {
+            this.head = newNode; // Update head when appending
+        }
     }
     this.size++;
 }
@@ -226,7 +229,7 @@ public inline f<bool> LinkedList.isEmpty() {
  */
 public f<T&> LinkedList.get(unsigned long idx) {
     // Abort if the index is out of bounds
-    if idx < 0 || idx >= this.size {
+    if idx >= this.size {
         panic(Error("Access index out of bound"));
     }
 

--- a/std/data/map.spice
+++ b/std/data/map.spice
@@ -157,7 +157,7 @@ public inline p MapIterator.next() {
  * @param it MapIterator
  */
 public inline p operator++<K, V>(MapIterator<K, V>& it) {
-    this.htIterator.next();
+    it.rbtIterator.next();
 }
 
 /**

--- a/std/data/queue.spice
+++ b/std/data/queue.spice
@@ -103,6 +103,7 @@ public p Queue.push(const T& item) {
  */
 #[ignoreUnusedReturnValue]
 public f<T&> Queue.pop() {
+    if this.isEmpty() { panic(Error("The queue is empty")); }
     this.size--;
     unsafe {
         return this.contents[this.idxFront++];
@@ -129,7 +130,7 @@ public f<T&> Queue.front() {
 public f<T&> Queue.back() {
     if this.isEmpty() { panic(Error("Access index out of bounds")); }
     unsafe {
-        return this.contents[this.idxBack];
+        return this.contents[this.idxBack - 1];
     }
 }
 

--- a/std/data/set.spice
+++ b/std/data/set.spice
@@ -81,8 +81,8 @@ public f<bool> Set.isEmpty() {
  */
 public f<LinkedList<V>> Set.toLinkedList() {
     result = LinkedList<V>();
-    foreach Pair<V, bool>& bucket : this.tree {
-        result.append(entry.key);
+    foreach Pair<V, bool>& entry : this.tree {
+        result.pushBack(entry.getFirst());
     }
 }
 
@@ -141,7 +141,7 @@ public inline p SetIterator.next() {
  * @param it SetIterator
  */
 public inline p operator++<V>(SetIterator<V>& it) {
-    this.rbtIterator.next();
+    it.rbtIterator.next();
 }
 
 /**

--- a/std/data/stack.spice
+++ b/std/data/stack.spice
@@ -26,7 +26,7 @@ public p Stack.ctor(unsigned long initAllocItems, const T &defaultValue) {
     // Allocate space for the initial number of elements
     this.ctor(initAllocItems);
     // Fill in the default values
-    for unsigned long index = 0; index < initAllocItems; index++ {
+    for unsigned long index = 0ul; index < initAllocItems; index++ {
         unsafe {
             __placement_new<T>(&this.contents[index], defaultValue);
         }

--- a/std/data/unordered-map.spice
+++ b/std/data/unordered-map.spice
@@ -162,7 +162,7 @@ public inline p UnorderedMapIterator.next() {
  * @param it UnorderedMapIterator
  */
 public inline p operator++<K, V>(UnorderedMapIterator<K, V>& it) {
-    this.htIterator.next();
+    it.htIterator.next();
 }
 
 /**

--- a/std/data/unordered-set.spice
+++ b/std/data/unordered-set.spice
@@ -85,8 +85,8 @@ public f<bool> UnorderedSet.isEmpty() {
  */
 public f<LinkedList<V>> UnorderedSet.toLinkedList() {
     result = LinkedList<V>();
-    foreach Pair<V, bool>& bucket : this.hashTable {
-        result.append(entry.key);
+    foreach Pair<V, bool>& entry : this.hashTable {
+        result.pushBack(entry.getFirst());
     }
 }
 
@@ -145,7 +145,7 @@ public inline p UnorderedSetIterator.next() {
  * @param it UnorderedSetIterator
  */
 public inline p operator++<V>(UnorderedSetIterator<V>& it) {
-    this.htIterator.next();
+    it.htIterator.next();
 }
 
 /**

--- a/std/data/vector.spice
+++ b/std/data/vector.spice
@@ -47,7 +47,7 @@ public p Vector.ctor(unsigned long initAllocItems, const T& defaultValue) {
     // Allocate space for the initial number of elements
     this.ctor(initAllocItems);
     // Fill in the default values
-    for int index = 0; index < initAllocItems; index++ {
+    for unsigned long index = 0ul; index < initAllocItems; index++ {
         unsafe {
             __placement_new<T>(&this.contents[index], defaultValue);
         }


### PR DESCRIPTION
## Summary
Fixes a batch of bugs found while auditing every container type under `std/data/`:

- **`deque`** — `popBack()` read from `idxBack` (the next-free slot) instead of the last element; `back()` returned `idxBack - 1` without wrapping around the ring buffer.
- **`doubly-linked-list`** — `insertAt()` allocated a node and then delegated to `pushFront`/`pushBack`, leaking the original; `remove()`/`removeAt()` dereferenced nil when removing the only element of the list and never freed the removed node. Removal paths now use `sMove` to sever the `heap Node<T>* next` field before calling `sDelete`, mirroring the pattern in `linked-list.spice` — without this, the auto-generated `Node` destructor recursively frees the rest of the list (this was the segfault in `test/test-files/std/data/doubly-linked-list-normal-usecase`).
- **`linked-list`** — `insertAt()` rejected `idx == size` (valid append) with a silent return and had a spurious `idx < 0l` check on an unsigned type; `get()` had the same useless `idx < 0` check.
- **`queue`** — `pop()` was missing an empty-check, so `size--` underflowed on an empty queue; `back()` returned `contents[idxBack]` (the next-free slot) instead of `contents[idxBack - 1]`.
- **`map` / `unordered-map` / `set` / `unordered-set`** — every `operator++` used `this.<member>` (which is meaningless in a free operator) and in some cases the wrong member name (`htIterator` on the map iterator), so iterator advancement was broken or non-compiling.
- **`set` / `unordered-set`** — `toLinkedList()` referenced an undeclared `entry` variable (the loop variable was `bucket`) and called a non-existent `append()` method instead of `pushBack()`.
- **`vector` / `stack`** — loop counters used `int` / untyped `0` against `unsigned long` bounds; standardized to `unsigned long` with `0ul` literals.

## Test plan
- [x] `cmake --build cmake-build-debug --target spice spicetest`
- [x] `cmake-build-debug/test/spicetest --gtest_filter=*doubly-linked-list*` passes (previously segfaulting)
- [x] `cmake-build-debug/test/spicetest --gtest_filter=*deque*:*queue*:*stack*:*vector*:*linked-list*:*map*:*set*` all pass
- [x] Full `cmake-build-debug/test/spicetest` run is green

🤖 Generated with [Claude Code](https://claude.com/claude-code)