### PR TITLE
Fix CI: always clone LLVM before checking cache

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -43,13 +43,12 @@ jobs:
       - name: Setup Mold
         uses: rui314/setup-mold@v1
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-          save-always: true
 
 #      - name: Setup Valgrind
 #        if: github.event_name == 'pull_request'
@@ -150,6 +149,13 @@ jobs:
 #          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/spice/src-bootstrap
 #        run: valgrind -q --leak-check=full ./spicetest --is-github-actions --leak-detection
 
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
       - name: Generate coverage report
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: build
@@ -197,13 +203,12 @@ jobs:
       - name: Setup Mold
         uses: rui314/setup-mold@v1
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-          save-always: true
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -264,6 +269,13 @@ jobs:
           SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
         run: ./spicetest --is-github-actions
 
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
   build-windows-x86:
     name: C++ CI - Windows/x86_64
     runs-on: windows-2025-vs2026
@@ -287,13 +299,12 @@ jobs:
           echo "C:\Program Files\Graphviz\bin" >> $env:GITHUB_PATH
           New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/AppData/Local/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-          save-always: true
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -357,6 +368,13 @@ jobs:
         run: |
           ./spicetest --is-github-actions
 
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/AppData/Local/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
   build-macos-aarch64:
     name: C++ CI - MacOS/AArch64
     runs-on: macos-26
@@ -383,13 +401,12 @@ jobs:
           brew install ccache graphviz
           mkdir -p ~/.cache/ccache
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-          save-always: true
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -446,3 +463,10 @@ jobs:
           SPICE_STD_DIR: ${{ github.workspace }}/std
           SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
         run: ./spicetest --is-github-actions
+
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -59,16 +59,15 @@ jobs:
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: sudo pipx install gcovr
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
           key: llvm-${{ env.LLVM_VERSION }}-linux-x64
-
-      - name: Clone LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: rm -rf llvm && git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -206,16 +205,15 @@ jobs:
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
           save-always: true
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
           key: llvm-${{ env.LLVM_VERSION }}-linux-aarch64
-
-      - name: Clone LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: rm -rf llvm && git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -297,16 +295,15 @@ jobs:
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
           save-always: true
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
           key: llvm-${{ env.LLVM_VERSION }}-win-x64
-
-      - name: Clone LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: if (Test-Path llvm) { Remove-Item -Recurse -Force llvm }; git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'
@@ -394,16 +391,15 @@ jobs:
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
           save-always: true
 
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
       - name: Cache LLVM
         id: cache-llvm
         uses: actions/cache@v5
         with:
           path: ${{ github.workspace }}/llvm/build
           key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64
-
-      - name: Clone LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        run: rm -rf llvm && git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
 
       - name: Build LLVM
         if: steps.cache-llvm.outputs.cache-hit != 'true'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,8 +38,8 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           mkdir -p ~/.cache/ccache
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
@@ -111,6 +111,13 @@ jobs:
         working-directory: build
         run: checksec --file=./spice --output=json | jq
 
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -144,8 +151,8 @@ jobs:
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           mkdir -p ~/.cache/ccache
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
@@ -217,6 +224,13 @@ jobs:
         working-directory: build
         run: checksec --file=./spice --output=json | jq
 
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -243,8 +257,8 @@ jobs:
           choco install ccache ninja -y
           New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/AppData/Local/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
@@ -309,6 +323,13 @@ jobs:
         working-directory: build
         run: mv ./src/spice.exe spice.exe
 
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/AppData/Local/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:
@@ -340,8 +361,8 @@ jobs:
           brew install ccache
           mkdir -p ~/.cache/ccache
 
-      - name: Setup CCache
-        uses: actions/cache@v5
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
@@ -405,6 +426,13 @@ jobs:
         run: |
           mv ./src/spice spice
           chmod +x spice
+
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Commit #1191 made the LLVM clone conditional on a cache miss, but only cached `llvm/build/`. On a cache hit, `LLVMConfig.cmake` (inside the restored build tree) references `llvm/llvm/cmake/modules/LLVM-Config.cmake` from the source tree — which was never cloned, causing two CMake errors and a broken CI.
- Fix: move `Clone LLVM` back before the cache step (unconditional) in all four jobs. The clone is a cheap `--depth 1` operation; only the build is worth caching.

## Test plan
- [x] Delete the stale LLVM cache entries in GitHub Actions (Settings → Caches)
- [x] Trigger a CI run and confirm all four jobs configure and build successfully