### PR TITLE
Rearrange docs home feature cards into 3x2 grid and fix mobile padding

### DIFF
--- a/docs/docs/overrides/home.html
+++ b/docs/docs/overrides/home.html
@@ -202,7 +202,7 @@
 	 * Shared section layout
 	 * -------------------------------------------------------------------- */
 	.tx-section {
-		padding: 2.5rem 0 1rem;
+		padding: 2.5rem .8rem 1rem;
 	}
 
 	.tx-section__header {
@@ -239,8 +239,20 @@
 	 * -------------------------------------------------------------------- */
 	.tx-features {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+		grid-template-columns: 1fr;
 		gap: 1rem;
+	}
+
+	@media screen and (min-width:45em) {
+		.tx-features {
+			grid-template-columns: repeat(2, 1fr);
+		}
+	}
+
+	@media screen and (min-width:60em) {
+		.tx-features {
+			grid-template-columns: repeat(3, 1fr);
+		}
 	}
 
 	.tx-card {


### PR DESCRIPTION
@
## Summary

Tweaks the documentation home page (`docs/docs/overrides/home.html`):

- **Feature cards layout:** rearranged from two columns × three rows into **three columns × two rows** on wide screens. The grid now collapses responsively — 3 columns (≥60em), 2 columns (≥45em), 1 column on mobile — replacing the previous `auto-fit, minmax(15rem, 1fr)` rule.
- **Mobile padding:** added `.8rem` horizontal padding to `.tx-section`. It previously only had vertical padding, so on viewports narrower than the `.md-grid` max-width (61rem) the Features and Code-showcase sections ran right to the screen edges. The value matches the hero margin and Material's default content gutter.

## Test plan

- [ ] Verify the home page shows 3 columns × 2 rows of feature cards on desktop
- [ ] Verify it collapses to 2 / 1 columns at narrower widths
- [ ] Verify the Features and Code-showcase sections have side padding on a phone-width viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@