### PR TITLE
Fix ctor body preamble using generic scope instead of manifestation scope

### DIFF
--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -118,9 +118,11 @@ std::any TypeChecker::visitProcDefCheck(ProcDefNode *node) {
     if (node->hasParams)
       visit(node->paramLst);
 
-    // Prepare generation of special ctor preamble to store VTable, default field values, etc. if required
+    // Prepare generation of special ctor preamble to store VTable, default field values, etc. if required.
+    // Use the concrete manifestation body scope, not node->scope (generic), to avoid stale types from one
+    // concrete manifestation polluting the generic struct scope for subsequent manifestations.
     if (node->isCtor)
-      createCtorBodyPreamble(node->scope);
+      createCtorBodyPreamble(manifestation->bodyScope);
 
     // Visit statements in new scope
     visit(node->body);


### PR DESCRIPTION
## What changed
- `createCtorBodyPreamble` is now called with `manifestation->bodyScope` instead of `node->scope`

## Why
`node->scope` is the generic (uninstantiated) struct scope. When a generic struct has multiple concrete manifestations, using it caused stale types from one manifestation to pollute the generic scope, which subsequent manifestations then picked up — leading to incorrect type information during IR generation.

## How it was validated
- Build and local inspection of the affected code path

## Follow-up / known limitations
- Full test suite was not run in this environment (LLVM not available); CI will validate