### PR TITLE
Disallow implicit composed-base upcasts; require explicit cast

### DIFF
--- a/src-bootstrap/model/generic-type.spice
+++ b/src-bootstrap/model/generic-type.spice
@@ -61,7 +61,7 @@ f<bool> GenericType.checkTypeConditionOf(const QualType& requestedType, QualType
         return true;
     }
     // Succeed if the given qual type is generic and matches the current one
-    if requestedType.hasAnyGenericParts() && requestedType == *this {
+    if requestedType.hasAnyGenericParts() && requestedType == this.qualType {
         return true;
     }
     // Check type conditions

--- a/src-bootstrap/parser/parser.spice
+++ b/src-bootstrap/parser/parser.spice
@@ -53,7 +53,7 @@ f<T*> Parser.createNode<T>() {
         __placement_new<T>(node, this.lexer.getCodeLoc());
     }
     // Upcast to the composed ASTNode base. This is what the parent/child book-keeping operates on.
-    ASTNode* nodeBase = node;
+    ASTNode* nodeBase = cast<ASTNode*>(node);
 
     // If this is not the entry node, we need to add the new node to its parent
     if !isRootNode {
@@ -68,7 +68,7 @@ f<T*> Parser.createNode<T>() {
 
 f<T*> Parser.concludeNode<T>(T* node) {
     assert !this.parentStack.isEmpty();
-    ASTNode* nodeBase = node;
+    ASTNode* nodeBase = cast<ASTNode*>(node);
     assert this.parentStack.top() == nodeBase;
     this.parentStack.pop();
     return node;

--- a/src-bootstrap/util/block-allocator.spice
+++ b/src-bootstrap/util/block-allocator.spice
@@ -74,7 +74,7 @@ public f<T*> BlockAllocator.reserve<T>() {
 
     // Track the object so it can be destructed in the allocator's dtor and update the offset to be ready
     // to store the next object. The object is not constructed yet, but its address is already stable.
-    Base* basePtr = ptr;
+    Base* basePtr = cast<Base*>(ptr);
     this.allocatedObjects.pushBack(basePtr);
     this.offsetInBlock += objSize;
     return ptr;

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -53,6 +53,64 @@ llvm::Value *IRGenerator::doImplicitCast(llvm::Value *src, QualType dstSTy, Qual
   return src;
 }
 
+llvm::Value *IRGenerator::getUpcastedStructPtr(llvm::Value *structPtr, const QualType &dstType, const QualType &srcType) const {
+  // Adjusts a pointer to a struct instance so it points at the embedded subobject the destination type
+  // refers to. This backs the explicit 'cast<Base*>(derived)' / 'cast<Interface*>(struct)' conversions.
+  // When the struct carries a vtable prefix (because it implements interfaces), the composed base no longer
+  // sits at offset 0, so the pointer has to be advanced via a GEP. For subobjects that already sit at offset
+  // 0 (e.g. the leading interface field), insertStructGEP() with index 0 is a no-op and returns the pointer
+  // unchanged, so no superfluous IR is emitted. If the given pair of types is not such an upcast, the
+  // pointer is returned unchanged.
+  QualType dstPointee = dstType.removeReferenceWrapper();
+  QualType srcPointee = srcType.removeReferenceWrapper();
+  // Both sides are pointers ('structPtr' is the pointer value itself), so look one level deeper
+  if (dstPointee.isPtr() && srcPointee.isPtr()) {
+    dstPointee = dstPointee.getContained();
+    srcPointee = srcPointee.getContained();
+  }
+  // Bail out if this is not an interface/composed-base upcast that requires a pointer adjustment
+  if (!srcPointee.is(TY_STRUCT))
+    return structPtr;
+  if (!dstPointee.matchesInterfaceImplementedByStruct(srcPointee) && !dstPointee.matchesComposedBaseOfStruct(srcPointee))
+    return structPtr;
+
+  QualType walkType = srcPointee;
+  while (!walkType.matches(dstPointee, false, true, true)) {
+    assert(walkType.is(TY_STRUCT));
+    Scope *structScope = walkType.getBodyScope();
+    assert(structScope != nullptr);
+    const Struct *spiceStruct = walkType.getStruct(nullptr);
+    assert(spiceStruct != nullptr);
+    llvm::Type *llvmStructType = walkType.toLLVMType(sourceFile);
+    // Implicit (interface) fields are inserted before the explicit fields, so their count is the difference
+    // between the total field count and the number of explicit fields.
+    const size_t implicitFieldCount = structScope->getFieldCount() - spiceStruct->fieldTypes.size();
+
+    // Case 1: the destination is an interface implemented directly by the struct -> step into its implicit field
+    if (dstPointee.is(TY_INTERFACE)) {
+      bool found = false;
+      for (size_t i = 0; i < implicitFieldCount; i++) {
+        const SymbolTableEntry *implicitField = structScope->lookupField(i);
+        if (dstPointee.matches(implicitField->getQualType(), false, true, true)) {
+          structPtr = insertStructGEP(llvmStructType, structPtr, implicitField->orderIndex);
+          found = true;
+          break;
+        }
+      }
+      assert(found);
+      (void)found;
+      return structPtr;
+    }
+
+    // Case 2: the destination is a composed base struct -> step into the first explicit (composed) field
+    const SymbolTableEntry *baseField = structScope->lookupField(implicitFieldCount);
+    assert(baseField != nullptr && baseField->getQualType().isComposition());
+    structPtr = insertStructGEP(llvmStructType, structPtr, baseField->orderIndex);
+    walkType = baseField->getQualType();
+  }
+  return structPtr;
+}
+
 void IRGenerator::generateScopeCleanup(const StmtLstNode *node) const {
   // Do not clean up if the block is already terminated
   if (blockAlreadyTerminated)

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -159,7 +159,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
 
         // Unwrap as far as possible and remove reference wrappers if possible
         QualType::unwrapBoth(expectedTy, actualTy);
-        return expectedTy.matchesInterfaceImplementedByStruct(actualTy) || expectedTy.matchesComposedBaseOfStruct(actualTy);
+        return expectedTy.matchesInterfaceImplementedByStruct(actualTy);
       };
 
       if (matchFct(expectedSTy, actualSTy)) {

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -183,6 +183,7 @@ private:
 
   // Generate implicit
   llvm::Value *doImplicitCast(llvm::Value *src, QualType dstSTy, QualType srcSTy);
+  llvm::Value *getUpcastedStructPtr(llvm::Value *structPtr, const QualType &dstType, const QualType &srcType) const;
   void generateScopeCleanup(const StmtLstNode *node) const;
   void generateFctDecl(const Function *fct, const std::vector<llvm::Value *> &args) const;
   llvm::CallInst *generateFctCall(const Function *fct, const std::vector<llvm::Value *> &args) const;

--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -1632,9 +1632,18 @@ LLVMExprResult OpRuleConversionManager::getCastInst(const ASTNode *node, QualTyp
   case COMB(TY_BYTE, TY_BYTE):     // fallthrough
   case COMB(TY_CHAR, TY_CHAR):     // fallthrough
   case COMB(TY_STRING, TY_STRING): // fallthrough
-  case COMB(TY_BOOL, TY_BOOL):     // fallthrough
-  case COMB(TY_PTR, TY_PTR):
+  case COMB(TY_BOOL, TY_BOOL):
     return rhs; // Identity cast
+  case COMB(TY_PTR, TY_PTR): {
+    // Handle safe struct-pointer upcasts: cast<Base*>(derived) / cast<Interface*>(struct). The pointer must be
+    // advanced to the embedded subobject (past any vtable prefix) instead of being passed through unchanged.
+    const QualType lhsContained = lhsSTy.getContained();
+    const QualType rhsContained = rhsSTy.getContained();
+    if (lhsContained.matchesInterfaceImplementedByStruct(rhsContained) ||
+        lhsContained.matchesComposedBaseOfStruct(rhsContained))
+      return {.value = irGenerator->getUpcastedStructPtr(rhsV(), lhsSTy, rhsSTy)};
+    return rhs;
+  }
   case COMB(TY_DOUBLE, TY_INT):
   case COMB(TY_DOUBLE, TY_SHORT):
   case COMB(TY_DOUBLE, TY_LONG):

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -496,9 +496,11 @@ bool QualType::matchesInterfaceImplementedByStruct(const QualType &structType) c
 
 /**
  * Check if the current (struct) type is a base of the given struct type, embedded via the 'compose'
- * qualifier. Only first-field compositions are considered, because only those sit at offset 0 and can
- * therefore be reached without adjusting the pointer value. The check follows the chain of first-field
- * compositions transitively, so a base that is composed several levels deep is still matched.
+ * qualifier as its first field. The compiler does not perform implicit struct-to-composed-base upcasts;
+ * this matcher only gates the explicit 'cast<Base*>(derived)' conversion (and the matching IR pointer
+ * adjustment). Only first-field compositions are considered, because those are the ones reachable by
+ * advancing the pointer along the first-field chain. The check follows that chain transitively, so a base
+ * that is composed several levels deep is still matched.
  */
 bool QualType::matchesComposedBaseOfStruct(const QualType &structType) const {
   if (!is(TY_STRUCT) || !structType.is(TY_STRUCT))
@@ -508,7 +510,7 @@ bool QualType::matchesComposedBaseOfStruct(const QualType &structType) const {
   if (spiceStruct == nullptr || spiceStruct->fieldTypes.empty())
     return false;
 
-  // Only the first field is guaranteed to be located at offset 0
+  // Only the first field can be a composed base that is reachable along the first-field chain
   const QualType &firstFieldType = spiceStruct->fieldTypes.front();
   if (!firstFieldType.isComposition())
     return false;

--- a/src/typechecker/OpRuleManager.cpp
+++ b/src/typechecker/OpRuleManager.cpp
@@ -151,15 +151,6 @@ QualType OpRuleManager::getAssignResultTypeCommon(const ASTNode *node, const Exp
     if (lhsTypeCopy.matchesInterfaceImplementedByStruct(rhsTypeCopy))
       return lhsType;
   }
-  // Allow baseStruct* = derivedStruct* or baseStruct& = derivedStruct where derivedStruct composes
-  // baseStruct as its first field (and is therefore located at the same address)
-  if (typesCompatible && lhsType.isBase(TY_STRUCT) && rhsType.isBase(TY_STRUCT)) {
-    QualType lhsTypeCopy = lhsType;
-    QualType rhsTypeCopy = rhsType;
-    QualType::unwrapBothWithRefWrappers(lhsTypeCopy, rhsTypeCopy);
-    if (lhsTypeCopy.matchesComposedBaseOfStruct(rhsTypeCopy))
-      return lhsType;
-  }
   // Allow type* = heap type* straight away. This is used for initializing non-owning pointers to heap allocations
   if (lhsType.isPtr() && rhsType.isHeap() && lhsType.matches(rhsType, false, true, true)) {
     TypeQualifiers rhsQualifiers = rhsType.getQualifiers();
@@ -721,6 +712,17 @@ QualType OpRuleManager::getCastResultType(const ASTNode *node, QualType lhsType,
   // Allow casts char* -> string and char[] -> string
   if (lhsType.is(TY_STRING) && rhsType.isOneOf({TY_PTR, TY_ARRAY}) && rhsType.getContained().is(TY_CHAR))
     return lhsType;
+  // Allow safe upcasts baseStruct* <- derivedStruct* and interface* <- struct* without requiring an unsafe
+  // block. These are the only struct-pointer casts where the target subobject is guaranteed to be present;
+  // the IR generator advances the pointer to that subobject (past any vtable prefix). The reverse direction
+  // (down/sibling casts) is not covered here and still falls through to the unsafe any* -> any* rule below.
+  if (lhsType.isPtr() && rhsType.isPtr()) {
+    const QualType lhsContained = lhsType.getContained();
+    const QualType rhsContained = rhsType.getContained();
+    if (lhsContained.matchesInterfaceImplementedByStruct(rhsContained) ||
+        lhsContained.matchesComposedBaseOfStruct(rhsContained))
+      return lhsType;
+  }
   // Allow casts any* -> any*
   if (lhsType.isOneOf({TY_PTR, TY_STRING}) && rhsType.isOneOf({TY_PTR, TY_STRING})) {
     ensureUnsafeAllowed(node, "(cast)", lhsType, rhsType);

--- a/src/typechecker/TypeMatcher.cpp
+++ b/src/typechecker/TypeMatcher.cpp
@@ -39,11 +39,7 @@ bool TypeMatcher::matchRequestedToCandidateType(QualType candidateType, QualType
     if (candidateType.matchesInterfaceImplementedByStruct(requestedType))
       return true;
     // Normal equality check
-    if (candidateType.matches(requestedType, true, !strictQualifierMatching, true))
-      return true;
-    // As a fallback, check if the right one is a struct that composes the struct on the left as its
-    // first field. This is kept last so the common (non-composing) path does not pay for the lookup.
-    return candidateType.matchesComposedBaseOfStruct(requestedType);
+    return candidateType.matches(requestedType, true, !strictQualifierMatching, true);
   }
 
   // Check if the candidate type itself is generic

--- a/test/test-files/bootstrap-compiler/standalone-parser-smoke-test/source.spice
+++ b/test/test-files/bootstrap-compiler/standalone-parser-smoke-test/source.spice
@@ -50,7 +50,7 @@ f<int> main() {
     ASTEntryNode* entry = parser.parse();
     assert entry != nil<ASTEntryNode*>;
 
-    ASTNode* root = entry;
+    ASTNode* root = cast<ASTNode*>(entry);
     const Vector<ASTNode*>& topLevelDefs = root.getChildren();
     assert topLevelDefs.getSize() == 10l;
     assert countNodes(root) == 919l;
@@ -64,7 +64,7 @@ f<int> main() {
     Lexer lexer2 = Lexer(filePath);
     Parser parser2 = Parser(lexer2);
     ASTEntryNode* entry2 = parser2.parse();
-    ASTNode* root2 = entry2;
+    ASTNode* root2 = cast<ASTNode*>(entry2);
     const Vector<ASTNode*>& topLevelDefs2 = root2.getChildren();
     assert topLevelDefs2.getSize() == 10l;
     assert countNodes(root2) == 919l;

--- a/test/test-files/bootstrap-compiler/standalone-parser-stress-test/source.spice
+++ b/test/test-files/bootstrap-compiler/standalone-parser-stress-test/source.spice
@@ -49,7 +49,7 @@ f<int> main() {
     ASTEntryNode* entry = parser.parse();
     assert entry != nil<ASTEntryNode*>;
 
-    ASTNode* root = entry;
+    ASTNode* root = cast<ASTNode*>(entry);
     const Vector<ASTNode*>& topLevelDefs = root.getChildren();
     assert topLevelDefs.getSize() == 88l;
     assert countNodes(root) == 36361l;
@@ -66,7 +66,7 @@ f<int> main() {
         Lexer runLexer = Lexer(filePath);
         Parser runParser = Parser(runLexer);
         ASTEntryNode* runEntry = runParser.parse();
-        ASTNode* runRoot = runEntry;
+        ASTNode* runRoot = cast<ASTNode*>(runEntry);
         assert countNodes(runRoot) == 36361l;
         assert runLexer.isEOF();
     }

--- a/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/cout.out
+++ b/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/cout.out
@@ -1,0 +1,3 @@
+derived->base:  7
+leaf->base:     1
+derived->iface: 99

--- a/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/ir-code.ll
@@ -1,0 +1,196 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+
+%struct.Base = type { i32 }
+%struct.Derived = type { %interface.IMarker, %struct.Base, i32 }
+%interface.IMarker = type { ptr }
+%struct.Leaf = type { %interface.IMarker, %struct.Derived, i32 }
+
+@_ZTS7IMarker = private constant [9 x i8] c"7IMarker\00", align 4
+@_ZTV8TypeInfo = external global ptr
+@_ZTI7IMarker = private constant { ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTV8TypeInfo, i64 2), ptr @_ZTS7IMarker }, align 8
+@_ZTV7IMarker = private unnamed_addr constant { [3 x ptr] } { [3 x ptr] [ptr null, ptr @_ZTI7IMarker, ptr null] }, align 8
+@_ZTS7Derived = private constant [9 x i8] c"7Derived\00", align 4
+@_ZTI7Derived = private constant { ptr, ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTV8TypeInfo, i64 2), ptr @_ZTS7Derived, ptr @_ZTI7IMarker }, align 8
+@_ZTV7Derived = private unnamed_addr constant { [3 x ptr] } { [3 x ptr] [ptr null, ptr @_ZTI7Derived, ptr @_ZN7Derived6markerEv] }, align 8
+@_ZTS4Leaf = private constant [6 x i8] c"4Leaf\00", align 4
+@_ZTI4Leaf = private constant { ptr, ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTV8TypeInfo, i64 2), ptr @_ZTS4Leaf, ptr @_ZTI7IMarker }, align 8
+@_ZTV4Leaf = private unnamed_addr constant { [3 x ptr] } { [3 x ptr] [ptr null, ptr @_ZTI4Leaf, ptr @_ZN4Leaf6markerEv] }, align 8
+@printf.str.0 = private unnamed_addr constant [20 x i8] c"derived->base:  %d\0A\00", align 4
+@printf.str.1 = private unnamed_addr constant [20 x i8] c"leaf->base:     %d\0A\00", align 4
+@printf.str.2 = private unnamed_addr constant [20 x i8] c"derived->iface: %d\0A\00", align 4
+
+define private void @_ZN4Base4initEi(ptr noundef nonnull align 4 dereferenceable(4) %0, i32 noundef %1) {
+  %this = alloca ptr, align 8
+  %v = alloca i32, align 4
+  store ptr %0, ptr %this, align 8
+  store i32 %1, ptr %v, align 4
+  %3 = load ptr, ptr %this, align 8
+  %baseVal.addr = getelementptr inbounds %struct.Base, ptr %3, i64 0, i32 0
+  %4 = load i32, ptr %v, align 4
+  store i32 %4, ptr %baseVal.addr, align 4
+  ret void
+}
+
+define private noundef i32 @_ZN4Base3getEv(ptr noundef nonnull align 4 dereferenceable(4) %0) {
+  %result = alloca i32, align 4
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = load ptr, ptr %this, align 8
+  %baseVal.addr = getelementptr inbounds %struct.Base, ptr %2, i64 0, i32 0
+  %3 = load i32, ptr %baseVal.addr, align 4
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define void @_ZN7Derived4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = load ptr, ptr %this, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV7Derived, i64 0, i32 0, i32 2), ptr %2, align 8
+  %3 = getelementptr inbounds nuw %struct.Derived, ptr %2, i32 0, i32 2
+  store i32 0, ptr %3, align 4
+  ret void
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define void @_ZN7Derived4ctorERK7Derived(ptr noundef nonnull align 8 dereferenceable(16) %0, ptr %1) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %3 = load ptr, ptr %this, align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr %3, ptr %1, i64 8, i1 false)
+  %4 = getelementptr inbounds nuw %struct.Derived, ptr %1, i32 0, i32 1
+  %5 = getelementptr inbounds nuw %struct.Derived, ptr %3, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr %5, ptr %4, i64 4, i1 false)
+  %6 = getelementptr inbounds nuw %struct.Derived, ptr %1, i32 0, i32 2
+  %7 = getelementptr inbounds nuw %struct.Derived, ptr %3, i32 0, i32 2
+  call void @llvm.memcpy.p0.p0.i64(ptr %7, ptr %6, i64 4, i1 false)
+  ret void
+}
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
+
+define private void @_ZN7Derived4initEii(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1, i32 noundef %2) {
+  %this = alloca ptr, align 8
+  %b = alloca i32, align 4
+  %d = alloca i32, align 4
+  store ptr %0, ptr %this, align 8
+  store i32 %1, ptr %b, align 4
+  store i32 %2, ptr %d, align 4
+  %4 = load ptr, ptr %this, align 8
+  %5 = getelementptr inbounds nuw %struct.Derived, ptr %4, i32 0, i32 1
+  %6 = load i32, ptr %b, align 4
+  call void @_ZN4Base4initEi(ptr noundef nonnull align 4 dereferenceable(4) %5, i32 noundef %6)
+  %7 = load ptr, ptr %this, align 8
+  %derivedVal.addr = getelementptr inbounds %struct.Derived, ptr %7, i64 0, i32 2
+  %8 = load i32, ptr %d, align 4
+  store i32 %8, ptr %derivedVal.addr, align 4
+  ret void
+}
+
+define private noundef i32 @_ZN7Derived6markerEv(ptr noundef nonnull align 8 dereferenceable(16) %0) {
+  %result = alloca i32, align 4
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = load ptr, ptr %this, align 8
+  %derivedVal.addr = getelementptr inbounds %struct.Derived, ptr %2, i64 0, i32 2
+  %3 = load i32, ptr %derivedVal.addr, align 4
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress noinline nounwind optnone uwtable
+define void @_ZN4Leaf4ctorEv(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = load ptr, ptr %this, align 8
+  store ptr getelementptr inbounds ({ [3 x ptr] }, ptr @_ZTV4Leaf, i64 0, i32 0, i32 2), ptr %2, align 8
+  %3 = getelementptr inbounds nuw %struct.Leaf, ptr %2, i32 0, i32 1
+  call void @_ZN7Derived4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %3)
+  %4 = getelementptr inbounds nuw %struct.Leaf, ptr %2, i32 0, i32 2
+  store i32 0, ptr %4, align 4
+  ret void
+}
+
+define private void @_ZN4Leaf4initEiii(ptr noundef nonnull align 8 dereferenceable(32) %0, i32 noundef %1, i32 noundef %2, i32 noundef %3) {
+  %this = alloca ptr, align 8
+  %b = alloca i32, align 4
+  %d = alloca i32, align 4
+  %l = alloca i32, align 4
+  store ptr %0, ptr %this, align 8
+  store i32 %1, ptr %b, align 4
+  store i32 %2, ptr %d, align 4
+  store i32 %3, ptr %l, align 4
+  %5 = load ptr, ptr %this, align 8
+  %6 = getelementptr inbounds nuw %struct.Leaf, ptr %5, i32 0, i32 1
+  %7 = load i32, ptr %b, align 4
+  %8 = load i32, ptr %d, align 4
+  call void @_ZN7Derived4initEii(ptr noundef nonnull align 8 dereferenceable(16) %6, i32 noundef %7, i32 noundef %8)
+  %9 = load ptr, ptr %this, align 8
+  %leafVal.addr = getelementptr inbounds %struct.Leaf, ptr %9, i64 0, i32 2
+  %10 = load i32, ptr %l, align 4
+  store i32 %10, ptr %leafVal.addr, align 4
+  ret void
+}
+
+define private noundef i32 @_ZN4Leaf6markerEv(ptr noundef nonnull align 8 dereferenceable(32) %0) {
+  %result = alloca i32, align 4
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = load ptr, ptr %this, align 8
+  %leafVal.addr = getelementptr inbounds %struct.Leaf, ptr %2, i64 0, i32 2
+  %3 = load i32, ptr %leafVal.addr, align 4
+  ret i32 %3
+}
+
+; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
+define dso_local noundef i32 @main() #2 {
+  %result = alloca i32, align 4
+  %der = alloca %struct.Derived, align 8
+  %b = alloca ptr, align 8
+  %leaf = alloca %struct.Leaf, align 8
+  %lb = alloca ptr, align 8
+  %m = alloca ptr, align 8
+  store i32 0, ptr %result, align 4
+  call void @_ZN7Derived4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %der)
+  call void @_ZN7Derived4initEii(ptr noundef nonnull align 8 dereferenceable(16) %der, i32 noundef 7, i32 noundef 99)
+  %1 = getelementptr inbounds nuw %struct.Derived, ptr %der, i32 0, i32 1
+  store ptr %1, ptr %b, align 8
+  %2 = load ptr, ptr %b, align 8
+  %3 = call noundef i32 @_ZN4Base3getEv(ptr noundef nonnull align 4 dereferenceable(4) %2)
+  %4 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 noundef %3)
+  call void @_ZN4Leaf4ctorEv(ptr noundef nonnull align 8 dereferenceable(32) %leaf)
+  call void @_ZN4Leaf4initEiii(ptr noundef nonnull align 8 dereferenceable(32) %leaf, i32 noundef 1, i32 noundef 2, i32 noundef 3)
+  %5 = getelementptr inbounds nuw %struct.Leaf, ptr %leaf, i32 0, i32 1
+  %6 = getelementptr inbounds nuw %struct.Derived, ptr %5, i32 0, i32 1
+  store ptr %6, ptr %lb, align 8
+  %7 = load ptr, ptr %lb, align 8
+  %8 = call noundef i32 @_ZN4Base3getEv(ptr noundef nonnull align 4 dereferenceable(4) %7)
+  %9 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 noundef %8)
+  store ptr %der, ptr %m, align 8
+  %10 = load ptr, ptr %m, align 8
+  %vtable.addr = load ptr, ptr %10, align 8
+  %vfct.addr = getelementptr inbounds ptr, ptr %vtable.addr, i64 0
+  %fct = load ptr, ptr %vfct.addr, align 8
+  %11 = call noundef i32 %fct(ptr noundef nonnull align 8 dereferenceable(8) %10)
+  %12 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 noundef %11)
+  %13 = load i32, ptr %result, align 4
+  ret i32 %13
+}
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #3
+
+attributes #0 = { mustprogress noinline nounwind optnone uwtable }
+attributes #1 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { mustprogress noinline norecurse nounwind optnone uwtable }
+attributes #3 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/source.spice
+++ b/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/source.spice
@@ -1,0 +1,65 @@
+// Explicit 'cast<Base*>(derived)' is allowed in a safe context (no unsafe block) when Base is a composed
+// base of the derived struct, or an interface it implements. The compiler advances the pointer to the
+// embedded subobject - importantly past any vtable prefix that an implemented interface adds in front of
+// the composed base, so the base no longer sits at offset 0. Implicit upcasts remain disallowed.
+
+type IMarker interface {
+    f<int> marker();
+}
+
+type Base struct {
+    int baseVal
+}
+
+p Base.init(int v) {
+    this.baseVal = v;
+}
+
+f<int> Base.get() {
+    return this.baseVal;
+}
+
+// Implements an interface (vtable pointer prefix at offset 0) AND composes Base, so Base is at offset != 0.
+type Derived struct : IMarker {
+    compose Base base
+    int derivedVal
+}
+
+p Derived.init(int b, int d) {
+    this.base.init(b);
+    this.derivedVal = d;
+}
+
+f<int> Derived.marker() {
+    return this.derivedVal;
+}
+
+// Two levels of composition, to exercise the transitive walk Leaf -> Derived -> Base.
+type Leaf struct : IMarker {
+    compose Derived derived
+    int leafVal
+}
+
+p Leaf.init(int b, int d, int l) {
+    this.derived.init(b, d);
+    this.leafVal = l;
+}
+
+f<int> Leaf.marker() {
+    return this.leafVal;
+}
+
+f<int> main() {
+    Derived der;
+    der.init(7, 99);
+    Base* b = cast<Base*>(&der); // safe upcast, must shift past the vtable prefix
+    printf("derived->base:  %d\n", b.get());
+
+    Leaf leaf;
+    leaf.init(1, 2, 3);
+    Base* lb = cast<Base*>(&leaf); // transitive upcast Leaf -> Derived -> Base
+    printf("leaf->base:     %d\n", lb.get());
+
+    IMarker* m = cast<IMarker*>(&der); // explicit interface upcast
+    printf("derived->iface: %d\n", m.marker());
+}

--- a/test/test-files/typechecker/structs/error-no-implicit-composed-base-upcast/exception.out
+++ b/test/test-files/typechecker/structs/error-no-implicit-composed-base-upcast/exception.out
@@ -1,0 +1,5 @@
+[Error|Semantic] ./source.spice:18:5:
+Wrong data type for operator: Cannot apply '=' operator on types Base* and Derived*
+
+18  Base* b = &der;
+    ^^^^^^^^^^^^^^

--- a/test/test-files/typechecker/structs/error-no-implicit-composed-base-upcast/source.spice
+++ b/test/test-files/typechecker/structs/error-no-implicit-composed-base-upcast/source.spice
@@ -1,0 +1,20 @@
+// The compiler must not perform implicit struct-to-composed-base upcasts. A struct that composes another
+// struct as its first field is NOT implicitly convertible to that base; the base has to be reached
+// explicitly (e.g. via the composed field). This keeps pointer identity explicit and avoids silent,
+// layout-dependent conversions.
+
+type Base struct {
+    int baseVal
+}
+
+type Derived struct {
+    compose Base base
+    int derivedVal
+}
+
+f<int> main() {
+    Derived der;
+    // The next line is a composed-base upcast and must be rejected
+    Base* b = &der;
+    return b.baseVal;
+}


### PR DESCRIPTION
## What changed
- Disallow the **implicit** struct-to-composed-base upcast (a struct composing another struct as its first field is no longer implicitly convertible to that base in assignments/arguments/returns). Interface upcasts are unaffected.
- Allow the **explicit** `cast<Base*>(derived)` / `cast<Interface*>(struct)` in a safe (non-`unsafe`) context, but only for the upcast direction. The IR generator advances the pointer to the embedded subobject via GEPs, following the first-field composition chain transitively and correctly skipping any vtable prefix added by an implemented interface. Down/sibling pointer casts still require `unsafe`.
- Migrate the bootstrap compiler (`parser`, block allocator, generic type) to the explicit cast / explicit composed-field access.

## Why
The implicit composed-base upcast was silent and layout-dependent. When a struct also implements an interface, a vtable pointer is placed in front of the composed base, so the base no longer sits at offset 0 — the implicitly emitted identity pointer copy then aliased the vtable region (garbage reads / segfault). Making the conversion explicit keeps pointer identity visible, and routing it through `cast<>` lets the compiler emit the correct, vtable-aware pointer adjustment.

## How it was validated
- `spicetest --gtest_filter='TypeCheckerTests.*:IRGeneratorTests.*:BootstrapCompilerTests.*'` — all pass except the pre-existing `BootstrapCompilerTests.standaloneCommonUtilTest` (local version/build-string golden mismatch, unrelated).
- New success test `irgenerator/structs/success-explicit-composed-base-cast` (cout + IR snapshot) verifies the GEP adjustments: single-level cast skips the vtable (field index 1), two-level cast emits two GEPs (`Leaf -> Derived -> Base`), and an interface cast stays at offset 0.
- New error test `typechecker/structs/error-no-implicit-composed-base-upcast` asserts the implicit upcast is rejected.
- Manually confirmed a downcast still requires `unsafe`.

## Follow-up / known limitations
- Down/sibling struct-pointer casts remain `unsafe` by design (no runtime check).
- The `commonUtil` bootstrap test failure is pre-existing and environmental.

🤖 Generated with [Claude Code](https://claude.com/claude-code)