### PR TITLE
Skip LLVM clone on cache hit and always save ccache

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -68,7 +68,7 @@ jobs:
 
       - name: Clone LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+        run: rm -rf llvm && git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -215,7 +215,7 @@ jobs:
 
       - name: Clone LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+        run: rm -rf llvm && git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -306,7 +306,7 @@ jobs:
 
       - name: Clone LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+        run: if (Test-Path llvm) { Remove-Item -Recurse -Force llvm }; git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -403,7 +403,7 @@ jobs:
 
       - name: Clone LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+        run: rm -rf llvm && git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -49,6 +49,7 @@ jobs:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
+          save-always: true
 
 #      - name: Setup Valgrind
 #        if: github.event_name == 'pull_request'
@@ -58,15 +59,16 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: sudo pipx install gcovr
 
-      - name: Clone LLVM
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
-
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
+
+      - name: Clone LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -202,16 +204,18 @@ jobs:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Clone LLVM
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+          save-always: true
 
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
-          path: ${{ github.workspace }}/llvm
-          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64-nortti
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64
+
+      - name: Clone LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -291,16 +295,18 @@ jobs:
           path: ~/AppData/Local/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Clone LLVM
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+          save-always: true
 
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-win-x64-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-win-x64
+
+      - name: Clone LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -386,16 +392,18 @@ jobs:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Clone LLVM
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+          save-always: true
 
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64
+
+      - name: Clone LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-all-targets-nozlib-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64-all-targets-nozlib
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -159,7 +159,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64-all-targets-nozlib-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64-all-targets-nozlib
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -258,7 +258,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-win-x64-all-targets-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-win-x64-all-targets
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -355,7 +355,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-all-targets-nortti
+          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-all-targets
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary

- Move `Cache LLVM` before `Clone LLVM` in all four `ci-cpp.yml` jobs so the ~41s git clone is fully skipped on cache hits
- Gate `Clone LLVM` and `Build LLVM` on `steps.cache-llvm.outputs.cache-hit != 'true'`
- Add `save-always: true` to all four CCache steps so partial/failed builds still warm the cache for the next run

## Expected impact

On cache-hit runs (the common case), each job saves ~41s by not cloning the LLVM repo at all.