### PR TITLE
Expand seven thin documentation pages

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -2,7 +2,46 @@
 title: Introduction
 ---
 
-Spice is a compiled language which sets a focus on performance and practicality. It is considered as a systems language,
-which means that is rather not suitable for coding user interfaces, but for coding drivers and cli tools. Spice has
-support for cross-compiling for multiple target platforms. In order to get started, visit the
-[installation guide](install/linux.md).
+Spice is a compiled, statically typed systems programming language that targets performance and practicality. It compiles
+directly to native machine code via [LLVM](https://llvm.org), producing lean binaries with no runtime overhead.
+
+## Design goals
+
+- **Performance first** — zero-cost abstractions, value semantics by default, and LLVM optimizations at every level.
+- **Familiar syntax** — borrows the curly-brace style of C/C++ so existing systems programmers feel at home.
+- **Safety where it counts** — strong static typing, immutability via `const`, and automatic memory management
+  through deterministic destructors, without a garbage collector.
+- **Practical interop** — can call C and C++ libraries directly and cross-compile to any LLVM-supported target.
+- **Self-contained toolchain** — a single binary covers compilation, running, testing, and installing packages.
+
+## What Spice is good for
+
+Spice is a systems language. It shines for:
+
+- CLI tools and utilities
+- Compilers and interpreters
+- Embedded and low-level drivers
+- Performance-critical libraries
+- WebAssembly modules
+
+It is not aimed at user-interface development — for GUI applications, a higher-level language is usually a better fit.
+
+## A first look
+
+```spice
+import "std/text/print";
+
+f<int> main() {
+    println("Hello, Spice!");
+    return 0;
+}
+```
+
+Functions return values (`f<ReturnType>`), procedures do not (`p`). The entry point is always `main`, returning `int`.
+The standard library is imported with `import "std/..."`.
+
+## Next steps
+
+- [Install Spice](install/linux.md) on your platform.
+- Work through the [Hello World](language/hello-world.md) example.
+- Browse the [language documentation](language/main-function.md) for a full reference.

--- a/docs/docs/language/aliases.md
+++ b/docs/docs/language/aliases.md
@@ -17,3 +17,40 @@ type TestStruct<T> struct {
 }
 type TS alias TestStruct<short>;
 ```
+
+## True aliases vs. type constraints
+
+The `type` keyword serves two different purposes depending on what follows it:
+
+**`type Name alias OtherType`** — creates a true alias. `Name` and `OtherType` are completely interchangeable; the
+compiler treats them as the same type:
+
+```spice
+type Meters alias double;
+type Seconds alias double;
+
+f<Meters> speed(Meters dist, Seconds time) {
+    return dist / time;
+}
+```
+
+**`type Name A|B|C`** — declares a *generic type constraint*, not an alias. It does not create a new type on its own;
+it is only meaningful as a template parameter in a generic function, procedure, or struct. It restricts which concrete
+types may be substituted for that parameter:
+
+```spice
+type NumericType int|long|double;
+
+f<NumericType> sum<NumericType>(NumericType a, NumericType b) {
+    return a + b;
+}
+
+f<int> main() {
+    sum<int>(1, 2);      // ok
+    sum<double>(1.0, 2.0); // ok
+    // sum<string>("a", "b"); // compiler error — string not in the constraint
+}
+```
+
+Using `type T dyn` as a constraint means the generic type parameter is unconstrained and may be substituted by any
+type.

--- a/docs/docs/language/constructors-destructors.md
+++ b/docs/docs/language/constructors-destructors.md
@@ -6,6 +6,7 @@ Sometimes you want to initialize the field of a struct or execute some action ri
 enables you doing that, by supporting constructors. To clean up a struct instance, destructors can be used.
 
 ## Constructors
+
 Whenever you create a struct instance like this, Spice will automatically call the `ctor` method of this struct:
 
 ```spice
@@ -44,7 +45,62 @@ f<int> main() {
 
 The `ctor` method can also be called manually like calling [other methods](methods.md).
 
+## Constructor overloading
+
+A struct can have multiple constructors with different parameter lists, just like [function overloading](functions.md):
+
+```spice
+type Vec2 struct {
+    double x
+    double y
+}
+
+p Vec2.ctor() {
+    this.x = 0.0;
+    this.y = 0.0;
+}
+
+p Vec2.ctor(double x, double y) {
+    this.x = x;
+    this.y = y;
+}
+
+f<int> main() {
+    Vec2 origin = Vec2();         // calls the no-arg constructor
+    Vec2 point  = Vec2(3.0, 4.0); // calls the two-arg constructor
+}
+```
+
+## Copy constructors
+
+When a struct value is copied (passed by value, returned by value, or assigned), Spice calls the *copy constructor*
+if one is defined. The copy constructor takes a `const` reference to an instance of the same type:
+
+```spice
+type Buffer struct {
+    int copies
+}
+
+p Buffer.ctor() {
+    this.copies = 0;
+}
+
+p Buffer.ctor(const Buffer& other) {
+    this.copies = other.copies + 1;
+    printf("copy #%d\n", this.copies);
+}
+
+f<int> main() {
+    Buffer a = Buffer();
+    Buffer b = a;   // prints "copy #1"
+    Buffer c = b;   // prints "copy #2"
+}
+```
+
+If no copy constructor is defined, Spice generates a default one that copies each field.
+
 ## Destructors
+
 You have the option to create a destructor by providing a `dtor` method on a struct. It does not allow any arguments and has no
 return type, since it is a procedure. Destructors can be especially useful for de-allocating objects in heap memory, that were
 allocated via `malloc()`. Whenever a struct variable goes out of scope somewhere in the program, the compiler searches for a

--- a/docs/docs/language/functions.md
+++ b/docs/docs/language/functions.md
@@ -35,6 +35,48 @@ int result1 = demoFunction("input");
 int result1 = demoFunction("another input", 1.0);
 ```
 
+## The implicit `result` variable
+
+Inside any function, Spice provides an implicit variable called `result` that holds the return value. You can assign
+to it at any point and return early with a bare `return`, or simply fall off the end of the function:
+
+```spice
+f<int> getAge(bool adult) {
+    if adult {
+        result = 18;
+        return; // returns 18
+    }
+    result = 10; // returned when adult is false
+}
+```
+
+This is equivalent to using an explicit `return` expression, but can be more readable when the return value is built
+up across multiple branches.
+
+## Function overloading
+
+Multiple functions may share the same name as long as their parameter lists differ. The compiler picks the best match
+at the call site:
+
+```spice
+f<int> describe(int n) {
+    printf("integer: %d\n", n);
+    return n;
+}
+
+f<int> describe(string s) {
+    printf("string: %s\n", s);
+    return 0;
+}
+
+f<int> main() {
+    describe(42);        // calls the int overload
+    describe("hello");   // calls the string overload
+}
+```
+
+Overloads can also differ in the number of parameters or in whether parameters have default values.
+
 !!! tip
     If you only want to execute some actions and don't need to return a value to the caller, please consider to use
     [procedures](procedures.md) instead of functions.

--- a/docs/docs/language/generics.md
+++ b/docs/docs/language/generics.md
@@ -9,6 +9,7 @@ Spice resolves the substantiations of generic types at compile time. This helps 
 Generic function substantiations that are unused, are removed by the compiler automatically.
 
 ## Generic types
+
 Before using generic types, you have to declare the types first. This can be done like this:
 
 ```spice
@@ -16,12 +17,19 @@ type T dyn;
 type U int|double|long;
 ```
 
-In the above example `T` can substantiate to an arbitrary type, whilst `U` can only become an `int`, a `double` or a `long`.
+`type T dyn` declares an unconstrained generic type — `T` can be substituted by any type at the call site.
+
+`type U int|double|long` declares a *constrained* generic type — `U` may only be substituted by `int`, `double`, or
+`long`. This is not a type alias; it is purely a constraint used by the compiler to validate generic instantiations.
 
 ## Generic functions or procedures
+
 Here is an example function:
 
 ```spice
+type T dyn;
+type U dyn;
+
 f<double> genericFunction<T, U>(T arg1, U arg2, int arg3 = 10) {
     return arg1 + arg2 + arg3;
 }
@@ -35,7 +43,23 @@ As mentioned above, the substantiations of generic types are collected at compil
 type-check all concrete substantiations to ensure that e.g. operators are compatible with the concrete types. Furthermore, this
 enables more optimizations and does not require to carry runtime type information at runtime, which improves runtime speed.
 
+You can also call a generic function with explicit type arguments to disambiguate or to fix the types when they cannot
+be inferred:
+
+```spice
+type T dyn;
+
+f<T> identity<T>(T val) {
+    return val;
+}
+
+f<int> main() {
+    dyn result = identity<int>(42);
+}
+```
+
 ## Generic structs
+
 Here is a generic struct example:
 
 ```spice
@@ -54,3 +78,35 @@ p Vector.print() {
 The above example shows, that you can use the generic type as part of struct field types. Like normal structs, generic structs can
 also have [methods](./methods.md). The concrete types for the generic types, used for the parent struct, are inherited by the method,
 so you do not have to define the method above with following signature: `Vector<T>.print()`.
+
+When instantiating a generic struct, provide the concrete type in angle brackets:
+
+```spice
+f<int> main() {
+    Vector<short> v;     // T = short
+    Vector<long> vl;     // T = long
+}
+```
+
+## Generic interfaces
+
+Interfaces can also carry generic type parameters. The struct implementing the interface must supply concrete types
+for those parameters in its declaration:
+
+```spice
+type T dyn;
+
+type Comparable<T> interface {
+    f<int> compareTo<T>(const T& other);
+}
+
+type Score struct : Comparable<int> {
+    int value
+}
+
+f<int> Score.compareTo(const int& other) {
+    if this.value < other { return -1; }
+    if this.value > other { return 1; }
+    return 0;
+}
+```

--- a/docs/docs/language/methods.md
+++ b/docs/docs/language/methods.md
@@ -33,6 +33,51 @@ Output:
 Content: Hello World!
 ```
 
+## Method visibility
+
+Like functions and struct fields, methods are private by default. Mark a method `public` to allow code in other
+source files to call it:
+
+```spice
+public type Counter struct {
+    int value
+}
+
+public p Counter.increment() {
+    this.value++;
+}
+
+public f<int> Counter.get() {
+    return this.value;
+}
+```
+
+A method that is not marked `public` can only be called from within the same source file.
+
+## Methods on generic structs
+
+Methods on a generic struct automatically inherit the struct's type parameters — you do not repeat the parameter list
+on the method:
+
+```spice
+type T dyn;
+
+type Stack<T> struct {
+    T* data
+    int size
+}
+
+p Stack.push(T item) {
+    // ...
+}
+
+f<T> Stack.pop() {
+    // ...
+}
+```
+
+When `Stack<int>` is instantiated, `push` accepts an `int` and `pop` returns an `int`.
+
 !!! tip
     You can initialize or destroy structs by using [constructors and destructors](constructors-destructors.md).
     Read more about those in the respective documentation section.

--- a/docs/docs/language/structs.md
+++ b/docs/docs/language/structs.md
@@ -96,7 +96,7 @@ f<int> main() {
 Multiple structs can be composed; if two composed structs expose the same field name, the compiler will require an
 explicit qualifier to disambiguate.
 
-## Adding behaviour
+## Adding behavior
 
 Structs can be extended with [methods](methods.md), [constructors and destructors](constructors-destructors.md), and
 can implement [interfaces](interfaces.md).

--- a/docs/docs/language/structs.md
+++ b/docs/docs/language/structs.md
@@ -34,3 +34,69 @@ f<int> main() {
 	printf("John's age: %d", john.age);
 }
 ```
+
+## Default field values
+
+Fields can be given default values. A field with a default value does not need to be supplied when instantiating the
+struct without a constructor:
+
+```spice
+type Config struct {
+    int retries = 3
+    bool verbose = false
+    string host = "localhost"
+}
+
+f<int> main() {
+    Config cfg;              // all fields take their defaults
+    cfg.retries = 5;
+    printf("retries: %d\n", cfg.retries);
+}
+```
+
+## Public and private fields
+
+All fields are private by default — they are only accessible within the same source file. Mark individual fields
+`public` to expose them to code that imports the struct:
+
+```spice
+public type Socket struct {
+    public int sock
+    short _errorCode       // private — not accessible from importers
+    public string host
+}
+```
+
+This follows the same [visibility rules](declaration-qualifiers.md) as functions and structs themselves.
+
+## Struct composition
+
+The [`compose` qualifier](declaration-qualifiers.md#the-compose-qualifier) lets you embed one struct inside another
+and access its fields directly on the outer struct, without going through an intermediate field name:
+
+```spice
+type Point struct {
+    int x
+    int y
+}
+
+type ColoredPoint struct {
+    compose Point base
+    int color
+}
+
+f<int> main() {
+    ColoredPoint cp;
+    cp.x = 10;      // accessed directly, no cp.base.x needed
+    cp.y = 20;
+    cp.color = 0xFF0000;
+}
+```
+
+Multiple structs can be composed; if two composed structs expose the same field name, the compiler will require an
+explicit qualifier to disambiguate.
+
+## Adding behaviour
+
+Structs can be extended with [methods](methods.md), [constructors and destructors](constructors-destructors.md), and
+can implement [interfaces](interfaces.md).


### PR DESCRIPTION
## Summary

Expands seven pages that were previously stubs or had thin coverage:

| Page | What was added |
|---|---|
| `intro.md` | Design goals, target use-cases, first-look code example, next-steps links |
| `functions.md` | Implicit `result` variable, function overloading |
| `generics.md` | Clarified `dyn` vs constrained type declarations, explicit type argument syntax, generic interfaces section |
| `structs.md` | Default field values, public/private field visibility, struct composition via `compose` |
| `methods.md` | Method visibility (`public`), methods on generic structs |
| `aliases.md` | Section distinguishing true `alias` from generic type constraints (`A\|B\|C`) |
| `constructors-destructors.md` | Constructor overloading, copy constructors |

All new code examples are derived from existing test files in the repository.

## Test plan
- [ ] Review all pages render correctly in the docs site (admonitions, code blocks, cross-links)
- [ ] Verify internal cross-links resolve (`declaration-qualifiers.md`, `interfaces.md`, `foreach-loops.md`, etc.)