### PR TITLE
Disable LLVM RTTI in all build pipelines

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -69,7 +69,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             ../llvm
           cmake --build .

--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -70,6 +70,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             ../llvm
           cmake --build .
 

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -77,7 +77,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             ../llvm
           cmake --build .
@@ -199,7 +198,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm
-          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64
+          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -215,7 +214,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             ../llvm
           cmake --build .
@@ -279,7 +277,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-win-x64
+          key: llvm-${{ env.LLVM_VERSION }}-win-x64-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -295,7 +293,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ `
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" `
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" `
-            -DLLVM_ENABLE_RTTI=ON `
             -DLLVM_BUILD_TOOLS=OFF `
             ../llvm
           cmake --build .
@@ -373,7 +370,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64
+          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -386,7 +383,6 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             ../llvm
           cmake --build .

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -78,6 +78,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             ../llvm
           cmake --build .
 
@@ -215,6 +218,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             ../llvm
           cmake --build .
 
@@ -294,6 +300,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" `
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" `
             -DLLVM_BUILD_TOOLS=OFF `
+            -DLLVM_INCLUDE_TESTS=OFF `
+            -DLLVM_INCLUDE_EXAMPLES=OFF `
+            -DLLVM_INCLUDE_BENCHMARKS=OFF `
             ../llvm
           cmake --build .
 
@@ -384,6 +393,9 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             ../llvm
           cmake --build .
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -71,7 +71,6 @@ jobs:
             -DCMAKE_C_COMPILER=gcc \
             -DCMAKE_CXX_COMPILER=g++ \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             ../llvm
           cmake --build .

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -72,6 +72,9 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ \
             -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             ../llvm
           cmake --build .
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,6 +65,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             -DLLVM_ENABLE_ZLIB=OFF \
             -DLLVM_ENABLE_ZSTD=OFF \
             -Wno-dev \
@@ -163,6 +166,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             -DLLVM_ENABLE_ZLIB=OFF \
             -DLLVM_ENABLE_ZSTD=OFF \
             -Wno-dev \
@@ -253,6 +259,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" `
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" `
             -DLLVM_BUILD_TOOLS=OFF `
+            -DLLVM_INCLUDE_TESTS=OFF `
+            -DLLVM_INCLUDE_EXAMPLES=OFF `
+            -DLLVM_INCLUDE_BENCHMARKS=OFF `
             -Wno-dev `
             -Wattributes `
             ../llvm
@@ -338,6 +347,9 @@ jobs:
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
             -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
             -Wno-dev \
             -Wattributes \
             ../llvm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-all-targets-nozlib
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-all-targets-nozlib-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -64,7 +64,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             -DLLVM_ENABLE_ZLIB=OFF \
             -DLLVM_ENABLE_ZSTD=OFF \
@@ -147,7 +146,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64-all-targets-nozlib
+          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64-all-targets-nozlib-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -163,7 +162,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             -DLLVM_ENABLE_ZLIB=OFF \
             -DLLVM_ENABLE_ZSTD=OFF \
@@ -238,7 +236,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-win-x64-all-targets
+          key: llvm-${{ env.LLVM_VERSION }}-win-x64-all-targets-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -254,7 +252,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ `
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" `
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" `
-            -DLLVM_ENABLE_RTTI=ON `
             -DLLVM_BUILD_TOOLS=OFF `
             -Wno-dev `
             -Wattributes `
@@ -324,7 +321,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-all-targets
+          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-all-targets-nortti
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -340,7 +337,6 @@ jobs:
             -DCMAKE_CXX_COMPILER=g++ \
             -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
             -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
-            -DLLVM_ENABLE_RTTI=ON \
             -DLLVM_BUILD_TOOLS=OFF \
             -Wno-dev \
             -Wattributes \

--- a/dev-setup.bat
+++ b/dev-setup.bat
@@ -41,7 +41,7 @@ echo done.
 echo [Step 3] Building LLVM (Could take a whole while, please be patient) ...
 mkdir .\llvm\build-release
 pushd .\llvm\build-release
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -GNinja ../llvm
 cmake --build .
 popd
 echo done.

--- a/dev-setup.bat
+++ b/dev-setup.bat
@@ -41,7 +41,7 @@ echo done.
 echo [Step 3] Building LLVM (Could take a whole while, please be patient) ...
 mkdir .\llvm\build-release
 pushd .\llvm\build-release
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -GNinja ../llvm
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -GNinja ../llvm
 cmake --build .
 popd
 echo done.

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -24,7 +24,7 @@ colored_echo "[Step 3] Building LLVM (Could take a whole while, please be patien
 mkdir ./llvm/build-release 2>/dev/null
 (
   cd ./llvm/build-release || exit
-  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -DLLVM_ENABLE_RTTI=ON -GNinja ../llvm
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -GNinja ../llvm
   cmake --build .
 )
 colored_echo "done."

--- a/dev-setup.sh
+++ b/dev-setup.sh
@@ -24,7 +24,7 @@ colored_echo "[Step 3] Building LLVM (Could take a whole while, please be patien
 mkdir ./llvm/build-release 2>/dev/null
 (
   cd ./llvm/build-release || exit
-  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -GNinja ../llvm
+  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O3" -DLLVM_USE_LINKER=lld -DLLVM_ENABLE_PROJECTS="clang" -DLLVM_ENABLE_RUNTIMES="libcxx;libcxxabi;compiler-rt;libunwind" -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" -DCOMPILER_RT_BUILD_SANITIZERS=ON -DLLVM_INCLUDE_TESTS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_BENCHMARKS=OFF -GNinja ../llvm
   cmake --build .
 )
 colored_echo "done."

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,12 @@ separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 target_compile_definitions(spicecore PRIVATE ${LLVM_DEFINITIONS_LIST})
 # Enable pedantic warnings
 target_compile_options(spicecore PRIVATE -Wpedantic -Wall -Werror -Wno-unknown-pragmas ${SPICE_EXTRA_COMPILE_OPTIONS})
+# RawStringOStream derives from the polymorphic LLVM type llvm::raw_pwrite_stream. Compiling it with
+# RTTI emits a type_info that references "typeinfo for llvm::raw_pwrite_stream", which does not exist
+# when LLVM is built without RTTI (the default). The class is never used with dynamic_cast/typeid, so
+# compile this single translation unit without RTTI to drop the unused type_info and avoid the
+# dangling reference at link time.
+set_source_files_properties(util/RawStringOStream.cpp PROPERTIES COMPILE_OPTIONS -fno-rtti)
 
 ################## spice executable ##################
 


### PR DESCRIPTION
## What

Removes the explicit `-DLLVM_ENABLE_RTTI=ON` flag from **every** place LLVM is built for Spice, so LLVM builds with its default no-RTTI configuration:

- CI workflows: `ci-cpp.yml` (all 4 platforms), `ci-asan.yml`, `codeql-analysis.yml`
- Release pipeline: `publish.yml` (all 4 platforms)
- Local developer setup: `dev-setup.sh`, `dev-setup.bat`

LLVM cache keys gain a `-nortti` suffix so the no-RTTI build is actually produced and validated rather than restored from the existing RTTI-enabled cache.

## Why

Spice uses C++ RTTI (`dynamic_cast` / `typeid`) only on its **own** AST and symbol/type classes, never on `llvm::` types. RTTI is a per-translation-unit flag, so Spice keeps compiling with `-frtti` while linking against a no-RTTI LLVM.

The one boundary case is `RawStringOStream`, the only Spice class that derives from a polymorphic LLVM type (`llvm::raw_pwrite_stream`). Compiling it with RTTI emitted a `type_info` referencing `typeinfo for llvm::raw_pwrite_stream`, which doesn't exist in a no-RTTI LLVM (caught by CI as a link error). It's never used with `dynamic_cast`/`typeid`, so it's now compiled with `-fno-rtti` in `src/CMakeLists.txt` — dropping the unused `type_info`. It is the only class in `src` inheriting from an `llvm::` type.

Beyond a faster/smaller LLVM build, this aligns our LLVM config with the **official prebuilt LLVM releases** (which ship no-RTTI), opening the door to replacing the from-source LLVM build with downloaded prebuilt binaries in a follow-up.

## Commits

1. Disable RTTI in the CI workflows (validated green before touching the release path).
2. Compile `RawStringOStream` with `-fno-rtti` (fixes the link error surfaced by step 1).
3. Disable RTTI in `publish.yml` and the local `dev-setup` scripts.

## Follow-up (separate PR)

Replace the from-source LLVM build with downloaded official prebuilt binaries in CI and local `setup-deps`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
