### PR TITLE
Add missing doc comments and time complexity to std containers

### DIFF
--- a/std/data/doubly-linked-list.spice
+++ b/std/data/doubly-linked-list.spice
@@ -14,6 +14,15 @@ type Node<T> struct {
  * A doubly linked list is a common, dynamically resizable data structure to store uniform data in order.
  * It is characterized by the pointer for every item, pointing to the next one and the pointer, pointing
  * to the previous one.
+ *
+ * Time complexity:
+ * Insert at front/back: O(1)
+ * Insert at index:      O(n)
+ * Delete at front/back: O(1)
+ * Delete at index:      O(n)
+ * Search:               O(n)
+ *
+ * Beware that each add operation allocates memory and every remove operation frees memory.
  */
 public type DoublyLinkedList<T> struct {
     Node<T>* head = nil<Node<T>*>
@@ -21,6 +30,11 @@ public type DoublyLinkedList<T> struct {
     unsigned long size = 0l
 }
 
+/**
+ * Pushes a new item to the back of the list
+ *
+ * @param value Value to push
+ */
 public p DoublyLinkedList.pushBack(const T& value) {
     heap Node<T>* newNode = this.createNode(value);
     if this.isEmpty() {
@@ -34,6 +48,11 @@ public p DoublyLinkedList.pushBack(const T& value) {
     this.size++;
 }
 
+/**
+ * Pushes a new item to the front of the list
+ *
+ * @param value Value to push
+ */
 public p DoublyLinkedList.pushFront(const T& value) {
     heap Node<T>* newNode = this.createNode(value);
     if this.isEmpty() {
@@ -47,6 +66,12 @@ public p DoublyLinkedList.pushFront(const T& value) {
     this.size++;
 }
 
+/**
+ * Inserts a new item at the given index
+ *
+ * @param idx Index to insert the new item
+ * @param value Value to insert
+ */
 public p DoublyLinkedList.insertAt(unsigned long idx, const T& value) {
     // Abort if the index is out of bounds
     if idx < 0 || idx > this.size { panic(Error("Access index out of bound")); }
@@ -71,6 +96,11 @@ public p DoublyLinkedList.insertAt(unsigned long idx, const T& value) {
     this.size++;
 }
 
+/**
+ * Removes the first occurrence of the given value
+ *
+ * @param valueToRemove Value to remove
+ */
 public p DoublyLinkedList.remove(const T& valueToRemove) {
     Node<T>* curr = this.tail;
     while curr != nil<Node<T>*> {
@@ -97,6 +127,11 @@ public p DoublyLinkedList.remove(const T& valueToRemove) {
     }
 }
 
+/**
+ * Removes the item at the given index
+ *
+ * @param idx Index to remove
+ */
 public p DoublyLinkedList.removeAt(unsigned long idx) {
     // Abort if the index is out of bounds
     if idx < 0 || idx >= this.size { panic(Error("Access index out of bound")); }
@@ -123,26 +158,53 @@ public p DoublyLinkedList.removeAt(unsigned long idx) {
     this.size--;
 }
 
+/**
+ * Removes the item at the given index
+ *
+ * @param idx Index to remove
+ */
 public p DoublyLinkedList.removeAt(unsigned int idx) {
     this.removeAt(cast<unsigned long>(idx));
 }
 
+/**
+ * Removes the first item of the list
+ */
 public p DoublyLinkedList.removeFront() {
     this.removeAt(0l);
 }
 
+/**
+ * Removes the last item of the list
+ */
 public p DoublyLinkedList.removeBack() {
     this.removeAt(this.size - 1l);
 }
 
+/**
+ * Returns the size of the list
+ *
+ * @return Size of the list
+ */
 public inline f<unsigned long> DoublyLinkedList.getSize() {
     return this.size;
 }
 
+/**
+ * Returns if the list is empty
+ *
+ * @return true if the list is empty, false otherwise
+ */
 public inline f<bool> DoublyLinkedList.isEmpty() {
     return this.size == 0l;
 }
 
+/**
+ * Returns the item at the given index
+ *
+ * @param idx Index to access
+ * @return Reference to the item
+ */
 public f<T&> DoublyLinkedList.get(unsigned long idx) {
     // Abort if the index is out of bounds
     if idx < 0 || idx >= this.size { panic(Error("Access index out of bound")); }
@@ -154,15 +216,31 @@ public f<T&> DoublyLinkedList.get(unsigned long idx) {
     return curr.value;
 }
 
+/**
+ * Returns the item at the given index
+ *
+ * @param idx Index to access
+ * @return Reference to the item
+ */
 public f<T&> DoublyLinkedList.get(unsigned int idx) {
     return this.get(cast<unsigned long>(idx));
 }
 
+/**
+ * Returns the first item of the list
+ *
+ * @return Reference to the first item
+ */
 public inline f<T&> DoublyLinkedList.getFront() {
     if this.isEmpty() { panic(Error("Access index out of bounds")); }
     return this.tail.value;
 }
 
+/**
+ * Returns the last item of the list
+ *
+ * @return Reference to the last item
+ */
 public inline f<T&> DoublyLinkedList.getBack() {
     if this.isEmpty() { panic(Error("Access index out of bounds")); }
     return this.head.value;

--- a/std/data/graph.spice
+++ b/std/data/graph.spice
@@ -12,6 +12,9 @@ import "std/iterator/iterator";
 // Generic types
 type T dyn;
 
+/**
+ * A vertex (or node) of a graph, wrapping a single value of arbitrary type
+ */
 public type Vertex<T> struct : IHashable {
     T value
 }
@@ -20,6 +23,11 @@ public p Vertex.ctor(const T& value) {
     this.value = value;
 }
 
+/**
+ * Retrieve the value stored in the vertex
+ *
+ * @return Reference to the stored value
+ */
 public f<T&> Vertex.getValue() {
     return this.value;
 }
@@ -33,9 +41,17 @@ public f<Hash> Vertex.hash() {
 }
 
 /**
- * Graph data structure
+ * A graph in Spice is a data structure consisting of a set of vertices and a set of edges connecting
+ * them. It is stored as an adjacency list, mapping each vertex to the list of its neighbours. The
+ * graph can be either directed or undirected, which is decided at construction time.
  *
- * ToDo: Add time complexities for common operations
+ * Time complexity (V = number of vertices, E = number of edges):
+ * Add vertex:           O(1) (average case)
+ * Add edge:             O(1) (average case)
+ * Traversal (DFS/BFS):  O(V + E)
+ *
+ * The average case for adding vertices and edges assumes a good hash distribution in the underlying
+ * unordered map. In the worst case, hash collisions degrade these operations to O(V).
  */
 public type Graph<T> struct : IIterable<T> {
     Vector<Vertex<T>> vertices
@@ -47,6 +63,12 @@ public p Graph.ctor(bool directed = true) {
     this.directed = directed;
 }
 
+/**
+ * Add a new vertex with the given value to the graph
+ *
+ * @param value The value to store in the new vertex
+ * @return Reference to the newly added vertex
+ */
 public f<Vertex<T>&> Graph.addVertex(const T& value) {
     this.vertices.pushBack(Vertex<T>(value));
     Vertex<T>& vertex = this.vertices.back();
@@ -54,6 +76,13 @@ public f<Vertex<T>&> Graph.addVertex(const T& value) {
     return vertex;
 }
 
+/**
+ * Add an edge between two vertices that are already part of the graph.
+ * For undirected graphs the caller is responsible for adding the reverse edge as well.
+ *
+ * @param from The source vertex of the edge
+ * @param to The destination vertex of the edge
+ */
 public p Graph.addEdge(const Vertex<T>& from, const Vertex<T>& to) {
     if !this.adjList.contains(from) || !this.adjList.contains(to) {
         panic(Error("Graph must already contain both given vertices"));
@@ -71,18 +100,38 @@ const f<bool> Graph.hasCyclesUndirected() {
     return false;
 }
 
+/**
+ * Check whether the graph contains at least one cycle
+ *
+ * @return true if the graph contains a cycle, false otherwise
+ */
 public const f<bool> Graph.hasCycles() {
     return this.directed ? this.hasCyclesDirected() : this.hasCyclesUndirected();
 }
 
+/**
+ * Check whether the graph is directed
+ *
+ * @return true if the graph is directed, false if it is undirected
+ */
 public const f<bool> Graph.isDirected() {
     return this.directed;
 }
 
+/**
+ * Check whether the graph is a directed acyclic graph (DAG)
+ *
+ * @return true if the graph is directed and contains no cycles, false otherwise
+ */
 public const f<bool> Graph.isDAG() {
     return this.directed && !this.hasCycles();
 }
 
+/**
+ * Serialize the graph to the Graphviz DOT format and write it into the given string stream
+ *
+ * @param ss The string stream to write the DOT representation to
+ */
 public const p Graph.toGraphviz(StringStream& ss) {
     const string graphType = this.directed ? "digraph" : "graph";
     const string edgeSep = this.directed ? "->" : "--";

--- a/std/data/graph.spice
+++ b/std/data/graph.spice
@@ -42,7 +42,7 @@ public f<Hash> Vertex.hash() {
 
 /**
  * A graph in Spice is a data structure consisting of a set of vertices and a set of edges connecting
- * them. It is stored as an adjacency list, mapping each vertex to the list of its neighbours. The
+ * them. It is stored as an adjacency list, mapping each vertex to the list of its neighbors. The
  * graph can be either directed or undirected, which is decided at construction time.
  *
  * Time complexity (V = number of vertices, E = number of edges):

--- a/std/data/hash-table.spice
+++ b/std/data/hash-table.spice
@@ -9,6 +9,9 @@ import "std/data/pair";
 type K dyn;
 type V dyn;
 
+/**
+ * A single key-value entry stored within a hash table bucket
+ */
 type HashEntry<K, V> struct {
     K key
     V value
@@ -19,6 +22,19 @@ public p HashEntry.ctor(const HashEntry<K, V>& original) {
     this.value = original.value;
 }
 
+/**
+ * A hash table in Spice is a commonly used data structure, which stores key-value pairs and allows
+ * fast access to a value by its key. Collisions are resolved via separate chaining, where each
+ * bucket holds a linked list of entries that hash to the same index.
+ *
+ * Time complexity:
+ * Insert: O(1) (average case), O(n) (worst case)
+ * Delete: O(1) (average case), O(n) (worst case)
+ * Lookup: O(1) (average case), O(n) (worst case)
+ *
+ * The average case assumes a good hash distribution. In the worst case, all keys hash to the same
+ * bucket, degrading every operation to a linear scan of that bucket.
+ */
 public type HashTable<K, V> struct : IIterable<Pair<K, V>> {
     Vector<LinkedList<HashEntry<K, V>>> buckets
 }

--- a/std/data/pair.spice
+++ b/std/data/pair.spice
@@ -15,18 +15,38 @@ public inline p Pair.ctor(V1 first, V2 second) {
     this.second = second;
 }
 
+/**
+ * Retrieve the first value of the pair
+ *
+ * @return Reference to the first value
+ */
 public inline f<V1&> Pair.getFirst() {
     return this.first;
 }
 
+/**
+ * Retrieve the second value of the pair
+ *
+ * @return Reference to the second value
+ */
 public inline f<V2&> Pair.getSecond() {
     return this.second;
 }
 
+/**
+ * Set the first value of the pair
+ *
+ * @param first New first value
+ */
 public inline p Pair.setFirst(const V1& first) {
     this.first = first;
 }
 
+/**
+ * Set the second value of the pair
+ *
+ * @param second New second value
+ */
 public inline p Pair.setSecond(const V2& second) {
     this.second = second;
 }

--- a/std/data/triple.spice
+++ b/std/data/triple.spice
@@ -18,26 +18,56 @@ public inline p Triple.ctor(V1 first, V2 second, V3 third) {
     this.third = third;
 }
 
+/**
+ * Retrieve the first value of the triple
+ *
+ * @return Reference to the first value
+ */
 public inline f<V1&> Triple.getFirst() {
     return this.first;
 }
 
+/**
+ * Retrieve the second value of the triple
+ *
+ * @return Reference to the second value
+ */
 public inline f<V2&> Triple.getSecond() {
     return this.second;
 }
 
+/**
+ * Retrieve the third value of the triple
+ *
+ * @return Reference to the third value
+ */
 public inline f<V3&> Triple.getThird() {
     return this.third;
 }
 
+/**
+ * Set the first value of the triple
+ *
+ * @param first New first value
+ */
 public inline p Triple.setFirst(V1& first) {
     this.first = first;
 }
 
+/**
+ * Set the second value of the triple
+ *
+ * @param second New second value
+ */
 public inline p Triple.setSecond(V2& second) {
     this.second = second;
 }
 
+/**
+ * Set the third value of the triple
+ *
+ * @param third New third value
+ */
 public inline p Triple.setThird(V3& third) {
     this.third = third;
 }


### PR DESCRIPTION
## What

Adds the missing code doc comments across the standard library container types and a time-complexity block to every container type that was still missing one.

### Time complexity added (the only 3 containers lacking it)

| File | Change |
|------|--------|
| `std/data/hash-table.spice` | Struct had **no doc comment at all** — added a full description plus average/worst-case complexity (separate chaining), and documented `HashEntry` |
| `std/data/graph.spice` | Replaced the `ToDo: Add time complexities` placeholder with real complexities (add vertex/edge O(1) avg, traversal O(V+E)) |
| `std/data/doubly-linked-list.spice` | Added a time-complexity block to the struct (front/back O(1), index/search O(n)) |

The remaining container files (`vector`, `linked-list`, `queue`, `stack`, `deque`, `map`, `unordered-map`, `set`, `unordered-set`, `binary-tree`, `red-black-tree`, `bitset`, `priority-queue`, `trie`) already had complexity blocks and were left untouched. `pair`, `triple` and `optional` are value wrappers (all operations O(1)), so no complexity block applies.

### Doc comments added where methods were undocumented

- **graph**: `Vertex` struct, `getValue`, `addVertex`, `addEdge`, `hasCycles`, `isDirected`, `isDAG`, `toGraphviz`
- **doubly-linked-list**: all public methods (`pushBack`/`pushFront`/`insertAt`/`remove`/`removeAt`/`removeFront`/`removeBack`/`getSize`/`isEmpty`/`get`/`getFront`/`getBack`), mirroring the wording in `linked-list.spice`
- **pair** / **triple**: all `getX`/`setX` accessors and mutators

## Why

Several container types in `std/data` were missing the doc comments and time-complexity annotations that the rest of the containers already document, making the API reference inconsistent.

## Notes for reviewers

- Documentation-only change — no behavior or signatures were modified.
- Style matches the existing `/** ... */` convention with `@param`/`@return` and the `Time complexity:` block used by the already-documented containers.
- Not compiled locally (sandbox build constraints); changes are comment-only and follow established patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
