### PR TITLE
Replace reinterpret_cast with llvm::cast where possible

### DIFF
--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -334,7 +334,7 @@ llvm::DIType *DebugInfoGenerator::getDITypeForQualType(const ASTNode *node, cons
     llvm::Type *structType = spiceStruct->entry->getQualType().toLLVMType(irGenerator->sourceFile);
     assert(structType != nullptr);
     const llvm::DataLayout &dataLayout = irGenerator->module->getDataLayout();
-    const llvm::StructLayout *structLayout = dataLayout.getStructLayout(reinterpret_cast<llvm::StructType *>(structType));
+    const llvm::StructLayout *structLayout = dataLayout.getStructLayout(llvm::cast<llvm::StructType>(structType));
     const uint32_t alignInBits = dataLayout.getABITypeAlign(structType).value();
 
     // Create struct ty
@@ -387,7 +387,7 @@ llvm::DIType *DebugInfoGenerator::getDITypeForQualType(const ASTNode *node, cons
     llvm::Type *interfaceType = spiceInterface->entry->getQualType().toLLVMType(irGenerator->sourceFile);
     assert(interfaceType != nullptr);
     const llvm::DataLayout dataLayout = irGenerator->module->getDataLayout();
-    const llvm::StructLayout *structLayout = dataLayout.getStructLayout(reinterpret_cast<llvm::StructType *>(interfaceType));
+    const llvm::StructLayout *structLayout = dataLayout.getStructLayout(llvm::cast<llvm::StructType>(interfaceType));
     const uint32_t alignInBits = dataLayout.getABITypeAlign(interfaceType).value();
 
     // Create interface ty

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -412,7 +412,7 @@ std::any IRGenerator::visitStructInstantiation(const StructInstantiationNode *no
 
   // Get struct type
   assert(spiceStruct->entry != nullptr);
-  const auto structType = reinterpret_cast<llvm::StructType *>(spiceStruct->entry->getQualType().toLLVMType(sourceFile));
+  const auto structType = llvm::cast<llvm::StructType>(spiceStruct->entry->getQualType().toLLVMType(sourceFile));
   assert(structType != nullptr);
 
   if (!node->fieldLst) {

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -299,13 +299,13 @@ llvm::Constant *IRGenerator::getDefaultValueForSymbolType(const QualType &symbol
       fieldConstants.push_back(defaultFieldValue);
     }
 
-    const auto structType = reinterpret_cast<llvm::StructType *>(symbolType.toLLVMType(sourceFile));
+    const auto structType = llvm::cast<llvm::StructType>(symbolType.toLLVMType(sourceFile));
     return llvm::ConstantStruct::get(structType, fieldConstants);
   }
 
   // Interface
   if (symbolType.is(TY_INTERFACE)) {
-    const auto structType = reinterpret_cast<llvm::StructType *>(symbolType.toLLVMType(sourceFile));
+    const auto structType = llvm::cast<llvm::StructType>(symbolType.toLLVMType(sourceFile));
     return llvm::ConstantStruct::get(structType, llvm::Constant::getNullValue(builder.getPtrTy()));
   }
 


### PR DESCRIPTION
Replace reinterpret_cast with llvm::cast where possible