### PR TITLE
Drop mold from Linux publish jobs to fix GCC 16 static link

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,9 +35,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
 
-      - name: Setup Mold
-        uses: rui314/setup-mold@v1
-
       - name: Setup CCache
         uses: hendrikmuhs/ccache-action@v1
 
@@ -132,9 +129,6 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
-
-      - name: Setup Mold
-        uses: rui314/setup-mold@v1
 
       - name: Setup CCache
         uses: hendrikmuhs/ccache-action@v1


### PR DESCRIPTION
## Summary
- Follow-up to #1119, which did not resolve the publish failure: `mold: fatal: library not found: gcc_s_asneeded`.
- Even with `-static-libgcc -static-libstdc++`, GCC 16 still emits `-lgcc_s_asneeded` (a linker-script wrapper around `libgcc_s`) under `-static`, and mold — installed as the system default linker by `rui314/setup-mold@v1` — cannot resolve it.
- Removing the `Setup Mold` step from the Linux publish jobs lets the workflow use the system BFD linker, which handles GCC 16's spec correctly. Mold's speed gain is negligible vs LTO link time for a release build.

## Test plan
- [ ] Trigger the publish workflow (tag push) and confirm the Linux/x86_64 and Linux/AArch64 link steps succeed.
- [ ] Verify the produced binary still passes `checksec` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)