### PR TITLE
Add Trie data structure to the std library

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -42,11 +42,13 @@ Common data structures for organizing and storing data.
 | `vector`                             | Dynamic, growable array.                              |
 | `deque`                              | Double-ended queue.                                   |
 | `queue` / `stack`                    | FIFO queue and LIFO stack.                            |
+| `priority-queue`                     | Binary max-heap served by priority.                   |
 | `linked-list` / `doubly-linked-list` | Singly and doubly linked lists.                       |
 | `map` / `unordered-map`              | Ordered and hash-based key/value maps.                |
 | `set` / `unordered-set`              | Ordered and hash-based sets.                          |
 | `hash-table`                         | Hash table backing the unordered containers.          |
 | `binary-tree` / `red-black-tree`     | Binary search tree and self-balancing red-black tree. |
+| `trie`                               | Prefix tree for fast prefix-based string lookups.     |
 | `graph`                              | Generic graph structure.                              |
 | `bitset`                             | Fixed-size set of bits.                               |
 | `pair` / `triple`                    | Tuples holding two or three values.                   |

--- a/std/data/trie.spice
+++ b/std/data/trie.spice
@@ -65,7 +65,7 @@ public p Trie.dtor() {
  * @param word The word to insert
  */
 public p Trie.insert(string word) {
-    const unsigned long len = getRawLength(word);
+    const unsigned long len = this.rawLength(word);
     TrieNode* node = this.root;
     for unsigned long i = 0l; i < len; i++ {
         const char c = word[i];
@@ -156,13 +156,28 @@ public p Trie.clear() {
 }
 
 /**
+ * Compute the length of a raw string by counting characters up to the null terminator.
+ * This avoids depending on the `String` runtime, since the trie only ever deals with raw
+ * `string` values.
+ *
+ * @param s The raw string to measure
+ * @return Number of characters before the null terminator
+ */
+f<unsigned long> Trie.rawLength(string s) {
+    result = 0l;
+    while s[result] != '\0' {
+        result++;
+    }
+}
+
+/**
  * Walk the trie along the given string and return the node reached at its end.
  *
  * @param str The string to walk along
  * @return The node at the end of the path, or nil if the path does not exist
  */
 f<TrieNode*> Trie.findNode(string str) {
-    const unsigned long len = getRawLength(str);
+    const unsigned long len = this.rawLength(str);
     TrieNode* node = this.root;
     for unsigned long i = 0l; i < len; i++ {
         node = this.getChild(node, str[i]);
@@ -224,7 +239,7 @@ f<unsigned long> Trie.countEndNodes(TrieNode* node) {
  */
 #[ignoreUnusedReturnValue]
 f<bool> Trie.removeHelper(TrieNode* node, string word, unsigned long depth) {
-    const unsigned long len = getRawLength(word);
+    const unsigned long len = this.rawLength(word);
     if depth == len {
         // We reached the node that should spell the word. Unmark it if it is a word.
         if node.isEndOfWord {

--- a/std/data/trie.spice
+++ b/std/data/trie.spice
@@ -1,0 +1,253 @@
+import "std/data/vector";
+
+/**
+ * Node of a Trie.
+ *
+ * Each node owns its child nodes as heap-allocated pointers. The edge labels are stored in
+ * `keys`, parallel to `children`, so the edge `keys[i]` leads to the child `children[i]`.
+ * `isEndOfWord` marks whether the path from the root to this node spells a complete word.
+ */
+type TrieNode struct {
+    Vector<char> keys              // Edge labels, parallel to children
+    Vector<TrieNode*> children     // Child nodes, parallel to keys
+    bool isEndOfWord = false
+}
+
+p TrieNode.ctor() {
+    this.isEndOfWord = false;
+}
+
+/**
+ * A trie (also called prefix tree) is a data structure that stores a set of strings in a way
+ * that makes prefix-based lookups efficient. Every edge is labeled with a single character, so
+ * a word corresponds to a path from the root down to a node marked as the end of a word.
+ * Words that share a common prefix also share the nodes that spell out that prefix.
+ *
+ * Time complexity (k = length of the word/prefix):
+ * Insert:        O(k)
+ * Contains:      O(k)
+ * Starts with:   O(k)
+ * Remove:        O(k)
+ */
+public type Trie struct {
+    TrieNode* root
+    unsigned long wordCount = 0l
+}
+
+public p Trie.ctor() {
+    this.root = __new<TrieNode>();
+    this.wordCount = 0l;
+}
+
+public p Trie.dtor() {
+    this.freeSubtrees(this.root);
+    sDelete(this.root);
+}
+
+/**
+ * Insert a word into the trie. Inserting a word that is already present has no effect.
+ *
+ * @param word The word to insert
+ */
+public p Trie.insert(string word) {
+    const unsigned long len = getRawLength(word);
+    TrieNode* node = this.root;
+    for unsigned long i = 0l; i < len; i++ {
+        const char c = word[i];
+        TrieNode* child = this.getChild(node, c);
+        if child == nil<TrieNode*> {
+            child = __new<TrieNode>();
+            node.children.pushBack(child);
+            node.keys.pushBack(c);
+        }
+        node = child;
+    }
+    // Mark the end of the word, counting it only if it was not already present
+    if !node.isEndOfWord {
+        node.isEndOfWord = true;
+        this.wordCount++;
+    }
+}
+
+/**
+ * Check if the trie contains the given word.
+ *
+ * @param word The word to look for
+ * @return True if the exact word was inserted before, false otherwise
+ */
+public f<bool> Trie.contains(string word) {
+    TrieNode* node = this.findNode(word);
+    return node != nil<TrieNode*> && node.isEndOfWord;
+}
+
+/**
+ * Check if the trie contains any word that starts with the given prefix.
+ * The empty prefix is contained in every trie.
+ *
+ * @param prefix The prefix to look for
+ * @return True if at least one stored word starts with the prefix, false otherwise
+ */
+public f<bool> Trie.startsWith(string prefix) {
+    return this.findNode(prefix) != nil<TrieNode*>;
+}
+
+/**
+ * Count how many stored words start with the given prefix.
+ *
+ * @param prefix The prefix to look for
+ * @return Number of stored words that start with the prefix
+ */
+public f<unsigned long> Trie.countWordsWithPrefix(string prefix) {
+    TrieNode* node = this.findNode(prefix);
+    if node == nil<TrieNode*> { return 0l; }
+    return this.countEndNodes(node);
+}
+
+/**
+ * Remove a word from the trie. Removing a word that is not present has no effect.
+ * Nodes that become unused after the removal are pruned and their memory is freed.
+ *
+ * @param word The word to remove
+ */
+public p Trie.remove(string word) {
+    this.removeHelper(this.root, word, 0l);
+}
+
+/**
+ * Get the number of words stored in the trie.
+ *
+ * @return The number of stored words
+ */
+public f<unsigned long> Trie.getSize() {
+    return this.wordCount;
+}
+
+/**
+ * Check if the trie is empty.
+ *
+ * @return True if no words are stored, false otherwise
+ */
+public f<bool> Trie.isEmpty() {
+    return this.wordCount == 0l;
+}
+
+/**
+ * Remove all words from the trie, freeing all nodes but the root.
+ */
+public p Trie.clear() {
+    this.freeSubtrees(this.root);
+    this.root.isEndOfWord = false;
+    this.wordCount = 0l;
+}
+
+/**
+ * Walk the trie along the given string and return the node reached at its end.
+ *
+ * @param str The string to walk along
+ * @return The node at the end of the path, or nil if the path does not exist
+ */
+f<TrieNode*> Trie.findNode(string str) {
+    const unsigned long len = getRawLength(str);
+    TrieNode* node = this.root;
+    for unsigned long i = 0l; i < len; i++ {
+        node = this.getChild(node, str[i]);
+        if node == nil<TrieNode*> { return nil<TrieNode*>; }
+    }
+    return node;
+}
+
+/**
+ * Retrieve the child of the given node that is reached via the edge labeled `c`.
+ *
+ * @param node The node whose children to search
+ * @param c The edge label to look for
+ * @return The matching child node, or nil if there is none
+ */
+f<TrieNode*> Trie.getChild(TrieNode* node, char c) {
+    for unsigned long i = 0l; i < node.keys.getSize(); i++ {
+        if node.keys.get(i) == c {
+            return node.children.get(i);
+        }
+    }
+    return nil<TrieNode*>;
+}
+
+/**
+ * Retrieve the index of the child of the given node that is reached via the edge labeled `c`.
+ *
+ * @param node The node whose children to search
+ * @param c The edge label to look for
+ * @return The index of the matching child, or -1 if there is none
+ */
+f<long> Trie.findChildIndex(TrieNode* node, char c) {
+    for unsigned long i = 0l; i < node.keys.getSize(); i++ {
+        if node.keys.get(i) == c {
+            return cast<long>(i);
+        }
+    }
+    return -1l;
+}
+
+/**
+ * Count the number of end-of-word markers in the subtree rooted at the given node.
+ *
+ * @param node The root of the subtree to count
+ * @return Number of stored words in the subtree
+ */
+f<unsigned long> Trie.countEndNodes(TrieNode* node) {
+    result = node.isEndOfWord ? 1l : 0l;
+    for unsigned long i = 0l; i < node.children.getSize(); i++ {
+        result += this.countEndNodes(node.children.get(i));
+    }
+}
+
+/**
+ * Recursion helper for remove(). Unmarks the word at the end of the path and prunes nodes that
+ * become unused on the way back up.
+ *
+ * @param node The current node
+ * @param word The word being removed
+ * @param depth The current depth, i.e. the index of the next character to match
+ * @return True if `node` is now unused and may be pruned by its parent
+ */
+#[ignoreUnusedReturnValue]
+f<bool> Trie.removeHelper(TrieNode* node, string word, unsigned long depth) {
+    const unsigned long len = getRawLength(word);
+    if depth == len {
+        // We reached the node that should spell the word. Unmark it if it is a word.
+        if node.isEndOfWord {
+            node.isEndOfWord = false;
+            this.wordCount--;
+        }
+    } else {
+        const long idx = this.findChildIndex(node, word[depth]);
+        if idx >= 0l {
+            const unsigned long uidx = cast<unsigned long>(idx);
+            TrieNode* child = node.children.get(uidx);
+            if this.removeHelper(child, word, depth + 1l) {
+                // The child became unused: free it and detach it from this node
+                sDelete(child);
+                node.children.removeAt(uidx);
+                node.keys.removeAt(uidx);
+            }
+        }
+    }
+    // The root is never pruned, even if it ends up empty
+    return node != this.root && node.children.isEmpty() && !node.isEndOfWord;
+}
+
+/**
+ * Recursively free all descendant nodes of the given node and clear its child lists.
+ * The node itself is left allocated and usable.
+ *
+ * @param node The node whose subtrees to free
+ */
+p Trie.freeSubtrees(TrieNode* node) {
+    for unsigned long i = 0l; i < node.children.getSize(); i++ {
+        TrieNode* child = node.children.get(i);
+        this.freeSubtrees(child);
+        sDelete(child);
+    }
+    node.children.clear();
+    node.keys.clear();
+}

--- a/std/data/trie.spice
+++ b/std/data/trie.spice
@@ -39,6 +39,21 @@ public p Trie.ctor() {
     this.wordCount = 0l;
 }
 
+public p Trie.ctor(const Trie& original) {
+    // Deep-copy the other trie so the two instances own independent node trees.
+    // A shallow copy would alias `root` and double-free it when both are destructed.
+    this.root = __new<TrieNode>();
+    this.wordCount = original.wordCount;
+    this.copySubtree(this.root, original.root);
+}
+
+public p operator=(Trie& this, const Trie& other) {
+    // Drop the current node tree, then deep-copy the other trie into the fresh root
+    this.freeSubtrees(this.root);
+    this.wordCount = other.wordCount;
+    this.copySubtree(this.root, other.root);
+}
+
 public p Trie.dtor() {
     this.freeSubtrees(this.root);
     sDelete(this.root);
@@ -164,12 +179,9 @@ f<TrieNode*> Trie.findNode(string str) {
  * @return The matching child node, or nil if there is none
  */
 f<TrieNode*> Trie.getChild(TrieNode* node, char c) {
-    for unsigned long i = 0l; i < node.keys.getSize(); i++ {
-        if node.keys.get(i) == c {
-            return node.children.get(i);
-        }
-    }
-    return nil<TrieNode*>;
+    const long idx = this.findChildIndex(node, c);
+    if idx < 0l { return nil<TrieNode*>; }
+    return node.children.get(cast<unsigned long>(idx));
 }
 
 /**
@@ -250,4 +262,21 @@ p Trie.freeSubtrees(TrieNode* node) {
     }
     node.children.clear();
     node.keys.clear();
+}
+
+/**
+ * Recursively deep-copy the subtree rooted at `src` into the (freshly allocated, empty) node
+ * `dest`. New child nodes are allocated so the copy owns an independent node tree.
+ *
+ * @param dest The destination node to copy into
+ * @param src The source node to copy from
+ */
+p Trie.copySubtree(TrieNode* dest, TrieNode* src) {
+    dest.isEndOfWord = src.isEndOfWord;
+    for unsigned long i = 0l; i < src.children.getSize(); i++ {
+        TrieNode* newChild = __new<TrieNode>();
+        dest.keys.pushBack(src.keys.get(i));
+        dest.children.pushBack(newChild);
+        this.copySubtree(newChild, src.children.get(i));
+    }
 }

--- a/test/test-files/std/data/trie-smoke/cout.out
+++ b/test/test-files/std/data/trie-smoke/cout.out
@@ -1,0 +1,1 @@
+Trie smoke tests passed!

--- a/test/test-files/std/data/trie-smoke/source.spice
+++ b/test/test-files/std/data/trie-smoke/source.spice
@@ -1,0 +1,92 @@
+import "std/data/trie";
+
+f<int> main() {
+    // Default ctor: empty trie
+    Trie t;
+    assert t.isEmpty();
+    assert t.getSize() == 0l;
+    assert !t.contains("anything");
+    // The empty prefix is contained in every trie, even an empty one
+    assert t.startsWith("");
+
+    // insert/contains - words that share a prefix share their nodes
+    t.insert("car");
+    t.insert("card");
+    t.insert("care");
+    t.insert("cat");
+    assert t.getSize() == 4l;
+    assert !t.isEmpty();
+    assert t.contains("car");
+    assert t.contains("card");
+    assert t.contains("care");
+    assert t.contains("cat");
+
+    // Prefixes of stored words are not themselves stored words
+    assert !t.contains("ca");
+    assert !t.contains("c");
+    assert !t.contains("cars");
+
+    // startsWith reflects whether any word continues the prefix
+    assert t.startsWith("c");
+    assert t.startsWith("ca");
+    assert t.startsWith("car");
+    assert t.startsWith("card");
+    assert !t.startsWith("d");
+    assert !t.startsWith("cab");
+
+    // countWordsWithPrefix counts every word below the prefix
+    assert t.countWordsWithPrefix("car") == 3l; // car, card, care
+    assert t.countWordsWithPrefix("ca") == 4l;  // car, card, care, cat
+    assert t.countWordsWithPrefix("cat") == 1l;
+    assert t.countWordsWithPrefix("d") == 0l;
+    assert t.countWordsWithPrefix("") == 4l;    // all words
+
+    // Inserting an existing word does not change the size
+    t.insert("car");
+    assert t.getSize() == 4l;
+
+    // remove unmarks a word but keeps words that share its prefix
+    t.remove("card");
+    assert !t.contains("card");
+    assert t.contains("car");
+    assert t.contains("care");
+    assert t.getSize() == 3l;
+    assert t.startsWith("car");
+
+    // Removing a word that is not present is a no-op
+    t.remove("dog");
+    assert t.getSize() == 3l;
+
+    // Removing the last word with a given prefix prunes that branch
+    t.remove("cat");
+    assert !t.contains("cat");
+    assert !t.startsWith("cat");
+    assert t.getSize() == 2l;
+
+    // The empty string can be stored and removed like any other word
+    Trie t2;
+    assert !t2.contains("");
+    t2.insert("");
+    assert t2.contains("");
+    assert t2.getSize() == 1l;
+    t2.remove("");
+    assert !t2.contains("");
+    assert t2.getSize() == 0l;
+
+    // clear empties the trie but keeps it usable
+    Trie t3;
+    t3.insert("hello");
+    t3.insert("help");
+    t3.insert("world");
+    assert t3.getSize() == 3l;
+    t3.clear();
+    assert t3.isEmpty();
+    assert t3.getSize() == 0l;
+    assert !t3.contains("hello");
+    assert !t3.startsWith("hel");
+    t3.insert("fresh");
+    assert t3.contains("fresh");
+    assert t3.getSize() == 1l;
+
+    printf("Trie smoke tests passed!\n");
+}

--- a/test/test-files/std/data/trie-smoke/source.spice
+++ b/test/test-files/std/data/trie-smoke/source.spice
@@ -88,5 +88,41 @@ f<int> main() {
     assert t3.contains("fresh");
     assert t3.getSize() == 1l;
 
+    // The copy ctor produces an independent deep copy: mutating one must not affect the other
+    Trie original;
+    original.insert("apple");
+    original.insert("apply");
+    original.insert("banana");
+    Trie copy = Trie(original);
+    assert copy.getSize() == 3l;
+    assert copy.contains("apple");
+    assert copy.contains("apply");
+    assert copy.contains("banana");
+    // Mutate the copy - the original must stay untouched
+    copy.remove("apple");
+    copy.insert("cherry");
+    assert !copy.contains("apple");
+    assert copy.contains("cherry");
+    assert original.contains("apple");
+    assert !original.contains("cherry");
+    assert original.getSize() == 3l;
+    assert copy.getSize() == 3l;
+    // Mutate the original - the copy must stay untouched
+    original.insert("date");
+    assert original.contains("date");
+    assert !copy.contains("date");
+
+    // operator= overwrites the destination and stays independent afterwards
+    Trie assigned;
+    assigned.insert("temporary");
+    assigned = original;
+    assert !assigned.contains("temporary");
+    assert assigned.contains("apple");
+    assert assigned.contains("date");
+    assert assigned.getSize() == original.getSize();
+    assigned.remove("apple");
+    assert !assigned.contains("apple");
+    assert original.contains("apple");
+
     printf("Trie smoke tests passed!\n");
 }

--- a/test/test-files/std/data/trie-stress/cout.out
+++ b/test/test-files/std/data/trie-stress/cout.out
@@ -1,0 +1,1 @@
+Trie stress tests passed!

--- a/test/test-files/std/data/trie-stress/source.spice
+++ b/test/test-files/std/data/trie-stress/source.spice
@@ -19,36 +19,43 @@ f<int> main() {
     Trie t1;
     const unsigned long wordCount = 2000l;
     for unsigned long i = 0l; i < wordCount; i++ {
-        t1.insert(makeWord(i).getRaw());
+        String w = makeWord(i);
+        t1.insert(w.getRaw());
     }
     assert t1.getSize() == wordCount;
     for unsigned long i = 0l; i < wordCount; i++ {
-        assert t1.contains(makeWord(i).getRaw());
+        String w = makeWord(i);
+        assert t1.contains(w.getRaw());
     }
     // A word that was never inserted must not be found
-    assert !t1.contains(makeWord(wordCount).getRaw());
+    String absentWord = makeWord(wordCount);
+    assert !t1.contains(absentWord.getRaw());
     assert !t1.contains("absent");
     // Every stored word starts with the empty prefix
     assert t1.countWordsWithPrefix("") == wordCount;
 
     // 2. Re-inserting all words again must not change the size (idempotent insert)
     for unsigned long i = 0l; i < wordCount; i++ {
-        t1.insert(makeWord(i).getRaw());
+        String w = makeWord(i);
+        t1.insert(w.getRaw());
     }
     assert t1.getSize() == wordCount;
 
     // 3. Remove the first half; the trie must prune unused branches and keep the rest intact
     for unsigned long i = 0l; i < wordCount / 2l; i++ {
-        t1.remove(makeWord(i).getRaw());
+        String w = makeWord(i);
+        t1.remove(w.getRaw());
     }
     assert t1.getSize() == wordCount / 2l;
     for unsigned long i = 0l; i < wordCount; i++ {
         const bool shouldExist = i >= wordCount / 2l;
-        assert t1.contains(makeWord(i).getRaw()) == shouldExist;
+        String w = makeWord(i);
+        assert t1.contains(w.getRaw()) == shouldExist;
     }
     // Removing already removed words is a no-op
     for unsigned long i = 0l; i < wordCount / 2l; i++ {
-        t1.remove(makeWord(i).getRaw());
+        String w = makeWord(i);
+        t1.remove(w.getRaw());
     }
     assert t1.getSize() == wordCount / 2l;
 
@@ -126,20 +133,26 @@ f<int> main() {
     // 7. Drain via clear, then reuse the same trie
     Trie t5;
     for unsigned long i = 0l; i < 100l; i++ {
-        t5.insert(makeWord(i).getRaw());
+        String w = makeWord(i);
+        t5.insert(w.getRaw());
     }
     assert t5.getSize() == 100l;
     t5.clear();
     assert t5.isEmpty();
     assert t5.getSize() == 0l;
-    assert !t5.contains(makeWord(0l).getRaw());
+    String firstWord = makeWord(0l);
+    assert !t5.contains(firstWord.getRaw());
     for unsigned long i = 0l; i < 50l; i++ {
-        t5.insert(makeWord(i).getRaw());
+        String w = makeWord(i);
+        t5.insert(w.getRaw());
     }
     assert t5.getSize() == 50l;
-    assert t5.contains(makeWord(0l).getRaw());
-    assert t5.contains(makeWord(49l).getRaw());
-    assert !t5.contains(makeWord(50l).getRaw());
+    String w0 = makeWord(0l);
+    String w49 = makeWord(49l);
+    String w50 = makeWord(50l);
+    assert t5.contains(w0.getRaw());
+    assert t5.contains(w49.getRaw());
+    assert !t5.contains(w50.getRaw());
 
     printf("Trie stress tests passed!\n");
 }

--- a/test/test-files/std/data/trie-stress/source.spice
+++ b/test/test-files/std/data/trie-stress/source.spice
@@ -1,0 +1,145 @@
+import "std/data/trie";
+
+// Build a deterministic, distinct 5-letter lowercase word for the given index.
+// The encoding is bijective for indices below 26^5, so different indices always
+// produce different words.
+f<String> makeWord(unsigned long index) {
+    String w;
+    unsigned long n = index;
+    for unsigned long i = 0l; i < 5l; i++ {
+        const char c = cast<char>(cast<int>('a') + cast<int>(n % 26l));
+        w.append(c);
+        n = n / 26l;
+    }
+    return w;
+}
+
+f<int> main() {
+    // 1. Insert many distinct words; every one must be found and counted exactly once
+    Trie t1;
+    const unsigned long wordCount = 2000l;
+    for unsigned long i = 0l; i < wordCount; i++ {
+        t1.insert(makeWord(i).getRaw());
+    }
+    assert t1.getSize() == wordCount;
+    for unsigned long i = 0l; i < wordCount; i++ {
+        assert t1.contains(makeWord(i).getRaw());
+    }
+    // A word that was never inserted must not be found
+    assert !t1.contains(makeWord(wordCount).getRaw());
+    assert !t1.contains("absent");
+    // Every stored word starts with the empty prefix
+    assert t1.countWordsWithPrefix("") == wordCount;
+
+    // 2. Re-inserting all words again must not change the size (idempotent insert)
+    for unsigned long i = 0l; i < wordCount; i++ {
+        t1.insert(makeWord(i).getRaw());
+    }
+    assert t1.getSize() == wordCount;
+
+    // 3. Remove the first half; the trie must prune unused branches and keep the rest intact
+    for unsigned long i = 0l; i < wordCount / 2l; i++ {
+        t1.remove(makeWord(i).getRaw());
+    }
+    assert t1.getSize() == wordCount / 2l;
+    for unsigned long i = 0l; i < wordCount; i++ {
+        const bool shouldExist = i >= wordCount / 2l;
+        assert t1.contains(makeWord(i).getRaw()) == shouldExist;
+    }
+    // Removing already removed words is a no-op
+    for unsigned long i = 0l; i < wordCount / 2l; i++ {
+        t1.remove(makeWord(i).getRaw());
+    }
+    assert t1.getSize() == wordCount / 2l;
+
+    // 4. A large fan-out under a single shared prefix; countWordsWithPrefix must see all of them
+    Trie t2;
+    for unsigned long i = 0l; i < 26l; i++ {
+        String w = String("key");
+        w.append(cast<char>(cast<int>('a') + cast<int>(i)));
+        t2.insert(w.getRaw());
+    }
+    assert t2.getSize() == 26l;
+    assert t2.countWordsWithPrefix("key") == 26l;
+    assert t2.startsWith("key");
+    assert t2.contains("keya");
+    assert t2.contains("keyz");
+    assert !t2.contains("key");
+    // Remove half of the fan-out, the prefix must remain valid and the count must shrink
+    for unsigned long i = 0l; i < 13l; i++ {
+        String w = String("key");
+        w.append(cast<char>(cast<int>('a') + cast<int>(i)));
+        t2.remove(w.getRaw());
+    }
+    assert t2.getSize() == 13l;
+    assert t2.countWordsWithPrefix("key") == 13l;
+    assert t2.startsWith("key");
+    assert !t2.contains("keya");
+    assert t2.contains("keyz");
+    // Remove the remaining words, the whole branch must disappear
+    for unsigned long i = 13l; i < 26l; i++ {
+        String w = String("key");
+        w.append(cast<char>(cast<int>('a') + cast<int>(i)));
+        t2.remove(w.getRaw());
+    }
+    assert t2.isEmpty();
+    assert !t2.startsWith("key");
+    assert t2.countWordsWithPrefix("key") == 0l;
+
+    // 5. Nested words where each is a prefix of the next
+    Trie t3;
+    t3.insert("a");
+    t3.insert("ab");
+    t3.insert("abc");
+    t3.insert("abcd");
+    t3.insert("abcde");
+    assert t3.getSize() == 5l;
+    assert t3.countWordsWithPrefix("a") == 5l;
+    assert t3.countWordsWithPrefix("abc") == 3l;
+    // Removing an inner word keeps the longer words reachable
+    t3.remove("abc");
+    assert !t3.contains("abc");
+    assert t3.contains("ab");
+    assert t3.contains("abcd");
+    assert t3.contains("abcde");
+    assert t3.getSize() == 4l;
+    assert t3.countWordsWithPrefix("abc") == 2l; // abcd, abcde
+
+    // 6. A very long word builds a deep trie; prefixes of every length must be visible
+    Trie t4;
+    const unsigned long depth = 500l;
+    String longWord;
+    for unsigned long i = 0l; i < depth; i++ {
+        longWord.append('a');
+    }
+    t4.insert(longWord.getRaw());
+    assert t4.getSize() == 1l;
+    assert t4.contains(longWord.getRaw());
+    // Any proper prefix is a valid prefix but not a stored word
+    String prefix;
+    for unsigned long i = 0l; i < depth - 1l; i++ {
+        prefix.append('a');
+        assert t4.startsWith(prefix.getRaw());
+        assert !t4.contains(prefix.getRaw());
+    }
+
+    // 7. Drain via clear, then reuse the same trie
+    Trie t5;
+    for unsigned long i = 0l; i < 100l; i++ {
+        t5.insert(makeWord(i).getRaw());
+    }
+    assert t5.getSize() == 100l;
+    t5.clear();
+    assert t5.isEmpty();
+    assert t5.getSize() == 0l;
+    assert !t5.contains(makeWord(0l).getRaw());
+    for unsigned long i = 0l; i < 50l; i++ {
+        t5.insert(makeWord(i).getRaw());
+    }
+    assert t5.getSize() == 50l;
+    assert t5.contains(makeWord(0l).getRaw());
+    assert t5.contains(makeWord(49l).getRaw());
+    assert !t5.contains(makeWord(50l).getRaw());
+
+    printf("Trie stress tests passed!\n");
+}


### PR DESCRIPTION
## What

Adds a `Trie` (prefix tree) to the standard library as `std/data/trie.spice`, plus smoke and stress tests, and lists it in the std README.

### `Trie` API
- `insert(string)` — idempotent
- `contains(string) -> bool`
- `startsWith(string) -> bool` — prefix existence (empty prefix is always present)
- `countWordsWithPrefix(string) -> unsigned long`
- `remove(string)` — unmarks the word and prunes unused branches, freeing their nodes
- `getSize()` / `isEmpty()` / `clear()`
- recursive `dtor` that frees the whole tree

## How it's built

Each `TrieNode` owns its children as heap-allocated nodes (`__new`) reached through a self-referential `Vector<TrieNode*>`, with a parallel `Vector<char>` of edge labels — the same recursive-tree pattern already used by `std/text/xml-parser.spice` (`Vector<XmlNode*>` children) and the `sDelete`-on-node idiom from `std/data/linked-list.spice`. Raw-string walking uses `getRawLength`/`word[i]` as in the XML/JSON parsers.

Unlike `binary-tree`/`red-black-tree` (which leak their nodes), the trie ships a recursive `clear`/`dtor` so all nodes are actually freed.

## Tests

`test/test-files/std/data/trie-smoke` and `trie-stress`, following the directory + `source.spice`/`cout.out` layout of the other data structures (closely modeled on `priority-queue-*`):
- smoke: shared prefixes, word-vs-prefix distinction, `startsWith`, prefix counting, idempotent insert, pruning on remove, empty-string-as-word, clear/reuse.
- stress: 2000 generated words, idempotent re-insertion, bulk removal with pruning, 26-wide fan-out under one prefix, fully-nested prefix words, a 500-deep trie, and clear/reuse.

## Note for reviewers

I could not compile/run the suite in my environment (no prebuilt `spice` binary and the compiler couldn't be built locally), so the code was written by matching existing compiling std patterns rather than verified by a green test run. **Please run `spicetest` filtered to `trie` before merging.** Also incidentally added the missing `priority-queue` row to the README data-structures table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
