### PR TITLE
Add typename builtin returning the type name as string

### DIFF
--- a/docs/docs/language/builtins.md
+++ b/docs/docs/language/builtins.md
@@ -2,7 +2,7 @@
 title: Builtin Functions
 ---
 
-Spice offers seven builtin functions out of the box. Those can be used anywhere without having to be imported manually and
+Spice offers eight builtin functions out of the box. Those can be used anywhere without having to be imported manually and
 can be used to establish a minimal setup for testing or the like.
 
 ## The `printf` builtin
@@ -100,6 +100,24 @@ typeid<int>() // 1015829715
 DemoStruct s = DemoStruct{123, 56l, 12s, "String"};
 typeid(s); // 1502876624
 typeid<DemoStruct>(); // 1502876624
+```
+
+## The `typename` builtin
+Typename returns the name of the type of a variable, constant or type as string.
+
+### Signature
+`string typename(<any variable or constant>)` or `string typename<any type>()`
+
+`any variable`: Variable or constant of any type, `any type`: Any data type
+
+### Usage example
+```spice
+typename(12); // "int"
+typename<int>() // "int"
+
+DemoStruct s = DemoStruct{123, 56l, 12s, "String"};
+typename(s); // "DemoStruct"
+typename<DemoStruct>(); // "DemoStruct"
 ```
 
 ## The `len` builtin

--- a/src/typechecker/Builtins.h
+++ b/src/typechecker/Builtins.h
@@ -35,6 +35,7 @@ static constexpr std::string_view BUILTIN_FCT_NAME_PRINTF = "printf";
 static constexpr std::string_view BUILTIN_FCT_NAME_SIZEOF = "sizeof";
 static constexpr std::string_view BUILTIN_FCT_NAME_ALIGNOF = "alignof";
 static constexpr std::string_view BUILTIN_FCT_NAME_TYPEID = "typeid";
+static constexpr std::string_view BUILTIN_FCT_NAME_TYPENAME = "typename";
 static constexpr std::string_view BUILTIN_FCT_NAME_LEN = "len";
 static constexpr std::string_view BUILTIN_FCT_NAME_PANIC = "panic";
 static constexpr std::string_view BUILTIN_FCT_NAME_SYSCALL = "syscall";
@@ -89,6 +90,15 @@ static constexpr std::array BUILTIN_FUNCTIONS = {
         BUILTIN_FCT_NAME_TYPEID,
         BuiltinFunctionInfo{
             .typeCheckerVisitMethod = &TypeChecker::visitBuiltinTypeIdCall,
+            .maxTemplateTypes = 1,
+            .maxArgTypes = 1,
+            .allTemplateTypesOrAllArgTypes = true,
+        },
+    },
+    BuiltinFunctionEntry{
+        BUILTIN_FCT_NAME_TYPENAME,
+        BuiltinFunctionInfo{
+            .typeCheckerVisitMethod = &TypeChecker::visitBuiltinTypeNameCall,
             .maxTemplateTypes = 1,
             .maxArgTypes = 1,
             .allTemplateTypesOrAllArgTypes = true,

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -130,6 +130,7 @@ public:
   std::any visitBuiltinAlignOfCall(FctCallNode *node) const;
   std::any visitBuiltinOffsetOfCall(FctCallNode *node) const;
   std::any visitBuiltinTypeIdCall(FctCallNode *node) const;
+  std::any visitBuiltinTypeNameCall(FctCallNode *node) const;
   std::any visitBuiltinLenCall(FctCallNode *node) const;
   std::any visitBuiltinPanicCall(FctCallNode *node) const;
   std::any visitBuiltinSyscallCall(FctCallNode *node) const;

--- a/src/typechecker/TypeCheckerBuiltinFunctions.cpp
+++ b/src/typechecker/TypeCheckerBuiltinFunctions.cpp
@@ -299,6 +299,23 @@ std::any TypeChecker::visitBuiltinTypeIdCall(FctCallNode *node) const {
   return ExprResult{node->setEvaluatedSymbolType(QualType(TY_LONG), manIdx)};
 }
 
+std::any TypeChecker::visitBuiltinTypeNameCall(FctCallNode *node) const {
+  assert(node->fqFunctionName == BUILTIN_FCT_NAME_TYPENAME);
+
+  // Directly set compile time value here, so that compile time ifs can be evaluated.
+  QualType qualType;
+  if (node->hasTemplateTypes) { // typename of type
+    qualType = node->templateTypeLst->dataTypes.front()->getEvaluatedSymbolType(manIdx);
+  } else { // typename of value
+    qualType = node->argLst->args.front()->getEvaluatedSymbolType(manIdx);
+  }
+  const size_t stringValueOffset = resourceManager.compileTimeStringValues.size();
+  resourceManager.compileTimeStringValues.push_back(qualType.getName());
+  node->data.at(manIdx).setCompileTimeValue({.stringValueOffset = stringValueOffset});
+
+  return ExprResult{node->setEvaluatedSymbolType(QualType(TY_STRING), manIdx)};
+}
+
 std::any TypeChecker::visitBuiltinLenCall(FctCallNode *node) const {
   assert(node->fqFunctionName == BUILTIN_FCT_NAME_LEN);
 

--- a/test/test-files/irgenerator/builtins/success-typename/cout.out
+++ b/test/test-files/irgenerator/builtins/success-typename/cout.out
@@ -1,0 +1,4 @@
+int
+int
+DemoStruct
+DemoStruct

--- a/test/test-files/irgenerator/builtins/success-typename/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-typename/ir-code.ll
@@ -1,0 +1,42 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+
+%struct.DemoStruct = type { i32, i64 }
+
+@printf.str.0 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 4
+@anon.string.0 = private unnamed_addr constant [4 x i8] c"int\00", align 4
+@printf.str.1 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 4
+@anon.string.1 = private unnamed_addr constant [4 x i8] c"int\00", align 4
+@printf.str.2 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 4
+@anon.string.2 = private unnamed_addr constant [11 x i8] c"DemoStruct\00", align 4
+@printf.str.3 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 4
+@anon.string.3 = private unnamed_addr constant [11 x i8] c"DemoStruct\00", align 4
+
+; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
+define dso_local noundef i32 @main() #0 {
+  %result = alloca i32, align 4
+  %s = alloca %struct.DemoStruct, align 8
+  store i32 0, ptr %result, align 4
+  %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr noundef @anon.string.0)
+  %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr noundef @anon.string.1)
+  store %struct.DemoStruct { i32 123, i64 56 }, ptr %s, align 8
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, ptr noundef @anon.string.2)
+  %4 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.3, ptr noundef @anon.string.3)
+  %5 = load i32, ptr %result, align 4
+  ret i32 %5
+}
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
+
+attributes #0 = { mustprogress noinline norecurse nounwind optnone uwtable }
+attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-typename/source.spice
+++ b/test/test-files/irgenerator/builtins/success-typename/source.spice
@@ -1,0 +1,13 @@
+type DemoStruct struct {
+    int intField
+    long longField
+}
+
+f<int> main() {
+    printf("%s\n", typename(4));
+    printf("%s\n", typename<int>());
+
+    DemoStruct s = DemoStruct{123, 56l};
+    printf("%s\n", typename(s));
+    printf("%s\n", typename<DemoStruct>());
+}

--- a/test/test-files/typechecker/builtins/error-typename/exception.out
+++ b/test/test-files/typechecker/builtins/error-typename/exception.out
@@ -1,0 +1,26 @@
+[Error|Compiler]:
+Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
+
+[Error|Semantic] ./source.spice:2:5:
+Builtin function signature mismatch: This builtin expects either template types or arguments, but got none
+
+2  typename(); // No template typ
+   ^^^^^^^^^^
+
+[Error|Semantic] ./source.spice:3:5:
+Builtin function signature mismatch: This builtin expects either template types or arguments, but got both
+
+3  typename<short>(8s); // Template types 
+   ^^^^^^^^^^^^^^^^^^^
+
+[Error|Semantic] ./source.spice:4:5:
+Builtin function template type count mismatch: This builtin expects between 0 and 1 template type(s) template type(s), but got 2
+
+4  typename<double, int>(); // Too many templa
+   ^^^^^^^^^^^^^^^^^^^^^^^
+
+[Error|Semantic] ./source.spice:5:5:
+Builtin function argument count mismatch: This builtin expects between 0 and 1 argument(s) argument(s), but got 2
+
+5  typename(1, 2); // Too many args
+   ^^^^^^^^^^^^^^

--- a/test/test-files/typechecker/builtins/error-typename/source.spice
+++ b/test/test-files/typechecker/builtins/error-typename/source.spice
@@ -1,0 +1,6 @@
+f<int> main() {
+    typename(); // No template types and no args
+    typename<short>(8s); // Template types and args
+    typename<double, int>(); // Too many template types
+    typename(1, 2); // Too many args
+}


### PR DESCRIPTION
## What changed
- Add a new `typename` builtin that returns the name of a variable, constant, or type as a `string` (e.g. `typename<int>()` → `"int"`, `typename(demoStruct)` → `"DemoStruct"`).
- Mirror the existing `typeid` builtin's shape: accepts either one template type *or* one argument; resolves entirely at compile time (stores a compile-time string constant), so it also works inside compile-time `if`s and needs no runtime IR-generator delegate.
- Document the builtin in `docs/docs/language/builtins.md` (and bump the intro count from seven to eight).
- Add success (irgenerator) and error (typechecker) reference tests.

## Why
Companion to `typeid` for cases where a human-readable type name is wanted (debugging, logging, reflection-like helpers) rather than an opaque numeric hash.

## How it was validated
- `spicetest --gtest_filter='*successTypename*:*errorTypename*'` — both pass
- Manually ran a scratch program: `typename(4)` → `int`, `typename<int>()` → `int`, `typename(demoStruct)` → `DemoStruct`, `typename<double>()` → `double`, `typename<int*>()` → `int*`
- Confirmed generated `ir-code.ll` emits the expected string global constants

## Follow-up / known limitations
- The self-hosted bootstrap compiler (`src-bootstrap/`) was intentionally left untouched, as it is a WIP port.
- This environment has ~208 pre-existing, unrelated test failures (bootstrap, cross-compile, foreach); verified via `git stash` that they fail identically without this change.