### PR TITLE
Fix factual errors in enums, attributes and declaration-qualifiers docs

### DIFF
--- a/docs/docs/language/attributes.md
+++ b/docs/docs/language/attributes.md
@@ -5,7 +5,7 @@ title: Attributes
 Spice offers the option to annotate single function or whole modules via attributes.
 
 !!! note "Optional value for bool attributes"
-For attributes of type bool, the value `true` can be omitted.
+    For attributes of type bool, the value `true` can be omitted.
 
 ## Module attributes
 ```spice
@@ -24,7 +24,7 @@ For attributes of type bool, the value `true` can be omitted.
 
 ## Function attributes
 ```spice
-#[core.compiler.mangleName = false]
+#[core.compiler.mangle = false]
 f<int> test(long input) {
     return input == 0 ? 123 : 456;
 }
@@ -39,7 +39,7 @@ f<int> test(long input) {
 
 ## External declaration attributes
 ```spice
-#[core.compiler.mangleName = false]
+#[core.compiler.mangle = false]
 ext f<heap byte*> malloc(unsigned long);
 
 // ...

--- a/docs/docs/language/declaration-qualifiers.md
+++ b/docs/docs/language/declaration-qualifiers.md
@@ -156,7 +156,7 @@ type TestStruct struct {
 
 ## The `compose` qualifier
 
-Includes a struct info the current strut. This is useful for composing structs from other structs.
+Includes a struct into the current struct. This is useful for composing structs from other structs.
 
 *Note: The `compose` qualifier only works for by-value struct types. This is enforced by the compiler.*
 

--- a/docs/docs/language/enums.md
+++ b/docs/docs/language/enums.md
@@ -35,4 +35,6 @@ type Vegetable enum {
 }
 ```
 
-Spice will then assign 0 for `TOMATO` and 1 for `POTATO`.
+For items without an explicit value, Spice assigns the lowest non-negative integer not already taken by any other
+item in the enum. Here `CUCUMBER = 5` and `CARROT = 2` are already claimed, so the compiler assigns `TOMATO = 0`
+and `POTATO = 1`.


### PR DESCRIPTION
## Summary

Three factual corrections across the language documentation:

**`enums.md`**
- The description of how un-assigned enum item values are computed was wrong. The compiler assigns the lowest non-negative integer not already taken by *any* item in the enum (not simply next-after-previous). The example values (`TOMATO=0`, `POTATO=1`) were actually correct but the prose explanation was misleading — fixed to match the actual compiler behaviour (verified in `TypeCheckerTopLevelDefinitionsPrepare.cpp` and the `success-enums` test).

**`attributes.md`**
- Both code examples used `core.compiler.mangleName` but the attribute table immediately below lists the key as `core.compiler.mangle`. Fixed both examples to match the table.
- The `!!! note` admonition body was not indented, so it rendered as plain text outside the note box. Fixed indentation.

**`declaration-qualifiers.md`**
- Typo in the `compose` qualifier description: "Includes a struct info the current strut" → "Includes a struct into the current struct".

## Test plan
- [x] Confirm `enums.md` example values match `test/test-files/irgenerator/enums/success-enums/cout.out`
- [x] Confirm `core.compiler.mangle` attribute name matches compiler source
- [x] Review rendered admonition in `attributes.md`