### PR TITLE
Suppress warnings for the bootstrap-compiler test suite

### DIFF
--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -213,13 +213,17 @@ void execTestCase(const TestCase &testCase) {
     // GCOV_EXCL_STOP
 
     // Check warnings
-    mainSourceFile->collectAndPrintWarnings();
-    TestUtil::checkRefMatch(testCase.testPath / REF_NAME_WARNING_OUTPUT, [&] {
-      std::stringstream actualWarningString;
-      for (const CompilerWarning &warning : mainSourceFile->compilerOutput.warnings)
-        actualWarningString << warning.warningMessage << "\n";
-      return actualWarningString.str();
-    });
+    // The bootstrap compiler is still incomplete, so its sources emit huge amounts of unused-symbol warnings. Skip warning
+    // collection for the whole bootstrap-compiler suite to keep the test output readable.
+    if (testCase.testSuite != "bootstrapCompiler") {
+      mainSourceFile->collectAndPrintWarnings();
+      TestUtil::checkRefMatch(testCase.testPath / REF_NAME_WARNING_OUTPUT, [&] {
+        std::stringstream actualWarningString;
+        for (const CompilerWarning &warning : mainSourceFile->compilerOutput.warnings)
+          actualWarningString << warning.warningMessage << "\n";
+        return actualWarningString.str();
+      });
+    }
 
     // Do linking and conclude compilation
     const bool needsNormalRunForOutput = TestUtil::doesRefExist(testCase.testPath / REF_NAME_EXECUTION_OUTPUT);


### PR DESCRIPTION
## Summary
- The bootstrap compiler is still incomplete, so the `src-bootstrap` sources imported by the `bootstrap-compiler` test suite emit huge amounts of unused-symbol warnings (`UNUSED_FUNCTION`, `UNUSED_VARIABLE`, `UNUSED_STRUCT`, …), all printed to stdout via `CompilerWarning::print()`.
- This skips warning collection/printing for the entire `bootstrap-compiler` suite in `execTestCase`, keeping the test output readable.

## Notes
- `CompilerWarning` only stores the formatted message string, not the `CompilerWarningType`, so filtering to *only* the unused categories would require a larger refactor. Since every warning from the incomplete bootstrap compiler is currently noise, the suite-wide skip is the clean, low-risk fix.
- There are no `warning.out` ref files under `test/test-files/bootstrap-compiler`, so the warning `checkRefMatch` was already a no-op for these tests — nothing relied on it.
- Scope is test-only; real `spice build` runs on bootstrap files still emit warnings as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)