### PR TITLE
Split CSV/JSON/XML std modules into separate parser and serializer files

### DIFF
--- a/LLVMOptions.cmake
+++ b/LLVMOptions.cmake
@@ -44,6 +44,16 @@ list(APPEND LLVM_COMPONENTS mcjit target nativecodegen passes)
 # Map components to library names
 llvm_map_components_to_libnames(LLVM_LIBS ${LLVM_COMPONENTS})
 
+# Link every target compiled into the LLVM distribution, since the
+# InitializeAll* entry points reference all of them
+foreach (LLVM_TARGET ${LLVM_TARGETS_TO_BUILD})
+    foreach (LLVM_TARGET_LIB_KIND CodeGen AsmParser Desc Info Utils Disassembler)
+        if (EXISTS "${LLVM_LIBRARY_DIR}/libLLVM${LLVM_TARGET}${LLVM_TARGET_LIB_KIND}.a")
+            list(APPEND LLVM_LIBS "LLVM${LLVM_TARGET}${LLVM_TARGET_LIB_KIND}")
+        endif ()
+    endforeach ()
+endforeach ()
+
 # Print status messages
 string(JOIN "," LLVM_TARGET_ARCHITECTURES_JOINED ${LLVM_TARGET_ARCHITECTURES})
 message(STATUS "Spice: Enabled targets: ${LLVM_TARGET_ARCHITECTURES_JOINED}")

--- a/std/README.md
+++ b/std/README.md
@@ -131,14 +131,16 @@ Basic mechanisms for testing in Spice.
 ### `std/text`
 Text processing, parsing, and formatted output.
 
-| Module                                      | Description                     |
-|---------------------------------------------|---------------------------------|
-| `print`                                     | Formatted printing helpers.     |
-| `format`                                    | String formatting.              |
-| `stringstream`                              | Stream-style string building.   |
-| `string-ext`                                | Extra string utility functions. |
-| `analysis`                                  | Text analysis helpers.          |
-| `csv-parser` / `json-parser` / `xml-parser` | Parsers for CSV, JSON, and XML. |
+| Module                                                  | Description                                        |
+|---------------------------------------------------------|----------------------------------------------------|
+| `print`                                                 | Formatted printing helpers.                        |
+| `format`                                                | String formatting.                                 |
+| `stringstream`                                          | Stream-style string building.                      |
+| `string-ext`                                            | Extra string utility functions.                    |
+| `analysis`                                              | Text analysis helpers.                             |
+| `csv-parser` / `json-parser` / `xml-parser`             | Parsers for CSV, JSON, and XML.                    |
+| `csv-serializer` / `json-serializer` / `xml-serializer` | Serializers for CSV, JSON, and XML.                |
+| `json-value` / `xml-node`                               | Data models shared by the parsers and serializers. |
 
 ### `std/time`
 Accessing system time in different formats and measuring durations.

--- a/std/text/csv-parser.spice
+++ b/std/text/csv-parser.spice
@@ -10,6 +10,8 @@ const char DEFAULT_QUOTE     = '"';
  * Supports quoted fields, embedded delimiters/newlines and escaped quotes
  * (by doubling, e.g. `""` inside a quoted field yields a single `"`).
  * Both `\n` and `\r\n` are accepted as line terminators.
+ *
+ * The matching serializer lives in "std/text/csv-serializer".
  */
 public type CsvParser struct {
     char delimiter
@@ -136,75 +138,4 @@ public f<Vector<Vector<String>>> CsvParser.parse(const String& input) {
         // Drop the trailing empty row created after the last terminator
         result.removeAt(result.getSize() - 1l);
     }
-}
-
-/**
- * Serializes a single field, quoting it when necessary.
- *
- * A field is wrapped in quotes when it contains the delimiter, the quote
- * character or a line terminator. Embedded quotes are escaped by doubling,
- * so the result round-trips through `parseLine`/`parse`. The empty field is
- * also quoted (as `""`): an empty record would otherwise serialize to an
- * empty line, which `parse` does not reproduce as a row.
- *
- * @param field Field value to serialize
- * @return Serialized (and possibly quoted) field
- */
-public f<String> CsvParser.serializeField(const String& field) {
-    const unsigned long length = field.getLength();
-    bool needsQuoting = length == 0l;
-    for unsigned long i = 0l; i < length; i++ {
-        const char c = field[i];
-        if c == this.delimiter || c == this.quote || c == '\n' || c == '\r' {
-            needsQuoting = true;
-            break;
-        }
-    }
-    if !needsQuoting { return field; }
-
-    String out;
-    out += this.quote;
-    for unsigned long i = 0l; i < length; i++ {
-        const char c = field[i];
-        if c == this.quote {
-            // Escape by doubling the quote character
-            out += this.quote;
-        }
-        out += c;
-    }
-    out += this.quote;
-    return out;
-}
-
-/**
- * Serializes a single row into one CSV record. Fields are separated by the
- * configured delimiter; no trailing line terminator is appended.
- *
- * @param row Fields of the record
- * @return Serialized CSV record
- */
-public f<String> CsvParser.serializeRow(const Vector<String>& row) {
-    String out;
-    for unsigned long i = 0l; i < row.getSize(); i++ {
-        if i > 0l { out += this.delimiter; }
-        out += this.serializeField(row.get(i));
-    }
-    return out;
-}
-
-/**
- * Serializes a whole document into CSV text. Records are separated by `\r\n`
- * as recommended by RFC 4180; no trailing line terminator is appended, so
- * `parse(serialize(rows))` reproduces the input rows.
- *
- * @param rows Rows of the document
- * @return Serialized CSV document
- */
-public f<String> CsvParser.serialize(const Vector<Vector<String>>& rows) {
-    String out;
-    for unsigned long i = 0l; i < rows.getSize(); i++ {
-        if i > 0l { out += "\r\n"; }
-        out += this.serializeRow(rows.get(i));
-    }
-    return out;
 }

--- a/std/text/csv-serializer.spice
+++ b/std/text/csv-serializer.spice
@@ -1,0 +1,99 @@
+import "std/data/vector";
+
+// Default control characters (RFC 4180)
+const char DEFAULT_DELIMITER = ',';
+const char DEFAULT_QUOTE     = '"';
+
+/**
+ * Serializer for CSV (comma-separated values) output.
+ *
+ * Fields are quoted when necessary and embedded quotes are escaped by
+ * doubling, so the output round-trips through the CsvParser from
+ * "std/text/csv-parser" when both use the same control characters.
+ */
+public type CsvSerializer struct {
+    char delimiter
+    char quote
+}
+
+/**
+ * Construct a CSV serializer with the given control characters
+ *
+ * @param delimiter Field delimiter character
+ * @param quote Quote character used to wrap fields
+ */
+public p CsvSerializer.ctor(char delimiter = DEFAULT_DELIMITER, char quote = DEFAULT_QUOTE) {
+    this.delimiter = delimiter;
+    this.quote = quote;
+}
+
+/**
+ * Serializes a single field, quoting it when necessary.
+ *
+ * A field is wrapped in quotes when it contains the delimiter, the quote
+ * character or a line terminator. Embedded quotes are escaped by doubling,
+ * so the result round-trips through `parseLine`/`parse`. The empty field is
+ * also quoted (as `""`): an empty record would otherwise serialize to an
+ * empty line, which `parse` does not reproduce as a row.
+ *
+ * @param field Field value to serialize
+ * @return Serialized (and possibly quoted) field
+ */
+public f<String> CsvSerializer.serializeField(const String& field) {
+    const unsigned long length = field.getLength();
+    bool needsQuoting = length == 0l;
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = field[i];
+        if c == this.delimiter || c == this.quote || c == '\n' || c == '\r' {
+            needsQuoting = true;
+            break;
+        }
+    }
+    if !needsQuoting { return field; }
+
+    String out;
+    out += this.quote;
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = field[i];
+        if c == this.quote {
+            // Escape by doubling the quote character
+            out += this.quote;
+        }
+        out += c;
+    }
+    out += this.quote;
+    return out;
+}
+
+/**
+ * Serializes a single row into one CSV record. Fields are separated by the
+ * configured delimiter; no trailing line terminator is appended.
+ *
+ * @param row Fields of the record
+ * @return Serialized CSV record
+ */
+public f<String> CsvSerializer.serializeRow(const Vector<String>& row) {
+    String out;
+    for unsigned long i = 0l; i < row.getSize(); i++ {
+        if i > 0l { out += this.delimiter; }
+        out += this.serializeField(row.get(i));
+    }
+    return out;
+}
+
+/**
+ * Serializes a whole document into CSV text. Records are separated by `\r\n`
+ * as recommended by RFC 4180; no trailing line terminator is appended, so
+ * `parse(serialize(rows))` reproduces the input rows.
+ *
+ * @param rows Rows of the document
+ * @return Serialized CSV document
+ */
+public f<String> CsvSerializer.serialize(const Vector<Vector<String>>& rows) {
+    String out;
+    for unsigned long i = 0l; i < rows.getSize(); i++ {
+        if i > 0l { out += "\r\n"; }
+        out += this.serializeRow(rows.get(i));
+    }
+    return out;
+}

--- a/std/text/json-parser.spice
+++ b/std/text/json-parser.spice
@@ -1,236 +1,15 @@
-import "std/data/vector";
+import "std/text/json-value";
 import "std/text/analysis";
 import "std/type/type-conversion";
-
-/**
- * Tag for the variant stored inside a JsonValue.
- */
-public type JsonValueKind enum {
-    JSON_NULL,
-    JSON_BOOL,
-    JSON_NUMBER,
-    JSON_STRING,
-    JSON_ARRAY,
-    JSON_OBJECT
-}
-
-/**
- * Represents a single JSON value.
- *
- * Composite values (arrays and objects) own their children as heap pointers,
- * so a JsonValue is always reached via `heap JsonValue*` once it has been
- * parsed. Numbers are stored as `double`; integers are representable up to
- * 2^53. Object fields preserve insertion order.
- */
-public type JsonValue struct {
-    JsonValueKind kind
-    bool boolValue
-    double numberValue
-    String stringValue
-    Vector<JsonValue*> arrayItems
-    Vector<String> objectKeys
-    Vector<JsonValue*> objectValues
-}
-
-/**
- * Construct a JSON null value
- */
-public p JsonValue.ctor() {
-    this.kind = JsonValueKind::JSON_NULL;
-}
-
-/**
- * Construct a JSON boolean value
- *
- * @param value Boolean value
- */
-public p JsonValue.ctor(bool value) {
-    this.kind = JsonValueKind::JSON_BOOL;
-    this.boolValue = value;
-}
-
-/**
- * Construct a JSON number value
- *
- * @param value Number value
- */
-public p JsonValue.ctor(double value) {
-    this.kind = JsonValueKind::JSON_NUMBER;
-    this.numberValue = value;
-}
-
-/**
- * Construct a JSON string value
- *
- * @param value String value
- */
-public p JsonValue.ctor(const String& value) {
-    this.kind = JsonValueKind::JSON_STRING;
-    this.stringValue = value;
-}
-
-// --- Kind inspection -------------------------------------------------------
-
-/**
- * Retrieve the kind of the JSON value
- *
- * @return Kind of the value
- */
-public f<JsonValueKind> JsonValue.getKind() { return this.kind; }
-/**
- * Check whether the JSON value is null
- *
- * @return true if the value is null, false otherwise
- */
-public f<bool> JsonValue.isNull()   { return this.kind == JsonValueKind::JSON_NULL; }
-/**
- * Check whether the JSON value is a boolean
- *
- * @return true if the value is a boolean, false otherwise
- */
-public f<bool> JsonValue.isBool()   { return this.kind == JsonValueKind::JSON_BOOL; }
-/**
- * Check whether the JSON value is a number
- *
- * @return true if the value is a number, false otherwise
- */
-public f<bool> JsonValue.isNumber() { return this.kind == JsonValueKind::JSON_NUMBER; }
-/**
- * Check whether the JSON value is a string
- *
- * @return true if the value is a string, false otherwise
- */
-public f<bool> JsonValue.isString() { return this.kind == JsonValueKind::JSON_STRING; }
-/**
- * Check whether the JSON value is an array
- *
- * @return true if the value is an array, false otherwise
- */
-public f<bool> JsonValue.isArray()  { return this.kind == JsonValueKind::JSON_ARRAY; }
-/**
- * Check whether the JSON value is an object
- *
- * @return true if the value is an object, false otherwise
- */
-public f<bool> JsonValue.isObject() { return this.kind == JsonValueKind::JSON_OBJECT; }
-
-// --- Scalar accessors (panic on wrong kind) --------------------------------
-
-/**
- * Retrieve the boolean payload. Panics if the value is not a boolean.
- *
- * @return Boolean value
- */
-public f<bool> JsonValue.getBool() {
-    assert this.kind == JsonValueKind::JSON_BOOL;
-    return this.boolValue;
-}
-
-/**
- * Retrieve the number payload. Panics if the value is not a number.
- *
- * @return Number value
- */
-public f<double> JsonValue.getNumber() {
-    assert this.kind == JsonValueKind::JSON_NUMBER;
-    return this.numberValue;
-}
-
-/**
- * Retrieve the string payload. Panics if the value is not a string.
- *
- * @return String value
- */
-public f<const String&> JsonValue.getString() {
-    assert this.kind == JsonValueKind::JSON_STRING;
-    return this.stringValue;
-}
-
-// --- Array operations ------------------------------------------------------
-
-/**
- * Retrieve the number of items in the array. Panics if the value is not an array.
- *
- * @return Number of array items
- */
-public f<unsigned long> JsonValue.getArraySize() {
-    assert this.kind == JsonValueKind::JSON_ARRAY;
-    return this.arrayItems.getSize();
-}
-
-/**
- * Retrieve the array item at the given index. Panics if the value is not an array.
- *
- * @param idx Index of the item
- * @return Pointer to the array item
- */
-public f<JsonValue*> JsonValue.getArrayItem(unsigned long idx) {
-    assert this.kind == JsonValueKind::JSON_ARRAY;
-    return this.arrayItems.get(idx);
-}
-
-/**
- * Retrieve the array item at the given index. Panics if the value is not an array.
- *
- * @param idx Index of the item
- * @return Pointer to the array item
- */
-public f<JsonValue*> JsonValue.getArrayItem(unsigned int idx) {
-    return this.getArrayItem(cast<unsigned long>(idx));
-}
-
-// --- Object operations -----------------------------------------------------
-
-/**
- * Retrieve the number of fields in the object. Panics if the value is not an object.
- *
- * @return Number of object fields
- */
-public f<unsigned long> JsonValue.getObjectSize() {
-    assert this.kind == JsonValueKind::JSON_OBJECT;
-    return this.objectKeys.getSize();
-}
-
-/**
- * Check whether the object contains a field with the given key
- *
- * @param key Field key to look for
- * @return true if the field exists, false otherwise
- */
-public f<bool> JsonValue.hasField(string key) {
-    if this.kind != JsonValueKind::JSON_OBJECT { return false; }
-    const String keyStr = String(key);
-    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
-        if this.objectKeys.get(i) == keyStr { return true; }
-    }
-    return false;
-}
-
-/**
- * Retrieve the value of the object field with the given key. Panics if the value is not an object
- * or the field does not exist.
- *
- * @param key Field key to look up
- * @return Pointer to the field value
- */
-public f<JsonValue*> JsonValue.getField(string key) {
-    assert this.kind == JsonValueKind::JSON_OBJECT;
-    const String keyStr = String(key);
-    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
-        if this.objectKeys.get(i) == keyStr {
-            return this.objectValues.get(i);
-        }
-    }
-    panic(Error("JSON object has no such field"));
-}
-
-// --- Parser ----------------------------------------------------------------
 
 /**
  * Recursive-descent JSON parser.
  *
  * Use `parseJson` for one-shot parsing; the struct is exposed mainly so the
  * parser state (position, error message) can be inspected when needed.
+ *
+ * The JsonValue data model lives in "std/text/json-value" and serialization
+ * in "std/text/json-serializer".
  */
 public type JsonParser struct {
     String input
@@ -444,8 +223,7 @@ f<String> JsonParser.parseStringLiteral() {
 
 f<JsonValue*> JsonParser.parseArray() {
     this.pos++; // consume '['
-    heap JsonValue* arr = __new<JsonValue>();
-    arr.kind = JsonValueKind::JSON_ARRAY;
+    heap JsonValue* arr = __new<JsonValue>(JsonValueKind::JSON_ARRAY);
     this.skipWhitespace();
     if this.pos < this.input.getLength() && this.input[this.pos] == ']' {
         this.pos++;
@@ -455,7 +233,7 @@ f<JsonValue*> JsonParser.parseArray() {
         this.skipWhitespace();
         JsonValue* item = this.parseValue();
         if this.hasError { return nil<JsonValue*>; }
-        arr.arrayItems.pushBack(item);
+        arr.addArrayItem(item);
         this.skipWhitespace();
         if this.pos >= this.input.getLength() {
             this.fail("Unterminated array");
@@ -478,8 +256,7 @@ f<JsonValue*> JsonParser.parseArray() {
 
 f<JsonValue*> JsonParser.parseObject() {
     this.pos++; // consume '{'
-    heap JsonValue* obj = __new<JsonValue>();
-    obj.kind = JsonValueKind::JSON_OBJECT;
+    heap JsonValue* obj = __new<JsonValue>(JsonValueKind::JSON_OBJECT);
     this.skipWhitespace();
     if this.pos < this.input.getLength() && this.input[this.pos] == '}' {
         this.pos++;
@@ -502,8 +279,7 @@ f<JsonValue*> JsonParser.parseObject() {
         this.skipWhitespace();
         JsonValue* value = this.parseValue();
         if this.hasError { return nil<JsonValue*>; }
-        obj.objectKeys.pushBack(key);
-        obj.objectValues.pushBack(value);
+        obj.addObjectField(key, value);
         this.skipWhitespace();
         if this.pos >= this.input.getLength() {
             this.fail("Unterminated object");
@@ -522,131 +298,4 @@ f<JsonValue*> JsonParser.parseObject() {
         return nil<JsonValue*>;
     }
     return nil<JsonValue*>;
-}
-
-// --- Serialization ---------------------------------------------------------
-
-ext f<int> snprintf(char*, unsigned long, string, ...);
-
-/**
- * Serializes this value into a compact JSON string (no insignificant
- * whitespace). The result round-trips through `parseJson`.
- *
- * @return Compact JSON representation
- */
-public f<String> JsonValue.serialize() {
-    String out;
-    this.serializeInto(out, false, 0l);
-    return out;
-}
-
-/**
- * Serializes this value into a human-readable JSON string using two-space
- * indentation for nested arrays and objects.
- *
- * @return Pretty-printed JSON representation
- */
-public f<String> JsonValue.serializePretty() {
-    String out;
-    this.serializeInto(out, true, 0l);
-    return out;
-}
-
-p JsonValue.serializeInto(String& out, bool pretty, unsigned long depth) {
-    if this.kind == JsonValueKind::JSON_NULL {
-        out += "null";
-    } else if this.kind == JsonValueKind::JSON_BOOL {
-        out += this.boolValue ? "true" : "false";
-    } else if this.kind == JsonValueKind::JSON_NUMBER {
-        out += serializeJsonNumber(this.numberValue);
-    } else if this.kind == JsonValueKind::JSON_STRING {
-        serializeJsonString(out, this.stringValue);
-    } else if this.kind == JsonValueKind::JSON_ARRAY {
-        const unsigned long size = this.arrayItems.getSize();
-        if size == 0l {
-            out += "[]";
-            return;
-        }
-        out += '[';
-        for unsigned long i = 0l; i < size; i++ {
-            if i > 0l { out += ','; }
-            if pretty { appendJsonNewlineIndent(out, depth + 1l); }
-            JsonValue* item = this.arrayItems.get(i);
-            item.serializeInto(out, pretty, depth + 1l);
-        }
-        if pretty { appendJsonNewlineIndent(out, depth); }
-        out += ']';
-    } else {
-        const unsigned long size = this.objectKeys.getSize();
-        if size == 0l {
-            out += "{}";
-            return;
-        }
-        out += '{';
-        for unsigned long i = 0l; i < size; i++ {
-            if i > 0l { out += ','; }
-            if pretty { appendJsonNewlineIndent(out, depth + 1l); }
-            serializeJsonString(out, this.objectKeys.get(i));
-            out += pretty ? ": " : ":";
-            JsonValue* value = this.objectValues.get(i);
-            value.serializeInto(out, pretty, depth + 1l);
-        }
-        if pretty { appendJsonNewlineIndent(out, depth); }
-        out += '}';
-    }
-}
-
-// Append a newline followed by `depth` levels of two-space indentation.
-p appendJsonNewlineIndent(String& out, unsigned long depth) {
-    out += '\n';
-    for unsigned long i = 0l; i < depth; i++ {
-        out += "  ";
-    }
-}
-
-// Serialize a string value with surrounding quotes and JSON escaping.
-p serializeJsonString(String& out, const String& value) {
-    out += '"';
-    const unsigned long length = value.getLength();
-    for unsigned long i = 0l; i < length; i++ {
-        const char c = value[i];
-        if c == '"' {
-            out += "\\\"";
-        } else if c == '\\' {
-            out += "\\\\";
-        } else if c == '\n' {
-            out += "\\n";
-        } else if c == '\r' {
-            out += "\\r";
-        } else if c == '\t' {
-            out += "\\t";
-        } else if c == '\b' {
-            out += "\\b";
-        } else if c == '\f' {
-            out += "\\f";
-        } else if cast<int>(c) < 0x20 {
-            // Other control characters are emitted as \u00XX escapes
-            string hexDigits = "0123456789abcdef";
-            const int code = cast<int>(c);
-            out += "\\u00";
-            out += hexDigits[(code >> 4) & 0xF];
-            out += hexDigits[code & 0xF];
-        } else {
-            out += c;
-        }
-    }
-    out += '"';
-}
-
-// Serialize a number, printing integral values without a fractional part.
-// Non-integral values use 17 significant digits ("%.17g"), which is enough to
-// round-trip any double exactly so reparsing yields the same numeric value.
-f<String> serializeJsonNumber(double value) {
-    const long asLong = cast<long>(value);
-    if cast<double>(asLong) == value {
-        return toString(asLong);
-    }
-    const int length = snprintf(nil<char*>, 0l, "%.17g", value);
-    result = String(length);
-    snprintf(cast<char*>(result.getRaw()), cast<unsigned long>(length + 1), "%.17g", value);
 }

--- a/std/text/json-serializer.spice
+++ b/std/text/json-serializer.spice
@@ -4,62 +4,53 @@ import "std/type/type-conversion";
 ext f<int> snprintf(char*, unsigned long, string, ...);
 
 /**
- * Serializes a JSON value into a compact JSON string (no insignificant
- * whitespace). The result round-trips through `parseJson` from
- * "std/text/json-parser".
+ * Serializer for JSON output.
+ *
+ * In compact mode (the default) the output contains no insignificant
+ * whitespace. In pretty mode nested arrays and objects are laid out with
+ * two-space indentation. Either way the result round-trips through
+ * `parseJson` from "std/text/json-parser".
+ */
+public type JsonSerializer struct {
+    bool pretty
+}
+
+/**
+ * Construct a JSON serializer
+ *
+ * @param pretty Emit human-readable output with two-space indentation
+ */
+public p JsonSerializer.ctor(bool pretty = false) {
+    this.pretty = pretty;
+}
+
+/**
+ * Serializes a JSON value into a JSON string
  *
  * @param value JSON value to serialize
- * @return Compact JSON representation
+ * @return JSON representation
  */
-public f<String> serializeJson(JsonValue& value) {
+public f<String> JsonSerializer.serialize(JsonValue& value) {
     String out;
-    serializeJsonInto(&value, out, false, 0l);
+    this.serializeInto(&value, out, 0l);
     return out;
 }
 
 /**
- * Serializes a JSON value into a compact JSON string (no insignificant
- * whitespace). The result round-trips through `parseJson` from
- * "std/text/json-parser".
+ * Serializes a JSON value into a JSON string
  *
  * @param value JSON value to serialize
- * @return Compact JSON representation
+ * @return JSON representation
  */
-public f<String> serializeJson(JsonValue* value) {
+public f<String> JsonSerializer.serialize(JsonValue* value) {
     String out;
-    serializeJsonInto(value, out, false, 0l);
-    return out;
-}
-
-/**
- * Serializes a JSON value into a human-readable JSON string using two-space
- * indentation for nested arrays and objects.
- *
- * @param value JSON value to serialize
- * @return Pretty-printed JSON representation
- */
-public f<String> serializeJsonPretty(JsonValue& value) {
-    String out;
-    serializeJsonInto(&value, out, true, 0l);
-    return out;
-}
-
-/**
- * Serializes a JSON value into a human-readable JSON string using two-space
- * indentation for nested arrays and objects.
- *
- * @param value JSON value to serialize
- * @return Pretty-printed JSON representation
- */
-public f<String> serializeJsonPretty(JsonValue* value) {
-    String out;
-    serializeJsonInto(value, out, true, 0l);
+    this.serializeInto(value, out, 0l);
     return out;
 }
 
 // --- Internal serializer helpers --------------------------------------------
 
-p serializeJsonInto(JsonValue* value, String& out, bool pretty, unsigned long depth) {
+p JsonSerializer.serializeInto(JsonValue* value, String& out, unsigned long depth) {
     const JsonValueKind kind = value.getKind();
     if kind == JsonValueKind::JSON_NULL {
         out += "null";
@@ -78,10 +69,10 @@ p serializeJsonInto(JsonValue* value, String& out, bool pretty, unsigned long de
         out += '[';
         for unsigned long i = 0l; i < size; i++ {
             if i > 0l { out += ','; }
-            if pretty { appendJsonNewlineIndent(out, depth + 1l); }
-            serializeJsonInto(value.getArrayItem(i), out, pretty, depth + 1l);
+            if this.pretty { appendJsonNewlineIndent(out, depth + 1l); }
+            this.serializeInto(value.getArrayItem(i), out, depth + 1l);
         }
-        if pretty { appendJsonNewlineIndent(out, depth); }
+        if this.pretty { appendJsonNewlineIndent(out, depth); }
         out += ']';
     } else {
         const unsigned long size = value.getObjectSize();
@@ -92,12 +83,12 @@ p serializeJsonInto(JsonValue* value, String& out, bool pretty, unsigned long de
         out += '{';
         for unsigned long i = 0l; i < size; i++ {
             if i > 0l { out += ','; }
-            if pretty { appendJsonNewlineIndent(out, depth + 1l); }
+            if this.pretty { appendJsonNewlineIndent(out, depth + 1l); }
             serializeJsonString(out, value.getObjectKey(i));
-            out += pretty ? ": " : ":";
-            serializeJsonInto(value.getObjectValue(i), out, pretty, depth + 1l);
+            out += this.pretty ? ": " : ":";
+            this.serializeInto(value.getObjectValue(i), out, depth + 1l);
         }
-        if pretty { appendJsonNewlineIndent(out, depth); }
+        if this.pretty { appendJsonNewlineIndent(out, depth); }
         out += '}';
     }
 }

--- a/std/text/json-serializer.spice
+++ b/std/text/json-serializer.spice
@@ -1,0 +1,158 @@
+import "std/text/json-value";
+import "std/type/type-conversion";
+
+ext f<int> snprintf(char*, unsigned long, string, ...);
+
+/**
+ * Serializes a JSON value into a compact JSON string (no insignificant
+ * whitespace). The result round-trips through `parseJson` from
+ * "std/text/json-parser".
+ *
+ * @param value JSON value to serialize
+ * @return Compact JSON representation
+ */
+public f<String> serializeJson(JsonValue& value) {
+    String out;
+    serializeJsonInto(&value, out, false, 0l);
+    return out;
+}
+
+/**
+ * Serializes a JSON value into a compact JSON string (no insignificant
+ * whitespace). The result round-trips through `parseJson` from
+ * "std/text/json-parser".
+ *
+ * @param value JSON value to serialize
+ * @return Compact JSON representation
+ */
+public f<String> serializeJson(JsonValue* value) {
+    String out;
+    serializeJsonInto(value, out, false, 0l);
+    return out;
+}
+
+/**
+ * Serializes a JSON value into a human-readable JSON string using two-space
+ * indentation for nested arrays and objects.
+ *
+ * @param value JSON value to serialize
+ * @return Pretty-printed JSON representation
+ */
+public f<String> serializeJsonPretty(JsonValue& value) {
+    String out;
+    serializeJsonInto(&value, out, true, 0l);
+    return out;
+}
+
+/**
+ * Serializes a JSON value into a human-readable JSON string using two-space
+ * indentation for nested arrays and objects.
+ *
+ * @param value JSON value to serialize
+ * @return Pretty-printed JSON representation
+ */
+public f<String> serializeJsonPretty(JsonValue* value) {
+    String out;
+    serializeJsonInto(value, out, true, 0l);
+    return out;
+}
+
+// --- Internal serializer helpers --------------------------------------------
+
+p serializeJsonInto(JsonValue* value, String& out, bool pretty, unsigned long depth) {
+    const JsonValueKind kind = value.getKind();
+    if kind == JsonValueKind::JSON_NULL {
+        out += "null";
+    } else if kind == JsonValueKind::JSON_BOOL {
+        out += value.getBool() ? "true" : "false";
+    } else if kind == JsonValueKind::JSON_NUMBER {
+        out += serializeJsonNumber(value.getNumber());
+    } else if kind == JsonValueKind::JSON_STRING {
+        serializeJsonString(out, value.getString());
+    } else if kind == JsonValueKind::JSON_ARRAY {
+        const unsigned long size = value.getArraySize();
+        if size == 0l {
+            out += "[]";
+            return;
+        }
+        out += '[';
+        for unsigned long i = 0l; i < size; i++ {
+            if i > 0l { out += ','; }
+            if pretty { appendJsonNewlineIndent(out, depth + 1l); }
+            serializeJsonInto(value.getArrayItem(i), out, pretty, depth + 1l);
+        }
+        if pretty { appendJsonNewlineIndent(out, depth); }
+        out += ']';
+    } else {
+        const unsigned long size = value.getObjectSize();
+        if size == 0l {
+            out += "{}";
+            return;
+        }
+        out += '{';
+        for unsigned long i = 0l; i < size; i++ {
+            if i > 0l { out += ','; }
+            if pretty { appendJsonNewlineIndent(out, depth + 1l); }
+            serializeJsonString(out, value.getObjectKey(i));
+            out += pretty ? ": " : ":";
+            serializeJsonInto(value.getObjectValue(i), out, pretty, depth + 1l);
+        }
+        if pretty { appendJsonNewlineIndent(out, depth); }
+        out += '}';
+    }
+}
+
+// Append a newline followed by `depth` levels of two-space indentation.
+p appendJsonNewlineIndent(String& out, unsigned long depth) {
+    out += '\n';
+    for unsigned long i = 0l; i < depth; i++ {
+        out += "  ";
+    }
+}
+
+// Serialize a string value with surrounding quotes and JSON escaping.
+p serializeJsonString(String& out, const String& value) {
+    out += '"';
+    const unsigned long length = value.getLength();
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = value[i];
+        if c == '"' {
+            out += "\\\"";
+        } else if c == '\\' {
+            out += "\\\\";
+        } else if c == '\n' {
+            out += "\\n";
+        } else if c == '\r' {
+            out += "\\r";
+        } else if c == '\t' {
+            out += "\\t";
+        } else if c == '\b' {
+            out += "\\b";
+        } else if c == '\f' {
+            out += "\\f";
+        } else if cast<int>(c) < 0x20 {
+            // Other control characters are emitted as \u00XX escapes
+            string hexDigits = "0123456789abcdef";
+            const int code = cast<int>(c);
+            out += "\\u00";
+            out += hexDigits[(code >> 4) & 0xF];
+            out += hexDigits[code & 0xF];
+        } else {
+            out += c;
+        }
+    }
+    out += '"';
+}
+
+// Serialize a number, printing integral values without a fractional part.
+// Non-integral values use 17 significant digits ("%.17g"), which is enough to
+// round-trip any double exactly so reparsing yields the same numeric value.
+f<String> serializeJsonNumber(double value) {
+    const long asLong = cast<long>(value);
+    if cast<double>(asLong) == value {
+        return toString(asLong);
+    }
+    const int length = snprintf(nil<char*>, 0l, "%.17g", value);
+    result = String(length);
+    snprintf(cast<char*>(result.getRaw()), cast<unsigned long>(length + 1), "%.17g", value);
+}

--- a/std/text/json-value.spice
+++ b/std/text/json-value.spice
@@ -1,0 +1,284 @@
+import "std/data/vector";
+
+/**
+ * Tag for the variant stored inside a JsonValue.
+ */
+public type JsonValueKind enum {
+    JSON_NULL,
+    JSON_BOOL,
+    JSON_NUMBER,
+    JSON_STRING,
+    JSON_ARRAY,
+    JSON_OBJECT
+}
+
+/**
+ * Represents a single JSON value.
+ *
+ * Composite values (arrays and objects) own their children as heap pointers,
+ * so a JsonValue is always reached via `heap JsonValue*` once it has been
+ * parsed. Numbers are stored as `double`; integers are representable up to
+ * 2^53. Object fields preserve insertion order.
+ *
+ * Parsing lives in "std/text/json-parser" and serialization in
+ * "std/text/json-serializer", so programs only pull in what they use.
+ */
+public type JsonValue struct {
+    JsonValueKind kind
+    bool boolValue
+    double numberValue
+    String stringValue
+    Vector<JsonValue*> arrayItems
+    Vector<String> objectKeys
+    Vector<JsonValue*> objectValues
+}
+
+/**
+ * Construct a JSON null value
+ */
+public p JsonValue.ctor() {
+    this.kind = JsonValueKind::JSON_NULL;
+}
+
+/**
+ * Construct an empty JSON value of the given kind. Useful for building
+ * arrays and objects from scratch.
+ *
+ * @param kind Kind of the value
+ */
+public p JsonValue.ctor(JsonValueKind kind) {
+    this.kind = kind;
+}
+
+/**
+ * Construct a JSON boolean value
+ *
+ * @param value Boolean value
+ */
+public p JsonValue.ctor(bool value) {
+    this.kind = JsonValueKind::JSON_BOOL;
+    this.boolValue = value;
+}
+
+/**
+ * Construct a JSON number value
+ *
+ * @param value Number value
+ */
+public p JsonValue.ctor(double value) {
+    this.kind = JsonValueKind::JSON_NUMBER;
+    this.numberValue = value;
+}
+
+/**
+ * Construct a JSON string value
+ *
+ * @param value String value
+ */
+public p JsonValue.ctor(const String& value) {
+    this.kind = JsonValueKind::JSON_STRING;
+    this.stringValue = value;
+}
+
+// --- Kind inspection -------------------------------------------------------
+
+/**
+ * Retrieve the kind of the JSON value
+ *
+ * @return Kind of the value
+ */
+public f<JsonValueKind> JsonValue.getKind() { return this.kind; }
+/**
+ * Check whether the JSON value is null
+ *
+ * @return true if the value is null, false otherwise
+ */
+public f<bool> JsonValue.isNull()   { return this.kind == JsonValueKind::JSON_NULL; }
+/**
+ * Check whether the JSON value is a boolean
+ *
+ * @return true if the value is a boolean, false otherwise
+ */
+public f<bool> JsonValue.isBool()   { return this.kind == JsonValueKind::JSON_BOOL; }
+/**
+ * Check whether the JSON value is a number
+ *
+ * @return true if the value is a number, false otherwise
+ */
+public f<bool> JsonValue.isNumber() { return this.kind == JsonValueKind::JSON_NUMBER; }
+/**
+ * Check whether the JSON value is a string
+ *
+ * @return true if the value is a string, false otherwise
+ */
+public f<bool> JsonValue.isString() { return this.kind == JsonValueKind::JSON_STRING; }
+/**
+ * Check whether the JSON value is an array
+ *
+ * @return true if the value is an array, false otherwise
+ */
+public f<bool> JsonValue.isArray()  { return this.kind == JsonValueKind::JSON_ARRAY; }
+/**
+ * Check whether the JSON value is an object
+ *
+ * @return true if the value is an object, false otherwise
+ */
+public f<bool> JsonValue.isObject() { return this.kind == JsonValueKind::JSON_OBJECT; }
+
+// --- Scalar accessors (panic on wrong kind) --------------------------------
+
+/**
+ * Retrieve the boolean payload. Panics if the value is not a boolean.
+ *
+ * @return Boolean value
+ */
+public f<bool> JsonValue.getBool() {
+    assert this.kind == JsonValueKind::JSON_BOOL;
+    return this.boolValue;
+}
+
+/**
+ * Retrieve the number payload. Panics if the value is not a number.
+ *
+ * @return Number value
+ */
+public f<double> JsonValue.getNumber() {
+    assert this.kind == JsonValueKind::JSON_NUMBER;
+    return this.numberValue;
+}
+
+/**
+ * Retrieve the string payload. Panics if the value is not a string.
+ *
+ * @return String value
+ */
+public f<const String&> JsonValue.getString() {
+    assert this.kind == JsonValueKind::JSON_STRING;
+    return this.stringValue;
+}
+
+// --- Array operations ------------------------------------------------------
+
+/**
+ * Retrieve the number of items in the array. Panics if the value is not an array.
+ *
+ * @return Number of array items
+ */
+public f<unsigned long> JsonValue.getArraySize() {
+    assert this.kind == JsonValueKind::JSON_ARRAY;
+    return this.arrayItems.getSize();
+}
+
+/**
+ * Retrieve the array item at the given index. Panics if the value is not an array.
+ *
+ * @param idx Index of the item
+ * @return Pointer to the array item
+ */
+public f<JsonValue*> JsonValue.getArrayItem(unsigned long idx) {
+    assert this.kind == JsonValueKind::JSON_ARRAY;
+    return this.arrayItems.get(idx);
+}
+
+/**
+ * Retrieve the array item at the given index. Panics if the value is not an array.
+ *
+ * @param idx Index of the item
+ * @return Pointer to the array item
+ */
+public f<JsonValue*> JsonValue.getArrayItem(unsigned int idx) {
+    return this.getArrayItem(cast<unsigned long>(idx));
+}
+
+/**
+ * Append an item to the array. Panics if the value is not an array.
+ * The array takes ownership of the heap-allocated item.
+ *
+ * @param item Item to append
+ */
+public p JsonValue.addArrayItem(JsonValue* item) {
+    assert this.kind == JsonValueKind::JSON_ARRAY;
+    this.arrayItems.pushBack(item);
+}
+
+// --- Object operations -----------------------------------------------------
+
+/**
+ * Retrieve the number of fields in the object. Panics if the value is not an object.
+ *
+ * @return Number of object fields
+ */
+public f<unsigned long> JsonValue.getObjectSize() {
+    assert this.kind == JsonValueKind::JSON_OBJECT;
+    return this.objectKeys.getSize();
+}
+
+/**
+ * Retrieve the key of the object field at the given index, in insertion order.
+ * Panics if the value is not an object.
+ *
+ * @param idx Index of the field
+ * @return Field key
+ */
+public f<const String&> JsonValue.getObjectKey(unsigned long idx) {
+    assert this.kind == JsonValueKind::JSON_OBJECT;
+    return this.objectKeys.get(idx);
+}
+
+/**
+ * Retrieve the value of the object field at the given index, in insertion order.
+ * Panics if the value is not an object.
+ *
+ * @param idx Index of the field
+ * @return Pointer to the field value
+ */
+public f<JsonValue*> JsonValue.getObjectValue(unsigned long idx) {
+    assert this.kind == JsonValueKind::JSON_OBJECT;
+    return this.objectValues.get(idx);
+}
+
+/**
+ * Check whether the object contains a field with the given key
+ *
+ * @param key Field key to look for
+ * @return true if the field exists, false otherwise
+ */
+public f<bool> JsonValue.hasField(string key) {
+    if this.kind != JsonValueKind::JSON_OBJECT { return false; }
+    const String keyStr = String(key);
+    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
+        if this.objectKeys.get(i) == keyStr { return true; }
+    }
+    return false;
+}
+
+/**
+ * Retrieve the value of the object field with the given key. Panics if the value is not an object
+ * or the field does not exist.
+ *
+ * @param key Field key to look up
+ * @return Pointer to the field value
+ */
+public f<JsonValue*> JsonValue.getField(string key) {
+    assert this.kind == JsonValueKind::JSON_OBJECT;
+    const String keyStr = String(key);
+    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
+        if this.objectKeys.get(i) == keyStr {
+            return this.objectValues.get(i);
+        }
+    }
+    panic(Error("JSON object has no such field"));
+}
+
+/**
+ * Append a field to the object. Panics if the value is not an object.
+ * The object takes ownership of the heap-allocated field value.
+ *
+ * @param key Field key
+ * @param value Field value
+ */
+public p JsonValue.addObjectField(const String& key, JsonValue* value) {
+    assert this.kind == JsonValueKind::JSON_OBJECT;
+    this.objectKeys.pushBack(key);
+    this.objectValues.pushBack(value);
+}

--- a/std/text/xml-node.spice
+++ b/std/text/xml-node.spice
@@ -1,0 +1,275 @@
+import "std/data/vector";
+
+/**
+ * Tag for the variant stored inside an XmlNode.
+ */
+public type XmlNodeKind enum {
+    XML_ELEMENT,
+    XML_TEXT
+}
+
+/**
+ * Represents a node in an XML document.
+ *
+ * Element nodes carry a tag name, ordered attributes and ordered child nodes
+ * (which may themselves be elements or text). Text nodes carry only the
+ * decoded character data. Children are owned as heap pointers so the parsed
+ * tree is reached via `XmlNode*` (`heap` on the root).
+ *
+ * Parsing lives in "std/text/xml-parser" and serialization in
+ * "std/text/xml-serializer", so programs only pull in what they use.
+ */
+public type XmlNode struct {
+    XmlNodeKind kind
+    String name           // tag name (element) - empty for text nodes
+    String textValue      // decoded character data (text) - empty for elements
+    Vector<String> attributeKeys
+    Vector<String> attributeValues
+    Vector<XmlNode*> children
+}
+
+/**
+ * Construct an empty XML element node
+ */
+public p XmlNode.ctor() {
+    this.kind = XmlNodeKind::XML_ELEMENT;
+}
+
+/**
+ * Construct an empty XML node of the given kind
+ *
+ * @param kind Kind of the node
+ */
+public p XmlNode.ctor(XmlNodeKind kind) {
+    this.kind = kind;
+}
+
+// --- Kind inspection -------------------------------------------------------
+
+/**
+ * Retrieve the kind of the XML node
+ *
+ * @return Kind of the node
+ */
+public f<XmlNodeKind> XmlNode.getKind() { return this.kind; }
+/**
+ * Check whether the node is an element node
+ *
+ * @return true if the node is an element, false otherwise
+ */
+public f<bool> XmlNode.isElement() { return this.kind == XmlNodeKind::XML_ELEMENT; }
+/**
+ * Check whether the node is a text node
+ *
+ * @return true if the node is text, false otherwise
+ */
+public f<bool> XmlNode.isText()    { return this.kind == XmlNodeKind::XML_TEXT; }
+
+/**
+ * Retrieve the tag name of the element. Panics if the node is not an element.
+ *
+ * @return Tag name
+ */
+public f<const String&> XmlNode.getName() {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    return this.name;
+}
+
+/**
+ * Set the tag name of the element. Panics if the node is not an element.
+ *
+ * @param name New tag name
+ */
+public p XmlNode.setName(const String& name) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    this.name = name;
+}
+
+/**
+ * Retrieve the character data of the text node. Panics if the node is not a text node.
+ *
+ * @return Text content
+ */
+public f<const String&> XmlNode.getText() {
+    assert this.kind == XmlNodeKind::XML_TEXT;
+    return this.textValue;
+}
+
+/**
+ * Set the character data of the text node. Panics if the node is not a text node.
+ *
+ * @param text New text content
+ */
+public p XmlNode.setText(const String& text) {
+    assert this.kind == XmlNodeKind::XML_TEXT;
+    this.textValue = text;
+}
+
+// --- Attribute operations --------------------------------------------------
+
+/**
+ * Retrieve the number of attributes on the element. Panics if the node is not an element.
+ *
+ * @return Number of attributes
+ */
+public f<unsigned long> XmlNode.getAttributeCount() {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    return this.attributeKeys.getSize();
+}
+
+/**
+ * Retrieve the name of the attribute at the given index, in document order.
+ * Panics if the node is not an element.
+ *
+ * @param idx Index of the attribute
+ * @return Attribute name
+ */
+public f<const String&> XmlNode.getAttributeKey(unsigned long idx) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    return this.attributeKeys.get(idx);
+}
+
+/**
+ * Retrieve the value of the attribute at the given index, in document order.
+ * Panics if the node is not an element.
+ *
+ * @param idx Index of the attribute
+ * @return Attribute value
+ */
+public f<const String&> XmlNode.getAttributeValue(unsigned long idx) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    return this.attributeValues.get(idx);
+}
+
+/**
+ * Check whether the element has an attribute with the given name
+ *
+ * @param name Attribute name to look for
+ * @return true if the attribute exists, false otherwise
+ */
+public f<bool> XmlNode.hasAttribute(string name) {
+    if this.kind != XmlNodeKind::XML_ELEMENT { return false; }
+    const String nameStr = String(name);
+    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
+        if this.attributeKeys.get(i) == nameStr { return true; }
+    }
+    return false;
+}
+
+/**
+ * Retrieve the value of the attribute with the given name. Panics if the node is not an element
+ * or the attribute does not exist.
+ *
+ * @param name Attribute name to look up
+ * @return Attribute value
+ */
+public f<const String&> XmlNode.getAttribute(string name) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    const String nameStr = String(name);
+    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
+        if this.attributeKeys.get(i) == nameStr {
+            return this.attributeValues.get(i);
+        }
+    }
+    panic(Error("XML element has no such attribute"));
+}
+
+/**
+ * Append an attribute to the element. Panics if the node is not an element.
+ * The caller is responsible for avoiding duplicate attribute names.
+ *
+ * @param name Attribute name
+ * @param value Attribute value
+ */
+public p XmlNode.addAttribute(const String& name, const String& value) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    this.attributeKeys.pushBack(name);
+    this.attributeValues.pushBack(value);
+}
+
+// --- Child operations ------------------------------------------------------
+
+/**
+ * Retrieve the number of child nodes. Panics if the node is not an element.
+ *
+ * @return Number of child nodes
+ */
+public f<unsigned long> XmlNode.getChildCount() {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    return this.children.getSize();
+}
+
+/**
+ * Retrieve the child node at the given index. Panics if the node is not an element.
+ *
+ * @param idx Index of the child
+ * @return Pointer to the child node
+ */
+public f<XmlNode*> XmlNode.getChild(unsigned long idx) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    return this.children.get(idx);
+}
+
+/**
+ * Retrieve the child node at the given index. Panics if the node is not an element.
+ *
+ * @param idx Index of the child
+ * @return Pointer to the child node
+ */
+public f<XmlNode*> XmlNode.getChild(unsigned int idx) {
+    return this.getChild(cast<unsigned long>(idx));
+}
+
+/**
+ * Append a child node to the element. Panics if the node is not an element.
+ * The element takes ownership of the heap-allocated child.
+ *
+ * @param child Child node to append
+ */
+public p XmlNode.addChild(XmlNode* child) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    this.children.pushBack(child);
+}
+
+/**
+ * Find the first child element with the given tag name. Returns nil if none
+ * exists. Text-node children are ignored.
+ */
+public f<XmlNode*> XmlNode.findChild(string name) {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    const String nameStr = String(name);
+    for unsigned long i = 0l; i < this.children.getSize(); i++ {
+        XmlNode* child = this.children.get(i);
+        if child.kind == XmlNodeKind::XML_ELEMENT && child.name == nameStr {
+            return child;
+        }
+    }
+    return nil<XmlNode*>;
+}
+
+/**
+ * Check whether the element has a direct child element with the given tag name
+ *
+ * @param name Tag name to look for
+ * @return true if such a child exists, false otherwise
+ */
+public f<bool> XmlNode.hasChild(string name) {
+    return this.findChild(name) != nil<XmlNode*>;
+}
+
+/**
+ * Concatenated text of all direct text-node children, in document order.
+ * Useful for elements like `<title>Hello</title>` where the natural value
+ * is the text content.
+ */
+public f<String> XmlNode.getInnerText() {
+    assert this.kind == XmlNodeKind::XML_ELEMENT;
+    String out;
+    for unsigned long i = 0l; i < this.children.getSize(); i++ {
+        XmlNode* child = this.children.get(i);
+        if child.kind == XmlNodeKind::XML_TEXT {
+            out += child.textValue;
+        }
+    }
+    return out;
+}

--- a/std/text/xml-parser.spice
+++ b/std/text/xml-parser.spice
@@ -1,21 +1,8 @@
-import "std/data/vector";
+import "std/text/xml-node";
 import "std/text/analysis";
 
 /**
- * Tag for the variant stored inside an XmlNode.
- */
-public type XmlNodeKind enum {
-    XML_ELEMENT,
-    XML_TEXT
-}
-
-/**
- * Represents a node in an XML document.
- *
- * Element nodes carry a tag name, ordered attributes and ordered child nodes
- * (which may themselves be elements or text). Text nodes carry only the
- * decoded character data. Children are owned as heap pointers so the parsed
- * tree is reached via `XmlNode*` (`heap` on the root).
+ * Recursive-descent XML parser. Use `parseXml` for one-shot parsing.
  *
  * The parser handles a useful subset of XML 1.0: elements with attributes,
  * self-closing tags, character data with the standard predefined entities
@@ -23,189 +10,9 @@ public type XmlNodeKind enum {
  * (`&#NN;` and `&#xNN;`), CDATA sections, comments and an optional XML
  * declaration / processing instructions (which are skipped). DTDs,
  * namespaces and external entities are not interpreted.
- */
-public type XmlNode struct {
-    XmlNodeKind kind
-    String name           // tag name (element) - empty for text nodes
-    String textValue      // decoded character data (text) - empty for elements
-    Vector<String> attributeKeys
-    Vector<String> attributeValues
-    Vector<XmlNode*> children
-}
-
-/**
- * Construct an empty XML element node
- */
-public p XmlNode.ctor() {
-    this.kind = XmlNodeKind::XML_ELEMENT;
-}
-
-// --- Kind inspection -------------------------------------------------------
-
-/**
- * Retrieve the kind of the XML node
  *
- * @return Kind of the node
- */
-public f<XmlNodeKind> XmlNode.getKind() { return this.kind; }
-/**
- * Check whether the node is an element node
- *
- * @return true if the node is an element, false otherwise
- */
-public f<bool> XmlNode.isElement() { return this.kind == XmlNodeKind::XML_ELEMENT; }
-/**
- * Check whether the node is a text node
- *
- * @return true if the node is text, false otherwise
- */
-public f<bool> XmlNode.isText()    { return this.kind == XmlNodeKind::XML_TEXT; }
-
-/**
- * Retrieve the tag name of the element. Panics if the node is not an element.
- *
- * @return Tag name
- */
-public f<const String&> XmlNode.getName() {
-    assert this.kind == XmlNodeKind::XML_ELEMENT;
-    return this.name;
-}
-
-/**
- * Retrieve the character data of the text node. Panics if the node is not a text node.
- *
- * @return Text content
- */
-public f<const String&> XmlNode.getText() {
-    assert this.kind == XmlNodeKind::XML_TEXT;
-    return this.textValue;
-}
-
-// --- Attribute operations --------------------------------------------------
-
-/**
- * Retrieve the number of attributes on the element. Panics if the node is not an element.
- *
- * @return Number of attributes
- */
-public f<unsigned long> XmlNode.getAttributeCount() {
-    assert this.kind == XmlNodeKind::XML_ELEMENT;
-    return this.attributeKeys.getSize();
-}
-
-/**
- * Check whether the element has an attribute with the given name
- *
- * @param name Attribute name to look for
- * @return true if the attribute exists, false otherwise
- */
-public f<bool> XmlNode.hasAttribute(string name) {
-    if this.kind != XmlNodeKind::XML_ELEMENT { return false; }
-    const String nameStr = String(name);
-    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
-        if this.attributeKeys.get(i) == nameStr { return true; }
-    }
-    return false;
-}
-
-/**
- * Retrieve the value of the attribute with the given name. Panics if the node is not an element
- * or the attribute does not exist.
- *
- * @param name Attribute name to look up
- * @return Attribute value
- */
-public f<const String&> XmlNode.getAttribute(string name) {
-    assert this.kind == XmlNodeKind::XML_ELEMENT;
-    const String nameStr = String(name);
-    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
-        if this.attributeKeys.get(i) == nameStr {
-            return this.attributeValues.get(i);
-        }
-    }
-    panic(Error("XML element has no such attribute"));
-}
-
-// --- Child operations ------------------------------------------------------
-
-/**
- * Retrieve the number of child nodes. Panics if the node is not an element.
- *
- * @return Number of child nodes
- */
-public f<unsigned long> XmlNode.getChildCount() {
-    assert this.kind == XmlNodeKind::XML_ELEMENT;
-    return this.children.getSize();
-}
-
-/**
- * Retrieve the child node at the given index. Panics if the node is not an element.
- *
- * @param idx Index of the child
- * @return Pointer to the child node
- */
-public f<XmlNode*> XmlNode.getChild(unsigned long idx) {
-    assert this.kind == XmlNodeKind::XML_ELEMENT;
-    return this.children.get(idx);
-}
-
-/**
- * Retrieve the child node at the given index. Panics if the node is not an element.
- *
- * @param idx Index of the child
- * @return Pointer to the child node
- */
-public f<XmlNode*> XmlNode.getChild(unsigned int idx) {
-    return this.getChild(cast<unsigned long>(idx));
-}
-
-/**
- * Find the first child element with the given tag name. Returns nil if none
- * exists. Text-node children are ignored.
- */
-public f<XmlNode*> XmlNode.findChild(string name) {
-    assert this.kind == XmlNodeKind::XML_ELEMENT;
-    const String nameStr = String(name);
-    for unsigned long i = 0l; i < this.children.getSize(); i++ {
-        XmlNode* child = this.children.get(i);
-        if child.kind == XmlNodeKind::XML_ELEMENT && child.name == nameStr {
-            return child;
-        }
-    }
-    return nil<XmlNode*>;
-}
-
-/**
- * Check whether the element has a direct child element with the given tag name
- *
- * @param name Tag name to look for
- * @return true if such a child exists, false otherwise
- */
-public f<bool> XmlNode.hasChild(string name) {
-    return this.findChild(name) != nil<XmlNode*>;
-}
-
-/**
- * Concatenated text of all direct text-node children, in document order.
- * Useful for elements like `<title>Hello</title>` where the natural value
- * is the text content.
- */
-public f<String> XmlNode.getInnerText() {
-    assert this.kind == XmlNodeKind::XML_ELEMENT;
-    String out;
-    for unsigned long i = 0l; i < this.children.getSize(); i++ {
-        XmlNode* child = this.children.get(i);
-        if child.kind == XmlNodeKind::XML_TEXT {
-            out += child.textValue;
-        }
-    }
-    return out;
-}
-
-// --- Parser ----------------------------------------------------------------
-
-/**
- * Recursive-descent XML parser. Use `parseXml` for one-shot parsing.
+ * The XmlNode data model lives in "std/text/xml-node" and serialization in
+ * "std/text/xml-serializer".
  */
 public type XmlParser struct {
     String input
@@ -497,14 +304,13 @@ p XmlParser.parseAttributes(XmlNode* element) {
         this.skipWhitespace();
         const String attrValue = this.readAttributeValue();
         if this.hasError { return; }
-        for unsigned long i = 0l; i < element.attributeKeys.getSize(); i++ {
-            if element.attributeKeys.get(i) == attrName {
+        for unsigned long i = 0l; i < element.getAttributeCount(); i++ {
+            if element.getAttributeKey(i) == attrName {
                 this.fail("Duplicate attribute name");
                 return;
             }
         }
-        element.attributeKeys.pushBack(attrName);
-        element.attributeValues.pushBack(attrValue);
+        element.addAttribute(attrName, attrValue);
     }
 }
 
@@ -518,7 +324,7 @@ p XmlParser.parseChildren(XmlNode* element) {
             this.pos += 2l;
             const String closeName = this.readName();
             if this.hasError { return; }
-            if closeName != element.name {
+            if closeName != element.getName() {
                 this.fail("Mismatched closing tag");
                 return;
             }
@@ -556,10 +362,9 @@ p XmlParser.parseChildren(XmlNode* element) {
             }
             const String content = this.input.getSubstring(start, this.pos - start);
             this.pos += 3l; // consume ']]>'
-            XmlNode* cdataNode = __new<XmlNode>();
-            cdataNode.kind = XmlNodeKind::XML_TEXT;
-            cdataNode.textValue = content;
-            element.children.pushBack(cdataNode);
+            XmlNode* cdataNode = __new<XmlNode>(XmlNodeKind::XML_TEXT);
+            cdataNode.setText(content);
+            element.addChild(cdataNode);
             continue;
         }
         if this.startsWith("<?") {
@@ -577,7 +382,7 @@ p XmlParser.parseChildren(XmlNode* element) {
         if this.input[this.pos] == '<' {
             XmlNode* child = this.parseElement();
             if this.hasError { return; }
-            element.children.pushBack(child);
+            element.addChild(child);
             continue;
         }
         String text;
@@ -592,10 +397,9 @@ p XmlParser.parseChildren(XmlNode* element) {
             text += c;
             this.pos++;
         }
-        XmlNode* textNode = __new<XmlNode>();
-        textNode.kind = XmlNodeKind::XML_TEXT;
-        textNode.textValue = text;
-        element.children.pushBack(textNode);
+        XmlNode* textNode = __new<XmlNode>(XmlNodeKind::XML_TEXT);
+        textNode.setText(text);
+        element.addChild(textNode);
     }
 }
 
@@ -607,9 +411,8 @@ f<XmlNode*> XmlParser.parseElement() {
     this.pos++; // consume '<'
     const String name = this.readName();
     if this.hasError { return nil<XmlNode*>; }
-    XmlNode* element = __new<XmlNode>();
-    element.kind = XmlNodeKind::XML_ELEMENT;
-    element.name = name;
+    XmlNode* element = __new<XmlNode>(XmlNodeKind::XML_ELEMENT);
+    element.setName(name);
     this.parseAttributes(element);
     if this.hasError { return nil<XmlNode*>; }
     if this.pos >= this.input.getLength() {
@@ -634,123 +437,4 @@ f<XmlNode*> XmlParser.parseElement() {
     this.parseChildren(element);
     if this.hasError { return nil<XmlNode*>; }
     return element;
-}
-
-// --- Serialization ---------------------------------------------------------
-
-/**
- * Serializes this node into a compact XML string. Elements without children
- * are written as self-closing tags. Text content and attribute values are
- * escaped with the predefined entities, so the result round-trips through
- * `parseXml`.
- *
- * @return Compact XML representation
- */
-public f<String> XmlNode.serialize() {
-    String out;
-    this.serializeInto(out, false, 0l);
-    return out;
-}
-
-/**
- * Serializes this node into a human-readable XML string. Elements that
- * contain child elements are laid out with two-space indentation, one node
- * per line; elements containing only text are kept on a single line.
- *
- * @return Pretty-printed XML representation
- */
-public f<String> XmlNode.serializePretty() {
-    String out;
-    this.serializeInto(out, true, 0l);
-    return out;
-}
-
-p XmlNode.serializeInto(String& out, bool pretty, unsigned long depth) {
-    if this.kind == XmlNodeKind::XML_TEXT {
-        appendXmlEscapedText(out, this.textValue);
-        return;
-    }
-
-    out += '<';
-    out += this.name;
-    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
-        out += ' ';
-        out += this.attributeKeys.get(i);
-        out += "=\"";
-        appendXmlEscapedAttribute(out, this.attributeValues.get(i));
-        out += '"';
-    }
-
-    const unsigned long childCount = this.children.getSize();
-    if childCount == 0l {
-        out += "/>";
-        return;
-    }
-    out += '>';
-
-    // Lay children out on their own lines only when there is structure to show.
-    bool hasElementChild = false;
-    for unsigned long i = 0l; i < childCount; i++ {
-        if this.children.get(i).kind == XmlNodeKind::XML_ELEMENT {
-            hasElementChild = true;
-            break;
-        }
-    }
-    const bool block = pretty && hasElementChild;
-
-    for unsigned long i = 0l; i < childCount; i++ {
-        XmlNode* child = this.children.get(i);
-        if block { appendXmlNewlineIndent(out, depth + 1l); }
-        child.serializeInto(out, pretty, depth + 1l);
-    }
-    if block { appendXmlNewlineIndent(out, depth); }
-
-    out += "</";
-    out += this.name;
-    out += '>';
-}
-
-// Append a newline followed by `depth` levels of two-space indentation.
-p appendXmlNewlineIndent(String& out, unsigned long depth) {
-    out += '\n';
-    for unsigned long i = 0l; i < depth; i++ {
-        out += "  ";
-    }
-}
-
-// Escape character data: '&', '<' and '>' become their predefined entities.
-p appendXmlEscapedText(String& out, const String& text) {
-    const unsigned long length = text.getLength();
-    for unsigned long i = 0l; i < length; i++ {
-        const char c = text[i];
-        if c == '&' {
-            out += "&amp;";
-        } else if c == '<' {
-            out += "&lt;";
-        } else if c == '>' {
-            out += "&gt;";
-        } else {
-            out += c;
-        }
-    }
-}
-
-// Escape an attribute value (delimited by double quotes), additionally
-// escaping the '"' character.
-p appendXmlEscapedAttribute(String& out, const String& value) {
-    const unsigned long length = value.getLength();
-    for unsigned long i = 0l; i < length; i++ {
-        const char c = value[i];
-        if c == '&' {
-            out += "&amp;";
-        } else if c == '<' {
-            out += "&lt;";
-        } else if c == '>' {
-            out += "&gt;";
-        } else if c == '"' {
-            out += "&quot;";
-        } else {
-            out += c;
-        }
-    }
 }

--- a/std/text/xml-serializer.spice
+++ b/std/text/xml-serializer.spice
@@ -1,66 +1,56 @@
 import "std/text/xml-node";
 
 /**
- * Serializes an XML node into a compact XML string. Elements without children
- * are written as self-closing tags. Text content and attribute values are
- * escaped with the predefined entities, so the result round-trips through
- * `parseXml` from "std/text/xml-parser".
+ * Serializer for XML output.
+ *
+ * Elements without children are written as self-closing tags. Text content
+ * and attribute values are escaped with the predefined entities, so the
+ * result round-trips through `parseXml` from "std/text/xml-parser".
+ *
+ * In pretty mode, elements that contain child elements are laid out with
+ * two-space indentation, one node per line; elements containing only text
+ * are kept on a single line.
+ */
+public type XmlSerializer struct {
+    bool pretty
+}
+
+/**
+ * Construct an XML serializer
+ *
+ * @param pretty Emit human-readable output with two-space indentation
+ */
+public p XmlSerializer.ctor(bool pretty = false) {
+    this.pretty = pretty;
+}
+
+/**
+ * Serializes an XML node into an XML string
  *
  * @param node XML node to serialize
- * @return Compact XML representation
+ * @return XML representation
  */
-public f<String> serializeXml(XmlNode& node) {
+public f<String> XmlSerializer.serialize(XmlNode& node) {
     String out;
-    serializeXmlInto(&node, out, false, 0l);
+    this.serializeInto(&node, out, 0l);
     return out;
 }
 
 /**
- * Serializes an XML node into a compact XML string. Elements without children
- * are written as self-closing tags. Text content and attribute values are
- * escaped with the predefined entities, so the result round-trips through
- * `parseXml` from "std/text/xml-parser".
+ * Serializes an XML node into an XML string
  *
  * @param node XML node to serialize
- * @return Compact XML representation
+ * @return XML representation
  */
-public f<String> serializeXml(XmlNode* node) {
+public f<String> XmlSerializer.serialize(XmlNode* node) {
     String out;
-    serializeXmlInto(node, out, false, 0l);
-    return out;
-}
-
-/**
- * Serializes an XML node into a human-readable XML string. Elements that
- * contain child elements are laid out with two-space indentation, one node
- * per line; elements containing only text are kept on a single line.
- *
- * @param node XML node to serialize
- * @return Pretty-printed XML representation
- */
-public f<String> serializeXmlPretty(XmlNode& node) {
-    String out;
-    serializeXmlInto(&node, out, true, 0l);
-    return out;
-}
-
-/**
- * Serializes an XML node into a human-readable XML string. Elements that
- * contain child elements are laid out with two-space indentation, one node
- * per line; elements containing only text are kept on a single line.
- *
- * @param node XML node to serialize
- * @return Pretty-printed XML representation
- */
-public f<String> serializeXmlPretty(XmlNode* node) {
-    String out;
-    serializeXmlInto(node, out, true, 0l);
+    this.serializeInto(node, out, 0l);
     return out;
 }
 
 // --- Internal serializer helpers --------------------------------------------
 
-p serializeXmlInto(XmlNode* node, String& out, bool pretty, unsigned long depth) {
+p XmlSerializer.serializeInto(XmlNode* node, String& out, unsigned long depth) {
     if node.getKind() == XmlNodeKind::XML_TEXT {
         appendXmlEscapedText(out, node.getText());
         return;
@@ -92,11 +82,11 @@ p serializeXmlInto(XmlNode* node, String& out, bool pretty, unsigned long depth)
             break;
         }
     }
-    const bool block = pretty && hasElementChild;
+    const bool block = this.pretty && hasElementChild;
 
     for unsigned long i = 0l; i < childCount; i++ {
         if block { appendXmlNewlineIndent(out, depth + 1l); }
-        serializeXmlInto(node.getChild(i), out, pretty, depth + 1l);
+        this.serializeInto(node.getChild(i), out, depth + 1l);
     }
     if block { appendXmlNewlineIndent(out, depth); }
 

--- a/std/text/xml-serializer.spice
+++ b/std/text/xml-serializer.spice
@@ -1,0 +1,151 @@
+import "std/text/xml-node";
+
+/**
+ * Serializes an XML node into a compact XML string. Elements without children
+ * are written as self-closing tags. Text content and attribute values are
+ * escaped with the predefined entities, so the result round-trips through
+ * `parseXml` from "std/text/xml-parser".
+ *
+ * @param node XML node to serialize
+ * @return Compact XML representation
+ */
+public f<String> serializeXml(XmlNode& node) {
+    String out;
+    serializeXmlInto(&node, out, false, 0l);
+    return out;
+}
+
+/**
+ * Serializes an XML node into a compact XML string. Elements without children
+ * are written as self-closing tags. Text content and attribute values are
+ * escaped with the predefined entities, so the result round-trips through
+ * `parseXml` from "std/text/xml-parser".
+ *
+ * @param node XML node to serialize
+ * @return Compact XML representation
+ */
+public f<String> serializeXml(XmlNode* node) {
+    String out;
+    serializeXmlInto(node, out, false, 0l);
+    return out;
+}
+
+/**
+ * Serializes an XML node into a human-readable XML string. Elements that
+ * contain child elements are laid out with two-space indentation, one node
+ * per line; elements containing only text are kept on a single line.
+ *
+ * @param node XML node to serialize
+ * @return Pretty-printed XML representation
+ */
+public f<String> serializeXmlPretty(XmlNode& node) {
+    String out;
+    serializeXmlInto(&node, out, true, 0l);
+    return out;
+}
+
+/**
+ * Serializes an XML node into a human-readable XML string. Elements that
+ * contain child elements are laid out with two-space indentation, one node
+ * per line; elements containing only text are kept on a single line.
+ *
+ * @param node XML node to serialize
+ * @return Pretty-printed XML representation
+ */
+public f<String> serializeXmlPretty(XmlNode* node) {
+    String out;
+    serializeXmlInto(node, out, true, 0l);
+    return out;
+}
+
+// --- Internal serializer helpers --------------------------------------------
+
+p serializeXmlInto(XmlNode* node, String& out, bool pretty, unsigned long depth) {
+    if node.getKind() == XmlNodeKind::XML_TEXT {
+        appendXmlEscapedText(out, node.getText());
+        return;
+    }
+
+    out += '<';
+    out += node.getName();
+    for unsigned long i = 0l; i < node.getAttributeCount(); i++ {
+        out += ' ';
+        out += node.getAttributeKey(i);
+        out += "=\"";
+        appendXmlEscapedAttribute(out, node.getAttributeValue(i));
+        out += '"';
+    }
+
+    const unsigned long childCount = node.getChildCount();
+    if childCount == 0l {
+        out += "/>";
+        return;
+    }
+    out += '>';
+
+    // Lay children out on their own lines only when there is structure to show.
+    bool hasElementChild = false;
+    for unsigned long i = 0l; i < childCount; i++ {
+        XmlNode* child = node.getChild(i);
+        if child.isElement() {
+            hasElementChild = true;
+            break;
+        }
+    }
+    const bool block = pretty && hasElementChild;
+
+    for unsigned long i = 0l; i < childCount; i++ {
+        if block { appendXmlNewlineIndent(out, depth + 1l); }
+        serializeXmlInto(node.getChild(i), out, pretty, depth + 1l);
+    }
+    if block { appendXmlNewlineIndent(out, depth); }
+
+    out += "</";
+    out += node.getName();
+    out += '>';
+}
+
+// Append a newline followed by `depth` levels of two-space indentation.
+p appendXmlNewlineIndent(String& out, unsigned long depth) {
+    out += '\n';
+    for unsigned long i = 0l; i < depth; i++ {
+        out += "  ";
+    }
+}
+
+// Escape character data: '&', '<' and '>' become their predefined entities.
+p appendXmlEscapedText(String& out, const String& text) {
+    const unsigned long length = text.getLength();
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = text[i];
+        if c == '&' {
+            out += "&amp;";
+        } else if c == '<' {
+            out += "&lt;";
+        } else if c == '>' {
+            out += "&gt;";
+        } else {
+            out += c;
+        }
+    }
+}
+
+// Escape an attribute value (delimited by double quotes), additionally
+// escaping the '"' character.
+p appendXmlEscapedAttribute(String& out, const String& value) {
+    const unsigned long length = value.getLength();
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = value[i];
+        if c == '&' {
+            out += "&amp;";
+        } else if c == '<' {
+            out += "&lt;";
+        } else if c == '>' {
+            out += "&gt;";
+        } else if c == '"' {
+            out += "&quot;";
+        } else {
+            out += c;
+        }
+    }
+}

--- a/test/test-files/std/text/csv-parser/source.spice
+++ b/test/test-files/std/text/csv-parser/source.spice
@@ -64,54 +64,5 @@ f<int> main() {
     assert fields.get(0) == String("x");
     assert fields.get(2) == String("z");
 
-    // Serialization: plain fields are emitted verbatim
-    assert parser.serializeField(String("plain")) == String("plain");
-    // Empty fields are quoted so empty records survive a round-trip
-    assert parser.serializeField(String("")) == String("\"\"");
-    // Fields needing quoting (delimiter, quote, newline) are wrapped/escaped
-    assert parser.serializeField(String("a,b")) == String("\"a,b\"");
-    assert parser.serializeField(String("she said \"hi\"")) == String("\"she said \"\"hi\"\"\"");
-    assert parser.serializeField(String("line1\nline2")) == String("\"line1\nline2\"");
-
-    // Serializing a single row joins fields with the delimiter
-    Vector<String> row;
-    row.pushBack(String("Alice"));
-    row.pushBack(String("30"));
-    row.pushBack(String("New York"));
-    assert parser.serializeRow(row) == String("Alice,30,New York");
-
-    // Round-trip: parse -> serialize -> parse yields the same rows
-    String roundTripDoc = String("name,age,city\r\n");
-    roundTripDoc += "Alice,30,\"New York\"\r\n";
-    roundTripDoc += "Bob,25,\"Line1\nLine2\"";
-    Vector<Vector<String>> parsedRows = parser.parse(roundTripDoc);
-    String serialized = parser.serialize(parsedRows);
-    Vector<Vector<String>> reparsedRows = parser.parse(serialized);
-    assert reparsedRows.getSize() == 3;
-    Vector<String>& reHeader = reparsedRows.get(0);
-    Vector<String>& reAlice = reparsedRows.get(1);
-    Vector<String>& reBob = reparsedRows.get(2);
-    assert reHeader.get(2) == String("city");
-    assert reAlice.get(2) == String("New York");
-    assert reBob.get(2) == String("Line1\nLine2");
-
-    // A trailing record of a single empty field must survive the round-trip
-    Vector<Vector<String>> emptyFieldRows;
-    Vector<String> dataRow;
-    dataRow.pushBack(String("a"));
-    emptyFieldRows.pushBack(dataRow);
-    Vector<String> emptyRow;
-    emptyRow.pushBack(String(""));
-    emptyFieldRows.pushBack(emptyRow);
-    Vector<Vector<String>> reEmptyRows = parser.parse(parser.serialize(emptyFieldRows));
-    assert reEmptyRows.getSize() == 2;
-    Vector<String>& reEmptyTrailing = reEmptyRows.get(1);
-    assert reEmptyTrailing.getSize() == 1;
-    assert reEmptyTrailing.get(0) == String("");
-
-    // Custom delimiter is honored during serialization
-    assert semicolonParser.serializeField(String("a;b")) == String("\"a;b\"");
-    assert semicolonParser.serializeField(String("a,b")) == String("a,b");
-
     printf("All assertions passed!");
 }

--- a/test/test-files/std/text/csv-serializer/cout.out
+++ b/test/test-files/std/text/csv-serializer/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/csv-serializer/source.spice
+++ b/test/test-files/std/text/csv-serializer/source.spice
@@ -1,0 +1,72 @@
+import "std/text/csv-serializer";
+import "std/text/csv-parser";
+import "std/data/vector";
+
+f<int> main() {
+    CsvSerializer serializer;
+    CsvParser parser;
+
+    // Serialization: plain fields are emitted verbatim
+    assert serializer.serializeField(String("plain")) == String("plain");
+    // Empty fields are quoted so empty records survive a round-trip
+    assert serializer.serializeField(String("")) == String("\"\"");
+    // Fields needing quoting (delimiter, quote, newline) are wrapped/escaped
+    assert serializer.serializeField(String("a,b")) == String("\"a,b\"");
+    assert serializer.serializeField(String("she said \"hi\"")) == String("\"she said \"\"hi\"\"\"");
+    assert serializer.serializeField(String("line1\nline2")) == String("\"line1\nline2\"");
+
+    // Serializing a single row joins fields with the delimiter
+    Vector<String> row;
+    row.pushBack(String("Alice"));
+    row.pushBack(String("30"));
+    row.pushBack(String("New York"));
+    assert serializer.serializeRow(row) == String("Alice,30,New York");
+
+    // Serializing a document joins rows with CRLF
+    Vector<Vector<String>> document;
+    Vector<String> headerRow;
+    headerRow.pushBack(String("name"));
+    headerRow.pushBack(String("age"));
+    document.pushBack(headerRow);
+    Vector<String> dataRow;
+    dataRow.pushBack(String("Alice"));
+    dataRow.pushBack(String("30"));
+    document.pushBack(dataRow);
+    assert serializer.serialize(document) == String("name,age\r\nAlice,30");
+
+    // Round-trip: parse -> serialize -> parse yields the same rows
+    String roundTripDoc = String("name,age,city\r\n");
+    roundTripDoc += "Alice,30,\"New York\"\r\n";
+    roundTripDoc += "Bob,25,\"Line1\nLine2\"";
+    Vector<Vector<String>> parsedRows = parser.parse(roundTripDoc);
+    String serialized = serializer.serialize(parsedRows);
+    Vector<Vector<String>> reparsedRows = parser.parse(serialized);
+    assert reparsedRows.getSize() == 3;
+    Vector<String>& reHeader = reparsedRows.get(0);
+    Vector<String>& reAlice = reparsedRows.get(1);
+    Vector<String>& reBob = reparsedRows.get(2);
+    assert reHeader.get(2) == String("city");
+    assert reAlice.get(2) == String("New York");
+    assert reBob.get(2) == String("Line1\nLine2");
+
+    // A trailing record of a single empty field must survive the round-trip
+    Vector<Vector<String>> emptyFieldRows;
+    Vector<String> firstRow;
+    firstRow.pushBack(String("a"));
+    emptyFieldRows.pushBack(firstRow);
+    Vector<String> emptyRow;
+    emptyRow.pushBack(String(""));
+    emptyFieldRows.pushBack(emptyRow);
+    Vector<Vector<String>> reEmptyRows = parser.parse(serializer.serialize(emptyFieldRows));
+    assert reEmptyRows.getSize() == 2;
+    Vector<String>& reEmptyTrailing = reEmptyRows.get(1);
+    assert reEmptyTrailing.getSize() == 1;
+    assert reEmptyTrailing.get(0) == String("");
+
+    // Custom delimiter is honored during serialization
+    CsvSerializer semicolonSerializer = CsvSerializer(';');
+    assert semicolonSerializer.serializeField(String("a;b")) == String("\"a;b\"");
+    assert semicolonSerializer.serializeField(String("a,b")) == String("a,b");
+
+    printf("All assertions passed!");
+}

--- a/test/test-files/std/text/json-parser/source.spice
+++ b/test/test-files/std/text/json-parser/source.spice
@@ -1,3 +1,4 @@
+import "std/text/json-value";
 import "std/text/json-parser";
 
 f<int> main() {
@@ -104,6 +105,12 @@ f<int> main() {
     JsonValue* cityField = addrField.getField("city");
     assert cityField.getString() == String("NYC");
 
+    // Object fields are enumerable in insertion order
+    assert obj.getObjectKey(0l) == String("name");
+    assert obj.getObjectKey(5l) == String("address");
+    JsonValue* firstValue = obj.getObjectValue(0l);
+    assert firstValue.getString() == String("Alice");
+
     // Malformed input surfaces an error
     Result<JsonValue*> badRes = parseJson(String("{\"x\":}"));
     assert !badRes.isOk();
@@ -126,59 +133,6 @@ f<int> main() {
     assert !rawNewlineRes.isOk();
     Result<JsonValue*> rawTabRes = parseJson(String("\"a\tb\""));
     assert !rawTabRes.isOk();
-
-    // Serialization of scalars
-    JsonValue nullVal = JsonValue();
-    assert nullVal.serialize() == String("null");
-    JsonValue boolVal = JsonValue(true);
-    assert boolVal.serialize() == String("true");
-    JsonValue intVal = JsonValue(42.0);
-    assert intVal.serialize() == String("42");
-    JsonValue fracVal = JsonValue(-3.5);
-    assert fracVal.serialize() == String("-3.5");
-    JsonValue strVal = JsonValue(String("a\"b\nc"));
-    assert strVal.serialize() == String("\"a\\\"b\\nc\"");
-
-    // Compact serialization of a parsed object preserves field order
-    String compactDoc = String("{\"name\":\"Alice\",\"age\":30,\"admin\":true,\"tags\":[\"a\",\"b\"],\"address\":{\"city\":\"NYC\"}}");
-    Result<JsonValue*> compactRes = parseJson(compactDoc);
-    assert compactRes.isOk();
-    JsonValue* compact = compactRes.unwrap();
-    assert compact.serialize() == compactDoc;
-
-    // Empty array/object
-    Result<JsonValue*> emptyArrSerRes = parseJson(String("[]"));
-    JsonValue* emptyArrSer = emptyArrSerRes.unwrap();
-    assert emptyArrSer.serialize() == String("[]");
-    Result<JsonValue*> emptyObjSerRes = parseJson(String("{}"));
-    JsonValue* emptyObjSer = emptyObjSerRes.unwrap();
-    assert emptyObjSer.serialize() == String("{}");
-
-    // Round-trip: serialize -> parse -> serialize is stable
-    String onceSerialized = compact.serialize();
-    Result<JsonValue*> reParsedRes = parseJson(onceSerialized);
-    JsonValue* reParsed = reParsedRes.unwrap();
-    assert reParsed.serialize() == compactDoc;
-
-    // Pretty printing
-    Result<JsonValue*> prettyRes = parseJson(String("{\"a\":1,\"b\":[2,3]}"));
-    JsonValue* pretty = prettyRes.unwrap();
-    String expectedPretty = String("{\n");
-    expectedPretty += "  \"a\": 1,\n";
-    expectedPretty += "  \"b\": [\n";
-    expectedPretty += "    2,\n";
-    expectedPretty += "    3\n";
-    expectedPretty += "  ]\n";
-    expectedPretty += "}";
-    assert pretty.serializePretty() == expectedPretty;
-
-    // Non-integral numbers keep full precision across a serialize/parse round-trip
-    Result<JsonValue*> precRes = parseJson(String("1.23456789"));
-    JsonValue* prec = precRes.unwrap();
-    String precSerialized = prec.serialize();
-    Result<JsonValue*> precReparsedRes = parseJson(precSerialized);
-    JsonValue* precReparsed = precReparsedRes.unwrap();
-    assert precReparsed.getNumber() == 1.23456789;
 
     printf("All assertions passed!");
 }

--- a/test/test-files/std/text/json-serializer/cout.out
+++ b/test/test-files/std/text/json-serializer/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/json-serializer/source.spice
+++ b/test/test-files/std/text/json-serializer/source.spice
@@ -1,0 +1,71 @@
+import "std/text/json-value";
+import "std/text/json-serializer";
+import "std/text/json-parser";
+
+f<int> main() {
+    // Serialization of scalars
+    JsonValue nullVal = JsonValue();
+    assert serializeJson(nullVal) == String("null");
+    JsonValue boolVal = JsonValue(true);
+    assert serializeJson(boolVal) == String("true");
+    JsonValue intVal = JsonValue(42.0);
+    assert serializeJson(intVal) == String("42");
+    JsonValue fracVal = JsonValue(-3.5);
+    assert serializeJson(fracVal) == String("-3.5");
+    JsonValue strVal = JsonValue(String("a\"b\nc"));
+    assert serializeJson(strVal) == String("\"a\\\"b\\nc\"");
+
+    // Values built programmatically serialize as expected
+    JsonValue arrVal = JsonValue(JsonValueKind::JSON_ARRAY);
+    arrVal.addArrayItem(__new<JsonValue>(1.0));
+    arrVal.addArrayItem(__new<JsonValue>(2.0));
+    assert serializeJson(arrVal) == String("[1,2]");
+
+    JsonValue objVal = JsonValue(JsonValueKind::JSON_OBJECT);
+    objVal.addObjectField(String("a"), __new<JsonValue>(true));
+    objVal.addObjectField(String("b"), __new<JsonValue>(String("x")));
+    assert serializeJson(objVal) == String("{\"a\":true,\"b\":\"x\"}");
+
+    // Compact serialization of a parsed object preserves field order
+    String compactDoc = String("{\"name\":\"Alice\",\"age\":30,\"admin\":true,\"tags\":[\"a\",\"b\"],\"address\":{\"city\":\"NYC\"}}");
+    Result<JsonValue*> compactRes = parseJson(compactDoc);
+    assert compactRes.isOk();
+    JsonValue* compact = compactRes.unwrap();
+    assert serializeJson(compact) == compactDoc;
+
+    // Empty array/object
+    Result<JsonValue*> emptyArrSerRes = parseJson(String("[]"));
+    JsonValue* emptyArrSer = emptyArrSerRes.unwrap();
+    assert serializeJson(emptyArrSer) == String("[]");
+    Result<JsonValue*> emptyObjSerRes = parseJson(String("{}"));
+    JsonValue* emptyObjSer = emptyObjSerRes.unwrap();
+    assert serializeJson(emptyObjSer) == String("{}");
+
+    // Round-trip: serialize -> parse -> serialize is stable
+    String onceSerialized = serializeJson(compact);
+    Result<JsonValue*> reParsedRes = parseJson(onceSerialized);
+    JsonValue* reParsed = reParsedRes.unwrap();
+    assert serializeJson(reParsed) == compactDoc;
+
+    // Pretty printing
+    Result<JsonValue*> prettyRes = parseJson(String("{\"a\":1,\"b\":[2,3]}"));
+    JsonValue* pretty = prettyRes.unwrap();
+    String expectedPretty = String("{\n");
+    expectedPretty += "  \"a\": 1,\n";
+    expectedPretty += "  \"b\": [\n";
+    expectedPretty += "    2,\n";
+    expectedPretty += "    3\n";
+    expectedPretty += "  ]\n";
+    expectedPretty += "}";
+    assert serializeJsonPretty(pretty) == expectedPretty;
+
+    // Non-integral numbers keep full precision across a serialize/parse round-trip
+    Result<JsonValue*> precRes = parseJson(String("1.23456789"));
+    JsonValue* prec = precRes.unwrap();
+    String precSerialized = serializeJson(prec);
+    Result<JsonValue*> precReparsedRes = parseJson(precSerialized);
+    JsonValue* precReparsed = precReparsedRes.unwrap();
+    assert precReparsed.getNumber() == 1.23456789;
+
+    printf("All assertions passed!");
+}

--- a/test/test-files/std/text/json-serializer/source.spice
+++ b/test/test-files/std/text/json-serializer/source.spice
@@ -3,51 +3,54 @@ import "std/text/json-serializer";
 import "std/text/json-parser";
 
 f<int> main() {
+    JsonSerializer serializer;
+
     // Serialization of scalars
     JsonValue nullVal = JsonValue();
-    assert serializeJson(nullVal) == String("null");
+    assert serializer.serialize(nullVal) == String("null");
     JsonValue boolVal = JsonValue(true);
-    assert serializeJson(boolVal) == String("true");
+    assert serializer.serialize(boolVal) == String("true");
     JsonValue intVal = JsonValue(42.0);
-    assert serializeJson(intVal) == String("42");
+    assert serializer.serialize(intVal) == String("42");
     JsonValue fracVal = JsonValue(-3.5);
-    assert serializeJson(fracVal) == String("-3.5");
+    assert serializer.serialize(fracVal) == String("-3.5");
     JsonValue strVal = JsonValue(String("a\"b\nc"));
-    assert serializeJson(strVal) == String("\"a\\\"b\\nc\"");
+    assert serializer.serialize(strVal) == String("\"a\\\"b\\nc\"");
 
     // Values built programmatically serialize as expected
     JsonValue arrVal = JsonValue(JsonValueKind::JSON_ARRAY);
     arrVal.addArrayItem(__new<JsonValue>(1.0));
     arrVal.addArrayItem(__new<JsonValue>(2.0));
-    assert serializeJson(arrVal) == String("[1,2]");
+    assert serializer.serialize(arrVal) == String("[1,2]");
 
     JsonValue objVal = JsonValue(JsonValueKind::JSON_OBJECT);
     objVal.addObjectField(String("a"), __new<JsonValue>(true));
     objVal.addObjectField(String("b"), __new<JsonValue>(String("x")));
-    assert serializeJson(objVal) == String("{\"a\":true,\"b\":\"x\"}");
+    assert serializer.serialize(objVal) == String("{\"a\":true,\"b\":\"x\"}");
 
     // Compact serialization of a parsed object preserves field order
     String compactDoc = String("{\"name\":\"Alice\",\"age\":30,\"admin\":true,\"tags\":[\"a\",\"b\"],\"address\":{\"city\":\"NYC\"}}");
     Result<JsonValue*> compactRes = parseJson(compactDoc);
     assert compactRes.isOk();
     JsonValue* compact = compactRes.unwrap();
-    assert serializeJson(compact) == compactDoc;
+    assert serializer.serialize(compact) == compactDoc;
 
     // Empty array/object
     Result<JsonValue*> emptyArrSerRes = parseJson(String("[]"));
     JsonValue* emptyArrSer = emptyArrSerRes.unwrap();
-    assert serializeJson(emptyArrSer) == String("[]");
+    assert serializer.serialize(emptyArrSer) == String("[]");
     Result<JsonValue*> emptyObjSerRes = parseJson(String("{}"));
     JsonValue* emptyObjSer = emptyObjSerRes.unwrap();
-    assert serializeJson(emptyObjSer) == String("{}");
+    assert serializer.serialize(emptyObjSer) == String("{}");
 
     // Round-trip: serialize -> parse -> serialize is stable
-    String onceSerialized = serializeJson(compact);
+    String onceSerialized = serializer.serialize(compact);
     Result<JsonValue*> reParsedRes = parseJson(onceSerialized);
     JsonValue* reParsed = reParsedRes.unwrap();
-    assert serializeJson(reParsed) == compactDoc;
+    assert serializer.serialize(reParsed) == compactDoc;
 
     // Pretty printing
+    JsonSerializer prettySerializer = JsonSerializer(true);
     Result<JsonValue*> prettyRes = parseJson(String("{\"a\":1,\"b\":[2,3]}"));
     JsonValue* pretty = prettyRes.unwrap();
     String expectedPretty = String("{\n");
@@ -57,12 +60,12 @@ f<int> main() {
     expectedPretty += "    3\n";
     expectedPretty += "  ]\n";
     expectedPretty += "}";
-    assert serializeJsonPretty(pretty) == expectedPretty;
+    assert prettySerializer.serialize(pretty) == expectedPretty;
 
     // Non-integral numbers keep full precision across a serialize/parse round-trip
     Result<JsonValue*> precRes = parseJson(String("1.23456789"));
     JsonValue* prec = precRes.unwrap();
-    String precSerialized = serializeJson(prec);
+    String precSerialized = serializer.serialize(prec);
     Result<JsonValue*> precReparsedRes = parseJson(precSerialized);
     JsonValue* precReparsed = precReparsedRes.unwrap();
     assert precReparsed.getNumber() == 1.23456789;

--- a/test/test-files/std/text/xml-parser/source.spice
+++ b/test/test-files/std/text/xml-parser/source.spice
@@ -1,3 +1,4 @@
+import "std/text/xml-node";
 import "std/text/xml-parser";
 
 f<int> main() {
@@ -19,6 +20,9 @@ f<int> main() {
     assert !a.hasAttribute("missing");
     assert a.getAttribute("x") == String("1");
     assert a.getAttribute("y") == String("two & three");
+    // Attributes are enumerable in document order
+    assert a.getAttributeKey(0l) == String("x");
+    assert a.getAttributeValue(1l) == String("two & three");
 
     // Text content with character references
     Result<XmlNode*> textRes = parseXml(String("<msg>hi &lt;there&gt; &#65;</msg>"));
@@ -95,34 +99,6 @@ f<int> main() {
     assert prologRes.isOk();
     XmlNode* prologRoot = prologRes.unwrap();
     assert prologRoot.getName() == String("root");
-
-    // Serialization: self-closing element with escaped attributes
-    Result<XmlNode*> serSelfRes = parseXml(String("<a x=\"1\" y='two &amp; three'/>"));
-    XmlNode* serSelf = serSelfRes.unwrap();
-    assert serSelf.serialize() == String("<a x=\"1\" y=\"two &amp; three\"/>");
-
-    // Text content escaping round-trips through the parser
-    Result<XmlNode*> serTextRes = parseXml(String("<msg>hi &lt;there&gt; &amp; you</msg>"));
-    XmlNode* serText = serTextRes.unwrap();
-    assert serText.serialize() == String("<msg>hi &lt;there&gt; &amp; you</msg>");
-
-    // Round-trip: serialize -> parse -> serialize is stable
-    Result<XmlNode*> serRoundRes = parseXml(String("<book id=\"42\"><title>Spice</title><tags><tag>lang</tag><tag>systems</tag></tags></book>"));
-    XmlNode* serRound = serRoundRes.unwrap();
-    String serializedXml = serRound.serialize();
-    Result<XmlNode*> reparsedRes = parseXml(serializedXml);
-    assert reparsedRes.isOk();
-    XmlNode* reparsedRoot = reparsedRes.unwrap();
-    assert reparsedRoot.serialize() == serializedXml;
-
-    // Pretty printing lays element children on their own lines
-    Result<XmlNode*> prettyXmlRes = parseXml(String("<root><a>1</a><b>2</b></root>"));
-    XmlNode* prettyXml = prettyXmlRes.unwrap();
-    String expectedPrettyXml = String("<root>\n");
-    expectedPrettyXml += "  <a>1</a>\n";
-    expectedPrettyXml += "  <b>2</b>\n";
-    expectedPrettyXml += "</root>";
-    assert prettyXml.serializePretty() == expectedPrettyXml;
 
     printf("All assertions passed!");
 }

--- a/test/test-files/std/text/xml-serializer/cout.out
+++ b/test/test-files/std/text/xml-serializer/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/xml-serializer/source.spice
+++ b/test/test-files/std/text/xml-serializer/source.spice
@@ -3,15 +3,17 @@ import "std/text/xml-serializer";
 import "std/text/xml-parser";
 
 f<int> main() {
+    XmlSerializer serializer;
+
     // Serialization: self-closing element with escaped attributes
     Result<XmlNode*> serSelfRes = parseXml(String("<a x=\"1\" y='two &amp; three'/>"));
     XmlNode* serSelf = serSelfRes.unwrap();
-    assert serializeXml(serSelf) == String("<a x=\"1\" y=\"two &amp; three\"/>");
+    assert serializer.serialize(serSelf) == String("<a x=\"1\" y=\"two &amp; three\"/>");
 
     // Text content escaping round-trips through the parser
     Result<XmlNode*> serTextRes = parseXml(String("<msg>hi &lt;there&gt; &amp; you</msg>"));
     XmlNode* serText = serTextRes.unwrap();
-    assert serializeXml(serText) == String("<msg>hi &lt;there&gt; &amp; you</msg>");
+    assert serializer.serialize(serText) == String("<msg>hi &lt;there&gt; &amp; you</msg>");
 
     // Nodes built programmatically serialize as expected
     XmlNode root = XmlNode(XmlNodeKind::XML_ELEMENT);
@@ -20,25 +22,26 @@ f<int> main() {
     XmlNode* textChild = __new<XmlNode>(XmlNodeKind::XML_TEXT);
     textChild.setText(String("Hello & bye"));
     root.addChild(textChild);
-    assert serializeXml(root) == String("<greeting lang=\"en\">Hello &amp; bye</greeting>");
+    assert serializer.serialize(root) == String("<greeting lang=\"en\">Hello &amp; bye</greeting>");
 
     // Round-trip: serialize -> parse -> serialize is stable
     Result<XmlNode*> serRoundRes = parseXml(String("<book id=\"42\"><title>Spice</title><tags><tag>lang</tag><tag>systems</tag></tags></book>"));
     XmlNode* serRound = serRoundRes.unwrap();
-    String serializedXml = serializeXml(serRound);
+    String serializedXml = serializer.serialize(serRound);
     Result<XmlNode*> reparsedRes = parseXml(serializedXml);
     assert reparsedRes.isOk();
     XmlNode* reparsedRoot = reparsedRes.unwrap();
-    assert serializeXml(reparsedRoot) == serializedXml;
+    assert serializer.serialize(reparsedRoot) == serializedXml;
 
     // Pretty printing lays element children on their own lines
+    XmlSerializer prettySerializer = XmlSerializer(true);
     Result<XmlNode*> prettyXmlRes = parseXml(String("<root><a>1</a><b>2</b></root>"));
     XmlNode* prettyXml = prettyXmlRes.unwrap();
     String expectedPrettyXml = String("<root>\n");
     expectedPrettyXml += "  <a>1</a>\n";
     expectedPrettyXml += "  <b>2</b>\n";
     expectedPrettyXml += "</root>";
-    assert serializeXmlPretty(prettyXml) == expectedPrettyXml;
+    assert prettySerializer.serialize(prettyXml) == expectedPrettyXml;
 
     printf("All assertions passed!");
 }

--- a/test/test-files/std/text/xml-serializer/source.spice
+++ b/test/test-files/std/text/xml-serializer/source.spice
@@ -1,0 +1,44 @@
+import "std/text/xml-node";
+import "std/text/xml-serializer";
+import "std/text/xml-parser";
+
+f<int> main() {
+    // Serialization: self-closing element with escaped attributes
+    Result<XmlNode*> serSelfRes = parseXml(String("<a x=\"1\" y='two &amp; three'/>"));
+    XmlNode* serSelf = serSelfRes.unwrap();
+    assert serializeXml(serSelf) == String("<a x=\"1\" y=\"two &amp; three\"/>");
+
+    // Text content escaping round-trips through the parser
+    Result<XmlNode*> serTextRes = parseXml(String("<msg>hi &lt;there&gt; &amp; you</msg>"));
+    XmlNode* serText = serTextRes.unwrap();
+    assert serializeXml(serText) == String("<msg>hi &lt;there&gt; &amp; you</msg>");
+
+    // Nodes built programmatically serialize as expected
+    XmlNode root = XmlNode(XmlNodeKind::XML_ELEMENT);
+    root.setName(String("greeting"));
+    root.addAttribute(String("lang"), String("en"));
+    XmlNode* textChild = __new<XmlNode>(XmlNodeKind::XML_TEXT);
+    textChild.setText(String("Hello & bye"));
+    root.addChild(textChild);
+    assert serializeXml(root) == String("<greeting lang=\"en\">Hello &amp; bye</greeting>");
+
+    // Round-trip: serialize -> parse -> serialize is stable
+    Result<XmlNode*> serRoundRes = parseXml(String("<book id=\"42\"><title>Spice</title><tags><tag>lang</tag><tag>systems</tag></tags></book>"));
+    XmlNode* serRound = serRoundRes.unwrap();
+    String serializedXml = serializeXml(serRound);
+    Result<XmlNode*> reparsedRes = parseXml(serializedXml);
+    assert reparsedRes.isOk();
+    XmlNode* reparsedRoot = reparsedRes.unwrap();
+    assert serializeXml(reparsedRoot) == serializedXml;
+
+    // Pretty printing lays element children on their own lines
+    Result<XmlNode*> prettyXmlRes = parseXml(String("<root><a>1</a><b>2</b></root>"));
+    XmlNode* prettyXml = prettyXmlRes.unwrap();
+    String expectedPrettyXml = String("<root>\n");
+    expectedPrettyXml += "  <a>1</a>\n";
+    expectedPrettyXml += "  <b>2</b>\n";
+    expectedPrettyXml += "</root>";
+    assert serializeXmlPretty(prettyXml) == expectedPrettyXml;
+
+    printf("All assertions passed!");
+}


### PR DESCRIPTION
## What changed
- Split each of the `std/text` CSV/JSON/XML modules into separate parser and serializer source files, so a program only imports what it actually uses:
  - CSV: `csv-parser` / `csv-serializer`
  - JSON: `json-value` (shared data model) + `json-parser` / `json-serializer`
  - XML: `xml-node` (shared data model) + `xml-parser` / `xml-serializer`
- Each serializer module exposes a struct mirroring `CsvParser`/`CsvSerializer` for a consistent API across formats: `CsvSerializer` (configurable delimiter/quote), `JsonSerializer` and `XmlSerializer` (pretty-printing as constructor config, e.g. `JsonSerializer(true)`), each with `serialize(...)` methods.
- Added the mutators/accessors the split needs while keeping fields private: `JsonValue.addArrayItem`/`addObjectField`/`getObjectKey`/`getObjectValue` and `XmlNode.setName`/`setText`/`addAttribute`/`addChild`/`getAttributeKey`/`getAttributeValue`, plus kind-taking constructors. As a side effect, object fields and attributes are now publicly enumerable.
- Split the `std/text` test cases accordingly (parser tests keep parsing coverage; new `csv-serializer`/`json-serializer`/`xml-serializer` cases cover serialization, round-trips, and building documents programmatically) and updated `std/README.md`.
- `LLVMOptions.cmake`: additionally link the per-target libraries for every target in `LLVM_TARGETS_TO_BUILD`. The `InitializeAll*` entry points reference every target compiled into the LLVM distribution, so linking only the Spice-enabled targets fails against distributions built with more targets (e.g. the official release binaries). Happy to drop this commit if it should go in separately.

## Why
Users previously had to pull in the full parser+serializer implementation even when they only needed one direction. Since imports are not re-exported transitively, the shared JSON/XML data models live in their own files (`json-value`, `xml-node`) that users import alongside the parser or serializer.

## How it was validated
- Built `spice` and `spicetest` against the official LLVM 22.1.7 release binaries.
- `spicetest --gtest_filter='StdTests*'` — all `std/text` cases pass, including the six CSV/JSON/XML parser/serializer cases. The only failures are `bindings_libcurlFileDownload` and `bindings_llvm`, which fail in the sandboxed environment for unrelated reasons (no network access, no local LLVM dev tree).
- Full suite: remaining failures are environment-only (`BootstrapCompilerTests` need `SPICE_BOOTSTRAP_DIR`, two `DriverTest` cases depend on cwd-relative paths).

## Follow-up / known limitations
- Breaking API change: serialization moved off the data types into the serializer structs (`JsonValue.serialize()` → `JsonSerializer().serialize(value)`, `XmlNode.serialize()` → `XmlSerializer().serialize(node)`, `CsvParser.serialize*` → `CsvSerializer.serialize*`). Importers of `json-parser`/`xml-parser` now also import `json-value`/`xml-node` to name the model types.

https://claude.ai/code/session_01BxvXL3sx5rp9xmgfV3nhRD