### PR TITLE
Enrich std/ README with per-package module tables

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -1,41 +1,161 @@
 # Spice Standard Library
-This subdirectory is contained within every installation of Spice. It contains common functionality, which can be made use of, by
-importing it via `import "std/..."`.
 
-## Bindings
-The package `std/bindings` offers Spice bindings for common external libraries.
+This subdirectory is contained within every installation of Spice. It contains common functionality that can be made use
+of by importing it via `import "std/...";`.
 
-## Data
-The package `std/data` offers common data structures for organizing data, etc.
+The standard library is itself written in Spice. Each package is a collection of `.spice` source files grouped by topic.
+Files whose names end in a platform suffix (e.g. `_linux`, `_windows`, `_darwin`) or an architecture suffix
+(e.g. `_x86_64`, `_aarch64`) provide platform-specific implementations; the compiler selects the matching variant for the
+target.
 
-## I/O
-The package `std/io` offers functions for reading/writing files, etc.
+## Usage
+Import a module and use its exported symbols:
 
-## Iterator
-The package `std/iterator` offers the `Iterable` interface as well as commonly used iterators.
+```spice
+import "std/data/vector";
+import "std/io/file";
 
-## Math
-The package `std/math` offers functions for mathematical operations, etc.
+f<int> main() {
+    Vector<int> numbers;
+    numbers.pushBack(1);
+    numbers.pushBack(2);
+    printf("Sum: %d\n", numbers.get(0) + numbers.get(1));
+}
+```
 
-## Net
-The package `std/net` offers functions for network communication, etc.
+## Packages
 
-## OS
-The package `std/os` offers functions for interacting with the underlying operating system e.g. calling another program, etc.
+### `std/bindings`
+Spice bindings for common external libraries, allowing them to be called from Spice code.
 
-## Runtime
-The package `std/runtime` is an internal package which is linked automatically to any Spice executable if required by the compiler.
+| Module            | Description                                                            |
+|-------------------|------------------------------------------------------------------------|
+| `gtk/gtk4`        | Bindings for the GTK 4 GUI toolkit.                                    |
+| `libcurl/libcurl` | Bindings for libcurl, used for network transfers (see `std/net/http`). |
+| `llvm/llvm`       | Bindings for the LLVM C API, plus linker flags and a target wrapper.   |
 
-## Test
-The package `std/test` offers basic mechanisms for testing in Spice, including assertions, etc.
+### `std/data`
+Common data structures for organizing and storing data.
 
-## Text
-The package `std/text` offers functions for text processing, text output, etc.
+| Module                               | Description                                           |
+|--------------------------------------|-------------------------------------------------------|
+| `vector`                             | Dynamic, growable array.                              |
+| `deque`                              | Double-ended queue.                                   |
+| `queue` / `stack`                    | FIFO queue and LIFO stack.                            |
+| `linked-list` / `doubly-linked-list` | Singly and doubly linked lists.                       |
+| `map` / `unordered-map`              | Ordered and hash-based key/value maps.                |
+| `set` / `unordered-set`              | Ordered and hash-based sets.                          |
+| `hash-table`                         | Hash table backing the unordered containers.          |
+| `binary-tree` / `red-black-tree`     | Binary search tree and self-balancing red-black tree. |
+| `graph`                              | Generic graph structure.                              |
+| `bitset`                             | Fixed-size set of bits.                               |
+| `pair` / `triple`                    | Tuples holding two or three values.                   |
+| `optional`                           | Container that may or may not hold a value.           |
 
-## Time
-The package `std/time` offers functions for accessing system time in different formats, etc.
+### `std/io`
+Reading and writing files, working with paths and directories, command-line parsing, and logging.
 
-## Type
-The package `std/type` offers functions for type related work like type conversions, etc.
+| Module                                         | Description                                                    |
+|------------------------------------------------|----------------------------------------------------------------|
+| `file`                                         | Reading from and writing to files.                             |
+| `dir`                                          | Directory listing and manipulation.                            |
+| `filepath`                                     | Path construction and inspection.                              |
+| `cli-parser` / `cli-option` / `cli-subcommand` | Building command-line interfaces with options and subcommands. |
+| `logging`                                      | Leveled logging utilities.                                     |
+
+### `std/iterator`
+The `Iterable` interface and commonly used iterators that integrate with Spice's `foreach` loops.
+
+| Module            | Description                   |
+|-------------------|-------------------------------|
+| `iterable`        | The `Iterable` interface.     |
+| `iterator`        | Base iterator support.        |
+| `array-iterator`  | Iterator over arrays.         |
+| `number-iterator` | Iterator over numeric ranges. |
+
+### `std/math`
+Mathematical operations, constants, hashing, and randomness.
+
+| Module   | Description                                         |
+|----------|-----------------------------------------------------|
+| `const`  | Mathematical constants (e.g. pi, e).                |
+| `fct`    | Math functions (powers, roots, trigonometry, etc.). |
+| `hash`   | Hash functions used by hash-based containers.       |
+| `rand`   | Pseudo-random number generation.                    |
+
+### `std/net`
+Network communication via sockets and HTTP.
+
+| Module   | Description                                                                        |
+|----------|------------------------------------------------------------------------------------|
+| `socket` | Cross-platform socket abstraction (with `_linux`, `_darwin`, `_windows` variants). |
+| `http`   | HTTP client built on top of `std/bindings/libcurl`.                                |
+
+### `std/os`
+Interacting with the underlying operating system: processes, threads, memory, environment, and raw syscalls.
+
+| Module                   | Description                                             |
+|--------------------------|---------------------------------------------------------|
+| `cmd`                    | Running external programs and capturing their output.   |
+| `env`                    | Reading and setting environment variables.              |
+| `filesystem`             | Filesystem operations.                                  |
+| `cpu`                    | CPU information.                                        |
+| `system` / `os`          | System and OS information (platform-specific variants). |
+| `thread` / `thread-pool` | Spawning threads and managing pools of workers.         |
+| `mutex` / `atomic`       | Synchronization primitives.                             |
+| `allocator`              | Memory allocation utilities.                            |
+| `syscall`                | Architecture-specific raw system call interfaces.       |
+
+### `std/runtime`
+Internal package linked automatically into any Spice executable when required by the compiler. It backs core language
+features and is not normally imported directly.
+
+| Module      | Description                        |
+|-------------|------------------------------------|
+| `error_rt`  | Error handling runtime support.    |
+| `memory_rt` | Memory management runtime support. |
+| `result_rt` | `Result` type runtime support.     |
+| `rtti_rt`   | Runtime type information.          |
+| `string_rt` | String runtime support.            |
+
+### `std/test`
+Basic mechanisms for testing in Spice.
+
+| Module       | Description                       |
+|--------------|-----------------------------------|
+| `assertions` | Assertion helpers for unit tests. |
+| `bench`      | Benchmarking utilities.           |
+
+### `std/text`
+Text processing, parsing, and formatted output.
+
+| Module                                      | Description                     |
+|---------------------------------------------|---------------------------------|
+| `print`                                     | Formatted printing helpers.     |
+| `format`                                    | String formatting.              |
+| `stringstream`                              | Stream-style string building.   |
+| `string-ext`                                | Extra string utility functions. |
+| `analysis`                                  | Text analysis helpers.          |
+| `csv-parser` / `json-parser` / `xml-parser` | Parsers for CSV, JSON, and XML. |
+
+### `std/time`
+Accessing system time in different formats and measuring durations.
+
+| Module     | Description                                     |
+|------------|-------------------------------------------------|
+| `time`     | Low-level time access (with platform variants). |
+| `datetime` | Date and time representation.                   |
+| `timer`    | Measuring elapsed time.                         |
+| `delay`    | Sleeping/delaying execution.                    |
+
+### `std/type`
+Type-related work such as type conversions and inspection.
+
+| Module                   | Description                    |
+|--------------------------|--------------------------------|
+| `types`                  | Type-related helpers.          |
+| `type-conversion`        | Conversions between types.     |
+| `any`                    | A type-erased `Any` container. |
+| `short` / `int` / `long` | Integer type helpers.          |
 
 © ChilliBits 2021-2026


### PR DESCRIPTION
## Summary
Expands `std/README.md` from a flat list of one-line package descriptions into a richer reference for the standard library.

- Adds an intro explaining the stdlib is written in Spice and documents the platform/architecture filename suffix convention (`_linux`, `_windows`, `_darwin`, `_x86_64`, `_aarch64`).
- Adds a **Usage** section with a working code example.
- Adds per-package module tables listing every `.spice` module and what it does, covering `bindings`, `data`, `io`, `iterator`, `math`, `net`, `os`, `runtime`, `test`, `text`, `time`, and `type`.

The footer copyright line is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)