### PR TITLE
Replace deprecated ccache-action with manual install and cache

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
@@ -43,7 +43,11 @@ jobs:
         uses: rui314/setup-mold@v1
 
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm

--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -38,6 +38,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          mkdir -p ~/.cache/ccache
 
       - name: Setup Mold
         uses: rui314/setup-mold@v1
@@ -45,7 +46,7 @@ jobs:
       - name: Setup CCache
         uses: actions/cache@v5
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -264,7 +264,7 @@ jobs:
 
   build-windows-x86:
     name: C++ CI - Windows/x86_64
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
@@ -43,7 +43,11 @@ jobs:
         uses: rui314/setup-mold@v1
 
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
 #      - name: Setup Valgrind
 #        if: github.event_name == 'pull_request'
@@ -182,7 +186,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build graphviz uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
@@ -191,7 +195,11 @@ jobs:
         uses: rui314/setup-mold@v1
 
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -272,8 +280,17 @@ jobs:
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
 
+      - name: Install Dependencies
+        run: |
+          choco install graphviz ccache -y
+          echo "C:\Program Files\Graphviz\bin" >> $env:GITHUB_PATH
+
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/AppData/Local/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -308,12 +325,6 @@ jobs:
 
       - name: Download Libs
         run: .\setup-deps.bat
-
-      - name: Install Graphviz
-        run: |
-          choco install graphviz -y
-          echo "C:\Program Files\Graphviz\bin" >> $env:GITHUB_PATH
-          dot -V
 
       - name: Build test target
         env:
@@ -363,13 +374,17 @@ jobs:
       - name: Setup Mold
         uses: rui314/setup-mold@v1
 
-      - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
-
       - name: Setup Dependencies
         run: |
           brew update
-          brew install graphviz
+          brew install ccache graphviz
+
+      - name: Setup CCache
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -38,6 +38,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          mkdir -p ~/.cache/ccache
 
       - name: Setup Mold
         uses: rui314/setup-mold@v1
@@ -45,7 +46,7 @@ jobs:
       - name: Setup CCache
         uses: actions/cache@v5
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
@@ -190,6 +191,7 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          mkdir -p ~/.cache/ccache
 
       - name: Setup Mold
         uses: rui314/setup-mold@v1
@@ -197,7 +199,7 @@ jobs:
       - name: Setup CCache
         uses: actions/cache@v5
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
@@ -284,6 +286,7 @@ jobs:
         run: |
           choco install graphviz ccache -y
           echo "C:\Program Files\Graphviz\bin" >> $env:GITHUB_PATH
+          New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
 
       - name: Setup CCache
         uses: actions/cache@v5
@@ -378,11 +381,12 @@ jobs:
         run: |
           brew update
           brew install ccache graphviz
+          mkdir -p ~/.cache/ccache
 
       - name: Setup CCache
         uses: actions/cache@v5
         with:
-          path: ~/Library/Caches/ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -279,12 +279,9 @@ jobs:
           java-version: 25
           java-package: jre
 
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@master
-
       - name: Install Dependencies
         run: |
-          choco install graphviz ccache -y
+          choco install graphviz ccache ninja -y
           echo "C:\Program Files\Graphviz\bin" >> $env:GITHUB_PATH
           New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,17 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build uuid-dev checksec jq gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo apt-get install ccache ninja-build uuid-dev checksec jq gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
 
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -133,13 +137,17 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build uuid-dev checksec jq gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo apt-get install ccache ninja-build uuid-dev checksec jq gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
 
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/.ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -231,8 +239,15 @@ jobs:
       - name: Setup Ninja
         uses: seanmiddleditch/gha-setup-ninja@master
 
+      - name: Setup Dependencies
+        run: choco install ccache -y
+
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/AppData/Local/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -319,8 +334,15 @@ jobs:
       - name: Setup Mold
         uses: rui314/setup-mold@v1
 
+      - name: Setup Dependencies
+        run: brew install ccache
+
       - name: Setup CCache
-        uses: hendrikmuhs/ccache-action@v1
+        uses: actions/cache@v5
+        with:
+          path: ~/Library/Caches/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,11 +36,12 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          mkdir -p ~/.cache/ccache
 
       - name: Setup CCache
         uses: actions/cache@v5
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
@@ -141,11 +142,12 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          mkdir -p ~/.cache/ccache
 
       - name: Setup CCache
         uses: actions/cache@v5
         with:
-          path: ~/.ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
@@ -240,7 +242,9 @@ jobs:
         uses: seanmiddleditch/gha-setup-ninja@master
 
       - name: Setup Dependencies
-        run: choco install ccache -y
+        run: |
+          choco install ccache -y
+          New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
 
       - name: Setup CCache
         uses: actions/cache@v5
@@ -335,12 +339,14 @@ jobs:
         uses: rui314/setup-mold@v1
 
       - name: Setup Dependencies
-        run: brew install ccache
+        run: |
+          brew install ccache
+          mkdir -p ~/.cache/ccache
 
       - name: Setup CCache
         uses: actions/cache@v5
         with:
-          path: ~/Library/Caches/ccache
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -225,7 +225,7 @@ jobs:
 
   build-compiler-windows-x86:
     name: Build compiler - Windows/x86_64
-    runs-on: windows-2025
+    runs-on: windows-2025-vs2026
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -238,12 +238,9 @@ jobs:
           java-version: 25
           java-package: jre
 
-      - name: Setup Ninja
-        uses: seanmiddleditch/gha-setup-ninja@master
-
       - name: Setup Dependencies
         run: |
-          choco install ccache -y
+          choco install ccache ninja -y
           New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
 
       - name: Setup CCache


### PR DESCRIPTION
## What changed
- Removed `hendrikmuhs/ccache-action@v1` from all CI and publish workflows (9 occurrences across `ci-asan.yml`, `ci-cpp.yml`, `publish.yml`)
- Install ccache directly via the platform's package manager (`apt`, `brew`, `choco`) and restore/save the cache directory with `actions/cache@v5`

## Why
The `hendrikmuhs/ccache-action@v1` action runs on Node.js 20, which is deprecated on GitHub Actions runners with forced Node.js 24 starting June 16, 2026 and Node.js 20 removal on September 16, 2026.

## How it was validated
- Workflow files reviewed for correctness
- No functional change to build behaviour; ccache is used identically via `CMAKE_C_COMPILER_LAUNCHER` and `CMAKE_CXX_COMPILER_LAUNCHER`

## Follow-up / known limitations
None — the cache key scheme (`ccache-<os>-<arch>-<sha>` with prefix restore) mirrors what the old action used internally.