### PR TITLE
Extend vector smoke test to cover insertAt

### DIFF
--- a/test/test-files/std/data/vector-smoke/source.spice
+++ b/test/test-files/std/data/vector-smoke/source.spice
@@ -27,6 +27,26 @@ f<int> main() {
     assert v[0] == 10;
     assert v[1] == 30;
 
+    // insertAt(middle)
+    v.insertAt(1l, 20);
+    assert v.getSize() == 3;
+    assert v[0] == 10;
+    assert v[1] == 20;
+    assert v[2] == 30;
+
+    // insertAt(front)
+    v.insertAt(0l, 5);
+    assert v.getSize() == 4;
+    assert v[0] == 5;
+    assert v[1] == 10;
+    assert v[3] == 30;
+
+    // insertAt(back == size) appends
+    v.insertAt(v.getSize(), 40);
+    assert v.getSize() == 5;
+    assert v.front() == 5;
+    assert v.back() == 40;
+
     // clear
     v.clear();
     assert v.isEmpty();


### PR DESCRIPTION
## Summary
Extends the vector smoke test to exercise the `Vector.insertAt` method, which was previously uncovered.

Added assertions for three cases:
- **insertAt(middle)** — re-inserts an element between existing ones, verifying trailing elements shift back.
- **insertAt(front)** — insert at index `0`, verifying all elements shift.
- **insertAt(back == size)** — insert at `getSize()`, exercising the `index == size` append boundary (allowed by `insertAt`, unlike `removeAt`).

## Testing
- `spicetest --gtest_filter='*data_vectorSmoke*'` passes (with `SPICE_STD_DIR` set).
- No reference output change needed — the test only prints the final success line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)