### PR TITLE
Use LLVMs discard value names

### DIFF
--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -42,6 +42,9 @@ SourceFile::SourceFile(GlobalResourceManager &resourceManager, SourceFile *paren
   fileName = std::filesystem::path(filePath).filename().string();
   fileDir = std::filesystem::path(filePath).parent_path().string();
 
+  // Discard value names if not required
+  context.setDiscardValueNames(!cliOptions.namesForIRValues);
+
   // Search after the selected target
   std::string error;
   const llvm::Target *target = llvm::TargetRegistry::lookupTarget(cliOptions.targetTriple, error);

--- a/src/global/GlobalResourceManager.cpp
+++ b/src/global/GlobalResourceManager.cpp
@@ -44,9 +44,12 @@ GlobalResourceManager::GlobalResourceManager(const CliOptions &cliOptions)
     cpuFeatures = features.getString();
   }
 
-  // Create lto module
-  if (cliOptions.useLTO)
+  if (cliOptions.useLTO) {
+    // Discard value names if not required
+    ltoContext.setDiscardValueNames(!cliOptions.namesForIRValues);
+    // Create lto module
     ltoModule = std::make_unique<llvm::Module>(LTO_FILE_NAME, ltoContext);
+  }
 }
 
 GlobalResourceManager::~GlobalResourceManager() {

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -60,10 +60,7 @@ std::any IRGenerator::visitEntry(const EntryNode *node) {
   return nullptr;
 }
 
-llvm::AllocaInst *IRGenerator::insertAlloca(llvm::Type *llvmType, std::string varName) {
-  if (!cliOptions.namesForIRValues)
-    varName = "";
-
+llvm::AllocaInst *IRGenerator::insertAlloca(llvm::Type *llvmType, const std::string &varName) {
   if (allocaInsertInst != nullptr) { // If there is already an alloca inst, insert right after that
     llvm::AllocaInst *allocaInst = builder.CreateAlloca(llvmType, nullptr, varName);
     allocaInst->setDebugLoc(llvm::DebugLoc());
@@ -103,7 +100,7 @@ llvm::AllocaInst *IRGenerator::insertAlloca(const QualType &qualType, const std:
 llvm::LoadInst *IRGenerator::insertLoad(llvm::Type *llvmType, llvm::Value *ptr, bool isVolatile,
                                         const std::string &varName) const {
   assert(ptr->getType()->isPointerTy());
-  return builder.CreateLoad(llvmType, ptr, isVolatile, cliOptions.namesForIRValues ? varName : "");
+  return builder.CreateLoad(llvmType, ptr, isVolatile, varName);
 }
 
 llvm::LoadInst *IRGenerator::insertLoad(const QualType &qualType, llvm::Value *ptr, bool isVolatile, const std::string &varName) {
@@ -126,7 +123,7 @@ void IRGenerator::insertStore(llvm::Value *val, llvm::Value *ptr, const QualType
 }
 
 llvm::Value *IRGenerator::insertInBoundsGEP(llvm::Type *type, llvm::Value *basePtr, llvm::ArrayRef<llvm::Value *> indices,
-                                            std::string varName) const {
+                                            const std::string &varName) const {
   assert(basePtr->getType()->isPointerTy());
   assert(!indices.empty());
   assert(std::ranges::all_of(indices, [](const llvm::Value *index) {
@@ -134,18 +131,13 @@ llvm::Value *IRGenerator::insertInBoundsGEP(llvm::Type *type, llvm::Value *baseP
     return indexType->isIntegerTy(32) || indexType->isIntegerTy(64);
   }));
 
-  if (!cliOptions.namesForIRValues)
-    varName.clear();
-
   // Insert GEP
   return builder.CreateInBoundsGEP(type, basePtr, indices, varName);
 }
 
-llvm::Value *IRGenerator::insertStructGEP(llvm::Type *type, llvm::Value *basePtr, unsigned int index, std::string varName) const {
+llvm::Value *IRGenerator::insertStructGEP(llvm::Type *type, llvm::Value *basePtr, unsigned int index,
+                                          const std::string &varName) const {
   assert(basePtr->getType()->isPointerTy());
-
-  if (!cliOptions.namesForIRValues)
-    varName.clear();
 
   // If we use index 0 we can use the base pointer directly
   if (index == 0)

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -115,7 +115,7 @@ public:
   std::any visitDataType(const DataTypeNode *node) override;
 
   // Public methods
-  llvm::AllocaInst *insertAlloca(llvm::Type *llvmType, std::string varName = "");
+  llvm::AllocaInst *insertAlloca(llvm::Type *llvmType, const std::string &varName = "");
   llvm::AllocaInst *insertAlloca(const QualType &qualType, const std::string &varName = "");
   llvm::LoadInst *insertLoad(llvm::Type *llvmType, llvm::Value *ptr, bool isVolatile = false,
                              const std::string &varName = "") const;
@@ -124,8 +124,8 @@ public:
   llvm::StoreInst *insertStore(llvm::Value *val, llvm::Value *ptr, bool isVolatile = false) const;
   void insertStore(llvm::Value *val, llvm::Value *ptr, const QualType &qualType, bool isVolatile = false);
   llvm::Value *insertInBoundsGEP(llvm::Type *type, llvm::Value *basePtr, llvm::ArrayRef<llvm::Value *> indices,
-                                 std::string varName = "") const;
-  llvm::Value *insertStructGEP(llvm::Type *type, llvm::Value *basePtr, unsigned index, std::string varName = "") const;
+                                 const std::string &varName = "") const;
+  llvm::Value *insertStructGEP(llvm::Type *type, llvm::Value *basePtr, unsigned index, const std::string &varName = "") const;
   llvm::Value *resolveValue(const ExprNode *node);
   llvm::Value *resolveValue(const ExprNode *node, LLVMExprResult &exprResult);
   llvm::Value *resolveValue(const QualType &qualType, LLVMExprResult &exprResult);


### PR DESCRIPTION
Use LLVMs discard value names instead of own filter. This eliminates a few string copies as well, which should improve compile time slightly.