### PR TITLE
Emit vtables/type infos with weak ODR linkage for MachO compatibility

### DIFF
--- a/src/irgenerator/GenVTable.cpp
+++ b/src/irgenerator/GenVTable.cpp
@@ -27,7 +27,7 @@ llvm::Constant *IRGenerator::generateTypeInfoName(StructBase *spiceStruct) const
   // Set global attributes
   global->setConstant(true);
   global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::None);
-  global->setLinkage(getSymbolLinkageType(isPublic));
+  global->setLinkage(getVTableLinkageType(isPublic));
   global->setDSOLocal(isSymbolDSOLocal(isPublic));
   attachComdatToSymbol(global, globalName, isPublic);
 
@@ -83,7 +83,7 @@ llvm::Constant *IRGenerator::generateTypeInfo(StructBase *spiceStruct) const {
   // Set global attributes
   global->setConstant(true);
   global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::None);
-  global->setLinkage(getSymbolLinkageType(isPublic));
+  global->setLinkage(getVTableLinkageType(isPublic));
   global->setDSOLocal(isSymbolDSOLocal(isPublic));
   global->setAlignment(llvm::MaybeAlign(8));
   attachComdatToSymbol(global, mangledName, isPublic);
@@ -113,7 +113,7 @@ llvm::Constant *IRGenerator::generateVTable(StructBase *spiceStruct) const {
   // Set global attributes
   global->setConstant(true);
   global->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
-  global->setLinkage(getSymbolLinkageType(isPublic));
+  global->setLinkage(getVTableLinkageType(isPublic));
   global->setDSOLocal(isSymbolDSOLocal(isPublic));
   global->setAlignment(llvm::MaybeAlign(8));
   attachComdatToSymbol(global, mangledName, isPublic);

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -660,6 +660,14 @@ llvm::GlobalValue::LinkageTypes IRGenerator::getSymbolLinkageType(bool isPublic)
   return isPublic ? llvm::GlobalValue::ExternalLinkage : llvm::GlobalValue::PrivateLinkage;
 }
 
+llvm::GlobalValue::LinkageTypes IRGenerator::getVTableLinkageType(bool isPublic) const {
+  // VTables, type infos and type info names are ODR entities that may legitimately be emitted in more than one
+  // translation unit (e.g. an interface that is forward-declared in one file and fully defined in another). Giving
+  // them weak ODR linkage lets the linker coalesce the duplicates. On ELF this pairs with the comdat group below; on
+  // MachO, which has no comdat support, the weak/coalesced linkage is what prevents a duplicate-symbol error.
+  return isPublic ? llvm::GlobalValue::WeakODRLinkage : llvm::GlobalValue::PrivateLinkage;
+}
+
 void IRGenerator::attachComdatToSymbol(llvm::GlobalVariable *global, const std::string &comdatName, bool isPublic) const {
   // MachO does not support comdat annotations
   if (isPublic && cliOptions.targetTriple.getObjectFormat() != llvm::Triple::MachO)

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -179,6 +179,7 @@ private:
   llvm::Attribute::AttrKind getExtAttrKindForType(const QualType &type) const;
   bool isSymbolDSOLocal(bool isPublic) const;
   llvm::GlobalValue::LinkageTypes getSymbolLinkageType(bool isPublic) const;
+  llvm::GlobalValue::LinkageTypes getVTableLinkageType(bool isPublic) const;
   void attachComdatToSymbol(llvm::GlobalVariable *global, const std::string &comdatName, bool isPublic) const;
 
   // Generate implicit

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
@@ -10,11 +10,11 @@ $_ZTI3Car = comdat any
 
 $_ZTV3Car = comdat any
 
-@_ZTS3Car = dso_local constant [5 x i8] c"3Car\00", comdat, align 4
+@_ZTS3Car = weak_odr dso_local constant [5 x i8] c"3Car\00", comdat, align 4
 @_ZTV8TypeInfo = external global ptr
 @_ZTI9Driveable = external global ptr
-@_ZTI3Car = dso_local constant { ptr, ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTV8TypeInfo, i64 2), ptr @_ZTS3Car, ptr @_ZTI9Driveable }, comdat, align 8
-@_ZTV3Car = dso_local unnamed_addr constant { [4 x ptr] } { [4 x ptr] [ptr null, ptr @_ZTI3Car, ptr @_ZN3Car5driveEi, ptr @_ZN3Car9isDrivingEv] }, comdat, align 8
+@_ZTI3Car = weak_odr dso_local constant { ptr, ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTV8TypeInfo, i64 2), ptr @_ZTS3Car, ptr @_ZTI9Driveable }, comdat, align 8
+@_ZTV3Car = weak_odr dso_local unnamed_addr constant { [4 x ptr] } { [4 x ptr] [ptr null, ptr @_ZTI3Car, ptr @_ZN3Car5driveEi, ptr @_ZN3Car9isDrivingEv] }, comdat, align 8
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Is driving: %d\00", align 4
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write)

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
@@ -10,11 +10,11 @@ $_ZTI3Car = comdat any
 
 $_ZTV3Car = comdat any
 
-@_ZTS3Car = dso_local constant [5 x i8] c"3Car\00", comdat, align 4
+@_ZTS3Car = weak_odr dso_local constant [5 x i8] c"3Car\00", comdat, align 4
 @_ZTV8TypeInfo = external global ptr
 @_ZTI9Driveable = external global ptr
-@_ZTI3Car = dso_local constant { ptr, ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTV8TypeInfo, i64 2), ptr @_ZTS3Car, ptr @_ZTI9Driveable }, comdat, align 8
-@_ZTV3Car = dso_local unnamed_addr constant { [4 x ptr] } { [4 x ptr] [ptr null, ptr @_ZTI3Car, ptr @_ZN3Car5driveEi, ptr @_ZN3Car9isDrivingEv] }, comdat, align 8
+@_ZTI3Car = weak_odr dso_local constant { ptr, ptr, ptr } { ptr getelementptr inbounds (ptr, ptr @_ZTV8TypeInfo, i64 2), ptr @_ZTS3Car, ptr @_ZTI9Driveable }, comdat, align 8
+@_ZTV3Car = weak_odr dso_local unnamed_addr constant { [4 x ptr] } { [4 x ptr] [ptr null, ptr @_ZTI3Car, ptr @_ZN3Car5driveEi, ptr @_ZN3Car9isDrivingEv] }, comdat, align 8
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Is driving: %d\00", align 4
 
 define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) {


### PR DESCRIPTION
## Problem

Since the bootstrap accept()-dispatch commits, macOS CI fails to link `BootstrapCompilerTests.bootstrapCompiler_unitWrapperAstVisualizer`:

```
duplicate symbol 'vtable for IAbstractAstVisitor' in:
    .../abstract-ast-visitor-intf.o
    .../abstract-ast-visitor.o
ld: 3 duplicate symbols
```

`IAbstractAstVisitor` is deliberately declared in two files — an empty forward declaration in `abstract-ast-visitor-intf.spice` (so `ast-nodes.spice` can type `accept(IAbstractAstVisitor*)` without a circular import) and the full typed interface in `abstract-ast-visitor.spice`. Both translation units emit the `vtable`/`typeinfo`/`typeinfo name` symbols.

These were emitted as strong `ExternalLinkage` symbols relying on a **comdat group** to coalesce the duplicates. `attachComdatToSymbol` skips comdat on MachO (macOS has no comdat support), so on macOS the two strong definitions collide. On ELF the comdat coalesces them, which is why Linux CI was green.

## Fix

VTables, type infos and type info names are ODR entities that can legitimately appear in multiple translation units. Emit them with **`WeakODRLinkage`** instead of strong external, exactly as Clang emits C++ vtables/type infos:

- **ELF:** pairs with the existing comdat group — behavior unchanged, still coalesced.
- **MachO:** the weak/coalesced linkage lets the linker merge the duplicates instead of erroring.

Regular functions and global variables are unaffected (they still use `getSymbolLinkageType`).

## Tests

- The previously-failing `bootstrapCompiler_unitWrapperAstVisualizer` and the interface/bootstrap-linker tests pass (22/22).
- Full `IRGeneratorTests` suite passes (171/171).
- Only two reference IR files changed (`success-cross-sourcefile-interfaces`), regenerated via `--update-refs`; the only delta is the `weak_odr` prefix on the public vtable/type info, matching standard Clang codegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)