### PR TITLE
Add PriorityQueue to the std library

### DIFF
--- a/std/data/priority-queue.spice
+++ b/std/data/priority-queue.spice
@@ -1,0 +1,267 @@
+// Constants
+const unsigned long INITIAL_CAPACITY = 5l;
+const unsigned int RESIZE_FACTOR = 2;
+
+// Add generic type definition
+type T dyn;
+
+/**
+ * A priority queue in Spice is a commonly used data structure, in which every item has a priority
+ * attached to it. It is implemented as a binary max-heap stored in a contiguous array, so the item
+ * with the highest priority (the largest one according to the `<` operator) is always served first.
+ *
+ * Time complexity:
+ * Insert: O(log n)
+ * Delete: O(log n)
+ * Peek:   O(1)
+ *
+ * Priority queues pre-allocate space using an initial size and a resize factor to not have to
+ * re-allocate with every item pushed.
+ */
+public type PriorityQueue<T> struct {
+    heap T* contents        // Pointer to the first data element
+    unsigned long capacity  // Allocated number of items
+    unsigned long size = 0l // Current number of items
+}
+
+public p PriorityQueue.ctor(unsigned long initAllocItems, const T& defaultValue) {
+    // Allocate space for the initial number of elements
+    this.ctor(initAllocItems);
+    // Fill in the default values. All items are equal, so the heap property holds trivially.
+    for unsigned long index = 0ul; index < initAllocItems; index++ {
+        unsafe {
+            __placement_new<T>(&this.contents[index], defaultValue);
+        }
+    }
+    this.size = initAllocItems;
+}
+
+public p PriorityQueue.ctor(unsigned int initAllocItems) {
+    this.ctor(cast<unsigned long>(initAllocItems));
+}
+
+public p PriorityQueue.ctor(unsigned long initAllocItems = INITIAL_CAPACITY) {
+    // Allocate space for the initial number of elements
+    const unsigned long itemSize = sizeof<T>();
+    unsafe {
+        Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
+        this.contents = cast<heap T*>(allocResult.unwrap());
+    }
+    this.capacity = initAllocItems;
+}
+
+public p PriorityQueue.ctor(const PriorityQueue<T>& original) {
+    this.ctor(original.capacity);
+    // Copying the underlying array verbatim preserves the heap property
+    const unsigned long itemSize = sizeof<T>();
+    unsafe {
+        sCopy(cast<heap byte*>(original.contents), cast<heap byte*>(this.contents), itemSize * original.size);
+    }
+    this.size = original.size;
+}
+
+public p operator=<T>(PriorityQueue<T>& this, const PriorityQueue<T>& newValue) {
+    const unsigned long itemSize = sizeof<T>();
+    if newValue.capacity != this.capacity {
+        unsafe {
+            Result<heap byte*> allocResult = sRealloc(cast<heap byte*>(this.contents), itemSize * newValue.capacity);
+            this.contents = cast<heap T*>(allocResult.unwrap());
+        }
+        this.capacity = newValue.capacity;
+    }
+    this.size = newValue.size;
+    unsafe {
+        sCopy(cast<heap byte*>(newValue.contents), cast<heap byte*>(this.contents), itemSize * newValue.size);
+    }
+}
+
+/**
+ * Add an item to the priority queue
+ */
+public p PriorityQueue.push(const T& item) {
+    // Check if we need to re-allocate memory
+    if this.isFull() {
+        const unsigned long newCapacity = this.capacity == 0l ? INITIAL_CAPACITY : this.capacity * cast<unsigned long>(RESIZE_FACTOR);
+        this.resize(newCapacity);
+    }
+
+    // Insert the element at the back and restore the heap property by sifting it up
+    unsafe {
+        __placement_new<T>(&this.contents[this.size], item);
+    }
+    this.size++;
+    this.siftUp(this.size - 1l);
+}
+
+/**
+ * Retrieve the item with the highest priority and remove it from the priority queue
+ *
+ * @return Item with the highest priority
+ */
+#[ignoreUnusedReturnValue]
+public f<T> PriorityQueue.pop() {
+    if this.isEmpty() { panic(Error("The priority queue is empty")); }
+    unsafe {
+        // Copy out the root (highest priority) item
+        result = this.contents[0];
+        // Move the last element to the root and shrink, then restore the heap property
+        this.size--;
+        if this.size > 0l {
+            this.contents[0] = this.contents[this.size];
+            this.siftDown(0l);
+        }
+    }
+}
+
+/**
+ * Retrieve the item with the highest priority without removing it from the priority queue
+ *
+ * @return Item with the highest priority
+ */
+public f<T&> PriorityQueue.peek() {
+    if this.isEmpty() { panic(Error("The priority queue is empty")); }
+    unsafe {
+        return this.contents[0];
+    }
+}
+
+/**
+ * Retrieve the current size of the priority queue
+ *
+ * @return Current size of the priority queue
+ */
+public f<long> PriorityQueue.getSize() {
+    return this.size;
+}
+
+/**
+ * Retrieve the current capacity of the priority queue
+ *
+ * @return Current capacity of the priority queue
+ */
+public f<long> PriorityQueue.getCapacity() {
+    return this.capacity;
+}
+
+/**
+ * Checks if the priority queue contains any items at the moment
+ *
+ * @return Empty or not empty
+ */
+public f<bool> PriorityQueue.isEmpty() {
+    return this.size == 0;
+}
+
+/**
+ * Checks if the priority queue exhausts its capacity and needs to resize at the next call of push
+ *
+ * @return Full or not full
+ */
+public f<bool> PriorityQueue.isFull() {
+    return this.size == this.capacity;
+}
+
+/**
+ * Removes all items from the priority queue
+ */
+public p PriorityQueue.clear() {
+    this.size = 0l;
+}
+
+/**
+ * Reserves `itemCount` items
+ */
+public p PriorityQueue.reserve(unsigned long itemCount) {
+    if itemCount > this.capacity {
+        this.resize(itemCount);
+    }
+}
+
+/**
+ * Frees allocated memory that is not used by the priority queue
+ */
+public p PriorityQueue.pack() {
+    // Return if no packing is required
+    if this.isFull() { return; }
+    // Pack the array
+    this.resize(this.size);
+}
+
+public f<bool> operator==<T>(const PriorityQueue<T>& lhs, const PriorityQueue<T>& rhs) {
+    // Compare the sizes
+    if lhs.size != rhs.size { return false; }
+    // Two heaps are equal if they hold the same items in the same priority order. Since two equal
+    // multisets can have different internal array layouts, compare by draining copies in priority order.
+    PriorityQueue<T> a = PriorityQueue<T>(lhs);
+    PriorityQueue<T> b = PriorityQueue<T>(rhs);
+    while !a.isEmpty() {
+        if a.pop() != b.pop() { return false; }
+    }
+    return true;
+}
+
+public f<bool> operator!=<T>(const PriorityQueue<T>& lhs, const PriorityQueue<T>& rhs) {
+    return !(lhs == rhs);
+}
+
+/**
+ * Restores the heap property by moving the item at `index` up towards the root
+ */
+p PriorityQueue.siftUp(unsigned long index) {
+    unsafe {
+        while index > 0l {
+            const unsigned long parent = (index - 1l) / 2l;
+            // Stop as soon as the parent is not lower in priority than the current item
+            if !(this.contents[parent] < this.contents[index]) {
+                break;
+            }
+            T tmp = this.contents[parent];
+            this.contents[parent] = this.contents[index];
+            this.contents[index] = tmp;
+            index = parent;
+        }
+    }
+}
+
+/**
+ * Restores the heap property by moving the item at `index` down towards the leaves
+ */
+p PriorityQueue.siftDown(unsigned long index) {
+    unsafe {
+        while true {
+            const unsigned long left = 2l * index + 1l;
+            const unsigned long right = 2l * index + 2l;
+            unsigned long largest = index;
+            if left < this.size && this.contents[largest] < this.contents[left] {
+                largest = left;
+            }
+            if right < this.size && this.contents[largest] < this.contents[right] {
+                largest = right;
+            }
+            // Stop as soon as the item is not lower in priority than either child
+            if largest == index {
+                break;
+            }
+            T tmp = this.contents[index];
+            this.contents[index] = this.contents[largest];
+            this.contents[largest] = tmp;
+            index = largest;
+        }
+    }
+}
+
+/**
+ * Re-allocates heap space for the priority queue contents
+ */
+p PriorityQueue.resize(unsigned long itemCount) {
+    // Allocate the new memory
+    const unsigned long itemSize = sizeof<T>();
+    unsafe {
+        heap byte*& oldAddress = cast<heap byte*>(this.contents);
+        unsigned long newSize = cast<unsigned long>(itemSize * itemCount);
+        Result<heap byte*> allocResult = sRealloc(oldAddress, newSize);
+        this.contents = cast<heap T*>(allocResult.unwrap());
+    }
+    // Set new capacity
+    this.capacity = itemCount;
+}

--- a/std/data/priority-queue.spice
+++ b/std/data/priority-queue.spice
@@ -110,6 +110,10 @@ public f<T> PriorityQueue.pop() {
             this.contents[0] = this.contents[this.size];
             this.siftDown(0l);
         }
+        // Destruct the now-vacated last slot (cf. Vector.removeAt). In both branches this is
+        // the index `this.size`: the moved-from slot when size > 0, or the lone remaining slot
+        // (index 0) when the queue is now empty. Required so owning element types don't leak.
+        sDestruct(this.contents[this.size]);
     }
 }
 

--- a/test/test-files/std/data/priority-queue-smoke/cout.out
+++ b/test/test-files/std/data/priority-queue-smoke/cout.out
@@ -1,0 +1,1 @@
+Priority queue smoke tests passed!

--- a/test/test-files/std/data/priority-queue-smoke/source.spice
+++ b/test/test-files/std/data/priority-queue-smoke/source.spice
@@ -1,0 +1,70 @@
+import "std/data/priority-queue";
+
+f<int> main() {
+    // Default ctor: empty priority queue with INITIAL_CAPACITY=5
+    PriorityQueue<int> pq;
+    assert pq.isEmpty();
+    assert !pq.isFull();
+    assert pq.getSize() == 0;
+    assert pq.getCapacity() == 5;
+
+    // push/peek/getSize - the largest item bubbles to the top regardless of insertion order
+    pq.push(3);
+    pq.push(1);
+    pq.push(4);
+    pq.push(1);
+    pq.push(5);
+    assert pq.getSize() == 5;
+    assert !pq.isEmpty();
+    assert pq.peek() == 5;
+
+    // pop returns items in descending priority order
+    assert pq.pop() == 5;
+    assert pq.pop() == 4;
+    assert pq.peek() == 3;
+    assert pq.pop() == 3;
+    assert pq.pop() == 1;
+    assert pq.pop() == 1;
+    assert pq.isEmpty();
+
+    // ctor(capacity) reserves up front, but starts empty
+    PriorityQueue<int> pq2 = PriorityQueue<int>(16l);
+    assert pq2.getCapacity() == 16;
+    assert pq2.isEmpty();
+
+    // ctor(count, default) starts full with the default value
+    PriorityQueue<short> pq3 = PriorityQueue<short>(4l, 7s);
+    assert pq3.getSize() == 4;
+    assert pq3.isFull();
+    assert pq3.peek() == 7s;
+
+    // Items inserted in ascending order still come out in descending order
+    PriorityQueue<int> pq4;
+    for int i = 1; i <= 6; i++ { pq4.push(i); }
+    assert pq4.peek() == 6;
+    for int expected = 6; expected >= 1; expected-- {
+        assert pq4.pop() == expected;
+    }
+    assert pq4.isEmpty();
+
+    // clear empties the priority queue but keeps it usable
+    PriorityQueue<int> pq5;
+    pq5.push(10); pq5.push(20); pq5.push(30);
+    pq5.clear();
+    assert pq5.isEmpty();
+    assert pq5.getSize() == 0;
+    pq5.push(42);
+    assert pq5.peek() == 42;
+
+    // Equality compares items in priority order, independent of insertion order
+    PriorityQueue<int> a;
+    PriorityQueue<int> b;
+    a.push(1); a.push(2); a.push(3);
+    b.push(3); b.push(1); b.push(2);
+    assert a == b;
+    assert !(a != b);
+    b.pop();
+    assert a != b;
+
+    printf("Priority queue smoke tests passed!\n");
+}

--- a/test/test-files/std/data/priority-queue-stress/cout.out
+++ b/test/test-files/std/data/priority-queue-stress/cout.out
@@ -1,0 +1,1 @@
+Priority queue stress tests passed!

--- a/test/test-files/std/data/priority-queue-stress/source.spice
+++ b/test/test-files/std/data/priority-queue-stress/source.spice
@@ -17,13 +17,13 @@ f<int> main() {
 
     // 2. Pseudo-random insertion order: heap must act as a sorting machine (descending)
     PriorityQueue<int> pq2;
-    int state = 12345;
+    long state = 12345l;
     int count = 2000;
     for int i = 0; i < count; i++ {
-        // Simple LCG to get a spread of values
-        state = (state * 1103515245 + 12345) % 1000000007;
-        int value = state % 100000;
-        if value < 0 { value = -value; }
+        // Simple LCG to get a spread of values. Computed in 64-bit to avoid signed overflow:
+        // state stays in [0, 1e9), so state * 1103515245 reaches ~1.1e18, which fits in a long.
+        state = (state * 1103515245l + 12345l) % 1000000007l;
+        int value = cast<int>(state % 100000l);
         pq2.push(value);
     }
     assert pq2.getSize() == count;

--- a/test/test-files/std/data/priority-queue-stress/source.spice
+++ b/test/test-files/std/data/priority-queue-stress/source.spice
@@ -1,0 +1,148 @@
+import "std/data/priority-queue";
+
+f<int> main() {
+    // 1. Many pushes force multiple resizes; pop must yield strictly descending order
+    PriorityQueue<int> pq1;
+    for int i = 0; i < 1000; i++ { pq1.push(i); }
+    assert pq1.getSize() == 1000;
+    assert pq1.getCapacity() >= 1000;
+    assert pq1.peek() == 999;
+    int prev = 1000;
+    for int i = 0; i < 1000; i++ {
+        int top = pq1.pop();
+        assert top == prev - 1; // 999, 998, ..., 0
+        prev = top;
+    }
+    assert pq1.isEmpty();
+
+    // 2. Pseudo-random insertion order: heap must act as a sorting machine (descending)
+    PriorityQueue<int> pq2;
+    int state = 12345;
+    int count = 2000;
+    for int i = 0; i < count; i++ {
+        // Simple LCG to get a spread of values
+        state = (state * 1103515245 + 12345) % 1000000007;
+        int value = state % 100000;
+        if value < 0 { value = -value; }
+        pq2.push(value);
+    }
+    assert pq2.getSize() == count;
+    int last = pq2.pop();
+    int popped = 1;
+    while !pq2.isEmpty() {
+        int cur = pq2.pop();
+        assert cur <= last; // non-increasing
+        last = cur;
+        popped++;
+    }
+    assert popped == count;
+
+    // 3. Interleaved push/pop keeps the max invariant at all times
+    PriorityQueue<int> pq3;
+    pq3.push(50);
+    assert pq3.peek() == 50;
+    pq3.push(75);
+    assert pq3.peek() == 75;
+    pq3.push(25);
+    assert pq3.peek() == 75;
+    assert pq3.pop() == 75;
+    assert pq3.peek() == 50;
+    pq3.push(60);
+    assert pq3.peek() == 60;
+    pq3.push(100);
+    assert pq3.peek() == 100;
+    assert pq3.pop() == 100;
+    assert pq3.pop() == 60;
+    assert pq3.pop() == 50;
+    assert pq3.pop() == 25;
+    assert pq3.isEmpty();
+
+    // 4. Duplicates are handled correctly
+    PriorityQueue<int> pq4;
+    for int i = 0; i < 100; i++ { pq4.push(7); }
+    assert pq4.getSize() == 100;
+    for int i = 0; i < 100; i++ {
+        assert pq4.pop() == 7;
+    }
+    assert pq4.isEmpty();
+
+    // 5. Copy ctor produces an independent heap with the same priority order
+    PriorityQueue<int> pq5;
+    for int i = 0; i < 50; i++ { pq5.push(i * 3); }
+    PriorityQueue<int> pq6 = PriorityQueue<int>(pq5);
+    assert pq6.getSize() == 50;
+    assert pq6.peek() == 147; // 49 * 3
+    assert pq6.pop() == 147;
+    // Mutating the copy must not affect the original
+    assert pq5.getSize() == 50;
+    assert pq5.peek() == 147;
+
+    // 6. operator= overwrites the destination and stays independent
+    PriorityQueue<int> pq7;
+    pq7.push(1); pq7.push(2);
+    pq7 = pq5;
+    assert pq7.getSize() == 50;
+    assert pq7.peek() == 147;
+    int expected7 = 147;
+    while !pq7.isEmpty() {
+        assert pq7.pop() == expected7;
+        expected7 -= 3;
+    }
+    // Original is untouched
+    assert pq5.getSize() == 50;
+    assert pq5.peek() == 147;
+
+    // 7. reserve grows capacity without disturbing the contents or ordering
+    PriorityQueue<int> pq8;
+    pq8.push(5); pq8.push(15); pq8.push(10);
+    pq8.reserve(256l);
+    assert pq8.getCapacity() >= 256;
+    assert pq8.getSize() == 3;
+    assert pq8.pop() == 15;
+    assert pq8.pop() == 10;
+    assert pq8.pop() == 5;
+
+    // 8. pack shrinks capacity down to the current size; heap stays valid
+    PriorityQueue<int> pq9;
+    for int i = 0; i < 20; i++ { pq9.push(i); }
+    for int i = 0; i < 15; i++ { pq9.pop(); }
+    assert pq9.getSize() == 5;
+    pq9.pack();
+    assert pq9.getCapacity() == 5;
+    // Remaining items are the five largest: 4, 3, 2, 1, 0
+    assert pq9.pop() == 4;
+    assert pq9.pop() == 3;
+    assert pq9.pop() == 2;
+    assert pq9.pop() == 1;
+    assert pq9.pop() == 0;
+    assert pq9.isEmpty();
+
+    // 9. Drain, refill and drain again to ensure the structure is reusable
+    PriorityQueue<int> pq10;
+    for int i = 0; i < 30; i++ { pq10.push(i); }
+    while !pq10.isEmpty() { pq10.pop(); }
+    assert pq10.isEmpty();
+    for int i = 100; i > 70; i-- { pq10.push(i); }
+    assert pq10.getSize() == 30;
+    assert pq10.peek() == 100;
+    int expected10 = 100;
+    while !pq10.isEmpty() {
+        assert pq10.pop() == expected10;
+        expected10--;
+    }
+    assert expected10 == 70;
+
+    // 10. Works with a wider element type
+    PriorityQueue<long> pq11;
+    for long i = 0l; i < 500l; i++ { pq11.push(i * 1000l); }
+    assert pq11.getSize() == 500;
+    assert pq11.peek() == 499000l;
+    long prevLong = 1000000l;
+    while !pq11.isEmpty() {
+        long cur = pq11.pop();
+        assert cur < prevLong;
+        prevLong = cur;
+    }
+
+    printf("Priority queue stress tests passed!\n");
+}


### PR DESCRIPTION
@
## What

Adds a `PriorityQueue<T>` data structure to the standard library, plus smoke and stress reference tests.

- **`std/data/priority-queue.spice`** — a binary **max-heap** stored in a contiguous, auto-resizing array. It follows the same allocation/resize conventions (`INITIAL_CAPACITY`, `RESIZE_FACTOR`, `sAlloc`/`sRealloc`) as the existing `Queue`/`Stack`/`Vector` structures, and compares items generically with the `<` operator (the same approach the red-black tree already uses for keys). The highest-priority item — the largest one — is always served first.

### API
- `push` — O(log n), insert then sift up
- `pop` — O(log n), returns the top **by value** (`f<T>`, since sift-down invalidates the root reference) and restores the heap
- `peek` — O(1), reference to the top
- ctors: default, `(capacity)`, `(count, default)`, copy; `operator=`
- `operator==` / `operator!=` — compared in priority order by draining copies, so equality is independent of internal array layout
- `getSize` / `getCapacity` / `isEmpty` / `isFull` / `clear` / `reserve` / `pack`

## Tests

Two reference cases under `test/test-files/std/data` (auto-discovered by `TestRunner.cpp`, each with `source.spice` + `cout.out`):

- **`priority-queue-smoke`** — core API: heap ordering regardless of insertion order, the various ctors, `clear`, and equality.
- **`priority-queue-stress`** — 1000+ element heapsort checks, an LCG-driven pseudo-random sequence verifying non-increasing pop order, interleaved push/pop invariants, duplicates, copy-ctor / `operator=` independence, `reserve`, `pack`, drain-and-reuse, and a wider `long` element type.

## Notes for reviewers

- The design deliberately mirrors verified idioms from existing std code. The by-value `f<T> pop()` follows the `f<T> Atomic.exchange` precedent in `std/os/atomic.spice`.
- I was unable to build/run the suite locally (the CMake build dir needs a reconfigure that is blocked in my environment), so please confirm in CI / locally with:
  `spicetest --gtest_filter=StdTests*riority*`.
- Default ordering is a max-heap; happy to switch to a min-heap or a comparator-parameterized variant if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@