### PR TITLE
Add move constructor support

### DIFF
--- a/media/specs/ctors-and-dtors.md
+++ b/media/specs/ctors-and-dtors.md
@@ -7,7 +7,7 @@
 - [x] Generate default dtor
 - [x] Generate default ctor
 - [x] Generate default copy ctor
-- [ ] (Generate default move ctor)
+- [x] (Generate default move ctor)
 - [x] Make the compiler error out when reference fields do not get initialized by all ctors
 
 ## Overview
@@ -63,7 +63,33 @@ p TestStruct.ctor(const TestStruct& other) {
 
 ## Move constructors
 
-ToDo
+A constructor is a move constructor, if it has exactly one parameter that is a non-const reference to the type of the struct.
+The default move constructor is generated for a struct if it has no user-defined move constructor and at least one field needs
+non-trivial moving (either a heap-owning pointer or a struct field that itself has a move ctor).
+
+### Implicit move ctor actions
+
+The move constructor transfers state from the source instance to the new instance. The compiler-generated body performs the
+following steps:
+
+- For each struct field that has a move ctor, call the move ctor on the field (passing the corresponding source field).
+- For each struct field that does not have a move ctor but is non-trivially copyable, call the copy ctor on the field.
+- For each owning heap pointer field, transfer ownership: copy the pointer to the destination and null out the source pointer
+  so the source's dtor does not free the storage.
+- For all other fields, perform a shallow copy from the source.
+
+```spice
+p TestStruct.ctor(TestStruct& other) {
+    // Move-construct field-by-field. For heap-owning fields, ownership is transferred and the source is nulled.
+}
+```
+
+### Overload resolution
+
+When both a copy ctor (`ctor(const T&)`) and a move ctor (`ctor(T&)`) exist on the same struct, overload resolution picks the
+move ctor for non-const lvalue arguments (the candidate that requires no constification of the argument) and picks the copy
+ctor for const arguments (binding a const argument to a non-const reference parameter would require const-loss). Temporaries
+are not bindable to non-const reference parameters, so a temporary argument always selects the copy ctor.
 
 ## Destructors
 

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -562,6 +562,87 @@ void IRGenerator::generateDefaultCopyCtor(const Function *copyCtorFunction) {
   generateImplicitProcedure(generateBody, copyCtorFunction);
 }
 
+void IRGenerator::generateMoveCtorBodyPreamble(const Function *moveCtorFunction) {
+  // Retrieve struct scope
+  Scope *structScope = moveCtorFunction->bodyScope->parent;
+  assert(structScope != nullptr);
+
+  // Get struct address
+  const SymbolTableEntry *thisEntry = moveCtorFunction->bodyScope->lookupStrict(THIS_VARIABLE_NAME);
+  assert(thisEntry != nullptr);
+  llvm::Value *thisPtrPtr = thisEntry->getAddress();
+  assert(thisPtrPtr != nullptr);
+  llvm::Value *thisPtr = nullptr;
+  llvm::Type *structType = thisEntry->getQualType().getBase().toLLVMType(sourceFile);
+
+  // Retrieve the value of the original (source) struct, which is the only function parameter
+  llvm::Value *originalThisPtr = builder.GetInsertBlock()->getParent()->getArg(1);
+
+  const size_t fieldCount = structScope->getFieldCount();
+  for (size_t fieldIdx = 0; fieldIdx < fieldCount; fieldIdx++) {
+    const SymbolTableEntry *fieldSymbol = structScope->lookupField(fieldIdx);
+    assert(fieldSymbol != nullptr && fieldSymbol->isField());
+
+    // Retrieve the address of the original field (move source)
+    llvm::Value *originalFieldAddress = insertStructGEP(structType, originalThisPtr, fieldIdx);
+
+    const QualType &fieldType = fieldSymbol->getQualType();
+
+    // Call move ctor for struct fields if available, otherwise fall back to copy or shallow copy
+    if (fieldType.is(TY_STRUCT)) {
+      Scope *matchScope = fieldType.getBodyScope();
+      // First try to find a move ctor (non-const ref param). The lookup with a non-const ref arg
+      // can return either the move or the copy ctor (lookup allows constify), so verify the
+      // returned candidate's param qualifier matches what we asked for.
+      const ArgList moveArgs = {{fieldType.toNonConst().toRef(nullptr), false /* we have the field as storage */}};
+      const Function *moveCtor = FunctionManager::lookup(matchScope, CTOR_FUNCTION_NAME, fieldType, moveArgs, true);
+      const bool moveCtorIsActuallyMove = moveCtor != nullptr && !moveCtor->paramList.empty() &&
+                                          !moveCtor->paramList.front().qualType.isConstRef();
+      if (moveCtorIsActuallyMove) {
+        generateCtorOrDtorCall(fieldSymbol, moveCtor, {originalFieldAddress});
+        continue;
+      }
+      // No move ctor: fall back to copy ctor for non-trivially copyable types
+      if (!fieldType.isTriviallyCopyable(nullptr)) {
+        const ArgList copyArgs = {{fieldType.toConstRef(nullptr), false}};
+        const Function *copyCtor = FunctionManager::lookup(matchScope, CTOR_FUNCTION_NAME, fieldType, copyArgs, false);
+        assert(copyCtor != nullptr);
+        generateCtorOrDtorCall(fieldSymbol, copyCtor, {originalFieldAddress});
+        continue;
+      }
+    }
+
+    // Retrieve the address of the new field (move dest)
+    if (!thisPtr)
+      thisPtr = insertLoad(builder.getPtrTy(), thisPtrPtr);
+    llvm::Value *fieldAddress = insertStructGEP(structType, thisPtr, fieldIdx);
+
+    // For owning heap fields, transfer ownership: copy the pointer to the destination, and null out the source
+    if (fieldType.isHeap()) {
+      assert(fieldType.isPtr());
+
+      // Load original heap address
+      llvm::Value *originalHeapAddress = insertLoad(builder.getPtrTy(), originalFieldAddress);
+      // Store it in the destination field
+      insertStore(originalHeapAddress, fieldAddress);
+      // Null out the source field so its dtor does not free the storage
+      insertStore(llvm::Constant::getNullValue(builder.getPtrTy()), originalFieldAddress);
+
+      continue;
+    }
+
+    // Shallow copy non-heap, non-struct (or trivially copyable struct) fields
+    llvm::Type *type = fieldType.toLLVMType(sourceFile);
+    generateShallowCopy(originalFieldAddress, type, fieldAddress, false);
+  }
+}
+
+void IRGenerator::generateDefaultMoveCtor(const Function *moveCtorFunction) {
+  assert(moveCtorFunction->implicitDefault && moveCtorFunction->name == CTOR_FUNCTION_NAME);
+  const std::function<void()> generateBody = [&] { generateMoveCtorBodyPreamble(moveCtorFunction); };
+  generateImplicitProcedure(generateBody, moveCtorFunction);
+}
+
 void IRGenerator::generateDtorBodyPreamble(const Function *dtorFunction) const {
   // Retrieve struct scope
   Scope *structScope = dtorFunction->bodyScope->parent;

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -591,14 +591,10 @@ void IRGenerator::generateMoveCtorBodyPreamble(const Function *moveCtorFunction)
     // Call move ctor for struct fields if available, otherwise fall back to copy or shallow copy
     if (fieldType.is(TY_STRUCT)) {
       Scope *matchScope = fieldType.getBodyScope();
-      // First try to find a move ctor (non-const ref param). The lookup with a non-const ref arg
-      // can return either the move or the copy ctor (lookup allows constify), so verify the
-      // returned candidate's param qualifier matches what we asked for.
-      const ArgList moveArgs = {{fieldType.toNonConst().toRef(nullptr), false /* we have the field as storage */}};
-      const Function *moveCtor = FunctionManager::lookup(matchScope, CTOR_FUNCTION_NAME, fieldType, moveArgs, true);
-      const bool moveCtorIsActuallyMove = moveCtor != nullptr && !moveCtor->paramList.empty() &&
-                                          !moveCtor->paramList.front().qualType.isConstRef();
-      if (moveCtorIsActuallyMove) {
+      // First try to find a move ctor (non-const ref param). We scan the manifestations directly via
+      // findMoveCtor rather than FunctionManager::lookup with a non-const ref arg, because lookup permits
+      // const-param-to-non-const-arg "constify" matching and may return the copy ctor as a false positive.
+      if (const Function *moveCtor = FunctionManager::findMoveCtor(matchScope)) {
         generateCtorOrDtorCall(fieldSymbol, moveCtor, {originalFieldAddress});
         continue;
       }

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -540,10 +540,11 @@ std::any IRGenerator::visitStructDef(const StructDefNode *node) {
     if (copyCtorFunc != nullptr && copyCtorFunc->implicitDefault)
       generateDefaultCopyCtor(copyCtorFunc);
 
-    // Generate default move ctor if required
-    const ArgList moveArgs = {{thisType.toNonConst().toRef(node), false /* always non-temporary */}};
-    const Function *moveCtorFunc = FunctionManager::lookup(currentScope, CTOR_FUNCTION_NAME, thisType, moveArgs, true);
-    if (moveCtorFunc != nullptr && moveCtorFunc->implicitDefault)
+    // Generate default move ctor if required. We can't use FunctionManager::lookup with a non-const ref arg
+    // here, because the lookup permits const-param-to-non-const-arg matching ("constify") and may return the
+    // copy ctor as a false positive. findMoveCtor scans the manifestations directly and only matches the
+    // strict move ctor signature.
+    if (const Function *moveCtorFunc = FunctionManager::findMoveCtor(currentScope); moveCtorFunc && moveCtorFunc->implicitDefault)
       generateDefaultMoveCtor(moveCtorFunc);
 
     // Generate default dtor if required

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -540,6 +540,12 @@ std::any IRGenerator::visitStructDef(const StructDefNode *node) {
     if (copyCtorFunc != nullptr && copyCtorFunc->implicitDefault)
       generateDefaultCopyCtor(copyCtorFunc);
 
+    // Generate default move ctor if required
+    const ArgList moveArgs = {{thisType.toNonConst().toRef(node), false /* always non-temporary */}};
+    const Function *moveCtorFunc = FunctionManager::lookup(currentScope, CTOR_FUNCTION_NAME, thisType, moveArgs, true);
+    if (moveCtorFunc != nullptr && moveCtorFunc->implicitDefault)
+      generateDefaultMoveCtor(moveCtorFunc);
+
     // Generate default dtor if required
     const Function *dtorFunc = FunctionManager::lookup(currentScope, DTOR_FUNCTION_NAME, thisType, {}, true);
     if (dtorFunc != nullptr && dtorFunc->implicitDefault)

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -197,6 +197,8 @@ private:
   void generateDefaultCtor(const Function *ctorFunction);
   void generateCopyCtorBodyPreamble(const Function *copyCtorFunction);
   void generateDefaultCopyCtor(const Function *copyCtorFunction);
+  void generateMoveCtorBodyPreamble(const Function *moveCtorFunction);
+  void generateDefaultMoveCtor(const Function *moveCtorFunction);
   void generateDtorBodyPreamble(const Function *dtorFunction) const;
   void generateDefaultDtor(const Function *dtorFunction);
   void generateTestMain();

--- a/src/model/Function.cpp
+++ b/src/model/Function.cpp
@@ -156,6 +156,10 @@ std::string Function::getSymbolTableEntryNameDefaultCopyCtor(const CodeLoc &stru
   return "default_copy" + std::string(CTOR_FUNCTION_NAME) + ":" + structCodeLoc.toString();
 }
 
+std::string Function::getSymbolTableEntryNameDefaultMoveCtor(const CodeLoc &structCodeLoc) {
+  return "default_move" + std::string(CTOR_FUNCTION_NAME) + ":" + structCodeLoc.toString();
+}
+
 std::string Function::getSymbolTableEntryNameDefaultDtor(const CodeLoc &structCodeLoc) {
   return "default_" + std::string(DTOR_FUNCTION_NAME) + ":" + structCodeLoc.toString();
 }

--- a/src/model/Function.h
+++ b/src/model/Function.h
@@ -51,6 +51,7 @@ public:
   [[nodiscard]] static std::string getSymbolTableEntryName(const std::string &functionName, const CodeLoc &codeLoc);
   [[nodiscard]] static std::string getSymbolTableEntryNameDefaultCtor(const CodeLoc &structCodeLoc);
   [[nodiscard]] static std::string getSymbolTableEntryNameDefaultCopyCtor(const CodeLoc &structCodeLoc);
+  [[nodiscard]] static std::string getSymbolTableEntryNameDefaultMoveCtor(const CodeLoc &structCodeLoc);
   [[nodiscard]] static std::string getSymbolTableEntryNameDefaultDtor(const CodeLoc &structCodeLoc);
   [[nodiscard]] ALWAYS_INLINE bool isMethod() const { return !thisType.is(TY_DYN); }
   [[nodiscard]] ALWAYS_INLINE bool isFunction() const { return !returnType.is(TY_DYN); }

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -604,6 +604,21 @@ bool FunctionManager::hasCopyCtor(const Scope *matchScope) { return hasCtor(matc
 
 bool FunctionManager::hasMoveCtor(const Scope *matchScope) { return hasCtor(matchScope, CtorKind::MOVE); }
 
+Function *FunctionManager::findMoveCtor(Scope *matchScope) {
+  for (auto &manifestations : matchScope->functions | std::views::values) {
+    for (auto &function : manifestations | std::views::values) {
+      if (function.name != CTOR_FUNCTION_NAME)
+        continue;
+      const bool isMoveCtor = function.paramList.size() == 1 && function.paramList.at(0).qualType.isRef() &&
+                              !function.paramList.at(0).qualType.isConstRef() &&
+                              function.paramList.at(0).qualType.getBase() == function.thisType;
+      if (isMoveCtor)
+        return &function;
+    }
+  }
+  return nullptr;
+}
+
 bool FunctionManager::hasDtor(const Scope *matchScope) {
   for (const auto &manifestations : matchScope->functions | std::views::values)
     for (const auto &function : manifestations | std::views::values)

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -602,6 +602,20 @@ bool FunctionManager::hasAnyNonCopyCtor(const Scope *matchScope) { return hasCto
 
 bool FunctionManager::hasCopyCtor(const Scope *matchScope) { return hasCtor(matchScope, CtorKind::COPY); }
 
+bool FunctionManager::hasUserCopyCtor(const Scope *matchScope) {
+  for (const auto &manifestations : matchScope->functions | std::views::values) {
+    for (const auto &function : manifestations | std::views::values) {
+      if (function.name != CTOR_FUNCTION_NAME || function.implicitDefault)
+        continue;
+      const bool isCopyCtor = function.paramList.size() == 1 && function.paramList.at(0).qualType.isConstRef() &&
+                              function.paramList.at(0).qualType.getBase() == function.thisType;
+      if (isCopyCtor)
+        return true;
+    }
+  }
+  return false;
+}
+
 bool FunctionManager::hasMoveCtor(const Scope *matchScope) { return hasCtor(matchScope, CtorKind::MOVE); }
 
 Function *FunctionManager::findMoveCtor(Scope *matchScope) {

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -2,6 +2,8 @@
 
 #include "FunctionManager.h"
 
+#include <limits>
+
 #include <ast/ASTNodes.h>
 #include <exception/SemanticError.h>
 #include <model/GenericType.h>
@@ -310,6 +312,39 @@ Function *FunctionManager::match(Scope *matchScope, const std::string &reqName, 
   if (matches.empty())
     return nullptr;
 
+  // Tie-breaking: if multiple candidates match, prefer the candidate whose param qualifiers most closely match
+  // the argument qualifiers. This resolves the typical copy-vs-move ctor ambiguity where both a `const T&`
+  // (copy) and a `T&` (move) ctor match a non-const lvalue argument - we prefer the non-const-ref candidate
+  // (move) since it requires no constification. When the argument is const, we prefer the const-ref candidate
+  // (copy) since binding to a non-const ref would require const-loss.
+  if (matches.size() > 1) {
+    constexpr int CONSTIFY_PENALTY = 1;
+    constexpr int CONST_LOSS_PENALTY = 100;
+    const auto scoreSpecificity = [&](const Function *f) {
+      int penalty = 0;
+      for (size_t i = 0; i < std::min(reqArgs.size(), f->paramList.size()); i++) {
+        const QualType &paramType = f->paramList.at(i).qualType;
+        const QualType &argType = reqArgs.at(i).first;
+        const bool paramIsConst = paramType.removeReferenceWrapper().isConst();
+        const bool argIsConst = argType.removeReferenceWrapper().isConst();
+        if (paramIsConst && !argIsConst)
+          penalty += CONSTIFY_PENALTY;
+        else if (!paramIsConst && argIsConst)
+          penalty += CONST_LOSS_PENALTY;
+      }
+      return penalty;
+    };
+    int bestScore = std::numeric_limits<int>::max();
+    for (const Function *m : matches)
+      bestScore = std::min(bestScore, scoreSpecificity(m));
+    std::vector<Function *> filtered;
+    filtered.reserve(matches.size());
+    for (Function *m : matches)
+      if (scoreSpecificity(m) == bestScore)
+        filtered.push_back(m);
+    matches = std::move(filtered);
+  }
+
   // Check if more than one function matches the requirements
   if (matches.size() > 1) {
     std::stringstream errorMessage;
@@ -533,26 +568,41 @@ uint64_t FunctionManager::getCacheKey(const Scope *scope, const std::string &nam
   return hash;
 }
 
-bool FunctionManager::hasCtor(const Scope *matchScope, bool lookForCopyCtor) {
+bool FunctionManager::hasCtor(const Scope *matchScope, CtorKind kind) {
   for (const auto &manifestations : matchScope->functions | std::views::values) {
     for (const auto &function : manifestations | std::views::values) {
       // If it is no ctor, skip it
       if (function.name != CTOR_FUNCTION_NAME)
         continue;
-      // If we don't search for a copy ctor and got none -> we found one
-      // If we search for a copy ctor and got one -> we found one
-      const bool isCopyCtor = function.paramList.size() == 1 && function.paramList.at(0).qualType.isConstRef() &&
-                              function.paramList.at(0).qualType.getBase() == function.thisType;
-      if (isCopyCtor == lookForCopyCtor)
-        return true;
+      // Classify the ctor based on its parameter list
+      const bool singleSelfRefParam = function.paramList.size() == 1 && function.paramList.at(0).qualType.isRef() &&
+                                      function.paramList.at(0).qualType.getBase() == function.thisType;
+      const bool isCopyCtor = singleSelfRefParam && function.paramList.at(0).qualType.isConstRef();
+      const bool isMoveCtor = singleSelfRefParam && !function.paramList.at(0).qualType.isConstRef();
+      switch (kind) {
+      case CtorKind::COPY:
+        if (isCopyCtor)
+          return true;
+        break;
+      case CtorKind::MOVE:
+        if (isMoveCtor)
+          return true;
+        break;
+      case CtorKind::ANY_NON_COPY_NON_MOVE:
+        if (!isCopyCtor && !isMoveCtor)
+          return true;
+        break;
+      }
     }
   }
   return false;
 }
 
-bool FunctionManager::hasAnyNonCopyCtor(const Scope *matchScope) { return hasCtor(matchScope, false); }
+bool FunctionManager::hasAnyNonCopyCtor(const Scope *matchScope) { return hasCtor(matchScope, CtorKind::ANY_NON_COPY_NON_MOVE); }
 
-bool FunctionManager::hasCopyCtor(const Scope *matchScope) { return hasCtor(matchScope, true); }
+bool FunctionManager::hasCopyCtor(const Scope *matchScope) { return hasCtor(matchScope, CtorKind::COPY); }
+
+bool FunctionManager::hasMoveCtor(const Scope *matchScope) { return hasCtor(matchScope, CtorKind::MOVE); }
 
 bool FunctionManager::hasDtor(const Scope *matchScope) {
   for (const auto &manifestations : matchScope->functions | std::views::values)

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -312,38 +312,8 @@ Function *FunctionManager::match(Scope *matchScope, const std::string &reqName, 
   if (matches.empty())
     return nullptr;
 
-  // Tie-breaking: if multiple candidates match, prefer the candidate whose param qualifiers most closely match
-  // the argument qualifiers. This resolves the typical copy-vs-move ctor ambiguity where both a `const T&`
-  // (copy) and a `T&` (move) ctor match a non-const lvalue argument - we prefer the non-const-ref candidate
-  // (move) since it requires no constification. When the argument is const, we prefer the const-ref candidate
-  // (copy) since binding to a non-const ref would require const-loss.
-  if (matches.size() > 1) {
-    constexpr int CONSTIFY_PENALTY = 1;
-    constexpr int CONST_LOSS_PENALTY = 100;
-    const auto scoreSpecificity = [&](const Function *f) {
-      int penalty = 0;
-      for (size_t i = 0; i < std::min(reqArgs.size(), f->paramList.size()); i++) {
-        const QualType &paramType = f->paramList.at(i).qualType;
-        const QualType &argType = reqArgs.at(i).first;
-        const bool paramIsConst = paramType.removeReferenceWrapper().isConst();
-        const bool argIsConst = argType.removeReferenceWrapper().isConst();
-        if (paramIsConst && !argIsConst)
-          penalty += CONSTIFY_PENALTY;
-        else if (!paramIsConst && argIsConst)
-          penalty += CONST_LOSS_PENALTY;
-      }
-      return penalty;
-    };
-    int bestScore = std::numeric_limits<int>::max();
-    for (const Function *m : matches)
-      bestScore = std::min(bestScore, scoreSpecificity(m));
-    std::vector<Function *> filtered;
-    filtered.reserve(matches.size());
-    for (Function *m : matches)
-      if (scoreSpecificity(m) == bestScore)
-        filtered.push_back(m);
-    matches = std::move(filtered);
-  }
+  // Tie-breaking: if multiple candidates match, narrow them by qualifier specificity (see breakOverloadTie).
+  breakOverloadTie(matches, reqArgs);
 
   // Check if more than one function matches the requirements
   if (matches.size() > 1) {
@@ -542,6 +512,51 @@ const GenericType *FunctionManager::getGenericTypeOfCandidateByName(const Functi
       return &templateType;
   }
   return nullptr;
+}
+
+/**
+ * Narrow a multi-match overload set by preferring the candidate whose parameter qualifiers most closely match
+ * the argument qualifiers. This resolves the typical copy-vs-move ctor ambiguity where both a `const T&`
+ * (copy) and a `T&` (move) ctor match a non-const lvalue argument - we prefer the non-const-ref candidate
+ * (move) since it requires no constification. When the argument is const, we prefer the const-ref candidate
+ * (copy) since binding to a non-const ref would require const-loss.
+ *
+ * Modifies `matches` in place, removing any candidate that scores worse than the best one. A no-op if there
+ * are fewer than two candidates.
+ *
+ * @param matches Candidate list to narrow
+ * @param reqArgs Argument list from the call site
+ */
+void FunctionManager::breakOverloadTie(std::vector<Function *> &matches, const ArgList &reqArgs) {
+  if (matches.size() < 2)
+    return;
+
+  constexpr int CONSTIFY_PENALTY = 1;
+  constexpr int CONST_LOSS_PENALTY = 100;
+  const auto scoreSpecificity = [&](const Function *f) {
+    int penalty = 0;
+    for (size_t i = 0; i < std::min(reqArgs.size(), f->paramList.size()); i++) {
+      const QualType &paramType = f->paramList.at(i).qualType;
+      const QualType &argType = reqArgs.at(i).first;
+      const bool paramIsConst = paramType.removeReferenceWrapper().isConst();
+      const bool argIsConst = argType.removeReferenceWrapper().isConst();
+      if (paramIsConst && !argIsConst)
+        penalty += CONSTIFY_PENALTY;
+      else if (!paramIsConst && argIsConst)
+        penalty += CONST_LOSS_PENALTY;
+    }
+    return penalty;
+  };
+
+  int bestScore = std::numeric_limits<int>::max();
+  for (const Function *m : matches)
+    bestScore = std::min(bestScore, scoreSpecificity(m));
+  std::vector<Function *> filtered;
+  filtered.reserve(matches.size());
+  for (Function *m : matches)
+    if (scoreSpecificity(m) == bestScore)
+      filtered.push_back(m);
+  matches = std::move(filtered);
 }
 
 /**

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -47,6 +47,7 @@ public:
   [[nodiscard]] static bool hasAnyNonCopyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasCopyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasMoveCtor(const Scope *matchScope);
+  [[nodiscard]] static Function *findMoveCtor(Scope *matchScope);
   [[nodiscard]] static bool hasDtor(const Scope *matchScope);
   static void cleanup();
   [[nodiscard]] static std::string dumpLookupCacheStatistics();

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -46,6 +46,7 @@ public:
                          const QualTypeList &templateTypeHints, bool strictQualifierMatching, const ASTNode *callNode);
   [[nodiscard]] static bool hasAnyNonCopyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasCopyCtor(const Scope *matchScope);
+  [[nodiscard]] static bool hasUserCopyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasMoveCtor(const Scope *matchScope);
   [[nodiscard]] static Function *findMoveCtor(Scope *matchScope);
   [[nodiscard]] static bool hasDtor(const Scope *matchScope);

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -46,6 +46,7 @@ public:
                          const QualTypeList &templateTypeHints, bool strictQualifierMatching, const ASTNode *callNode);
   [[nodiscard]] static bool hasAnyNonCopyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasCopyCtor(const Scope *matchScope);
+  [[nodiscard]] static bool hasMoveCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasDtor(const Scope *matchScope);
   static void cleanup();
   [[nodiscard]] static std::string dumpLookupCacheStatistics();
@@ -73,7 +74,8 @@ private:
                                                                           const std::string &templateTypeName);
   [[nodiscard]] static uint64_t getCacheKey(const Scope *scope, const std::string &name, const QualType &thisType,
                                             const ArgList &args, const QualTypeList &templateTypes);
-  [[nodiscard]] static bool hasCtor(const Scope *matchScope, bool lookForCopyCtor);
+  enum class CtorKind : uint8_t { ANY_NON_COPY_NON_MOVE, COPY, MOVE };
+  [[nodiscard]] static bool hasCtor(const Scope *matchScope, CtorKind kind);
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -76,6 +76,7 @@ private:
                                                                           const std::string &templateTypeName);
   [[nodiscard]] static uint64_t getCacheKey(const Scope *scope, const std::string &name, const QualType &thisType,
                                             const ArgList &args, const QualTypeList &templateTypes);
+  static void breakOverloadTie(std::vector<Function *> &matches, const ArgList &reqArgs);
   enum class CtorKind : uint8_t { ANY_NON_COPY_NON_MOVE, COPY, MOVE };
   [[nodiscard]] static bool hasCtor(const Scope *matchScope, CtorKind kind);
 };

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -31,9 +31,10 @@ std::any TypeChecker::visitEntry(EntryNode *node) {
   if (isPrepare) {
     const std::vector<const Struct *> manifestations = rootScope->getAllStructManifestationsInDeclarationOrder();
     for (const Struct *manifestation : manifestations) {
-      // Check if we need to create a default ctor, copy ctor or dtor
+      // Check if we need to create a default ctor, copy ctor, move ctor or dtor
       createDefaultCtorIfRequired(*manifestation, manifestation->scope);
       createDefaultCopyCtorIfRequired(*manifestation, manifestation->scope);
+      createDefaultMoveCtorIfRequired(*manifestation, manifestation->scope);
       createDefaultDtorIfRequired(*manifestation, manifestation->scope);
     }
   }
@@ -78,6 +79,13 @@ Function *TypeChecker::matchCopyCtor(const QualType &thisType, const ASTNode *no
   Scope *matchScope = thisType.getBodyScope();
   assert(matchScope != nullptr);
   const ArgList args = {{thisType.toConstRef(node), false}};
+  return FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType, args, {}, true, node);
+}
+
+Function *TypeChecker::matchMoveCtor(const QualType &thisType, const ASTNode *node) const {
+  Scope *matchScope = thisType.getBodyScope();
+  assert(matchScope != nullptr);
+  const ArgList args = {{thisType.toNonConst().toRef(node), false}};
   return FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType, args, {}, true, node);
 }
 

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -155,6 +155,7 @@ private:
   bool visitMethodCall(FctCallNode *node, Scope *structScope) const;
   bool checkAsyncLambdaCaptureRules(const LambdaBaseNode *node, const LambdaAttrNode *attrs) const;
   [[nodiscard]] Function *matchCopyCtor(const QualType &thisType, const ASTNode *node) const;
+  [[nodiscard]] Function *matchMoveCtor(const QualType &thisType, const ASTNode *node) const;
   [[nodiscard]] QualType mapLocalTypeToImportedScopeType(const Scope *targetScope, const QualType &symbolType) const;
   [[nodiscard]] QualType mapImportedScopeTypeToLocalType(const Scope *sourceScope, const QualType &symbolType) const;
   std::vector<const Function *> &getOpFctPointers(ASTNode *node) const;
@@ -168,9 +169,11 @@ private:
                                  const ParamList &params) const;
   void createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
   void createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
+  void createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
   void createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
   void createCtorBodyPreamble(const Scope *bodyScope) const;
   void createCopyCtorBodyPreamble(const Scope *bodyScope) const;
+  void createMoveCtorBodyPreamble(const Scope *bodyScope) const;
   void createDtorBodyPreamble(const Scope *bodyScope) const;
   Function *implicitlyCallStructMethod(const SymbolTableEntry *entry, const std::string &methodName, const ArgList &args,
                                        const ASTNode *node) const;
@@ -178,6 +181,8 @@ private:
                                        const ASTNode *node) const;
   Function *implicitlyCallStructCopyCtor(const SymbolTableEntry *entry, const ASTNode *node) const;
   Function *implicitlyCallStructCopyCtor(const QualType &thisType, const ASTNode *node) const;
+  Function *implicitlyCallStructMoveCtor(const SymbolTableEntry *entry, const ASTNode *node) const;
+  Function *implicitlyCallStructMoveCtor(const QualType &thisType, const ASTNode *node) const;
   void implicitlyCallStructDtor(SymbolTableEntry *entry, StmtLstNode *node) const;
   void implicitlyCallDeallocate(const ASTNode *node) const;
   void doScopeCleanup(StmtLstNode *node) const;

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -209,11 +209,29 @@ void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Sco
   const auto node = spice_pointer_cast<const StructDefNode *>(spiceStruct.declNode);
   assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
 
+  // Skip generic struct presets - we only synthesize a default move ctor for fully substantiated structs.
+  // Reason: each manifestation gets its own scope (deep-copied from the generic), and the implicit move ctor
+  // body's preamble writes to field lifecycle state via bodyScope->parent. If we created the move ctor on the
+  // generic struct, the deep-copied Function in the manifestation's scope would still carry a bodyScope pointer
+  // into the generic struct's scope, causing the preamble to update fields in the wrong scope.
+  if (!spiceStruct.isFullySubstantiated())
+    return;
+
   // Abort if the struct already has a user-defined move constructor.
   // We can't just call FunctionManager::lookup with a non-const ref arg here, since the lookup permits
   // const-param-to-non-const-arg matching ("constify") and would return the copy ctor (if one exists) as
   // a false positive. Instead, check the function manifestations directly for a single-self-non-const-ref ctor.
   if (FunctionManager::hasMoveCtor(structScope))
+    return;
+
+  // Abort if the struct has a user-defined copy ctor. Reason: in Spice the move-vs-copy tie-breaker picks the
+  // non-const-ref (move) candidate for non-const lvalue arguments, so silently auto-generating a move ctor on
+  // top of a user-defined copy ctor would change the behavior of existing `T b = T(a)` call sites (a's heap
+  // contents would be stolen instead of deep-copied). Users that want a default move ctor in addition to their
+  // own copy ctor can write an empty `p T.ctor(T& other) {}` to opt in. We still synthesize the default move
+  // ctor when only the auto-generated copy ctor exists (heap-owning struct with no user ctors) - the user did
+  // not write any binding semantics in that case, so picking move for non-const lvalues is fine.
+  if (FunctionManager::hasUserCopyCtor(structScope))
     return;
   const QualType structType = spiceStruct.entry->getQualType();
 

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -138,7 +138,6 @@ void TypeChecker::createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *
  *
  * For generating a default copy ctor, the following conditions need to be met:
  * - No user-defined copy ctor
- * - No user-defined move ctor
  *
  * @param spiceStruct Struct instance
  * @param structScope Scope of the struct
@@ -153,9 +152,6 @@ void TypeChecker::createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Sco
   const Function *copyCtor = FunctionManager::lookup(structScope, CTOR_FUNCTION_NAME, structType, lookupArgs, true);
   if (copyCtor != nullptr)
     return;
-
-  // Abort if the struct has a user-defined move constructor
-  // ToDo: Check for move ctor
 
   // Check if we have fields, that require us to do anything in the ctor
   const size_t fieldCount = structScope->getFieldCount();
@@ -196,6 +192,64 @@ void TypeChecker::createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Sco
   // Create the default copy ctor function
   const std::string entryName = Function::getSymbolTableEntryNameDefaultCopyCtor(node->codeLoc);
   const ParamList paramTypes = {{structType.toConstRef(node), false}};
+  createDefaultStructMethod(spiceStruct, entryName, CTOR_FUNCTION_NAME, paramTypes);
+}
+
+/**
+ * Checks if the given struct scope already has a user-defined move constructor and creates a default one if not.
+ *
+ * For generating a default move ctor, the following conditions need to be met:
+ * - No user-defined move ctor
+ * - At least one field requires non-trivial moving (heap pointer or struct field with move ctor)
+ *
+ * @param spiceStruct Struct instance
+ * @param structScope Scope of the struct
+ */
+void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const {
+  const auto node = spice_pointer_cast<const StructDefNode *>(spiceStruct.declNode);
+  assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
+
+  // Abort if the struct already has a user-defined move constructor
+  const QualType structType = spiceStruct.entry->getQualType();
+  const ArgList lookupArgs = {{structType.toNonConst().toRef(node), false}};
+  const Function *moveCtor = FunctionManager::lookup(structScope, CTOR_FUNCTION_NAME, structType, lookupArgs, true);
+  if (moveCtor != nullptr)
+    return;
+
+  // Check if we have fields, that require us to do anything in the move ctor
+  const size_t fieldCount = structScope->getFieldCount();
+  bool moveCtorRequired = false;
+  for (size_t i = 0; i < fieldCount; i++) {
+    const SymbolTableEntry *fieldSymbol = structScope->lookupField(i);
+    assert(fieldSymbol != nullptr && fieldSymbol->declNode != nullptr);
+
+    QualType fieldType = fieldSymbol->getQualType();
+    if (fieldType.hasAnyGenericParts() && !spiceStruct.typeMapping.empty())
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, spiceStruct.typeMapping, fieldSymbol->declNode);
+
+    // If the field is of type struct, check if this struct has a move ctor that has to be called
+    if (fieldType.is(TY_STRUCT)) {
+      Scope *bodyScope = fieldType.getBodyScope();
+      // Lookup move ctor function
+      const ArgList args = {{fieldType.toNonConst().toRef(node), false}};
+      const Function *ctorFct = FunctionManager::match(bodyScope, CTOR_FUNCTION_NAME, fieldType, args, {}, true, node);
+      moveCtorRequired |= ctorFct != nullptr;
+    }
+
+    // If we have an owning heap pointer, we transfer ownership of the heap storage
+    if (fieldType.isHeap()) {
+      assert(fieldType.isPtr());
+      moveCtorRequired = true;
+    }
+  }
+
+  // If we don't have any fields, that require us to do anything in the move ctor, we can skip it
+  if (!moveCtorRequired && !node->emitVTable)
+    return;
+
+  // Create the default move ctor function
+  const std::string entryName = Function::getSymbolTableEntryNameDefaultMoveCtor(node->codeLoc);
+  const ParamList paramTypes = {{structType.toNonConst().toRef(node), false}};
   createDefaultStructMethod(spiceStruct, entryName, CTOR_FUNCTION_NAME, paramTypes);
 }
 
@@ -338,6 +392,43 @@ void TypeChecker::createCopyCtorBodyPreamble(const Scope *bodyScope) const {
 }
 
 /**
+ * Prepare the generation of the move ctor body preamble. This preamble is used to initialize the VTable, move-construct or
+ * shallow-copy fields and transfer ownership of heap allocations.
+ */
+void TypeChecker::createMoveCtorBodyPreamble(const Scope *bodyScope) const {
+  // Retrieve struct scope
+  Scope *structScope = bodyScope->parent;
+  assert(structScope != nullptr);
+
+  const size_t fieldCount = structScope->getFieldCount();
+  for (size_t i = 0; i < fieldCount; i++) {
+    SymbolTableEntry *fieldSymbol = structScope->lookupField(i);
+    assert(fieldSymbol != nullptr && fieldSymbol->isField());
+    if (fieldSymbol->isImplicitField)
+      continue;
+
+    QualType fieldType = fieldSymbol->getQualType();
+    if (fieldType.hasAnyGenericParts())
+      TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping, fieldSymbol->declNode);
+
+    if (fieldType.is(TY_STRUCT)) {
+      const auto fieldNode = spice_pointer_cast<const FieldNode *>(fieldSymbol->declNode);
+      // Match move ctor function, create the concrete manifestation and set it to used. The matcher's tie-break
+      // (see FunctionManager::match) prefers the move ctor over a copy ctor for a non-const ref argument.
+      Scope *matchScope = fieldType.getBodyScope();
+      const ArgList args = {{fieldType.toNonConst().toRef(fieldNode), false}};
+      const Function *moveCtorFct = FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, fieldType, args, {}, false, fieldNode);
+      // Only update the body scope when we actually selected a move ctor (param is non-const ref)
+      if (moveCtorFct != nullptr && !moveCtorFct->paramList.empty() &&
+          !moveCtorFct->paramList.front().qualType.isConstRef())
+        fieldSymbol->updateType(fieldType.getWithBodyScope(moveCtorFct->thisType.getBodyScope()), true);
+    }
+
+    fieldSymbol->updateState(INITIALIZED, fieldSymbol->declNode);
+  }
+}
+
+/**
  * Prepare the generation of the dtor body preamble. This preamble is used to destruct all fields and to free all heap fields.
  */
 void TypeChecker::createDtorBodyPreamble(const Scope *bodyScope) const {
@@ -419,6 +510,29 @@ Function *TypeChecker::implicitlyCallStructCopyCtor(const SymbolTableEntry *entr
  */
 Function *TypeChecker::implicitlyCallStructCopyCtor(const QualType &thisType, const ASTNode *node) const {
   const QualType argType = thisType.removeReferenceWrapper().toConstRef(node);
+  const ArgList args = {{argType, false /* we always have an entry here */}};
+  return implicitlyCallStructMethod(thisType, CTOR_FUNCTION_NAME, args, node);
+}
+
+/**
+ * Prepare the generation of a call to the move ctor of a given struct
+ *
+ * @param entry Symbol entry to use as 'this' pointer for the move ctor call
+ * @param node Current AST node
+ */
+Function *TypeChecker::implicitlyCallStructMoveCtor(const SymbolTableEntry *entry, const ASTNode *node) const {
+  assert(entry != nullptr && entry->getQualType().is(TY_STRUCT));
+  return implicitlyCallStructMoveCtor(entry->getQualType(), node);
+}
+
+/**
+ * Prepare the generation of a call to the move ctor of a given struct
+ *
+ * @param thisType Struct type to call the move ctor on
+ * @param node Current AST node
+ */
+Function *TypeChecker::implicitlyCallStructMoveCtor(const QualType &thisType, const ASTNode *node) const {
+  const QualType argType = thisType.removeReferenceWrapper().toNonConst().toRef(node);
   const ArgList args = {{argType, false /* we always have an entry here */}};
   return implicitlyCallStructMethod(thisType, CTOR_FUNCTION_NAME, args, node);
 }

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -209,12 +209,13 @@ void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Sco
   const auto node = spice_pointer_cast<const StructDefNode *>(spiceStruct.declNode);
   assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
 
-  // Abort if the struct already has a user-defined move constructor
-  const QualType structType = spiceStruct.entry->getQualType();
-  const ArgList lookupArgs = {{structType.toNonConst().toRef(node), false}};
-  const Function *moveCtor = FunctionManager::lookup(structScope, CTOR_FUNCTION_NAME, structType, lookupArgs, true);
-  if (moveCtor != nullptr)
+  // Abort if the struct already has a user-defined move constructor.
+  // We can't just call FunctionManager::lookup with a non-const ref arg here, since the lookup permits
+  // const-param-to-non-const-arg matching ("constify") and would return the copy ctor (if one exists) as
+  // a false positive. Instead, check the function manifestations directly for a single-self-non-const-ref ctor.
+  if (FunctionManager::hasMoveCtor(structScope))
     return;
+  const QualType structType = spiceStruct.entry->getQualType();
 
   // Check if we have fields, that require us to do anything in the move ctor
   const size_t fieldCount = structScope->getFieldCount();
@@ -227,13 +228,14 @@ void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Sco
     if (fieldType.hasAnyGenericParts() && !spiceStruct.typeMapping.empty())
       TypeMatcher::substantiateTypeWithTypeMapping(fieldType, spiceStruct.typeMapping, fieldSymbol->declNode);
 
-    // If the field is of type struct, check if this struct has a move ctor that has to be called
+    // If the field is of type struct, check whether the field's struct has its own move ctor. We use
+    // findMoveCtor (a direct scan of the manifestations) rather than FunctionManager::match here for two
+    // reasons: (1) match permits const-param-to-non-const-arg "constify" matching and would return the
+    // field's copy ctor as a false positive, and (2) match populates the lookup cache, which would inflate
+    // the per-struct cache-miss counts even for structs that have nothing to do with move ctors.
     if (fieldType.is(TY_STRUCT)) {
       Scope *bodyScope = fieldType.getBodyScope();
-      // Lookup move ctor function
-      const ArgList args = {{fieldType.toNonConst().toRef(node), false}};
-      const Function *ctorFct = FunctionManager::match(bodyScope, CTOR_FUNCTION_NAME, fieldType, args, {}, true, node);
-      moveCtorRequired |= ctorFct != nullptr;
+      moveCtorRequired |= FunctionManager::findMoveCtor(bodyScope) != nullptr;
     }
 
     // If we have an owning heap pointer, we transfer ownership of the heap storage
@@ -243,8 +245,12 @@ void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Sco
     }
   }
 
-  // If we don't have any fields, that require us to do anything in the move ctor, we can skip it
-  if (!moveCtorRequired && !node->emitVTable)
+  // If we don't have any fields that require us to do anything special in the move ctor, we can skip it.
+  // Unlike the copy ctor we do NOT generate a default move ctor just because the struct emits a vtable - the
+  // vtable pointer is part of the struct layout and gets shallow-copied along with everything else, no
+  // special move handling needed. Users that want to move a vtable-bearing struct fall back to the default
+  // copy ctor.
+  if (!moveCtorRequired)
     return;
 
   // Create the default move ctor function
@@ -412,16 +418,16 @@ void TypeChecker::createMoveCtorBodyPreamble(const Scope *bodyScope) const {
       TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping, fieldSymbol->declNode);
 
     if (fieldType.is(TY_STRUCT)) {
-      const auto fieldNode = spice_pointer_cast<const FieldNode *>(fieldSymbol->declNode);
-      // Match move ctor function, create the concrete manifestation and set it to used. The matcher's tie-break
-      // (see FunctionManager::match) prefers the move ctor over a copy ctor for a non-const ref argument.
+      // Find a move ctor on the field's struct. We use findMoveCtor rather than FunctionManager::match to
+      // avoid a constify-based false positive returning the copy ctor. findMoveCtor doesn't mark the
+      // function as used, so do that explicitly to ensure the inner move ctor's body is actually emitted.
       Scope *matchScope = fieldType.getBodyScope();
-      const ArgList args = {{fieldType.toNonConst().toRef(fieldNode), false}};
-      const Function *moveCtorFct = FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, fieldType, args, {}, false, fieldNode);
-      // Only update the body scope when we actually selected a move ctor (param is non-const ref)
-      if (moveCtorFct != nullptr && !moveCtorFct->paramList.empty() &&
-          !moveCtorFct->paramList.front().qualType.isConstRef())
+      if (Function *moveCtorFct = FunctionManager::findMoveCtor(matchScope)) {
+        moveCtorFct->used = true;
+        if (moveCtorFct->entry)
+          moveCtorFct->entry->used = true;
         fieldSymbol->updateType(fieldType.getWithBodyScope(moveCtorFct->thisType.getBodyScope()), true);
+      }
     }
 
     fieldSymbol->updateState(INITIALIZED, fieldSymbol->declNode);

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -157,6 +157,12 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
     // Change to struct scope
     changeToScope(manifestation->scope, ScopeType::STRUCT);
 
+    // Mount type mapping for this manifestation, so that the body preamble helpers below can substantiate
+    // generic field types (e.g. `heap T*` on `Vector<T>`). Without this, an auto-generated body preamble that
+    // touches a still-generic field would assert in TypeMatcher::substantiateTypeWithTypeMapping.
+    assert(typeMapping.empty());
+    typeMapping = manifestation->typeMapping;
+
     // Re-visit all default values. This is required, since the type of the default value might vary for different manifestations
     for (const FieldNode *field : node->fields) {
       if (field->defaultValue != nullptr) {
@@ -244,6 +250,9 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
 
     // Reset field symbols to declared state for the next manifestation
     manifestation->resetFieldSymbolsToDeclared(node);
+
+    // Clear type mapping
+    typeMapping.clear();
 
     // Return to the root scope
     currentScope = rootScope;

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -230,10 +230,9 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
       assert(manifestation->areAllFieldsInitialized() == nullptr);
     }
 
-    // Check default move ctor body if required
-    const ArgList moveArgs = {{structType.toRef(node), false /* always non-temporary */}};
-    const Function *moveCtorFunc = FunctionManager::lookup(currentScope, CTOR_FUNCTION_NAME, structType, moveArgs, true);
-    if (moveCtorFunc != nullptr && moveCtorFunc->implicitDefault) {
+    // Check default move ctor body if required. findMoveCtor scans the manifestations directly to avoid the
+    // constify-based false-positive that FunctionManager::lookup with a non-const ref arg can produce.
+    if (const Function *moveCtorFunc = FunctionManager::findMoveCtor(currentScope); moveCtorFunc && moveCtorFunc->implicitDefault) {
       createMoveCtorBodyPreamble(moveCtorFunc->bodyScope);
       assert(manifestation->areAllFieldsInitialized() == nullptr);
     }

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -230,6 +230,14 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
       assert(manifestation->areAllFieldsInitialized() == nullptr);
     }
 
+    // Check default move ctor body if required
+    const ArgList moveArgs = {{structType.toRef(node), false /* always non-temporary */}};
+    const Function *moveCtorFunc = FunctionManager::lookup(currentScope, CTOR_FUNCTION_NAME, structType, moveArgs, true);
+    if (moveCtorFunc != nullptr && moveCtorFunc->implicitDefault) {
+      createMoveCtorBodyPreamble(moveCtorFunc->bodyScope);
+      assert(manifestation->areAllFieldsInitialized() == nullptr);
+    }
+
     // Check default dtor body if required
     const Function *dtorFunc = FunctionManager::lookup(currentScope, DTOR_FUNCTION_NAME, structType, {}, true);
     if (dtorFunc != nullptr && dtorFunc->implicitDefault)

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -39,6 +39,20 @@ declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr no
 
 declare ptr @_Z12sAllocUnsafem(i64)
 
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define void @_ZN5Inner4ctorER5Inner(ptr noundef nonnull align 8 dereferenceable(16) %0, ptr %1) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %3 = load ptr, ptr %this, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %3, ptr %1, i64 8, i1 false)
+  %4 = getelementptr inbounds nuw %struct.Inner, ptr %1, i32 0, i32 1
+  %5 = getelementptr inbounds nuw %struct.Inner, ptr %3, i32 0, i32 1
+  %6 = load ptr, ptr %4, align 8
+  store ptr %6, ptr %5, align 8
+  store ptr null, ptr %4, align 8
+  ret void
+}
+
 define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -82,6 +96,15 @@ define void @_ZN6Middle4ctorERK6Middle(ptr noundef nonnull align 8 dereferenceab
   store ptr %0, ptr %this, align 8
   %3 = load ptr, ptr %this, align 8
   call void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 8 dereferenceable(16) %3, ptr %1)
+  ret void
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define void @_ZN6Middle4ctorER6Middle(ptr noundef nonnull align 8 dereferenceable(16) %0, ptr %1) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %3 = load ptr, ptr %this, align 8
+  call void @_ZN5Inner4ctorER5Inner(ptr noundef nonnull align 8 dereferenceable(16) %3, ptr %1)
   ret void
 }
 

--- a/test/test-files/irgenerator/structs/success-default-move-ctor-heap/cout.out
+++ b/test/test-files/irgenerator/structs/success-default-move-ctor-heap/cout.out
@@ -1,0 +1,4 @@
+a holds 7
+a was moved-from: 0
+b holds 7
+a was moved-from: 1

--- a/test/test-files/irgenerator/structs/success-default-move-ctor-heap/source.spice
+++ b/test/test-files/irgenerator/structs/success-default-move-ctor-heap/source.spice
@@ -1,0 +1,33 @@
+// The compiler synthesizes a default move ctor when a struct owns a heap
+// pointer and no user-defined move ctor is present. The synthesized ctor
+// transfers ownership of the heap storage to the destination and nulls the
+// source's pointer so the source's dtor will not free the storage.
+
+type IntBox struct {
+    heap int* storage
+}
+
+p IntBox.ctor(int v) {
+    this.storage = __new<int>(v);
+}
+
+f<int> getValue(const IntBox& box) {
+    return *box.storage;
+}
+
+f<bool> isMovedFrom(const IntBox& box) {
+    return box.storage == nil<heap int*>;
+}
+
+f<int> main() {
+    IntBox a = IntBox(7);
+    printf("a holds %d\n", getValue(a));
+    printf("a was moved-from: %d\n", isMovedFrom(a));
+
+    // Trigger the synthesized move ctor by an explicit ctor call with a
+    // non-const lvalue argument. Overload resolution picks the move ctor
+    // over the auto-generated copy ctor because the argument is non-const.
+    IntBox b = IntBox(a);
+    printf("b holds %d\n", getValue(b));
+    printf("a was moved-from: %d\n", isMovedFrom(a));
+}

--- a/test/test-files/irgenerator/structs/success-default-move-ctor-nested/cout.out
+++ b/test/test-files/irgenerator/structs/success-default-move-ctor-nested/cout.out
@@ -1,0 +1,3 @@
+a: inner.value=99 inner.moveCount=0 tag=7
+b: inner.value=99 inner.moveCount=1 tag=7
+a after move: inner.value=-1 inner.moveCount=-1

--- a/test/test-files/irgenerator/structs/success-default-move-ctor-nested/source.spice
+++ b/test/test-files/irgenerator/structs/success-default-move-ctor-nested/source.spice
@@ -1,0 +1,39 @@
+// When a struct field has a move ctor of its own, the synthesized move ctor
+// of the outer struct calls the field's move ctor for that field. Other
+// fields are shallow-copied.
+
+type Inner struct {
+    int value
+    int moveCount
+}
+
+p Inner.ctor() {
+    this.value = 0;
+    this.moveCount = 0;
+}
+
+// Inner has a user-defined move ctor: increments a counter on move so we can
+// verify the synthesized outer move ctor delegates to it.
+p Inner.ctor(Inner& other) {
+    this.value = other.value;
+    this.moveCount = other.moveCount + 1;
+    other.value = -1;
+    other.moveCount = -1;
+}
+
+type Outer struct {
+    Inner inner
+    int tag
+}
+
+f<int> main() {
+    Outer a;
+    a.inner.value = 99;
+    a.tag = 7;
+    printf("a: inner.value=%d inner.moveCount=%d tag=%d\n", a.inner.value, a.inner.moveCount, a.tag);
+
+    // Triggers the synthesized Outer move ctor, which delegates to Inner.ctor(Inner&)
+    Outer b = Outer(a);
+    printf("b: inner.value=%d inner.moveCount=%d tag=%d\n", b.inner.value, b.inner.moveCount, b.tag);
+    printf("a after move: inner.value=%d inner.moveCount=%d\n", a.inner.value, a.inner.moveCount);
+}

--- a/test/test-files/irgenerator/structs/success-move-and-copy-ctor-coexist/cout.out
+++ b/test/test-files/irgenerator/structs/success-move-and-copy-ctor-coexist/cout.out
@@ -1,0 +1,3 @@
+initial: copies=0 moves=0
+after move:  copies=0 moves=1
+after copy:  copies=1 moves=1

--- a/test/test-files/irgenerator/structs/success-move-and-copy-ctor-coexist/source.spice
+++ b/test/test-files/irgenerator/structs/success-move-and-copy-ctor-coexist/source.spice
@@ -1,0 +1,37 @@
+// When both a user-defined copy ctor and a user-defined move ctor exist, the
+// compiler picks the move ctor for non-const lvalue arguments (less
+// constification needed) and the copy ctor for const lvalue arguments.
+
+type Counter struct {
+    int copies
+    int moves
+}
+
+p Counter.ctor() {
+    this.copies = 0;
+    this.moves = 0;
+}
+
+p Counter.ctor(const Counter& other) {
+    this.copies = other.copies + 1;
+    this.moves = other.moves;
+}
+
+p Counter.ctor(Counter& other) {
+    this.copies = other.copies;
+    this.moves = other.moves + 1;
+}
+
+f<int> main() {
+    Counter c;
+    printf("initial: copies=%d moves=%d\n", c.copies, c.moves);
+
+    // Non-const lvalue -> move ctor preferred
+    Counter c2 = Counter(c);
+    printf("after move:  copies=%d moves=%d\n", c2.copies, c2.moves);
+
+    // Const ref -> only the copy ctor matches (move ctor requires non-const)
+    const Counter& cref = c2;
+    Counter c3 = Counter(cref);
+    printf("after copy:  copies=%d moves=%d\n", c3.copies, c3.moves);
+}

--- a/test/test-files/irgenerator/structs/success-move-ctor-chained-heap/cout.out
+++ b/test/test-files/irgenerator/structs/success-move-ctor-chained-heap/cout.out
@@ -1,0 +1,6 @@
+a.storage is null: 0
+a.storage is null: 1
+b.storage is null: 0
+b.storage is null: 1
+c.storage is null: 0
+c holds 123

--- a/test/test-files/irgenerator/structs/success-move-ctor-chained-heap/source.spice
+++ b/test/test-files/irgenerator/structs/success-move-ctor-chained-heap/source.spice
@@ -1,0 +1,25 @@
+// Chained moves: moving from one IntBox to a new one, then again to a third.
+// Verifies that ownership is correctly transferred along the chain and that
+// each intermediate is left in the moved-from state.
+
+type IntBox struct {
+    heap int* storage
+}
+
+p IntBox.ctor(int v) {
+    this.storage = __new<int>(v);
+}
+
+f<int> main() {
+    IntBox a = IntBox(123);
+    printf("a.storage is null: %d\n", a.storage == nil<heap int*>);
+
+    IntBox b = IntBox(a);
+    printf("a.storage is null: %d\n", a.storage == nil<heap int*>);
+    printf("b.storage is null: %d\n", b.storage == nil<heap int*>);
+
+    IntBox c = IntBox(b);
+    printf("b.storage is null: %d\n", b.storage == nil<heap int*>);
+    printf("c.storage is null: %d\n", c.storage == nil<heap int*>);
+    printf("c holds %d\n", *c.storage);
+}

--- a/test/test-files/irgenerator/structs/success-move-ctor-only/cout.out
+++ b/test/test-files/irgenerator/structs/success-move-ctor-only/cout.out
@@ -1,0 +1,3 @@
+r.id=42 r.origin=42
+r2.id=42 r2.origin=-42
+r.id (after move)=0

--- a/test/test-files/irgenerator/structs/success-move-ctor-only/source.spice
+++ b/test/test-files/irgenerator/structs/success-move-ctor-only/source.spice
@@ -1,0 +1,29 @@
+// A struct that defines only a move ctor (in addition to a no-args ctor) and
+// no copy ctor. Verifies that the move ctor is recognized and selected when
+// the argument is a non-const lvalue. The struct has no heap fields and the
+// only struct-field-with-ctor is itself, so no copy ctor is auto-generated.
+
+type Resource struct {
+    int id
+    int origin
+}
+
+p Resource.ctor(int id) {
+    this.id = id;
+    this.origin = id;
+}
+
+p Resource.ctor(Resource& other) {
+    this.id = other.id;
+    this.origin = -other.origin;
+    other.id = 0;
+}
+
+f<int> main() {
+    Resource r = Resource(42);
+    printf("r.id=%d r.origin=%d\n", r.id, r.origin);
+
+    Resource r2 = Resource(r);
+    printf("r2.id=%d r2.origin=%d\n", r2.id, r2.origin);
+    printf("r.id (after move)=%d\n", r.id);
+}

--- a/test/test-files/irgenerator/structs/success-user-move-ctor/cout.out
+++ b/test/test-files/irgenerator/structs/success-user-move-ctor/cout.out
@@ -1,0 +1,7 @@
+a: value=42 valid=1
+copy
+b: value=42 valid=1
+a after copy: value=42 valid=1
+move
+c: value=42 valid=1
+b after move: value=0 valid=0

--- a/test/test-files/irgenerator/structs/success-user-move-ctor/source.spice
+++ b/test/test-files/irgenerator/structs/success-user-move-ctor/source.spice
@@ -1,0 +1,51 @@
+// A user-defined move ctor takes a non-const reference to the same struct type.
+// It transfers state from the source to the destination, and conventionally
+// leaves the source in a valid-but-empty state. Spice differentiates the move
+// ctor from the copy ctor by the const-qualifier on the parameter.
+
+type Buffer struct {
+    int value
+    bool valid
+}
+
+p Buffer.ctor() {
+    this.value = 0;
+    this.valid = false;
+}
+
+p Buffer.ctor(int v) {
+    this.value = v;
+    this.valid = true;
+}
+
+// Copy ctor: leaves the source intact
+p Buffer.ctor(const Buffer& other) {
+    this.value = other.value;
+    this.valid = other.valid;
+    printf("copy\n");
+}
+
+// Move ctor: steals the value from the source and resets the source
+p Buffer.ctor(Buffer& other) {
+    this.value = other.value;
+    this.valid = other.valid;
+    other.value = 0;
+    other.valid = false;
+    printf("move\n");
+}
+
+f<int> main() {
+    Buffer a = Buffer(42);
+    printf("a: value=%d valid=%d\n", a.value, a.valid);
+
+    // Copy: const ref binds, copy ctor is selected
+    const Buffer& ar = a;
+    Buffer b = Buffer(ar);
+    printf("b: value=%d valid=%d\n", b.value, b.valid);
+    printf("a after copy: value=%d valid=%d\n", a.value, a.valid);
+
+    // Move: non-const ref binds, move ctor is selected
+    Buffer c = Buffer(b);
+    printf("c: value=%d valid=%d\n", c.value, c.valid);
+    printf("b after move: value=%d valid=%d\n", b.value, b.valid);
+}


### PR DESCRIPTION
## Summary

Introduces support for move constructors in the Spice compiler. A move
constructor is a ctor whose single parameter is a non-const reference to
the struct's own type (`p Foo.ctor(Foo& other)`), distinguishing it from
the copy ctor (`const Foo&`).

- Recognize user-defined move ctors via a new `hasMoveCtor` helper and a
  `CtorKind` enum in `FunctionManager`.
- Synthesize a default move ctor when the struct owns a heap pointer or
  has a struct field with its own move ctor, and no user-defined move
  ctor exists.
- Emit IR for the synthesized body: for each field, call its move ctor
  if available, else its copy ctor for non-trivially-copyable structs;
  for heap-owning pointer fields, transfer the pointer to the destination
  and null out the source so the source's dtor does not free the storage;
  shallow-copy everything else.
- Add a qualifier-mismatch tie-breaker in `FunctionManager::match` so
  overload resolution picks the move ctor for non-const lvalue args
  (no constification needed) and the copy ctor for const args (binding
  to a non-const ref would require const-loss).
- Update the ctors-and-dtors spec; check off the roadmap item.

## Test plan

Six new integration tests under `test/test-files/irgenerator/structs/`:

- [ ] `success-user-move-ctor` — user-defined copy + move ctors,
      selection driven by argument const-ness.
- [ ] `success-move-ctor-only` — struct with only a move ctor.
- [ ] `success-default-move-ctor-heap` — synthesized move ctor transfers
      heap ownership and nulls the source pointer.
- [ ] `success-default-move-ctor-nested` — synthesized outer move ctor
      delegates to a field's user-defined move ctor.
- [ ] `success-move-and-copy-ctor-coexist` — overload resolution: move
      for non-const lvalue, copy for const ref.
- [ ] `success-move-ctor-chained-heap` — chained moves leave each
      intermediate in the moved-from state.

## Known limitations

- I could not run the test suite locally in the environment this was
  authored in: CMake configuration needed Windows symlink permissions
  (denied) and the ANTLR runtime sub-build tried to FetchContent
  googletest, which needed network access I did not have. The
  implementation has been reviewed for correctness but should be built
  and run locally / in CI before merging.
- Assignment and return paths are not changed: they continue to call the
  copy ctor implicitly. The move ctor is invoked when the user calls
  the ctor explicitly (e.g. `Foo b = Foo(a);` with `a` a non-const
  lvalue). Implicit moves on return / temp-stealing remain a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)