### PR TITLE
Add homebrew cask release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -443,10 +443,11 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: v2.15.4
+          version: v2.16.0
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.CR_PAT }}
           NEXUS_URL: ${{ secrets.NEXUS_URL }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -109,7 +109,8 @@ nfpms:
 
 homebrew_casks:
   - name: spice
-    binary: spice
+    binaries:
+      - spice
     homepage: https://www.spicelang.com
     description: Spice programming language.
     license: MIT

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -107,6 +107,29 @@ nfpms:
           - gtkmm-4.0
           - curl
 
+homebrew_casks:
+  - name: spice
+    binary: spice
+    homepage: https://www.spicelang.com
+    description: Spice programming language.
+    license: MIT
+    repository:
+      owner: spicelang
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: spicelang-bot
+      email: noreply@spicelang.com
+    hooks:
+      post:
+        install: |
+          system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/spice"]
+    caveats: |
+      The Spice standard library is staged alongside the binary in the cask's
+      staged path. If the compiler cannot locate it automatically, set:
+        export SPICE_STD_DIR="$(brew --caskroom)/spice/{{ .Version }}/std"
+
 release:
   name_template: "v{{ .Tag }}"
   prerelease: auto

--- a/docs/docs/install/macos.md
+++ b/docs/docs/install/macos.md
@@ -7,8 +7,22 @@ tags:
 ---
 
 ### Install from package manager
-!!! info "Upcoming feature"
-    As for now, this is not supported. We are working on a package manager distribution for macOS.
+The recommended installation method on macOS is via [Homebrew](https://brew.sh). Spice is distributed as a cask from
+the official Spice tap.
+
+```sh
+brew tap spicelang/tap
+brew install --cask spice
+```
+
+To upgrade to the latest release later, run:
+```sh
+brew upgrade --cask spice
+```
+
+!!! info "Apple Silicon only"
+    The Homebrew cask currently only ships an ARM64 (Apple Silicon) build. On Intel Macs, please use the archive file
+    below or build from source.
 
 ### Install from archive file
 Currently, it is only possible to install spice on macOS via the tar.gz archive, uploaded to the GitHub release.


### PR DESCRIPTION
Add release path via homebrew cask. This is still experimental and will be untested for now. The next release will be a test for this.