### PR TITLE
Add type-erased `Any` type to the standard library

### DIFF
--- a/std/type/any.spice
+++ b/std/type/any.spice
@@ -1,3 +1,174 @@
+import "std/runtime/memory_rt";
+
+// Generic type definitions
+type T dyn;
+
+// Number of bytes that can be stored inline before falling back to the heap.
+// Sized (8-byte aligned via the long array) to hold the largest payloads that
+// commonly flow through the compiler visitor (e.g. LLVMExprResult = 6 pointers).
+const unsigned long ANY_INLINE_BYTES = 48ul;
+
+/**
+ * Any is a type-erased container that can hold a value of an arbitrary type.
+ *
+ * Small payloads (<= ANY_INLINE_BYTES) are stored inline to avoid a heap
+ * allocation; larger payloads are boxed on the heap. The heap buffer is owned
+ * by the Any and released automatically when it goes out of scope.
+ *
+ * Note: Any performs a bitwise copy of the stored value. It is therefore
+ * intended for trivially-copyable/-destructible payloads (pointers, and PODs
+ * such as ExprResult, QualType or LLVMExprResult). Storing a type that owns
+ * heap resources (e.g. String or Vector) will not run its copy/destructor and
+ * is not supported.
+ */
 public type Any struct {
-    bool test
+    long typeId = 0ul                      // typeid of the stored value; 0 means empty
+    unsigned long size = 0ul               // size of the stored value in bytes
+    long[6] inlineStore                    // inline storage (8-byte aligned, ANY_INLINE_BYTES wide)
+    heap byte* heapStore = nil<heap byte*> // owned heap storage, non-nil iff size > ANY_INLINE_BYTES
+}
+
+/**
+ * Initialize an empty Any.
+ */
+public p Any.ctor() {}
+
+/**
+ * Copy-construct an Any, deep-copying any heap-allocated payload so that both
+ * instances own independent storage.
+ */
+public p Any.ctor(const Any& original) {
+    this.typeId = original.typeId;
+    this.size = original.size;
+    if original.size > ANY_INLINE_BYTES {
+        unsafe {
+            this.heapStore = sAllocUnsafe(original.size);
+            sCopy(original.heapStore, this.heapStore, original.size);
+        }
+    } else {
+        this.inlineStore = original.inlineStore;
+    }
+}
+
+/**
+ * Deep-copy assignment. Releases any previously held heap payload first.
+ */
+public p operator=<T>(Any& this, const Any& newValue) {
+    // Guard against self-assignment, which would free the payload we copy from
+    if &this == &newValue {
+        return;
+    }
+    // Release the currently held heap payload, if any
+    unsafe {
+        if this.heapStore != nil<heap byte*> {
+            sDealloc(this.heapStore);
+        }
+    }
+    this.typeId = newValue.typeId;
+    this.size = newValue.size;
+    if newValue.size > ANY_INLINE_BYTES {
+        unsafe {
+            this.heapStore = sAllocUnsafe(newValue.size);
+            sCopy(newValue.heapStore, this.heapStore, newValue.size);
+        }
+    } else {
+        this.inlineStore = newValue.inlineStore;
+    }
+}
+
+/**
+ * Returns if the data is stored in the inline buffer
+ */
+public inline f<bool> Any.isStoredInline() {
+    return this.size <= ANY_INLINE_BYTES;
+}
+
+/**
+ * Returns a raw pointer to the stored payload (inline or heap).
+ */
+f<byte*> Any.dataPtr() {
+    unsafe {
+        return this.isStoredInline() ? cast<byte*>(&this.inlineStore[0]) : cast<byte*>(this.heapStore);
+    }
+}
+
+/**
+ * Stores a value of arbitrary type T, type-erasing it into the Any.
+ *
+ * @param value Value to store
+ */
+public p Any.set<T>(const T& value) {
+    // Release any previously held heap payload to avoid leaking it
+    unsafe {
+        if this.heapStore != nil<heap byte*> {
+            sDealloc(this.heapStore);
+        }
+    }
+    this.typeId = typeid<T>();
+    this.size = sizeof<T>();
+    unsafe {
+        byte* slot;
+        if this.size > ANY_INLINE_BYTES {
+            this.heapStore = sAllocUnsafe(this.size);
+            slot = cast<byte*>(this.heapStore);
+        } else {
+            slot = cast<byte*>(&this.inlineStore[0]);
+        }
+        __placement_new<T>(cast<T*>(slot), value);
+    }
+}
+
+/**
+ * Retrieves the stored value as type T. Panics if the Any does not currently
+ * hold a value of type T.
+ *
+ * @return Stored value
+ */
+public inline f<T&> Any.get<T>() {
+    if this.typeId != typeid<T>() {
+        panic(Error("Any does not hold a value of the requested type"));
+    }
+    unsafe {
+        T* dataPtr = cast<T*>(this.dataPtr());
+        return *dataPtr;
+    }
+}
+
+/**
+ * Checks whether the Any currently holds a value of type T.
+ *
+ * @return Holds T or not
+ */
+public inline f<bool> Any.has<T>() {
+    return this.typeId == typeid<T>();
+}
+
+/**
+ * Checks whether the Any is empty (holds no value).
+ *
+ * @return Empty or not
+ */
+public inline f<bool> Any.isEmpty() {
+    return this.typeId == 0l;
+}
+
+/**
+ * Returns the typeid of the stored value, or 0 if the Any is empty.
+ *
+ * @return typeid of stored value
+ */
+public inline f<long> Any.getTypeId() {
+    return this.typeId;
+}
+
+/**
+ * Constructs an Any holding the given value.
+ *
+ * @param value Value to store
+ * @return Any wrapping the value
+ */
+public f<Any> any<T>(const T& value) {
+    Any box = Any();
+    box.set(value);
+    return box;
 }

--- a/std/type/any.spice
+++ b/std/type/any.spice
@@ -2,9 +2,9 @@
 type T dyn;
 
 // Number of bytes that can be stored inline before falling back to the heap.
-// Sized (8-byte aligned via the long array) to hold the largest payloads that
-// commonly flow through the compiler visitor (e.g. LLVMExprResult = 6 pointers).
-const unsigned long ANY_INLINE_BYTES = 48ul;
+// One 8-byte slot keeps the Any struct small while still storing the common
+// pointer-sized payloads inline; everything larger is boxed on the heap.
+const unsigned int ANY_INLINE_BYTES = 8u;
 
 // Thunk function pointer types that carry a type-erased payload's copy
 // constructor (dst, src) and destructor (obj) for non-trivial types.
@@ -19,9 +19,9 @@ type DtorThunk alias p(byte*);
  * methods) yield different result types. The stored type is identified via the
  * `typeid` builtin, so retrieval is checked: requesting the wrong type panics.
  *
- * Trivially-copyable and -destructible payloads up to ANY_INLINE_BYTES are
- * stored inline to avoid a heap allocation (the common, hot case). All other
- * payloads - larger ones, and non-trivial ones - are boxed on the heap. For
+ * Trivially-copyable and -destructible payloads up to ANY_INLINE_BYTES (a
+ * single pointer-sized slot) are stored inline to avoid a heap allocation. All
+ * other payloads - larger ones, and non-trivial ones - are boxed on the heap. For
  * non-trivial payloads, Any captures the type's copy constructor and destructor
  * as thunks at construction time and runs them on copy/destroy, just like a
  * std::any manager. Non-trivial types are therefore always heap-boxed, which
@@ -34,7 +34,7 @@ type DtorThunk alias p(byte*);
 public type Any struct {
     long typeId = 0l                       // typeid of the stored value; 0 means empty
     unsigned long size = 0ul               // size of the stored value in bytes
-    long[6] inlineStore                    // inline storage (8-byte aligned, ANY_INLINE_BYTES wide)
+    byte[ANY_INLINE_BYTES] inlineStore     // inline storage (8-byte aligned, ANY_INLINE_BYTES wide)
     heap byte* heapStore = nil<heap byte*> // owned heap storage, non-nil iff the payload is boxed
     CopyThunk copyThunk = nil<CopyThunk>   // copy constructor thunk, nil for trivially-copyable payloads
     DtorThunk dtorThunk = nil<DtorThunk>   // destructor thunk, nil for trivially-destructible payloads
@@ -92,7 +92,7 @@ public inline f<bool> Any.isStoredInline() {
  */
 f<byte*> Any.dataPtr() {
     unsafe {
-        return this.isStoredInline() ? cast<byte*>(&this.inlineStore[0]) : cast<byte*>(this.heapStore);
+        return this.isStoredInline() ? cast<byte*>(&this.inlineStore) : cast<byte*>(this.heapStore);
     }
 }
 
@@ -183,7 +183,7 @@ public p Any.set<T>(const T& value) {
             this.heapStore = sAllocUnsafe(this.size);
             slot = cast<byte*>(this.heapStore);
         } else {
-            slot = cast<byte*>(&this.inlineStore[0]);
+            slot = cast<byte*>(&this.inlineStore);
         }
         __placement_new<T>(cast<T*>(slot), value);
     }

--- a/std/type/any.spice
+++ b/std/type/any.spice
@@ -1,5 +1,3 @@
-import "std/runtime/memory_rt";
-
 // Generic type definitions
 type T dyn;
 
@@ -8,24 +6,38 @@ type T dyn;
 // commonly flow through the compiler visitor (e.g. LLVMExprResult = 6 pointers).
 const unsigned long ANY_INLINE_BYTES = 48ul;
 
+// Thunk function pointer types that carry a type-erased payload's copy
+// constructor (dst, src) and destructor (obj) for non-trivial types.
+type CopyThunk alias p(byte*, const byte*);
+type DtorThunk alias p(byte*);
+
 /**
  * Any is a type-erased container that can hold a value of an arbitrary type.
  *
- * Small payloads (<= ANY_INLINE_BYTES) are stored inline to avoid a heap
- * allocation; larger payloads are boxed on the heap. The heap buffer is owned
- * by the Any and released automatically when it goes out of scope.
+ * It is the Spice equivalent of C++'s std::any and is primarily used as the
+ * return type of the AST visitor, where different passes (and different visit
+ * methods) yield different result types. The stored type is identified via the
+ * `typeid` builtin, so retrieval is checked: requesting the wrong type panics.
  *
- * Note: Any performs a bitwise copy of the stored value. It is therefore
- * intended for trivially-copyable/-destructible payloads (pointers, and PODs
- * such as ExprResult, QualType or LLVMExprResult). Storing a type that owns
- * heap resources (e.g. String or Vector) will not run its copy/destructor and
- * is not supported.
+ * Trivially-copyable and -destructible payloads up to ANY_INLINE_BYTES are
+ * stored inline to avoid a heap allocation (the common, hot case). All other
+ * payloads - larger ones, and non-trivial ones - are boxed on the heap. For
+ * non-trivial payloads, Any captures the type's copy constructor and destructor
+ * as thunks at construction time and runs them on copy/destroy, just like a
+ * std::any manager. Non-trivial types are therefore always heap-boxed, which
+ * makes `heapStore != nil` a reliable "owns a live payload" signal and keeps the
+ * destructor correct under move/return (a moved-from Any has heapStore nil'd).
+ *
+ * Note: non-trivial payloads must follow the std convention of public copy
+ * constructor and destructor.
  */
 public type Any struct {
-    long typeId = 0ul                      // typeid of the stored value; 0 means empty
+    long typeId = 0l                       // typeid of the stored value; 0 means empty
     unsigned long size = 0ul               // size of the stored value in bytes
     long[6] inlineStore                    // inline storage (8-byte aligned, ANY_INLINE_BYTES wide)
-    heap byte* heapStore = nil<heap byte*> // owned heap storage, non-nil iff size > ANY_INLINE_BYTES
+    heap byte* heapStore = nil<heap byte*> // owned heap storage, non-nil iff the payload is boxed
+    CopyThunk copyThunk = nil<CopyThunk>   // copy constructor thunk, nil for trivially-copyable payloads
+    DtorThunk dtorThunk = nil<DtorThunk>   // destructor thunk, nil for trivially-destructible payloads
 }
 
 /**
@@ -34,53 +46,45 @@ public type Any struct {
 public p Any.ctor() {}
 
 /**
- * Copy-construct an Any, deep-copying any heap-allocated payload so that both
- * instances own independent storage.
+ * Copy-construct an Any, deep-copying the payload so that both instances own
+ * independent storage. Non-trivial payloads are copied via their copy ctor.
  */
 public p Any.ctor(const Any& original) {
     this.typeId = original.typeId;
     this.size = original.size;
-    if original.size > ANY_INLINE_BYTES {
-        unsafe {
-            this.heapStore = sAllocUnsafe(original.size);
-            sCopy(original.heapStore, this.heapStore, original.size);
-        }
-    } else {
-        this.inlineStore = original.inlineStore;
-    }
+    this.copyThunk = original.copyThunk;
+    this.dtorThunk = original.dtorThunk;
+    this.copyPayloadFrom(original);
 }
 
 /**
- * Deep-copy assignment. Releases any previously held heap payload first.
+ * Deep-copy assignment. Destroys and releases the currently held payload first.
  */
 public p operator=<T>(Any& this, const Any& newValue) {
-    // Guard against self-assignment, which would free the payload we copy from
+    // Guard against self-assignment, which would destroy the payload we copy from
     if &this == &newValue {
         return;
     }
-    // Release the currently held heap payload, if any
-    unsafe {
-        if this.heapStore != nil<heap byte*> {
-            sDealloc(this.heapStore);
-        }
-    }
+    this.reset();
     this.typeId = newValue.typeId;
     this.size = newValue.size;
-    if newValue.size > ANY_INLINE_BYTES {
-        unsafe {
-            this.heapStore = sAllocUnsafe(newValue.size);
-            sCopy(newValue.heapStore, this.heapStore, newValue.size);
-        }
-    } else {
-        this.inlineStore = newValue.inlineStore;
-    }
+    this.copyThunk = newValue.copyThunk;
+    this.dtorThunk = newValue.dtorThunk;
+    this.copyPayloadFrom(newValue);
 }
 
 /**
- * Returns if the data is stored in the inline buffer
+ * Destroy the held payload (if any) and release its storage.
+ */
+public p Any.dtor() {
+    this.reset();
+}
+
+/**
+ * Returns if the data is stored in the inline buffer.
  */
 public inline f<bool> Any.isStoredInline() {
-    return this.size <= ANY_INLINE_BYTES;
+    return this.heapStore == nil<heap byte*>;
 }
 
 /**
@@ -93,22 +97,89 @@ f<byte*> Any.dataPtr() {
 }
 
 /**
- * Stores a value of arbitrary type T, type-erasing it into the Any.
+ * Destroys the held payload (running its destructor thunk if non-trivial),
+ * releases the heap storage and resets the Any to the empty state.
+ */
+p Any.reset() {
+    unsafe {
+        // Only heap-boxed payloads can be non-trivial and need destruction. An
+        // inline payload is always trivial, and a moved-from Any has a nil
+        // heapStore, so this guard makes destruction idempotent and move-safe.
+        if this.heapStore != nil<heap byte*> {
+            if this.dtorThunk != nil<DtorThunk> {
+                DtorThunk dtor = this.dtorThunk; // fn-ptr fields must be called via a local
+                dtor(cast<byte*>(this.heapStore));
+            }
+            sDealloc(this.heapStore); // frees and nils heapStore
+        }
+    }
+    this.typeId = 0l;
+    this.size = 0ul;
+    this.copyThunk = nil<CopyThunk>;
+    this.dtorThunk = nil<DtorThunk>;
+}
+
+/**
+ * Copy-constructs this Any's payload from another Any. Assumes the type/thunk
+ * metadata has already been copied and that this Any owns no payload yet.
+ */
+p Any.copyPayloadFrom(const Any& original) {
+    if original.typeId == 0l {
+        return; // empty
+    }
+    const bool useHeap = original.heapStore != nil<heap byte*>;
+    unsafe {
+        if useHeap {
+            this.heapStore = sAllocUnsafe(original.size);
+            if original.copyThunk != nil<CopyThunk> {
+                CopyThunk copy = original.copyThunk; // fn-ptr fields must be called via a local
+                copy(cast<byte*>(this.heapStore), cast<const byte*>(original.heapStore));
+            } else {
+                sCopy(original.heapStore, this.heapStore, original.size);
+            }
+        } else {
+            // Inline payloads are always trivially copyable -> bitwise copy
+            this.inlineStore = original.inlineStore;
+        }
+    }
+}
+
+/**
+ * Stores a value of arbitrary type T, type-erasing it into the Any. Replaces
+ * and destroys any previously held value.
  *
  * @param value Value to store
  */
 public p Any.set<T>(const T& value) {
-    // Release any previously held heap payload to avoid leaking it
-    unsafe {
-        if this.heapStore != nil<heap byte*> {
-            sDealloc(this.heapStore);
-        }
-    }
+    this.reset();
     this.typeId = typeid<T>();
     this.size = sizeof<T>();
+
+    // Capture copy/destructor thunks for non-trivial payloads. Trivial payloads
+    // leave the thunks nil and take the fast bitwise path.
+    if !__is_trivially_copyable<T>() {
+        this.copyThunk = p(byte* dst, const byte* src) {
+            unsafe {
+                const T* typedSrc = cast<const T*>(src);
+                __placement_new<T>(cast<T*>(dst), *typedSrc);
+            }
+        };
+    }
+    if !__is_trivially_destructible<T>() {
+        this.dtorThunk = p(byte* obj) {
+            unsafe {
+                T* typedObj = cast<T*>(obj);
+                sDestruct(*typedObj);
+            }
+        };
+    }
+
+    // Non-trivial payloads must live on the heap (see the type doc comment), so
+    // that the move-safe `heapStore != nil` ownership signal holds.
+    const bool useHeap = this.copyThunk != nil<CopyThunk> || this.dtorThunk != nil<DtorThunk> || this.size > ANY_INLINE_BYTES;
     unsafe {
         byte* slot;
-        if this.size > ANY_INLINE_BYTES {
+        if useHeap {
             this.heapStore = sAllocUnsafe(this.size);
             slot = cast<byte*>(this.heapStore);
         } else {
@@ -122,7 +193,7 @@ public p Any.set<T>(const T& value) {
  * Retrieves the stored value as type T. Panics if the Any does not currently
  * hold a value of type T.
  *
- * @return Stored value
+ * @return Reference to the stored value
  */
 public inline f<T&> Any.get<T>() {
     if this.typeId != typeid<T>() {

--- a/test/test-files/std/type/any-nontrivial/cout.out
+++ b/test/test-files/std/type/any-nontrivial/cout.out
@@ -1,0 +1,1 @@
+Any non-trivial tests passed!

--- a/test/test-files/std/type/any-nontrivial/source.spice
+++ b/test/test-files/std/type/any-nontrivial/source.spice
@@ -1,0 +1,68 @@
+import "std/type/any";
+
+// Tracks object lifetimes to prove Any runs copy ctors and dtors correctly for
+// non-trivial payloads. LiveCount must return to 0 (no leaks, no missed dtors)
+// and DoubleFree must stay false (no dtor runs twice).
+int LiveCount = 0;
+bool DoubleFree = false;
+
+type Obj struct {
+    int tag
+    bool alive = false
+}
+
+public p Obj.ctor(int tag) {
+    this.tag = tag;
+    this.alive = true;
+    LiveCount++;
+}
+
+public p Obj.ctor(const Obj& other) {
+    this.tag = other.tag;
+    this.alive = true;
+    LiveCount++;
+}
+
+public p Obj.dtor() {
+    if !this.alive {
+        DoubleFree = true;
+    }
+    this.alive = false;
+    LiveCount--;
+}
+
+f<int> main() {
+    // Scope the Any usage so that all payloads are destroyed before we check the
+    // counters at the end.
+    {
+        Obj original = Obj(7);
+        Any a = any(original);
+        assert a.has<Obj>();
+        Obj& ra = a.get<Obj>();
+        assert ra.tag == 7;
+
+        // Copy construction must deep-copy the payload via its copy ctor
+        Any b = a;
+        Obj& rb = b.get<Obj>();
+        assert rb.tag == 7;
+
+        // Re-store into a: the old payload must be destroyed, b stays independent
+        Obj replacement = Obj(9);
+        a.set(replacement);
+        Obj& ra2 = a.get<Obj>();
+        Obj& rb2 = b.get<Obj>();
+        assert ra2.tag == 9;
+        assert rb2.tag == 7;
+
+        // Copy assignment must destroy a's payload, then deep-copy b's
+        a = b;
+        Obj& ra3 = a.get<Obj>();
+        assert ra3.tag == 7;
+    }
+
+    // Every constructed object must have been destroyed exactly once
+    assert LiveCount == 0;
+    assert !DoubleFree;
+
+    printf("Any non-trivial tests passed!\n");
+}

--- a/test/test-files/std/type/any-smoke/cout.out
+++ b/test/test-files/std/type/any-smoke/cout.out
@@ -1,0 +1,1 @@
+Any smoke tests passed!

--- a/test/test-files/std/type/any-smoke/source.spice
+++ b/test/test-files/std/type/any-smoke/source.spice
@@ -1,0 +1,79 @@
+import "std/type/any";
+
+// A small POD payload that fits into the inline storage
+type Small struct {
+    long* ptr
+    int tag
+}
+
+// A payload larger than the inline storage (7 * 8 = 56 bytes > 48), forcing
+// the heap storage path
+type Large struct {
+    long v1
+    long v2
+    long v3
+    long v4
+    long v5
+    long v6
+    long v7
+}
+
+f<int> main() {
+    // Empty Any
+    Any empty = Any();
+    assert empty.isEmpty();
+    assert empty.getTypeId() == 0l;
+    assert !empty.has<int>();
+    assert empty.isStoredInline();
+
+    // Inline scalar payload
+    Any scalar = any(42);
+    assert !scalar.isEmpty();
+    assert scalar.has<int>();
+    assert !scalar.has<long>();
+    assert scalar.get<int>() == 42;
+    assert scalar.getTypeId() == typeid<int>();
+    assert scalar.isStoredInline();
+
+    // Inline struct payload (pointers survive the round-trip)
+    long target = 7l;
+    Small small = Small{&target, 99};
+    Any smallAny = any(small);
+    assert smallAny.isStoredInline();
+    Small smallBack = smallAny.get<Small>();
+    assert smallBack.tag == 99;
+    unsafe {
+        assert smallBack.ptr == &target;
+        assert *smallBack.ptr == 7l;
+    }
+
+    // Heap struct payload (> inline size)
+    Large large = Large{1l, 2l, 3l, 4l, 5l, 6l, 7l};
+    Any largeAny = any(large);
+    assert largeAny.has<Large>();
+    assert !largeAny.isStoredInline();
+    Large largeBack = largeAny.get<Large>();
+    assert largeBack.v1 == 1l;
+    assert largeBack.v2 == 2l;
+    assert largeBack.v3 == 3l;
+    assert largeBack.v4 == 4l;
+    assert largeBack.v5 == 5l;
+    assert largeBack.v6 == 6l;
+    assert largeBack.v7 == 7l;
+
+    // Deep-copy independence on the heap path
+    Any copied = largeAny;
+    Large replacement = Large{9l, 9l, 9l, 9l, 9l, 9l, 9l};
+    largeAny.set(replacement);
+    assert copied.get<Large>().v1 == 1l;     // copy is untouched
+    assert copied.get<Large>().v7 == 7l;
+    assert largeAny.get<Large>().v1 == 9l;   // original was reassigned
+
+    // Re-set onto an inline-holding Any switches the stored type
+    scalar.set(123l);
+    assert scalar.has<long>();
+    assert !scalar.has<int>();
+    assert scalar.get<long>() == 123l;
+
+    printf("Any smoke tests passed!\n");
+}

--- a/test/test-files/std/type/any-smoke/source.spice
+++ b/test/test-files/std/type/any-smoke/source.spice
@@ -1,13 +1,13 @@
 import "std/type/any";
 
-// A small POD payload that fits into the inline storage
+// A POD payload larger than the 8-byte inline slot (8 + 4 = 16 bytes), forcing
+// the heap storage path
 type Small struct {
     long* ptr
     int tag
 }
 
-// A payload larger than the inline storage (7 * 8 = 56 bytes > 48), forcing
-// the heap storage path
+// A clearly oversized payload (7 * 8 = 56 bytes), also heap-stored
 type Large struct {
     long v1
     long v2
@@ -26,7 +26,7 @@ f<int> main() {
     assert !empty.has<int>();
     assert empty.isStoredInline();
 
-    // Inline scalar payload
+    // Inline scalar payload (4 bytes <= 8 -> inline)
     Any scalar = any(42);
     assert !scalar.isEmpty();
     assert scalar.has<int>();
@@ -35,11 +35,21 @@ f<int> main() {
     assert scalar.getTypeId() == typeid<int>();
     assert scalar.isStoredInline();
 
-    // Inline struct payload (pointers survive the round-trip)
+    // Inline pointer payload (exactly 8 bytes -> inline, survives the round-trip)
     long target = 7l;
+    long* targetPtr = &target;
+    Any ptrAny = any(targetPtr);
+    assert ptrAny.isStoredInline();
+    long* backPtr = ptrAny.get<long*>();
+    unsafe {
+        assert backPtr == &target;
+        assert *backPtr == 7l;
+    }
+
+    // Heap struct payload (16 bytes > 8 -> heap; pointers survive the round-trip)
     Small small = Small{&target, 99};
     Any smallAny = any(small);
-    assert smallAny.isStoredInline();
+    assert !smallAny.isStoredInline();
     Small smallBack = smallAny.get<Small>();
     assert smallBack.tag == 99;
     unsafe {
@@ -47,7 +57,7 @@ f<int> main() {
         assert *smallBack.ptr == 7l;
     }
 
-    // Heap struct payload (> inline size)
+    // Heap struct payload (larger)
     Large large = Large{1l, 2l, 3l, 4l, 5l, 6l, 7l};
     Any largeAny = any(large);
     assert largeAny.has<Large>();


### PR DESCRIPTION
## Summary

Adds `std/type/any.spice` — `Any`, a type-erased container that can hold a value of an arbitrary type (the Spice equivalent of C++'s `std::any`). The motivating use case is the bootstrap compiler's AST visitor, whose `visit*` methods return different result types per pass (the host compiler uses `std::any` for exactly this).

## Design

- **Type identity** via the `typeid` builtin (a stable 64-bit hash); retrieval is checked, so `get<T>()` panics if the `Any` holds a different type.
- **Small-buffer optimization**: a single 8-byte inline slot stores pointer-sized payloads without a heap allocation; everything larger is boxed on the heap (the heap buffer is an owned `heap` field, auto-freed by the compiler).
- **Non-trivial payloads** (non-trivially constructible/copyable/destructible) are fully supported via per-type copy + destroy thunks captured at `set<T>` time, gated on the `__is_trivially_copyable` / `__is_trivially_destructible` builtins so trivial types keep the fast bitwise path. Non-trivial payloads are always heap-boxed, which makes `heapStore != nil` a reliable "owns a live payload" signal and keeps the destructor correct under move/return. Such payload types must follow the std convention of a **public** copy ctor + dtor.
- API: `any<T>(value)` factory, `set<T>` / `get<T>` / `has<T>` / `isEmpty` / `getTypeId` / `isStoredInline`, plus deep-copy copy-ctor and `operator=` (with a self-assignment guard).

## Tests

- `test/test-files/std/type/any-smoke` — trivial payloads: empty, inline scalar, inline pointer (8 B), heap structs, deep-copy independence, type re-set, and inline-vs-heap placement assertions.
- `test/test-files/std/type/any-nontrivial` — verifies a balanced object lifecycle for non-trivial payloads (every construction destructed exactly once, no double-free) across store / copy / reassign / copy-assign.

Both pass through `spicetest` and are clean under the address sanitizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)