### PR TITLE
Port and test the bootstrap ErrorManager

### DIFF
--- a/src-bootstrap/exception/cli-error.spice
+++ b/src-bootstrap/exception/cli-error.spice
@@ -32,6 +32,15 @@ public p CliError.ctor(const CliErrorType errorType, const string message) {
 }
 
 /**
+ * Get the message for this particular error instance
+ *
+ * @return Error message
+ */
+public f<const String&> CliError.getMessage() {
+    return this.errorMessage;
+}
+
+/**
  * Get the prefix of the error message for a particular error
  *
  * @param errorType Type of the error

--- a/src-bootstrap/exception/error-manager.spice
+++ b/src-bootstrap/exception/error-manager.spice
@@ -2,6 +2,8 @@
 import "std/data/vector";
 
 // Own imports
+import "bootstrap/ast/ast-nodes";
+import "bootstrap/exception/semantic-error";
 import "bootstrap/reader/code-loc";
 
 public type SoftError struct {
@@ -9,6 +11,72 @@ public type SoftError struct {
     String message
 }
 
+public p SoftError.ctor(const CodeLoc& codeLoc, const String& message) {
+    this.codeLoc = codeLoc;
+    this.message = message;
+}
+
+public p SoftError.ctor(const SoftError& other) {
+    this.codeLoc = other.codeLoc;
+    this.message = other.message;
+}
+
+public p operator=(SoftError& this, const SoftError& other) {
+    this.codeLoc = other.codeLoc;
+    this.message = other.message;
+}
+
 public type ErrorManager struct {
-    Vector<SoftError> softErrors
+    public Vector<SoftError> softErrors
+}
+
+p ErrorManager.addSoftError(const CodeLoc& codeLoc, const String& message) {
+    // Avoid duplicate errors
+    foreach (const SoftError& error : this.softErrors) {
+        if error.codeLoc == codeLoc {
+            return;
+        }
+    }
+    this.softErrors.pushBack(SoftError(codeLoc, message));
+}
+
+public p ErrorManager.addSoftError(const ASTNode* astNode, SemanticErrorType errorType, const String& message) {
+    // Build error message
+    SemanticError semanticError = SemanticError(astNode, errorType, message.getRaw());
+    // Add to soft errors list
+    this.addSoftError(astNode.codeLoc, semanticError.getMessage());
+}
+
+#[test, test.name="ErrorManager Smoke test"]
+public f<bool> testErrorManagerSmoke() {
+    ErrorManager em;
+    assert em.softErrors.getSize() == 0l;
+
+    // Add a first soft error
+    em.addSoftError(CodeLoc(1l, 1l), String("first"));
+    assert em.softErrors.getSize() == 1l;
+    assert em.softErrors.get(0l).codeLoc == CodeLoc(1l, 1l);
+    assert em.softErrors.get(0l).message == "first";
+
+    // Add a second soft error at a different location
+    em.addSoftError(CodeLoc(2l, 5l), String("second"));
+    assert em.softErrors.getSize() == 2l;
+
+    // Adding another soft error at an already-recorded location is deduplicated
+    em.addSoftError(CodeLoc(1l, 1l), String("duplicate"));
+    assert em.softErrors.getSize() == 2l;
+    assert em.softErrors.get(0l).message == "first";
+
+    // Add a soft error through the AST-node/SemanticError overload
+    ASTNode node = ASTNode(CodeLoc(7l, 3l, "test.spice"));
+    em.addSoftError(&node, SemanticErrorType::REFERENCED_UNDEFINED_VARIABLE, String("x"));
+    assert em.softErrors.getSize() == 3l;
+    assert em.softErrors.get(2l).codeLoc == CodeLoc(7l, 3l, "test.spice");
+    assert em.softErrors.get(2l).message == "[Error|Semantic] test.spice:7:3:\nReferenced undefined variable: x";
+
+    // Adding a soft error for the same node again is deduplicated
+    em.addSoftError(&node, SemanticErrorType::REFERENCED_UNDEFINED_VARIABLE, String("x"));
+    assert em.softErrors.getSize() == 3l;
+
+    return true;
 }

--- a/src-bootstrap/exception/lexer-error.spice
+++ b/src-bootstrap/exception/lexer-error.spice
@@ -29,6 +29,15 @@ public p LexerError.ctor(const CodeLoc& codeLoc, const LexerErrorType errorType,
 }
 
 /**
+ * Get the message for this particular error instance
+ *
+ * @return Error message
+ */
+public f<const String&> LexerError.getMessage() {
+    return this.errorMessage;
+}
+
+/**
  * Get the prefix of the error message for a particular error
  *
  * @param errorType Type of the error

--- a/src-bootstrap/exception/linker-error.spice
+++ b/src-bootstrap/exception/linker-error.spice
@@ -26,6 +26,15 @@ public p LinkerError.ctor(const LinkerErrorType errorType, const string message)
 }
 
 /**
+ * Get the message for this particular error instance
+ *
+ * @return Error message
+ */
+public f<const String&> LinkerError.getMessage() {
+    return this.errorMessage;
+}
+
+/**
  * Get the prefix of the error message for a particular error
  *
  * @param errorType Type of the error

--- a/src-bootstrap/exception/parser-error.spice
+++ b/src-bootstrap/exception/parser-error.spice
@@ -35,6 +35,15 @@ public p ParserError.ctor(const CodeLoc& codeLoc, const ParserErrorType errorTyp
 }
 
 /**
+ * Get the message for this particular error instance
+ *
+ * @return Error message
+ */
+public f<const String&> ParserError.getMessage() {
+    return this.errorMessage;
+}
+
+/**
  * Get the prefix of the error message for a particular error
  *
  * @param errorType Type of the error

--- a/src-bootstrap/exception/semantic-error.spice
+++ b/src-bootstrap/exception/semantic-error.spice
@@ -1,3 +1,6 @@
+// Std imports
+import "std/text/stringstream";
+
 // Own imports
 import "bootstrap/ast/ast-nodes";
 import "bootstrap/reader/code-loc";
@@ -101,14 +104,23 @@ public type SemanticErrorType enum {
 }
 
 public type SemanticError struct {
-    String message
+    String errorMessage
 }
 
-public p SemanticError.ctor(const AstNode* node, const SemanticErrorType errorType, const string message) {
+public p SemanticError.ctor(const ASTNode* node, const SemanticErrorType errorType, const string message) {
     StringStream msg;
     msg << "[Error|Semantic] " << node.codeLoc.toPrettyString() << ":" << endl();
-    msg << this.getMessagePrefix(errorType) << ": " << message << endl() << endl() << node.errorMessage;
+    msg << this.getMessagePrefix(errorType) << ": " << message;
     this.errorMessage = msg.str();
+}
+
+/**
+ * Get the message for this particular error instance
+ *
+ * @return Error message
+ */
+public f<const String&> SemanticError.getMessage() {
+    return this.errorMessage;
 }
 
 /**

--- a/src/exception/ErrorManager.cpp
+++ b/src/exception/ErrorManager.cpp
@@ -6,17 +6,17 @@
 
 namespace spice::compiler {
 
+void ErrorManager::addSoftError(const CodeLoc &codeLoc, const std::string &message) {
+  // Avoid duplicate errors
+  if (std::ranges::none_of(softErrors, [&](const SoftError &err) { return err.codeLoc == codeLoc; }))
+    softErrors.emplace_back(SoftError{codeLoc, message});
+}
+
 void ErrorManager::addSoftError(const ASTNode *astNode, SemanticErrorType errorType, const std::string &message) {
   // Build error message
   const SemanticError semanticError(astNode, errorType, message);
   // Add to soft errors list
   addSoftError(astNode->codeLoc, semanticError.what());
-}
-
-void ErrorManager::addSoftError(const CodeLoc &codeLoc, const std::string &message) {
-  // Avoid duplicate errors
-  if (std::ranges::none_of(softErrors, [&](const SoftError &err) { return err.codeLoc == codeLoc; }))
-    softErrors.emplace_back(SoftError{codeLoc, message});
 }
 
 } // namespace spice::compiler

--- a/src/exception/SemanticError.h
+++ b/src/exception/SemanticError.h
@@ -131,7 +131,7 @@ enum SemanticErrorType : uint8_t {
 class SemanticError final : public std::exception {
 public:
   // Constructors
-  SemanticError(const ASTNode *node, const SemanticErrorType &type, const std::string &message, bool printErrorMessage = true);
+  SemanticError(const ASTNode *node, const SemanticErrorType &type, const std::string &msg, bool printErrorMessage = true);
 
   // Public methods
   [[nodiscard]] const char *what() const noexcept override;

--- a/test/test-files/bootstrap-compiler/unit-wrapper-error-manager/cout.out
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-error-manager/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/bootstrap-compiler/unit-wrapper-error-manager/source.spice
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-error-manager/source.spice
@@ -1,0 +1,7 @@
+import "bootstrap/exception/error-manager";
+
+// Wrapper for 'spice test' unit test
+f<int> main() {
+    testErrorManagerSmoke();
+    printf("All assertions passed!");
+}


### PR DESCRIPTION
## Summary
Makes the self-hosted `ErrorManager` (`src-bootstrap/exception/error-manager.spice`) actually compile, and adds a builtin smoke test plus a `spice test` wrapper following the existing bootstrap exception unit-test convention.

## Changes
- **`error-manager.spice`**: add a `SoftError` ctor (plus copy ctor and copy-assign operator — a custom ctor suppresses the implicit copy ctor that `Vector.pushBack` needs), make `softErrors` public to match the host `ErrorManager.h`, fix `push_back` → `pushBack`, and add the `ErrorManager Smoke test` builtin test covering both `addSoftError` overloads and the `CodeLoc`-based deduplication.
- **`semantic-error.spice`**: make it compile — import `std/text/stringstream`, rename the `message` field to `errorMessage` (the ctor was assigning to a non-existent field; all sibling exceptions use `errorMessage`), drop the reference to the non-existent `node.errorMessage`, and add `getMessage()`.
- **`cli`/`lexer`/`linker`/`parser-error.spice`**: add `getMessage()` for consistency across the exception classes.
- **Host `ErrorManager.cpp` / `SemanticError.h`**: cosmetic method reorder and a ctor parameter rename to keep the host compiler in sync.
- **New** `test/test-files/bootstrap-compiler/unit-wrapper-error-manager/` (`source.spice` + golden `cout.out`).

## Test plan
- `BootstrapCompilerTests.bootstrapCompiler_unitWrapperErrorManager` passes.
- The sibling exception wrappers (`unitWrapperCliError`, `unitWrapperLexerError`, `unitWrapperParserError`, `unitWrapperLinkerError`) still pass after the `getMessage()` additions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)