### PR TITLE
Inherit stdio when running compiled Spice binaries

### DIFF
--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -191,10 +191,10 @@ void Driver::runBinary() const {
   if (cliOptions.printDebugOutput)
     std::cout << "Running executable ...\n\n";
 
-  // Run executable
+  // Run executable, inheriting our standard streams so its output goes straight to the terminal
   std::filesystem::path executablePath = cliOptions.outputPath;
   executablePath.make_preferred();
-  const auto [output, exitCode] = SystemUtil::exec(executablePath.string());
+  const int exitCode = SystemUtil::run(executablePath.string());
   if (exitCode != EXIT_SUCCESS)
     throw CliError(NON_ZERO_EXIT_CODE, "Your Spice executable exited with non-zero exit code " + std::to_string(exitCode));
 }

--- a/src/util/SystemUtil.cpp
+++ b/src/util/SystemUtil.cpp
@@ -6,8 +6,11 @@
 #include <iostream> // IWYU pragma: keep (usage in Windows-only code)
 #include <vector>
 #if OS_UNIX
+#include <spawn.h>
+#include <sys/wait.h>
 #include <unistd.h>
 #elif OS_WINDOWS
+#include <process.h>
 #include <windows.h>
 #else
 #error "Unsupported platform"
@@ -53,6 +56,36 @@ ExecResult SystemUtil::exec(const std::string &command, bool redirectStdErrToStd
 
   const int status = pclose(pipe);
   return {result.str(), transformStatusToExitCode(status)};
+}
+
+/**
+ * Execute an external binary, inheriting the parent's standard streams.
+ * Unlike exec(), this does not capture the child's output: its stdin, stdout and stderr are
+ * connected directly to ours, so the program behaves as if invoked from the terminal.
+ *
+ * @param executablePath Path to the executable to run
+ * @return Exit code of the executed binary
+ */
+int SystemUtil::run(const std::string &executablePath) {
+#if OS_UNIX
+  // No file actions are given, so the child inherits our stdin/stdout/stderr
+  const char *argv[] = {executablePath.c_str(), nullptr};
+  pid_t pid;
+  if (posix_spawn(&pid, executablePath.c_str(), nullptr, nullptr, const_cast<char *const *>(argv), environ) != 0)
+    throw CompilerError(IO_ERROR, "Failed to execute: " + executablePath); // GCOV_EXCL_LINE
+  int status;
+  if (waitpid(pid, &status, 0) == -1)
+    throw CompilerError(IO_ERROR, "Failed to wait for: " + executablePath); // GCOV_EXCL_LINE
+  return transformStatusToExitCode(status);
+#elif OS_WINDOWS
+  // _P_WAIT inherits the parent's standard streams and returns the child's exit code
+  const intptr_t exitCode = _spawnl(_P_WAIT, executablePath.c_str(), executablePath.c_str(), nullptr);
+  if (exitCode == -1)
+    throw CompilerError(IO_ERROR, "Failed to execute: " + executablePath); // GCOV_EXCL_LINE
+  return static_cast<int>(exitCode);
+#else
+#error "Unsupported platform"
+#endif
 }
 
 /**

--- a/src/util/SystemUtil.cpp
+++ b/src/util/SystemUtil.cpp
@@ -9,6 +9,9 @@
 #include <spawn.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#if OS_MACOS
+extern char **environ;
+#endif
 #elif OS_WINDOWS
 #include <process.h>
 #include <windows.h>

--- a/src/util/SystemUtil.h
+++ b/src/util/SystemUtil.h
@@ -24,6 +24,7 @@ struct ExternalBinaryFinderResult {
 class SystemUtil {
 public:
   static ExecResult exec(const std::string &command, bool redirectStdErrToStdOut = false);
+  static int run(const std::string &executablePath);
   static bool isCommandAvailable(const std::string &cmd);
   static bool isGraphvizInstalled();
   static ExternalBinaryFinderResult findLinkerInvoker();


### PR DESCRIPTION
## What changed
- Add `SystemUtil::run`, which spawns a binary with the parent's standard streams inherited (`posix_spawn` on UNIX, `_spawnl` on Windows) instead of capturing its output through a pipe.
- `Driver::runBinary` now uses `SystemUtil::run` while still propagating a non-zero exit code as a `CliError`.

## Why
`Driver::runBinary` ran the compiled program through `SystemUtil::exec`, which uses `popen(..., "r")` and reads the child's stdout into a string that was never used — only the exit code was checked. As a result, a Spice program's output never reached the terminal (and was not streamed live). Inheriting stdio makes `spice run` behave like invoking the binary directly: live output, working stdin, and no shell re-parsing of the path.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest -j` — builds clean
- `cmake-build-debug/test/spicetest --gtest_filter='*SystemUtil*'` — all pass
- Manually ran `spice run media/test-project/test.spice` — program output (`Hello, Spice!`) now prints to the terminal

## Follow-up / known limitations
- `SystemUtil::exec` (pipe-capturing) is intentionally left in place for callers that need the captured output (linker invocation, bootstrap, tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)