### PR TITLE
Destruct the lhs before a copy-assignment overwrites it

### DIFF
--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -1448,7 +1448,10 @@ public:
   [[nodiscard]] bool isAssignExpr() const override { return true; }
   [[nodiscard]] std::vector<std::vector<const Function *>> *getOpFctPointers() override { return &opFct; }
   [[nodiscard]] const std::vector<std::vector<const Function *>> *getOpFctPointers() const override { return &opFct; }
-  void customItemsInitialization(const size_t manifestationCount) override { opFct.resize(manifestationCount, {nullptr}); }
+  void customItemsInitialization(const size_t manifestationCount) override {
+    opFct.resize(manifestationCount, {nullptr});
+    lhsDtorFct.resize(manifestationCount, nullptr);
+  }
   AtomicExprNode *getLhsAtomicNode() const;
 
   // Public members
@@ -1457,6 +1460,9 @@ public:
   ExprNode *ternaryExpr = nullptr;
   AssignOp op = AssignOp::OP_NONE;
   std::vector<std::vector<const Function *>> opFct; // Operator overloading functions
+  // Dtor of the left-hand side to call before a copy-assignment overwrites an already initialized value.
+  // Only set for non-declaration copy-assignments of non-trivially-destructible structs (one entry per manifestation).
+  std::vector<const Function *> lhsDtorFct;
 };
 
 // ======================================================= TernaryExprNode =======================================================

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -506,6 +506,22 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
     llvm::Value *rhsAddress = resolveAddress(rhs);
     assert(rhsAddress != nullptr);
 
+    // If the lhs already holds an initialized, non-trivially-destructible struct, its old value must be
+    // destructed before the copy overwrites it, otherwise its owning members (heap pointers, strings, ...)
+    // would leak. The typechecker only sets a dtor in exactly those cases. To stay correct for a self-
+    // assignment like 'a = a', the destruct + copy are skipped entirely when both sides share the address
+    // (the assignment is a no-op in that case, and destructing first would corrupt the value to copy from).
+    const auto *assignNode = dynamic_cast<const AssignExprNode *>(node);
+    const Function *lhsDtor = assignNode ? assignNode->lhsDtorFct.at(manIdx) : nullptr;
+    llvm::BasicBlock *bCopyEnd = nullptr;
+    if (lhsDtor != nullptr) {
+      llvm::BasicBlock *bCopy = createBlock("assign.copy");
+      bCopyEnd = createBlock("assign.copy.end");
+      insertCondJump(builder.CreateICmpEQ(lhsAddress, rhsAddress), bCopyEnd, bCopy);
+      switchToBlock(bCopy);
+      generateCtorOrDtorCall(lhsAddress, lhsDtor, {});
+    }
+
     const QualType rhsSTypeNonRef = rhsSType.removeReferenceWrapper().toNonConst();
     if (rhsSTypeNonRef.isTriviallyCopyable(node)) {
       // Create shallow copy
@@ -525,6 +541,12 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
         const std::string msg = "Cannot copy struct '" + structName + "', as it is not trivially copyable and has no copy ctor";
         throw SemanticError(node, COPY_CTOR_REQUIRED, msg);
       }
+    }
+
+    // Close the self-assignment guard
+    if (bCopyEnd != nullptr) {
+      insertJump(bCopyEnd);
+      switchToBlock(bCopyEnd);
     }
     return LLVMExprResult{.ptr = lhsAddress, .entry = lhsEntry};
   }

--- a/src/typechecker/TypeCheckerExpressions.cpp
+++ b/src/typechecker/TypeCheckerExpressions.cpp
@@ -32,7 +32,20 @@ std::any TypeChecker::visitAssignExpr(AssignExprNode *node) {
     // Take a look at the operator
     if (node->op == AssignExprNode::AssignOp::OP_ASSIGN) {
       const bool isDecl = lhs.entry != nullptr && lhs.entry->isField() && !lhs.entry->getLifecycle().isInitialized();
-      rhsType = opRuleManager.getAssignResultType(node, lhs, rhs, isDecl).first;
+      const auto [assignType, copyCtor] = opRuleManager.getAssignResultType(node, lhs, rhs, isDecl);
+      rhsType = assignType;
+      // If the assignment overwrites an already initialized struct by copying a new value into it, the old value
+      // of the lhs must be destructed first. Otherwise its owning members (heap pointers, strings, ...) would leak.
+      // A non-null copy ctor signals that a real copy (not a move/temporary steal or ref assignment) takes place.
+      // 'isInitialized()' is false for declarations, uninitialized fields and moved-from values, so those are skipped.
+      // Unsafe blocks are excluded on purpose: code that manually manages object lifetimes there (e.g. the raw
+      // element shifts in container implementations) relies on assignments not implicitly destructing the lhs.
+      if (copyCtor != nullptr && !isDecl && lhs.entry != nullptr && lhs.entry->isInitialized() &&
+          !currentScope->doesAllowUnsafeOperations()) {
+        const QualType lhsSType = lhs.type.removeReferenceWrapper().toNonConst();
+        if (lhsSType.is(TY_STRUCT) && !lhsSType.isTriviallyDestructible(node))
+          node->lhsDtorFct[manIdx] = implicitlyCallStructMethod(lhsSType, DTOR_FUNCTION_NAME, {}, node);
+      }
     } else if (node->op == AssignExprNode::AssignOp::OP_PLUS_EQUAL) {
       rhsType = opRuleManager.getPlusEqualResultType(node, lhs, rhs).type;
     } else if (node->op == AssignExprNode::AssignOp::OP_MINUS_EQUAL) {

--- a/test/test-files/irgenerator/variables/success-copy-assign-dtor/cout.out
+++ b/test/test-files/irgenerator/variables/success-copy-assign-dtor/cout.out
@@ -1,0 +1,6 @@
+before assign
+dtor: first
+a is now second
+a is still second
+dtor: second
+dtor: second

--- a/test/test-files/irgenerator/variables/success-copy-assign-dtor/source.spice
+++ b/test/test-files/irgenerator/variables/success-copy-assign-dtor/source.spice
@@ -1,0 +1,26 @@
+// Verifies that copy-assigning to an already initialized struct destructs the previous value first,
+// so its owning members do not leak. Also verifies that self-assignment stays a safe no-op.
+
+type Holder struct {
+    String s
+}
+
+p Holder.ctor(string val) {
+    this.s = String(val);
+}
+
+p Holder.dtor() {
+    printf("dtor: %s\n", this.s);
+}
+
+f<int> main() {
+    Holder a = Holder("first");
+    Holder b = Holder("second");
+    printf("before assign\n");
+    // Reassigning must destruct the old value of 'a' ("first") before copying 'b' into it
+    a = b;
+    printf("a is now %s\n", a.s);
+    // Self-assignment must be a safe no-op (no destruct, no corruption)
+    a = a;
+    printf("a is still %s\n", a.s);
+}

--- a/test/test-files/irgenerator/variables/success-self-assign/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-self-assign/ir-code.ll
@@ -49,10 +49,18 @@ define dso_local noundef i32 @main() #0 {
   %1 = load i32, ptr %i, align 4
   store i32 %1, ptr %i, align 4
   call void @_ZN4Test4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %t)
-  call void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferenceable(4) %t, ptr %t)
+  %2 = icmp eq ptr %t, %t
+  br i1 %2, label %assign.copy.end, label %assign.copy
+
+assign.copy:                                      ; preds = %0
   call void @_ZN4Test4dtorEv(ptr noundef nonnull align 4 dereferenceable(4) %t)
-  %2 = load i32, ptr %result, align 4
-  ret i32 %2
+  call void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferenceable(4) %t, ptr %t)
+  br label %assign.copy.end
+
+assign.copy.end:                                  ; preds = %assign.copy, %0
+  call void @_ZN4Test4dtorEv(ptr noundef nonnull align 4 dereferenceable(4) %t)
+  %3 = load i32, ptr %result, align 4
+  ret i32 %3
 }
 
 attributes #0 = { mustprogress noinline norecurse nounwind optnone uwtable }


### PR DESCRIPTION
## Summary

Fixes a memory leak in struct copy-assignment. When copy-assigning to an already initialized lhs (e.g. `a = b`), the compiler called the copy ctor straight onto the lhs without destructing its previous value first, leaking the old value's owning members (heap pointers, strings, ...).

```spice
Holder a = Holder("first");
Holder b = Holder("second");
a = b;   // "first"'s String used to leak — its dtor was never called
```

## Approach
- **Typechecker** (`visitAssignExpr`): when an `OP_ASSIGN` copy-assignment overwrites an already initialized, non-trivially-destructible struct, resolve the lhs dtor and store it on the node (one entry per manifestation).
  - `isInitialized()` is false for declarations, uninitialized fields and **moved-from** values, so those are never destructed (no double-free).
  - A non-null copy ctor signals a real copy (not a move / temporary steal / ref assignment).
  - **Unsafe blocks are excluded on purpose**: code that manually manages object lifetimes there (e.g. the raw element shifts in container implementations like `Vector.removeAt`) relies on assignments *not* implicitly destructing the lhs. Without this carve-out, those hand-rolled shifts would double-destruct.
- **IR generator** (`doAssignment`): if the node carries a dtor, emit it before the copy, wrapped in a **runtime self-assignment guard**. When `lhs` and `rhs` share the address the destruct + copy are skipped entirely (the assignment is a no-op). This also **fixes the pre-existing crash on `a = a`** — previously the copy ctor self-copied and corrupted the value.

## Behavior
For `a = b` the old `a` is now destructed before the copy; for `a = a` the whole thing is a guarded no-op. Verified under AddressSanitizer (with leak detection) — no leaks, no use-after-free.

## Test plan
- New runtime test `irgenerator/variables/success-copy-assign-dtor` asserts the dtor ordering (old value destructed on reassign, self-assign is a no-op).
- Updated the IR reference of the existing `success-self-assign` test to reflect the new guard.
- Full suite green except the 3 pre-existing `mold: library not found: LLVMAArch64AsmParser` environment failures (`StdTests.os_filesystem`, `StdTests.bindings_llvm`, `bootstrapCompiler_standaloneCommonUtilTest`), confirmed identical on a clean baseline. TypeChecker (188), IRGenerator (164), Std (91), Common, SymbolTableBuilder, Parser, Lexer, Example and unit suites pass.

## Note for reviewers
The unsafe-block carve-out is a deliberate design choice to avoid rewriting the standard-library container internals (which assume assignment does not destruct). Happy to revisit if you'd prefer a different boundary (e.g. updating the containers to use explicit lifetime ops instead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)