### PR TITLE
Add smoke tests for Interface and Struct bootstrap model types

### DIFF
--- a/src-bootstrap/model/interface.spice
+++ b/src-bootstrap/model/interface.spice
@@ -6,9 +6,13 @@ import "bootstrap/ast/ast-nodes";
 import "bootstrap/model/struct-base";
 import "bootstrap/model/function";
 import "bootstrap/model/generic-type";
+import "bootstrap/symboltablebuilder/super-type";
 import "bootstrap/symboltablebuilder/qual-type";
+import "bootstrap/symboltablebuilder/type-intf";
+import "bootstrap/symboltablebuilder/type-qualifiers";
 import "bootstrap/symboltablebuilder/symbol-table-entry";
 import "bootstrap/symboltablebuilder/scope-intf";
+import "bootstrap/global/type-registry";
 
 // Constants
 const string INTERFACE_SCOPE_PREFIX = "interface:";
@@ -44,4 +48,36 @@ public f<String> Interface.getScopeName() {
  */
 public f<String> Interface.getScopeName(const String& name, const QualTypeList& concreteTemplateTypes) {
     return String(INTERFACE_SCOPE_PREFIX) + this.structBase.getSignature(name, concreteTemplateTypes);
+}
+
+#[test, test.name="Interface Smoke test"]
+public f<bool> testInterfaceSmoke() {
+    TypeRegistry reg = TypeRegistry();
+    const IType* intType = reg.getOrInsert(SuperType::TY_INT);
+    const QualType intQual = QualType(intType, getTypeQualifiersOf(SuperType::TY_INT));
+
+    Vector<GenericType> noTemplates;
+
+    // A plain interface: no methods, no template types
+    Vector<Function*> noMethods;
+    Interface plain = Interface(String("Plain"), nil<SymbolTableEntry*>, nil<IScope*>, noMethods, noTemplates, nil<ASTNode*>);
+    assert plain.name == String("Plain");
+    assert plain.getScopeName() == String("interface:Plain");
+    assert plain.structBase.getSignature() == String("Plain");
+    assert !plain.structBase.isGenericSubstantiation();
+    assert plain.methods.isEmpty();
+
+    // An interface substantiated with a concrete template type (int)
+    Vector<GenericType> concreteTemplates;
+    GenericType gtInt = GenericType(intQual);
+    concreteTemplates.pushBack(gtInt);
+    Interface comparable = Interface(String("Comparable"), nil<SymbolTableEntry*>, nil<IScope*>, noMethods, concreteTemplates, nil<ASTNode*>);
+    assert comparable.structBase.getSignature() == String("Comparable<int>");
+    assert comparable.getScopeName() == String("interface:Comparable");
+
+    // getScopeName from an explicit name and concrete template types
+    QualTypeList comparableTemplates = comparable.structBase.getTemplateTypes();
+    assert comparable.getScopeName(String("Comparable"), comparableTemplates) == String("interface:Comparable<int>");
+
+    return true;
 }

--- a/src-bootstrap/model/struct.spice
+++ b/src-bootstrap/model/struct.spice
@@ -3,12 +3,17 @@ import "std/data/vector";
 
 // Own imports
 import "bootstrap/ast/ast-nodes";
+import "bootstrap/ast/ast-node-intf";
 import "bootstrap/model/struct-base";
 import "bootstrap/model/generic-type";
+import "bootstrap/symboltablebuilder/super-type";
 import "bootstrap/symboltablebuilder/qual-type";
+import "bootstrap/symboltablebuilder/type-intf";
+import "bootstrap/symboltablebuilder/type-qualifiers";
 import "bootstrap/symboltablebuilder/symbol-table-entry";
 import "bootstrap/symboltablebuilder/scope-intf";
 import "bootstrap/symboltablebuilder/lifecycle";
+import "bootstrap/global/type-registry";
 
 // Constants
 const string STRUCT_SCOPE_PREFIX = "struct:";
@@ -90,4 +95,54 @@ public f<SymbolTableEntry*> Struct.areAllFieldsInitialized() {
  */
 public p Struct.resetFieldSymbolsToDeclared(const ASTNode* node) {
     // ToDo: Reset field symbols via scope.lookupField(i).updateState(DECLARED, node) once IScope exposes lookupField.
+}
+
+#[test, test.name="Struct Smoke test"]
+public f<bool> testStructSmoke() {
+    TypeRegistry reg = TypeRegistry();
+    const IType* intType = reg.getOrInsert(SuperType::TY_INT);
+    const QualType intQual = QualType(intType, getTypeQualifiersOf(SuperType::TY_INT));
+    const IType* intfType = reg.getOrInsertSub(SuperType::TY_INTERFACE, String("Comparable"));
+    const QualType intfQual = QualType(intfType, getTypeQualifiersOf(SuperType::TY_INTERFACE));
+
+    Vector<GenericType> noTemplates;
+
+    // A plain struct: no fields, no template types, no interfaces
+    QualTypeList noFields;
+    QualTypeList noInterfaces;
+    Struct plain = Struct(String("Plain"), nil<SymbolTableEntry*>, nil<IScope*>, noFields, noTemplates, noInterfaces, nil<ASTNode*>);
+    assert plain.name == String("Plain");
+    assert plain.getScopeName() == String("struct:Plain");
+    assert plain.structBase.getSignature() == String("Plain");
+    assert !plain.structBase.isGenericSubstantiation();
+    assert !plain.hasReferenceFields();
+    assert plain.fieldTypes.isEmpty();
+    assert plain.interfaceTypes.isEmpty();
+
+    // A struct with one int field, a concrete template type, and one implemented interface
+    QualTypeList oneField;
+    oneField.pushBack(intQual);
+    QualTypeList oneInterface;
+    oneInterface.pushBack(intfQual);
+    Vector<GenericType> concreteTemplates;
+    GenericType gtInt = GenericType(intQual);
+    concreteTemplates.pushBack(gtInt);
+    Struct box = Struct(String("Box"), nil<SymbolTableEntry*>, nil<IScope*>, oneField, concreteTemplates, oneInterface, nil<ASTNode*>);
+    assert box.structBase.getSignature() == String("Box<int>");
+    assert box.getScopeName() == String("struct:Box");
+    assert !box.hasReferenceFields();
+    assert box.fieldTypes.getSize() == 1l;
+    assert box.interfaceTypes.getSize() == 1l;
+
+    // getScopeName from an explicit name and concrete template types
+    QualTypeList boxTemplates = box.structBase.getTemplateTypes();
+    assert box.getScopeName(String("Box"), boxTemplates) == String("struct:Box<int>");
+
+    // A struct with a reference field reports hasReferenceFields() == true
+    QualTypeList refField;
+    refField.pushBack(intQual.toRef(nil<IASTNode*>));
+    Struct refStruct = Struct(String("RefHolder"), nil<SymbolTableEntry*>, nil<IScope*>, refField, noTemplates, noInterfaces, nil<ASTNode*>);
+    assert refStruct.hasReferenceFields();
+
+    return true;
 }

--- a/test/test-files/bootstrap-compiler/unit-wrapper-interface/cout.out
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-interface/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/bootstrap-compiler/unit-wrapper-interface/source.spice
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-interface/source.spice
@@ -1,0 +1,7 @@
+import "bootstrap/model/interface";
+
+// Wrapper for 'spice test' unit test
+f<int> main() {
+    testInterfaceSmoke();
+    printf("All assertions passed!");
+}

--- a/test/test-files/bootstrap-compiler/unit-wrapper-struct/cout.out
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-struct/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/bootstrap-compiler/unit-wrapper-struct/source.spice
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-struct/source.spice
@@ -1,0 +1,7 @@
+import "bootstrap/model/struct";
+
+// Wrapper for 'spice test' unit test
+f<int> main() {
+    testStructSmoke();
+    printf("All assertions passed!");
+}


### PR DESCRIPTION
## Summary
Adds smoke tests for the `Struct` and `Interface` model types in the bootstrap compiler, mirroring the existing `Function`/`StructBase` smoke tests.

- `src-bootstrap/model/struct.spice` → `testStructSmoke()` — covers the ctor, `getScopeName()` (both overloads, `struct:` prefix), composed `getSignature()`/`isGenericSubstantiation()`/`getTemplateTypes()`, `hasReferenceFields()` (false for value fields, true for a reference field), and `fieldTypes`/`interfaceTypes` population.
- `src-bootstrap/model/interface.spice` → `testInterfaceSmoke()` — covers the ctor, `getScopeName()` (both overloads, `interface:` prefix), composed signature/substantiation/template-type accessors, and `methods` population.
- New `unit-wrapper-struct` and `unit-wrapper-interface` test cases (auto-collected by `BootstrapCompilerTests`) that invoke the smoke functions and compare against a golden `cout.out`.

Note: `compose` only forwards fields (not methods), so composed `StructBase` methods are called via `.structBase.` while forwarded fields like `.name` are accessed directly.

## Test plan
- Both new wrappers pass through `spicetest`:
  - `BootstrapCompilerTests.bootstrapCompiler_unitWrapperStruct` → OK
  - `BootstrapCompilerTests.bootstrapCompiler_unitWrapperInterface` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)