### PR TITLE
Fix minor issues in threads and operator-overloading docs

### DIFF
--- a/docs/docs/language/lambda-functions.md
+++ b/docs/docs/language/lambda-functions.md
@@ -24,15 +24,15 @@ lambda(5, 3.14);
 
 ```spice
 // Definition
-f<int>(string, bool) lambda = f<int>(string str, bool b) {
-    if b {
-        return cast<int>(str[0]);
+f<int>(const String&, bool) lambda = f<int>(const String& str, bool b) {
+    if (b) {
+        return str.getLength();
     } else {
         return -1;
     }
 };
 // Call
-int result = lambda("Hello", true);
+int result = lambda(String("Hello"), true);
 ```
 
 ### Inline lambdas

--- a/docs/docs/language/lambda-functions.md
+++ b/docs/docs/language/lambda-functions.md
@@ -24,15 +24,15 @@ lambda(5, 3.14);
 
 ```spice
 // Definition
-f<int>(const String&, bool) lambda = f<int>(const String& str, bool b) {
-    if (b) {
-        return str.getLength();
+f<int>(string, bool) lambda = f<int>(string str, bool b) {
+    if b {
+        return cast<int>(str[0]);
     } else {
         return -1;
     }
 };
 // Call
-int result = lambda(String("Hello"), true);
+int result = lambda("Hello", true);
 ```
 
 ### Inline lambdas

--- a/docs/docs/language/operator-overloading.md
+++ b/docs/docs/language/operator-overloading.md
@@ -5,7 +5,6 @@ title: Operator Overloading
 Spice allows overloading operators for [custom struct types](structs.md).
 Currently, this works for the operators `+`, `-`, `*`, `/`, `==`, `!=`, `<<`, `>>`, `&`, `|`, `^`, `~` (prefix), `+=`, `-=`,
 `*=`, `/=`, `[]`, `=`, `++` (postfix) and `--` (postfix).
-In the future, more operators will be supported for overloading.
 
 ## Usage
 

--- a/docs/docs/language/threads.md
+++ b/docs/docs/language/threads.md
@@ -71,6 +71,7 @@ The thread pool can be used like this:
 
 ```spice
 import "std/os/threadpool";
+import "std/time/delay";
 
 f<int> main() {
     ThreadPool tp = ThreadPool(3s); // Create a thread pool with 3 worker threads


### PR DESCRIPTION
## Summary

Three small corrections across the language documentation:

**`threads.md`**
- The thread pool example called `delay()` without importing `std/time/delay`. Added the missing import.

**`operator-overloading.md`**
- Removed the vague "In the future, more operators will be supported for overloading" sentence, which adds no actionable information.

## Test plan
- [x] Verify thread pool example compiles with the added `delay` import