### PR TITLE
Add Claude Code skills for common Spice dev tasks

### DIFF
--- a/.claude/skills/spice-build/SKILL.md
+++ b/.claude/skills/spice-build/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: spice-build
+description: Build the Spice compiler (`spice`) and/or the test runner (`spicetest`) with CMake/Ninja. Use when the user wants to compile/rebuild the project, build a specific target, produce a release/debug build, or set up the CMake build directory before running or testing.
+---
+
+# Build Spice
+
+The Spice repo is a CMake project (top-level `CMakeLists.txt`) that produces two
+main artifacts:
+
+- `spice` — the compiler CLI (`src/`, output at `<build-dir>/src/spice`)
+- `spicetest` — the GoogleTest runner (`test/`, output at `<build-dir>/test/spicetest`)
+
+## Build directory convention
+
+Reuse one of these directories so artifacts stay organized (per `AGENTS.md`):
+
+- `cmake-build-debug/` — day-to-day development and testing
+- `cmake-build-release/` — optimized builds for benchmarking
+
+The `./build.sh` helper instead builds into `build/` with `Release` + Ninja and
+moves the binaries to the repo root; prefer the directories above for agent work
+unless the user explicitly wants `build.sh`.
+
+## Prerequisites
+
+A configured LLVM build must be reachable. `find_package(LLVM)` locates it via
+`LLVM_DIR` (the local dev setup builds LLVM into `./llvm/build-release`):
+
+```sh
+export LLVM_DIR=$PWD/llvm/build-release/lib/cmake/llvm
+```
+
+If LLVM and third-party libs are missing, run `./dev-setup.sh` once (slow: it
+clones and builds LLVM). `./setup-libs.sh` alone fetches just the header-only
+deps (json, CLI11) into `lib/`.
+
+## Configure (first time / after CMakeLists changes)
+
+```sh
+cmake -S . -B cmake-build-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
+# release:
+cmake -S . -B cmake-build-release -G Ninja -DCMAKE_BUILD_TYPE=Release
+```
+
+## Build targets
+
+Run from inside the build dir, or pass `--build <dir>`:
+
+```sh
+# Everything (compiler + tests)
+cmake --build cmake-build-debug
+
+# Just the compiler
+cmake --build cmake-build-debug --target spice
+
+# Just the test runner
+cmake --build cmake-build-debug --target spicetest
+
+# Both, parallel
+cmake --build cmake-build-debug --target spice spicetest -j
+
+# Optional leak-check target (needs valgrind)
+cmake --build cmake-build-debug --target spicetest_leakcheck
+```
+
+## Tips
+
+- Incremental rebuilds: just re-run `cmake --build <dir> --target <t>`; Ninja
+  only recompiles what changed. No need to reconfigure unless CMake files change.
+- After building, the compiler is at `cmake-build-debug/src/spice` — see the
+  `spice-dump` skill for inspecting its IR/assembly output and `spice-test` for
+  running the suite.
+- Configure options live in `Options.cmake` / `Conditionals.cmake` /
+  `LLVMOptions.cmake` if the user needs non-default flags.

--- a/.claude/skills/spice-dump/SKILL.md
+++ b/.claude/skills/spice-dump/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: spice-dump
+description: Dump compiler intermediate output (LLVM IR, assembly, AST, CST, symbol table, types) for a Spice source or test-input file using the `spice` CLI dump flags. Use when the user wants to inspect what the compiler generates for a `.spice` file, debug codegen, or regenerate reference dumps.
+---
+
+# Dump Spice compiler output
+
+The `spice` compiler (built at `cmake-build-debug/src/spice`, see the
+`spice-build` skill) can dump every stage of compilation via flags on the
+`build` / `run` / `test` subcommands.
+
+## Quick start
+
+```sh
+SPICE=cmake-build-debug/src/spice
+
+# Dump LLVM IR for a source file (unoptimized)
+$SPICE build -O0 -ir path/to/source.spice
+
+# Dump assembly
+$SPICE build -O0 -s path/to/source.spice
+
+# Inspect IR for an existing test input
+$SPICE build -O0 -ir test/test-files/irgenerator/for-loops/success-for-loop/source.spice
+```
+
+Many test-case dirs reference IR at `-O2`/`-O3` — pass the matching opt level to
+reproduce those (e.g. `-O2 -ir` to compare against `ir-code-O2.ll`).
+
+## Dump flags (build / run / test subcommands)
+
+| Flag | Aliases | Dumps |
+|------|---------|-------|
+| `--dump-cst` | `-cst` | Concrete syntax tree (serialized + SVG) |
+| `--dump-ast` | `-ast` | Abstract syntax tree (serialized + SVG) |
+| `--dump-symtab` | | Serialized symbol tables |
+| `--dump-types` | | All used types |
+| `--dump-ir` | `-ir` | LLVM IR |
+| `--dump-assembly` | `-asm`, `-s` | Assembly |
+| `--dump-object-file` | | Object files |
+| `--dump-dependency-graph` | | Compile-unit dependency graph |
+| `--dump-cache-stats` | | Internal lookup-cache stats |
+
+Control flags (build subcommand):
+
+- `--dump-to-files` — write dumps to files instead of stdout.
+- `--abort-after-dump` — stop after the first requested dump (skip the rest of
+  compilation/linking). Handy for fast IR/AST inspection without producing a binary.
+
+Useful companions:
+
+- Optimization: `-O0`/`-O1`/`-O2`/`-O3`/`-Os`/`-Oz` (IR/asm differ per level).
+- `-d` / `--debug-output` — verbose compiler debug output.
+- `--target`, `--target-arch`, `--target-os` — cross-target IR/assembly
+  (e.g. assembly refs are kept per target like `assembly-linux-aarch64.asm`).
+- `--build-mode test -ir` (or the `test` subcommand) — dump IR for the test
+  harness variant of a file.
+
+## Common recipes
+
+```sh
+SPICE=cmake-build-debug/src/spice
+SRC=test/test-files/irgenerator/for-loops/success-for-loop/source.spice
+
+# Just the IR, nothing else, fast
+$SPICE build -O0 -ir --abort-after-dump $SRC
+
+# IR at O2 (matches ir-code-O2.ll references)
+$SPICE build -O2 -ir --abort-after-dump $SRC
+
+# AST + CST as SVG/text
+$SPICE build -ast -cst --abort-after-dump $SRC
+
+# Symbol table and type registry
+$SPICE build --dump-symtab --dump-types --abort-after-dump $SRC
+
+# Cross-target assembly
+$SPICE build -O2 -s --target-arch aarch64 --target-os linux --abort-after-dump $SRC
+```
+
+## Relation to reference tests
+
+The dump filenames above correspond to reference files in
+`test/test-files/<group>/<case>/` (e.g. `ir-code.ll`, `ir-code-O2.ll`,
+`assembly-linux-amd64.asm`, `symbol-table.json`, `type-registry.out`,
+`syntax-tree.dot`). To regenerate those en masse after an intended compiler
+change, prefer `spicetest --update-refs` (see the `spice-test` skill) rather
+than hand-copying dumps. Use the manual dumps here for ad-hoc inspection and
+debugging of a single file.
+
+Run `$SPICE --help` (or `$SPICE build --help`) to see the full, current option list.

--- a/.claude/skills/spice-run/SKILL.md
+++ b/.claude/skills/spice-run/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: spice-run
+description: Compile and/or run a Spice program with the `spice` CLI — build to an executable, run a file directly, run with a sanitizer, run its enclosed tests, or cross-compile. Use when the user wants to execute a `.spice` file or produce a binary from one.
+---
+
+# Compile & run Spice programs
+
+Uses the `spice` compiler at `cmake-build-debug/src/spice` (build it via the
+`spice-build` skill first).
+
+```sh
+SPICE=cmake-build-debug/src/spice
+```
+
+## Subcommands
+
+| Command | Alias | Purpose |
+|---------|-------|---------|
+| `spice build <file.spice>` | `b` | Compile to an output container (default: executable) |
+| `spice run <file.spice>` | `r` | Compile and execute immediately |
+| `spice test <file.spice>` | `t` | Compile with a test entry point and run enclosed tests |
+| `spice install <file.spice>` | `i` | Build and install to a PATH dir |
+| `spice uninstall <file.spice>` | `u` | Remove an installed program |
+
+## Common usage
+
+```sh
+# Compile to a named executable
+$SPICE build path/to/main.spice -o ./myprog
+./myprog
+
+# Compile + run in one step (best for quick checks)
+$SPICE run path/to/main.spice
+
+# Optimized build
+$SPICE build -O2 path/to/main.spice -o ./myprog
+
+# Run the program's own tests
+$SPICE test path/to/main.spice
+```
+
+## Useful options (build / run / test)
+
+- `-o, --output <path>` — output file path (build).
+- `-O0`..`-O3`, `-Os`, `-Oz` — optimization level; `-lto` enables LTO.
+- `-m, --build-mode debug|release|test` — build mode.
+- `--sanitizer=address` (and friends: TSAN, TYSAN, …) — run under a sanitizer,
+  e.g. `$SPICE run --sanitizer=address file.spice`.
+- `-b, --build-var key=value` — parametrize the compiled program.
+- `-j, --jobs <n>` — parallel compile jobs.
+- `--output-container exec|obj|lib|dylib` — output format (build).
+- `--static` — link statically.
+- `--no-entry` — don't generate a `main`.
+- `-d, --debug-output` — verbose compiler debug output.
+- `--ignore-cache` — force full recompilation.
+
+## Cross-compiling
+
+```sh
+# By target triple
+$SPICE build --target aarch64-linux-gnu path/to/main.spice -o ./myprog
+
+# Or piecewise
+$SPICE build --target-arch aarch64 --target-os linux path/to/main.spice -o ./myprog
+```
+
+Stable targets: linux/x86_64, linux/aarch64, windows/x86_64, darwin/aarch64,
+webassembly. Others (`x86`, `armv7`, `riscv`, `mips`, `powerpc`, `nvptx`,
+`amdgpu`, …) compile without stability guarantees.
+
+To inspect the IR/assembly the compiler produces instead of running, use the
+`spice-dump` skill. Run `$SPICE --help` for the complete, current option list.

--- a/.claude/skills/spice-test/SKILL.md
+++ b/.claude/skills/spice-test/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: spice-test
+description: Run the Spice `spicetest` suite (GoogleTest-based integration + unit tests). Use when the user wants to run all tests, a specific suite or case, update reference files, check for memory leaks with valgrind, or debug a failing test.
+---
+
+# Run Spice tests
+
+`spicetest` is a GoogleTest binary built from `test/`. It drives two kinds of
+tests:
+
+- **Reference / integration tests** parameterized over directories in
+  `test/test-files/<group>/...`. Each test case dir has a `source.spice` plus
+  reference files the runner compares against (see below).
+- **Unit tests** in `test/unittest/` (e.g. `BlockAllocatorTest`, `CommonUtilTest`).
+
+Build it first (see the `spice-build` skill):
+`cmake --build cmake-build-debug --target spicetest`.
+
+The binary lands at `cmake-build-debug/test/spicetest`.
+
+## Running
+
+```sh
+# All tests
+cmake-build-debug/test/spicetest
+
+# List every test name (best way to find an exact filter)
+cmake-build-debug/test/spicetest --gtest_list_tests
+
+# Filter by suite or case (GoogleTest globbing)
+cmake-build-debug/test/spicetest --gtest_filter='IRGeneratorTests*'
+cmake-build-debug/test/spicetest --gtest_filter='CommonUtilTest.*'
+cmake-build-debug/test/spicetest --gtest_filter='*ForLoop*'
+```
+
+Reference-test suites (instantiated from `test/test-files/<group>`):
+`CommonTests`, `LexerTests`, `ParserTests`, `SymbolTableBuilderTests`,
+`TypeCheckerTests`, `IRGeneratorTests`, `StdTests`, `BenchmarkTests`,
+`ExampleTests`, `BootstrapCompilerTests`.
+
+## Custom test-runner flags
+
+These are `spicetest`'s own flags (not GoogleTest):
+
+- `--update-refs` — regenerate/overwrite reference files from current output.
+  Use after an intentional change to compiler output, then review the diff.
+- `--run-benchmarks` — also run benchmark cases and check baselines.
+- `--leak-detection` — wrap tests in valgrind to detect leaks.
+- `--skip-sanitizer-tests` — skip tests exercising language sanitizers.
+- `--is-github-actions` — skip cases unsupported on CI.
+- `--verbose` — extra runner debug output.
+
+```sh
+# Update refs for one suite after an intended change, then inspect git diff
+cmake-build-debug/test/spicetest --gtest_filter='IRGeneratorTests*' --update-refs
+git diff test/test-files
+```
+
+## Memory-leak / debugging
+
+```sh
+# Valgrind on a focused set (full run is slow)
+valgrind --leak-check=full cmake-build-debug/test/spicetest --gtest_filter='ParserTests*'
+
+# Or the dedicated build target
+cmake --build cmake-build-debug --target spicetest_leakcheck
+
+# Debug a failing case under gdb
+gdb --args cmake-build-debug/test/spicetest --gtest_filter='TypeCheckerTests*'
+```
+
+## Reference files in a test-case directory
+
+Common files the runner reads/compares (presence is optional per case):
+
+- `source.spice` (+ `source1.spice`, …) — input program
+- `cout.out` — expected stdout; `exception.out` / `warning.out` — expected errors/warnings
+- `exit-code.out` — expected process exit code
+- `ir-code.ll`, `ir-code-O2.ll`, `ir-code-O3.ll`, … — expected LLVM IR per opt level
+- `assembly-linux-amd64.asm`, `assembly-linux-aarch64.asm` — expected assembly
+- `symbol-table.json`, `type-registry.out` — expected symbol/type dumps
+- `syntax-tree.dot` / `parse-tree.dot` / `dependency-graph.dot` — expected graphs
+- Platform/skip markers: `*-windows.*`, `*-macos.*`, `skip-windows`,
+  `skip-gh-actions`, `run-builtin-tests`, `cli-flags.txt`
+
+To produce these dumps manually for a single input, use the `spice-dump` skill.


### PR DESCRIPTION
Add four project skills under .claude/skills/:
- spice-build: configure/build the spice compiler and spicetest targets
- spice-test: run the spicetest suite, filter, update refs, leak-check
- spice-dump: dump IR/assembly/AST/CST/symbol-table for a source/test file
- spice-run: compile and run Spice programs, sanitizers, cross-compile

https://claude.ai/code/session_01AzjpinveUuiokaZDppANei