### PR TITLE
Fix corrupted VTable when struct method order differs from interface

### DIFF
--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -269,7 +269,10 @@ size_t Scope::getFieldCount() const {
 }
 
 /**
- * Get all virtual methods in this scope, sorted by declaration code location
+ * Get all virtual methods in this scope, sorted by their VTable index
+ *
+ * The VTable index is assigned based on the declaration order of the methods in the implemented interface(s). This must match the
+ * order the call sites use to index into the VTable, which may differ from the order the methods are defined in within the struct.
  *
  * @return List of virtual method pointers
  */
@@ -285,8 +288,8 @@ std::vector<Function *> Scope::getVirtualMethods() {
         methods.push_back(&functions.at(fctId).at(mangledName));
   }
 
-  // Sort the list
-  const auto pred = [](const Function *a, const Function *b) { return a->getDeclCodeLoc() < b->getDeclCodeLoc(); };
+  // Sort the list by VTable index, so that the VTable layout matches the slot indices used at the call sites
+  const auto pred = [](const Function *a, const Function *b) { return a->vtableIndex < b->vtableIndex; };
   std::ranges::sort(methods, pred);
 
   return methods;

--- a/test/test-files/irgenerator/interfaces/success-interface-method-reorder/cout.out
+++ b/test/test-files/irgenerator/interfaces/success-interface-method-reorder/cout.out
@@ -1,0 +1,2 @@
+Hello from foo!
+Hello from bar!

--- a/test/test-files/irgenerator/interfaces/success-interface-method-reorder/source.spice
+++ b/test/test-files/irgenerator/interfaces/success-interface-method-reorder/source.spice
@@ -1,0 +1,26 @@
+// Regression test for https://github.com/spicelang/spice/issues/1162
+// The methods are defined in the struct in a different order than they are declared in the interface.
+// The VTable must still be laid out according to the interface declaration order, so that virtual
+// dispatch through an interface pointer calls the correct method.
+type ITest interface {
+    public p foo();
+    public p bar();
+}
+
+type Test struct : ITest {}
+
+p Test.bar() {
+    printf("Hello from bar!\n");
+}
+
+p Test.foo() {
+    printf("Hello from foo!\n");
+}
+
+f<int> main() {
+    Test test;
+    ITest* i = &test;
+    i.foo();
+    i.bar();
+    return 0;
+}


### PR DESCRIPTION
The VTable layout was produced by Scope::getVirtualMethods() sorted by
the declaration code location of each method. However, virtual call
sites index into the VTable using Function::vtableIndex, which is
assigned according to the declaration order of the methods in the
implemented interface(s).

When a struct defines its methods in a different order than they are
declared in the interface, the VTable layout (def order) no longer
matched the slot indices used at the call sites (interface order),
causing virtual dispatch to call the wrong method.

Sort the virtual methods by their vtableIndex instead, so the VTable
layout always matches the slot indices used at the call sites.

Fixes #1162