### PR TITLE
Port model classes to the bootstrap compiler

### DIFF
--- a/src-bootstrap/ast/ast-nodes.spice
+++ b/src-bootstrap/ast/ast-nodes.spice
@@ -8,6 +8,10 @@ import "bootstrap/ast/ast-node-intf";
 //import "bootstrap/symboltablebuilder/qual-type";
 //import "bootstrap/model/function";
 
+// Access tokens used when building type/function/scope signatures
+public const string MEMBER_ACCESS_TOKEN = ".";
+public const string SCOPE_ACCESS_TOKEN = "::";
+
 /*public type IVisitable interface {
     f<Any> accept(IAbstractAstVisitor*);
 }*/

--- a/src-bootstrap/model/function.spice
+++ b/src-bootstrap/model/function.spice
@@ -1,12 +1,15 @@
 // Std imports
 import "std/data/vector";
-import "std/data/map";
+import "std/text/stringstream";
+import "std/bindings/llvm/llvm" as llvm;
 
 // Own imports
 import "bootstrap/ast/ast-nodes";
+import "bootstrap/reader/code-loc";
 import "bootstrap/symboltablebuilder/super-type";
 import "bootstrap/symboltablebuilder/qual-type";
 import "bootstrap/symboltablebuilder/symbol-table-entry";
+import "bootstrap/symboltablebuilder/scope-intf";
 import "bootstrap/model/generic-type";
 
 // Helper structs
@@ -22,20 +25,366 @@ public type NamedParam struct {
 }
 
 // Type aliases
-type ParamList alias Vector<Param>;
-type NamedParamList alias Vector<NamedParam>;
+public type ParamList alias Vector<Param>;
+public type NamedParamList alias Vector<NamedParam>;
 
 public type Function struct {
-    String name
-    QualType thisType = QualType(SuperType::TY_DYN)
-    QualType returnType = QualType(SuperType::TY_DYN)
-    ParamList paramList
-    Vector<GenericType> templateTypes
-    Map<String, QualType> typeMapping
-    SymbolTableEntry* entry
-    ASTNode* declNode
-    bool genericSubstantiation
-    bool alreadyTypeChecked
-    bool external
-    bool used
+    public String name
+    public QualType thisType = QualType(SuperType::TY_DYN)
+    public QualType returnType = QualType(SuperType::TY_DYN)
+    public ParamList paramList
+    public Vector<GenericType> templateTypes
+    public TypeMapping typeMapping
+    public SymbolTableEntry* entry = nil<SymbolTableEntry*>
+    public ASTNode* declNode = nil<ASTNode*>
+    public IScope* bodyScope = nil<IScope*>
+    public String predefinedMangledName
+    public String mangleSuffix
+    public Function* genericPreset = nil<Function*>
+    public bool isVararg = false
+    public bool mangleFunctionName = true
+    public bool alreadyTypeChecked = false
+    public bool used = false
+    public bool implicitDefault = false
+    public bool isVirtual = false
+    public bool isNewlyInserted = false
+    public llvm::Function* llvmFunction = nil<llvm::Function*>
+    public unsigned long vtableIndex = 0l
+}
+
+public p Function.ctor(const String& name, SymbolTableEntry* entry, const QualType& thisType, const QualType& returnType, const ParamList& paramList, const Vector<GenericType>& templateTypes, ASTNode* declNode) {
+    this.name = name;
+    this.entry = entry;
+    this.thisType = thisType;
+    this.returnType = returnType;
+    this.paramList = paramList;
+    this.templateTypes = templateTypes;
+    this.declNode = declNode;
+}
+
+/**
+ * Retrieve the parameter types of the current function
+ *
+ * @return Vector of parameter types
+ */
+public f<QualTypeList> Function.getParamTypes() {
+    result = QualTypeList();
+    foreach const Param& param : this.paramList {
+        result.pushBack(param.qualType);
+    }
+}
+
+/**
+ * Get a string representation of the current function.
+ *
+ * Example:
+ * string Vector<double>.setData<double>(double)
+ *
+ * @param withThisType Include 'this' type in signature
+ * @param withTemplateTypes Include concrete template types in the signature
+ * @return String representation as function signature
+ */
+public f<String> Function.getSignature(bool withThisType = true, bool withTemplateTypes = true) {
+    QualTypeList concreteTemplateTypes;
+    if withTemplateTypes {
+        foreach const GenericType& genericType : this.templateTypes {
+            if genericType.qualType.is(SuperType::TY_GENERIC) && !this.typeMapping.isEmpty() {
+                const String& subType = genericType.qualType.getSubType();
+                assert this.typeMapping.contains(subType);
+                concreteTemplateTypes.pushBack(this.typeMapping.get(subType));
+            } else {
+                concreteTemplateTypes.pushBack(genericType.qualType);
+            }
+        }
+    }
+
+    return this.getSignature(this.name, this.thisType, this.returnType, this.paramList, concreteTemplateTypes, true, withThisType, true);
+}
+
+/**
+ * Get a string representation of the current function.
+ *
+ * @param name Function name
+ * @param thisType This symbol type
+ * @param returnType Return symbol type
+ * @param paramList Param symbol types
+ * @param concreteTemplateTypes Concrete template symbol types
+ * @param withReturnType Include return type in signature
+ * @param withThisType Include 'this' type in signature
+ * @param ignorePublic Not include public modifiers in signature
+ * @return Function signature
+ */
+public f<String> Function.getSignature(const String& name, const QualType& thisType, const QualType& returnType, const ParamList& paramList, const QualTypeList& concreteTemplateTypes, bool withReturnType = true, bool withThisType = true, bool ignorePublic = true) {
+    StringStream signature;
+
+    // Build return type string
+    if withReturnType {
+        if returnType.is(SuperType::TY_DYN) {
+            signature << "p ";
+        } else {
+            signature << "f<";
+            returnType.getName(signature, false, ignorePublic);
+            signature << "> ";
+        }
+    }
+
+    // Build this type string
+    if withThisType && !thisType.is(SuperType::TY_DYN) {
+        const QualType thisBaseType = thisType.getBase();
+        signature << thisBaseType.getSubType();
+        const QualTypeList& thisTemplateTypes = thisType.getTemplateTypes();
+        if !thisTemplateTypes.isEmpty() {
+            signature << "<";
+            for unsigned long i = 0l; i < thisTemplateTypes.getSize(); i = i + 1l {
+                if i > 0l {
+                    signature << ",";
+                }
+                const QualType templateType = thisTemplateTypes.get(i);
+                templateType.getName(signature, false, ignorePublic);
+            }
+            signature << ">";
+        }
+        signature << MEMBER_ACCESS_TOKEN;
+    }
+
+    // Name
+    signature << name;
+
+    // Build template type string
+    if !concreteTemplateTypes.isEmpty() {
+        signature << "<";
+        for unsigned long i = 0l; i < concreteTemplateTypes.getSize(); i = i + 1l {
+            if i > 0l {
+                signature << ",";
+            }
+            const QualType templateType = concreteTemplateTypes.get(i);
+            templateType.getName(signature, false, ignorePublic);
+        }
+        signature << ">";
+    }
+
+    // Parameter type string
+    signature << "(";
+    for unsigned long i = 0l; i < paramList.getSize(); i = i + 1l {
+        if i > 0l {
+            signature << ",";
+        }
+        const Param param = paramList.get(i);
+        param.qualType.getName(signature, false, ignorePublic);
+        if param.isOptional {
+            signature << "?";
+        }
+    }
+    signature << ")";
+
+    return signature.str();
+}
+
+/**
+ * Get the name of the scope, where members and the body of the function live
+ *
+ * @return Scope name
+ */
+public f<String> Function.getScopeName() {
+    return this.getSignature(false, true);
+}
+
+/**
+ * Get the mangled name of the function
+ *
+ * @return Mangled name
+ */
+public f<String> Function.getMangledName() {
+    // Use predefined mangled name if available
+    if !this.predefinedMangledName.isEmpty() {
+        return this.predefinedMangledName;
+    }
+    // Use function name if mangling is disabled
+    if !this.mangleFunctionName {
+        return this.name;
+    }
+    // ToDo: Use NameMangling.mangleFunction(*this) once the name mangling pass is ported. Fall back to the raw name for now.
+    return this.name;
+}
+
+/**
+ * Get the name of the symbol table entry of the function
+ *
+ * @param functionName Function name
+ * @param codeLoc Code location
+ * @return Symbol table entry name
+ */
+public f<String> Function.getSymbolTableEntryName(const String& functionName, const CodeLoc& codeLoc) {
+    return functionName + ":" + codeLoc.toString();
+}
+
+/**
+ * Get the name of the symbol table entry of the default constructor of a struct
+ *
+ * @param structCodeLoc Code location of the struct
+ * @return Symbol table entry name
+ */
+public f<String> Function.getSymbolTableEntryNameDefaultCtor(const CodeLoc& structCodeLoc) {
+    return "default_" + CTOR_FUNCTION_NAME + ":" + structCodeLoc.toString();
+}
+
+/**
+ * Get the name of the symbol table entry of the default copy constructor of a struct
+ *
+ * @param structCodeLoc Code location of the struct
+ * @return Symbol table entry name
+ */
+public f<String> Function.getSymbolTableEntryNameDefaultCopyCtor(const CodeLoc& structCodeLoc) {
+    return "default_copy" + CTOR_FUNCTION_NAME + ":" + structCodeLoc.toString();
+}
+
+/**
+ * Get the name of the symbol table entry of the default move constructor of a struct
+ *
+ * @param structCodeLoc Code location of the struct
+ * @return Symbol table entry name
+ */
+public f<String> Function.getSymbolTableEntryNameDefaultMoveCtor(const CodeLoc& structCodeLoc) {
+    return "default_move" + CTOR_FUNCTION_NAME + ":" + structCodeLoc.toString();
+}
+
+/**
+ * Get the name of the symbol table entry of the default destructor of a struct
+ *
+ * @param structCodeLoc Code location of the struct
+ * @return Symbol table entry name
+ */
+public f<String> Function.getSymbolTableEntryNameDefaultDtor(const CodeLoc& structCodeLoc) {
+    return "default_" + DTOR_FUNCTION_NAME + ":" + structCodeLoc.toString();
+}
+
+/**
+ * Check if the current function is a method (has a 'this' type)
+ *
+ * @return Method or not
+ */
+public f<bool> Function.isMethod() {
+    return !this.thisType.is(SuperType::TY_DYN);
+}
+
+/**
+ * Check if the current function is a function (has a return type)
+ *
+ * @return Function or not
+ */
+public f<bool> Function.isFunction() {
+    return !this.returnType.is(SuperType::TY_DYN);
+}
+
+/**
+ * Check if the current function is a procedure (has no return type)
+ *
+ * @return Procedure or not
+ */
+public f<bool> Function.isProcedure() {
+    return this.returnType.is(SuperType::TY_DYN);
+}
+
+/**
+ * Check if the current function is a normal function (no method)
+ *
+ * @return Normal function or not
+ */
+public f<bool> Function.isNormalFunction() {
+    return this.isFunction() && !this.isMethod();
+}
+
+/**
+ * Check if the current function is a normal procedure (no method)
+ *
+ * @return Normal procedure or not
+ */
+public f<bool> Function.isNormalProcedure() {
+    return this.isProcedure() && !this.isMethod();
+}
+
+/**
+ * Check if the current function is a method function
+ *
+ * @return Method function or not
+ */
+public f<bool> Function.isMethodFunction() {
+    return this.isFunction() && this.isMethod();
+}
+
+/**
+ * Check if the current function is a method procedure
+ *
+ * @return Method procedure or not
+ */
+public f<bool> Function.isMethodProcedure() {
+    return this.isProcedure() && this.isMethod();
+}
+
+/**
+ * Check if the current function is a virtual method
+ *
+ * @return Virtual method or not
+ */
+public f<bool> Function.isVirtualMethod() {
+    return this.isMethod() && this.isVirtual;
+}
+
+/**
+ * Checks if a function contains optional parameters.
+ * This would imply that the function is not substantiated by its optional parameters yet.
+ *
+ * @return Substantiated params or not
+ */
+public f<bool> Function.hasSubstantiatedParams() {
+    foreach const Param& param : this.paramList {
+        if param.isOptional {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Checks if a function contains template types.
+ * This would imply that the function is not substantiated by its generic types yet.
+ *
+ * @return Substantiated generics or not
+ */
+public f<bool> Function.hasSubstantiatedGenerics() {
+    foreach const GenericType& genericType : this.templateTypes {
+        const String& subType = genericType.qualType.getSubType();
+        if !this.typeMapping.contains(subType) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Checks if a function contains optional parameters or has generic types present.
+ * This would imply that the function is not fully substantiated yet.
+ *
+ * @return Fully substantiated or not
+ */
+public f<bool> Function.isFullySubstantiated() {
+    return this.hasSubstantiatedParams() && this.hasSubstantiatedGenerics();
+}
+
+/**
+ * Returns, if this function is a substantiation of a generic one.
+ *
+ * @return Generic substantiation or not
+ */
+public f<bool> Function.isGenericSubstantiation() {
+    return this.genericPreset != nil<Function*>;
+}
+
+/**
+ * Retrieve the declaration code location of this function
+ *
+ * @return Declaration code location
+ */
+public f<const CodeLoc&> Function.getDeclCodeLoc() {
+    return this.declNode.codeLoc;
 }

--- a/src-bootstrap/model/generic-type.spice
+++ b/src-bootstrap/model/generic-type.spice
@@ -32,31 +32,57 @@ public p GenericType.ctor(const String& name, const QualTypeList& typeConditions
 /**
  * Checks if the given symbol type matches all conditions to get a manifestation of the current generic type
  *
- * @param qualType Qualified type to be checked
+ * @param requestedType Qualified type to be checked
+ * @param substantiation Concrete substantiation of the generic type
  * @param ignoreArraySize Ignore the array size for type comparison
  * @param ignoreQualifiers Ignore the type qualifiers for type comparison
  * @return True or false
  */
-public f<bool> GenericType.checkConditionsOf(const QualType& qualType, bool ignoreArraySize = false, bool ignoreQualifiers = false) {
-    return this.checkTypeConditionOf(qualType, ignoreArraySize, ignoreQualifiers);
+public f<bool> GenericType.checkConditionsOf(const QualType& requestedType, QualType& substantiation, bool ignoreArraySize = false, bool ignoreQualifiers = false) {
+    return this.checkTypeConditionOf(requestedType, substantiation, ignoreArraySize, ignoreQualifiers);
 }
 
 /**
- * Checks if the given symbol type matches all type conditions to get a manifestation of the current generic type
+ * Checks if the given type matches all type conditions to get a manifestation of the current generic type
  *
- * @param qualType Qualified type to be checked
+ * @param requestedType Qualified type to be checked
+ * @param substantiation Concrete substantiation of the generic type
  * @param ignoreArraySize Ignore the array size for type comparison
  * @param ignoreQualifiers Ignore the type qualifiers for type comparison
  * @return True or false
  */
-f<bool> GenericType.checkConditionOf(const QualType& qualType, bool ignoreArraySize, bool ignoreQualifiers) {
-    // Succeed if no qualType conditions are set
+f<bool> GenericType.checkTypeConditionOf(const QualType& requestedType, QualType& substantiation, bool ignoreArraySize, bool ignoreQualifiers) {
+    substantiation = requestedType;
+    // Succeed if there are no type conditions
     if this.typeConditions.isEmpty() {
+        return true;
+    }
+    // Succeed if the given qual type is generic and matches the current one
+    // ToDo: Use a dedicated QualType equality operator once available; matches(...) is used as an approximation here.
+    if requestedType.hasAnyGenericParts() && requestedType.matches(this.qualType, false, false, false) {
         return true;
     }
     // Check type conditions
     foreach const QualType& typeCondition : this.typeConditions {
-        if typeCondition.is(SuperType::TY_DYN) || typeCondition.matches(qualType, ignoreArraySize, ignoreQualifiers, ignoreQualifiers) {
+        // If we have a dyn type condition, the conditions are fulfilled immediately
+        if typeCondition.is(SuperType::TY_DYN) {
+            return true;
+        }
+        // In situations like this we need to unwrap: requestedType = const int&, typeCondition = int
+        // ToDo: Also unwrap matching pointer/array layers (Type::unwrapBoth) once that helper is available in the bootstrap.
+        QualType typeConditionCopy = typeCondition;
+        QualType requestedTypeCopy = requestedType;
+        // Remove reference wrapper of the condition type if required
+        if typeConditionCopy.isRef() && !requestedTypeCopy.isRef() {
+            typeConditionCopy = typeConditionCopy.removeReferenceWrapper();
+        }
+        // Remove reference wrapper of the requested type if required
+        const QualType conditionBaseType = typeConditionCopy.getBase();
+        if !typeConditionCopy.isRef() && requestedTypeCopy.isRef() && !conditionBaseType.is(SuperType::TY_GENERIC) {
+            requestedTypeCopy = requestedTypeCopy.removeReferenceWrapper();
+        }
+        if typeConditionCopy.matches(requestedTypeCopy, ignoreArraySize, ignoreQualifiers, ignoreQualifiers) {
+            substantiation = typeCondition;
             return true;
         }
     }

--- a/src-bootstrap/model/interface.spice
+++ b/src-bootstrap/model/interface.spice
@@ -10,12 +10,43 @@ import "bootstrap/symboltablebuilder/qual-type";
 import "bootstrap/symboltablebuilder/symbol-table-entry";
 import "bootstrap/symboltablebuilder/scope-intf";
 
+// Constants
+const string INTERFACE_SCOPE_PREFIX = "interface:";
+
 public type Interface struct {
     public compose StructBase structBase
-    Vector<Function*> methods
+    public Vector<Function*> methods
 }
 
 public p Interface.ctor(const String& name, SymbolTableEntry* entry, IScope* scope, const Vector<Function*>& methods, const Vector<GenericType>& templateTypes, ASTNode* declNode) {
     this.structBase = StructBase(name, entry, scope, templateTypes, declNode);
     this.methods = methods;
+}
+
+/**
+ * Retrieve the name of the scope, where signatures are placed. This is used to navigate to the scope of the interface
+ * from the parent scope.
+ *
+ * @return Name of the interface scope
+ */
+public f<String> Interface.getScopeName() {
+    String appendix;
+    if this.structBase.isGenericSubstantiation() {
+        appendix = this.structBase.getSignature();
+    } else {
+        appendix = this.structBase.name;
+    }
+    return String(INTERFACE_SCOPE_PREFIX) + appendix;
+}
+
+/**
+ * Retrieve the name of the scope, where signatures are placed. This is used to navigate to the scope of the interface
+ * from the parent scope.
+ *
+ * @param name Interface name
+ * @param concreteTemplateTypes Concrete template types
+ * @return Name of the interface scope
+ */
+public f<String> Interface.getScopeName(const String& name, const QualTypeList& concreteTemplateTypes) {
+    return String(INTERFACE_SCOPE_PREFIX) + this.structBase.getSignature(name, concreteTemplateTypes);
 }

--- a/src-bootstrap/model/struct-base.spice
+++ b/src-bootstrap/model/struct-base.spice
@@ -1,14 +1,17 @@
 // Std imports
 import "std/data/vector";
+import "std/text/stringstream";
 import "std/bindings/llvm/llvm" as llvm;
 
 // Own imports
 import "bootstrap/ast/ast-nodes";
 import "bootstrap/reader/code-loc";
 import "bootstrap/model/generic-type";
+import "bootstrap/symboltablebuilder/super-type";
 import "bootstrap/symboltablebuilder/qual-type";
 import "bootstrap/symboltablebuilder/symbol-table-entry";
 import "bootstrap/symboltablebuilder/scope-intf";
+import "bootstrap/util/common-util";
 
 public type VTableData struct {
     llvm::StructType* typeInfoType = nil<llvm::StructType*>
@@ -29,6 +32,7 @@ public type StructBase struct {
     public StructBase* genericPreset = nil<StructBase*>
     public VTableData vTableData
     public bool used = false
+    public bool isNewlyInserted = false
 }
 
 public p StructBase.ctor(const String& name, SymbolTableEntry* entry, IScope* scope, const Vector<GenericType>& templateTypes, ASTNode* declNode) {
@@ -39,9 +43,22 @@ public p StructBase.ctor(const String& name, SymbolTableEntry* entry, IScope* sc
     this.declNode = declNode;
 }
 
+/**
+ * Get a string representation of the current struct
+ *
+ * @return String representation as struct signature
+ */
 public f<String> StructBase.getSignature() {
-    // ToDo: Implement
-    return String();
+    QualTypeList templateSymbolTypes;
+    foreach const GenericType& genericType : this.templateTypes {
+        if genericType.qualType.is(SuperType::TY_GENERIC) && !this.typeMapping.isEmpty() {
+            assert this.typeMapping.contains(genericType.qualType.getSubType());
+            templateSymbolTypes.pushBack(this.typeMapping.get(genericType.qualType.getSubType()));
+        } else {
+            templateSymbolTypes.pushBack(genericType.qualType);
+        }
+    }
+    return this.getSignature(this.name, templateSymbolTypes);
 }
 
 /**
@@ -55,12 +72,21 @@ public f<String> StructBase.getSignature() {
  * @return Signature
  */
 public f<String> StructBase.getSignature(const String& name, const QualTypeList& concreteTemplateTypes) {
-    String templateTyStr;
-    if !this.concreteTemplateTypes.isEmpty() {
-
+    // Build template type string
+    StringStream templateTyStr;
+    if !concreteTemplateTypes.isEmpty() {
+        templateTyStr << "<";
+        for unsigned long i = 0l; i < concreteTemplateTypes.getSize(); i = i + 1l {
+            if i > 0l {
+                templateTyStr << ",";
+            }
+            const QualType templateType = concreteTemplateTypes.get(i);
+            templateType.getName(templateTyStr, false, true);
+        }
+        templateTyStr << ">";
     }
-    // ToDo: Implement
-    return String();
+
+    return getLastFragment(name, SCOPE_ACCESS_TOKEN) + templateTyStr.str();
 }
 
 /**
@@ -71,7 +97,7 @@ public f<String> StructBase.getSignature(const String& name, const QualTypeList&
  */
 public f<bool> StructBase.hasSubstantiatedGenerics() {
     foreach const GenericType& genericType : this.templateTypes {
-        if genericType.hasAnyGenericTypes() {
+        if genericType.qualType.hasAnyGenericParts() {
             return false;
         }
     }

--- a/src-bootstrap/model/struct.spice
+++ b/src-bootstrap/model/struct.spice
@@ -8,6 +8,10 @@ import "bootstrap/model/generic-type";
 import "bootstrap/symboltablebuilder/qual-type";
 import "bootstrap/symboltablebuilder/symbol-table-entry";
 import "bootstrap/symboltablebuilder/scope-intf";
+import "bootstrap/symboltablebuilder/lifecycle";
+
+// Constants
+const string STRUCT_SCOPE_PREFIX = "struct:";
 
 public type Struct struct {
     public compose StructBase structBase
@@ -19,6 +23,34 @@ public p Struct.ctor(const String& name, SymbolTableEntry* entry, IScope* scope,
     this.structBase = StructBase(name, entry, scope, templateTypes, declNode);
     this.fieldTypes = fieldTypes;
     this.interfaceTypes = interfaceTypes;
+}
+
+/**
+ * Retrieve the name of the scope, where members and methods are placed. This is used to navigate to the scope of the
+ * struct from the parent scope.
+ *
+ * @return Name of the struct scope
+ */
+public f<String> Struct.getScopeName() {
+    String appendix;
+    if this.structBase.isGenericSubstantiation() {
+        appendix = this.structBase.getSignature();
+    } else {
+        appendix = this.structBase.name;
+    }
+    return String(STRUCT_SCOPE_PREFIX) + appendix;
+}
+
+/**
+ * Retrieve the name of the scope, where members and methods are placed. This is used to navigate to the scope of the
+ * struct from the parent scope.
+ *
+ * @param name Struct name
+ * @param concreteTemplateTypes Concrete template types
+ * @return Name of the struct scope
+ */
+public f<String> Struct.getScopeName(const String& name, const QualTypeList& concreteTemplateTypes) {
+    return String(STRUCT_SCOPE_PREFIX) + this.structBase.getSignature(name, concreteTemplateTypes);
 }
 
 /**
@@ -34,4 +66,33 @@ public f<bool> Struct.hasReferenceFields() {
         }
     }
     return false;
+}
+
+/**
+ * Check that all fields are in a certain lifecycle state.
+ *
+ * @param state Lifecycle state to check for
+ * @return nil if all fields are in this state, otherwise the first mismatched field symbol
+ */
+public f<SymbolTableEntry*> Struct.areAllFieldsInState(const LifecycleState state) {
+    // ToDo: Iterate the fields via scope.lookupField(i) once IScope exposes it. For now, assume all fields are in state.
+    return nil<SymbolTableEntry*>;
+}
+
+/**
+ * Check that all fields are initialized.
+ *
+ * @return nil if all fields are initialized, otherwise the first uninitialized field symbol
+ */
+public f<SymbolTableEntry*> Struct.areAllFieldsInitialized() {
+    return this.areAllFieldsInState(LifecycleState::INITIALIZED);
+}
+
+/**
+ * Reset the initialization state of all fields to DECLARED.
+ *
+ * @param node AST node to associate with the update
+ */
+public p Struct.resetFieldSymbolsToDeclared(const ASTNode* node) {
+    // ToDo: Reset field symbols via scope.lookupField(i).updateState(DECLARED, node) once IScope exposes lookupField.
 }

--- a/src-bootstrap/symboltablebuilder/symbol-table-entry.spice
+++ b/src-bootstrap/symboltablebuilder/symbol-table-entry.spice
@@ -9,6 +9,10 @@ import "bootstrap/symboltablebuilder/qual-type";
 import "bootstrap/symboltablebuilder/lifecycle";
 import "bootstrap/reader/code-loc";
 
+// Reserved function names for implicitly generated struct constructors/destructors
+public const string CTOR_FUNCTION_NAME = "ctor";
+public const string DTOR_FUNCTION_NAME = "dtor";
+
 public type SymbolTableEntry struct {
     // Public fields
     public String name


### PR DESCRIPTION
## Summary

Ports the `src-bootstrap` model layer (`model/*.spice`) to match the host C++ model classes (`src/model/*`). These are faithful translations.

> **Note:** The model classes parse cleanly but **cannot be compiled or runtime-tested yet**, because the underlying `Type` / `QualType` / `TypeRegistry` layer is still stubbed. In particular, the host `TypeRegistry` is a static-singleton interning map, and Spice has no mutable module-level globals — so interning needs an architectural decision (e.g. a registry threaded through `GlobalResourceManager`) before `qual-type.spice` can compile. That is tracked as future work; this PR lands the model ports as groundwork (consistent with the rest of the WIP bootstrap, which does not fully compile yet).

## Changes

- **GenericType** — `checkConditionsOf` now takes a `substantiation` out-param; `checkTypeConditionOf` implements the host logic (`hasAnyGenericParts` early-out + inline ref-wrapper unwrap). `Type::unwrapBoth` (container-layer unwrap) and a real `QualType` equality operator are left as `ToDo`s.
- **StructBase** — implement `getSignature` (instance + static) via `getLastFragment` + `QualType.getName`; add `isNewlyInserted`; fix `hasSubstantiatedGenerics` to use `hasAnyGenericParts` (was calling a non-existent `hasAnyGenericTypes`).
- **Function** — full port: ctor, `getSignature` (instance + static), `getScopeName`, `getMangledName` (NameMangling `ToDo`), the `getSymbolTableEntryName*` statics, the `is*` predicate methods, `hasSubstantiatedParams/Generics`, `isFullySubstantiated`, `isGenericSubstantiation`, `getDeclCodeLoc`; members synced to the host.
- **Struct** — add `getScopeName` (instance + static); `areAllFieldsInState` / `areAllFieldsInitialized` / `resetFieldSymbolsToDeclared` as faithful API stubs (need `IScope.lookupField`, `ToDo`).
- **Interface** — add `getScopeName` (instance + static).

### Supporting additions
- `ast-nodes.spice` — `MEMBER_ACCESS_TOKEN` / `SCOPE_ACCESS_TOKEN` (host `ASTBuilder.h`). Also fixes a pre-existing dangling `SCOPE_ACCESS_TOKEN` reference in `source-file.spice`.
- `symbol-table-entry.spice` — `CTOR_FUNCTION_NAME` / `DTOR_FUNCTION_NAME` (host `SymbolTableBuilder.h`).

## Test plan
- All model files verified **parser-clean** (build past the parser stage when imported; only the documented downstream Type-layer errors remain).
- Existing bootstrap tests still pass (`standaloneParserSmokeTest`, `standaloneParserStressTest`, `unitWrapperAstNodes`, `unitWrapperLinkerError`, `standaloneSystemUtilTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)