### PR TITLE
Add CSV parser to std/text

### DIFF
--- a/std/text/csv-parser.spice
+++ b/std/text/csv-parser.spice
@@ -1,0 +1,133 @@
+import "std/data/vector";
+
+// Default control characters (RFC 4180)
+const char DEFAULT_DELIMITER = ',';
+const char DEFAULT_QUOTE     = '"';
+
+/**
+ * Parser for CSV (comma-separated values) input.
+ *
+ * Supports quoted fields, embedded delimiters/newlines and escaped quotes
+ * (by doubling, e.g. `""` inside a quoted field yields a single `"`).
+ * Both `\n` and `\r\n` are accepted as line terminators.
+ */
+public type CsvParser struct {
+    char delimiter
+    char quote
+}
+
+public p CsvParser.ctor(char delimiter = DEFAULT_DELIMITER, char quote = DEFAULT_QUOTE) {
+    this.delimiter = delimiter;
+    this.quote = quote;
+}
+
+/**
+ * Parses a single CSV record into its fields. Newlines inside the input are
+ * preserved as part of the field they appear in.
+ *
+ * @param input Single CSV record (without trailing line terminator)
+ * @return Parsed fields
+ */
+public f<Vector<String>> CsvParser.parseLine(const String& input) {
+    result = Vector<String>();
+    const unsigned long length = input.getLength();
+
+    String field;
+    bool inQuotes = false;
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = input[i];
+        if inQuotes {
+            if c == this.quote {
+                // Handle escaped quote (doubled quote)
+                if i + 1l < length && input[i + 1l] == this.quote {
+                    field += this.quote;
+                    i++;
+                } else {
+                    inQuotes = false;
+                }
+            } else {
+                field += c;
+            }
+        } else {
+            if c == this.quote {
+                inQuotes = true;
+            } else if c == this.delimiter {
+                result.pushBack(field);
+                field = String();
+            } else {
+                field += c;
+            }
+        }
+    }
+    result.pushBack(field);
+}
+
+/**
+ * Parses a whole CSV document into rows, where each row is a vector of fields.
+ *
+ * An optional trailing line terminator is not treated as an additional empty
+ * record. Empty input yields an empty result.
+ *
+ * @param input Full CSV document
+ * @return Parsed rows
+ */
+public f<Vector<Vector<String>>> CsvParser.parse(const String& input) {
+    result = Vector<Vector<String>>();
+    const unsigned long length = input.getLength();
+    if length == 0l { return result; }
+
+    // We pre-allocate the current row inside `result` and write fields through
+    // a reference. This avoids relying on copying a non-empty Vector<String>.
+    Vector<String> emptyRow;
+    result.pushBack(emptyRow);
+
+    String field;
+    bool inQuotes = false;
+    // Tracks whether the current row has been touched since the last record terminator.
+    // Prevents a trailing newline from emitting a spurious empty record.
+    bool rowOpen = false;
+
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = input[i];
+        if inQuotes {
+            if c == this.quote {
+                if i + 1l < length && input[i + 1l] == this.quote {
+                    field += this.quote;
+                    i++;
+                } else {
+                    inQuotes = false;
+                }
+            } else {
+                field += c;
+            }
+            continue;
+        }
+        if c == '\r' { continue; }
+        rowOpen = true;
+        if c == this.quote {
+            inQuotes = true;
+        } else if c == this.delimiter {
+            Vector<String>& currentRow = result.back();
+            currentRow.pushBack(field);
+            field = String();
+        } else if c == '\n' {
+            Vector<String>& currentRow = result.back();
+            currentRow.pushBack(field);
+            field = String();
+            // Start a new row
+            Vector<String> nextRow;
+            result.pushBack(nextRow);
+            rowOpen = false;
+        } else {
+            field += c;
+        }
+    }
+
+    if rowOpen {
+        Vector<String>& currentRow = result.back();
+        currentRow.pushBack(field);
+    } else {
+        // Drop the trailing empty row created after the last terminator
+        result.removeAt(result.getSize() - 1l);
+    }
+}

--- a/test/test-files/std/text/csv-parser/cout.out
+++ b/test/test-files/std/text/csv-parser/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/csv-parser/source.spice
+++ b/test/test-files/std/text/csv-parser/source.spice
@@ -1,0 +1,68 @@
+import "std/text/csv-parser";
+import "std/data/vector";
+
+f<int> main() {
+    CsvParser parser;
+
+    // Simple single-line parsing
+    Vector<String> fields = parser.parseLine(String("a,b,c"));
+    assert fields.getSize() == 3;
+    assert fields.get(0) == String("a");
+    assert fields.get(1) == String("b");
+    assert fields.get(2) == String("c");
+
+    // Quoted field containing a delimiter
+    fields = parser.parseLine(String("one,\"two,still two\",three"));
+    assert fields.getSize() == 3;
+    assert fields.get(0) == String("one");
+    assert fields.get(1) == String("two,still two");
+    assert fields.get(2) == String("three");
+
+    // Escaped quotes (doubled)
+    fields = parser.parseLine(String("\"He said \"\"hi\"\"\",ok"));
+    assert fields.getSize() == 2;
+    assert fields.get(0) == String("He said \"hi\"");
+    assert fields.get(1) == String("ok");
+
+    // Empty fields are preserved
+    fields = parser.parseLine(String(",,x,"));
+    assert fields.getSize() == 4;
+    assert fields.get(0) == String("");
+    assert fields.get(1) == String("");
+    assert fields.get(2) == String("x");
+    assert fields.get(3) == String("");
+
+    // Multi-row document with CRLF, quoted newline and trailing LF
+    String document = String("name,age,city\r\n");
+    document += "Alice,30,\"New York\"\r\n";
+    document += "Bob,25,\"Line1\nLine2\"\n";
+    Vector<Vector<String>> rows = parser.parse(document);
+    assert rows.getSize() == 3;
+
+    Vector<String>& header = rows.get(0);
+    assert header.getSize() == 3;
+    assert header.get(0) == String("name");
+    assert header.get(2) == String("city");
+
+    Vector<String>& alice = rows.get(1);
+    assert alice.get(0) == String("Alice");
+    assert alice.get(1) == String("30");
+    assert alice.get(2) == String("New York");
+
+    Vector<String>& bob = rows.get(2);
+    assert bob.get(0) == String("Bob");
+    assert bob.get(2) == String("Line1\nLine2");
+
+    // Empty input produces zero rows
+    rows = parser.parse(String(""));
+    assert rows.getSize() == 0;
+
+    // Custom delimiter (semicolon)
+    CsvParser semicolonParser = CsvParser(';');
+    fields = semicolonParser.parseLine(String("x;y;z"));
+    assert fields.getSize() == 3;
+    assert fields.get(0) == String("x");
+    assert fields.get(2) == String("z");
+
+    printf("All assertions passed!");
+}


### PR DESCRIPTION
## Summary
- Adds `std/text/csv-parser` providing `CsvParser` with configurable delimiter and quote character (defaults `,` / `"` per RFC 4180).
- `parseLine(const String&) -> Vector<String>` returns the fields of a single record; `parse(const String&) -> Vector<Vector<String>>` returns rows of fields for a whole document.
- Supports quoted fields, doubled-quote escapes, embedded delimiters/newlines and both `\n` and `\r\n` line terminators. A single trailing terminator does not produce a spurious empty row.
- New std test case at `test/test-files/std/text/csv-parser/` covering basic parsing, quoting, escaping, empty fields, multi-row CRLF input, embedded newlines and a custom delimiter.

## Implementation note
`std/data/vector.spice`'s `Vector.ctor(const Vector<T>&)` (and the matching copy ctors in `stack`/`queue`/`deque`) pass `original.size` to `sCopy` instead of `itemSize * original.size`, so copying a non-byte-sized `Vector` (e.g. `Vector<String>`) corrupts the contents. To avoid relying on that path, `parse` pre-allocates each row inside `result` and writes fields through a `Vector<String>&` reference. The underlying bug is unrelated to this PR but is probably worth a separate fix.

## Test plan
- [x] `cd cmake-build-debug && cmake --build . --target spicetest`
- [x] `SPICE_STD_DIR=$PWD/std cmake-build-debug/test/spicetest --gtest_filter="StdTests.text_csvParser"` -> PASS
- [x] `SPICE_STD_DIR=$PWD/std cmake-build-debug/test/spicetest --gtest_filter="StdTests.text_*"` -> all 4 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)