### PR TITLE
Add macOS x86_64 release build

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -276,102 +276,6 @@ jobs:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
-  build-macos-x86:
-    name: C++ CI - MacOS/x86_64
-    runs-on: macos-26-intel
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
-      - name: Setup Mold
-        uses: rui314/setup-mold@v1
-
-      - name: Setup Dependencies
-        run: |
-          brew update
-          brew install ccache graphviz
-          mkdir -p ~/.cache/ccache
-
-      - name: Restore CCache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
-          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Clone LLVM
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
-
-      - name: Cache LLVM
-        id: cache-llvm
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-macos-x64
-
-      - name: Build LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        working-directory: llvm
-        run: |
-          mkdir ./build
-          cd ./build
-          cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
-            -DLLVM_BUILD_TOOLS=OFF \
-            -DLLVM_INCLUDE_TESTS=OFF \
-            -DLLVM_INCLUDE_EXAMPLES=OFF \
-            -DLLVM_INCLUDE_BENCHMARKS=OFF \
-            ../llvm
-          cmake --build .
-
-      - name: Download Libs
-        run: ./setup-deps.sh
-
-      - name: Build test target
-        env:
-          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
-        run: |
-          mkdir ./build
-          cd ./build
-          cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DSPICE_BUILT_BY="ghactions" \
-            -Wattributes \
-            ..
-          cmake --build . --target spicetest
-
-      - name: Run Test target
-        working-directory: build/test
-        env:
-          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
-        run: ./spicetest --is-github-actions
-
-      - name: Save CCache
-        uses: actions/cache/save@v5
-        if: always()
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
-
   build-windows-x86:
     name: C++ CI - Windows/x86_64
     runs-on: windows-2025-vs2026
@@ -469,6 +373,102 @@ jobs:
         if: always()
         with:
           path: ~/AppData/Local/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
+  build-macos-x86:
+    name: C++ CI - MacOS/x86_64
+    runs-on: macos-26-intel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 25
+          java-package: jre
+
+      - name: Setup Mold
+        uses: rui314/setup-mold@v1
+
+      - name: Setup Dependencies
+        run: |
+          brew update
+          brew install ccache graphviz
+          mkdir -p ~/.cache/ccache
+
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-macos-x64
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
+            -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: ./setup-deps.sh
+
+      - name: Build test target
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DSPICE_BUILT_BY="ghactions" \
+            -Wattributes \
+            ..
+          cmake --build . --target spicetest
+
+      - name: Run Test target
+        working-directory: build/test
+        env:
+          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
+          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
+          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
+          SPICE_STD_DIR: ${{ github.workspace }}/std
+          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
+        run: ./spicetest --is-github-actions
+
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
   build-macos-aarch64:

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -276,6 +276,102 @@ jobs:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
+  build-macos-x86:
+    name: C++ CI - MacOS/x86_64
+    runs-on: macos-26-intel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 25
+          java-package: jre
+
+      - name: Setup Mold
+        uses: rui314/setup-mold@v1
+
+      - name: Setup Dependencies
+        run: |
+          brew update
+          brew install ccache graphviz
+          mkdir -p ~/.cache/ccache
+
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-macos-x64
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
+            -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: ./setup-deps.sh
+
+      - name: Build test target
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DSPICE_BUILT_BY="ghactions" \
+            -Wattributes \
+            ..
+          cmake --build . --target spicetest
+
+      - name: Run Test target
+        working-directory: build/test
+        env:
+          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
+          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
+          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
+          SPICE_STD_DIR: ${{ github.workspace }}/std
+          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
+        run: ./spicetest --is-github-actions
+
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
   build-windows-x86:
     name: C++ CI - Windows/x86_64
     runs-on: windows-2025-vs2026

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -440,13 +440,118 @@ jobs:
           name: spice-macos-arm64
           path: ./build/spice**
 
+  build-compiler-macos-x86:
+    name: Build compiler - MacOS/x86_64
+    runs-on: macos-26-intel
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 25
+          java-package: jre
+
+      - name: Setup Mold
+        uses: rui314/setup-mold@v1
+
+      - name: Setup Dependencies
+        run: |
+          brew install ccache
+          mkdir -p ~/.cache/ccache
+
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-macos-x64-all-targets
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
+            -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
+            -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            -Wno-dev \
+            -Wattributes \
+            ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: ./setup-deps.sh
+
+      - name: Build compiler
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DSPICE_ALL_TARGETS=ON \
+            -DSPICE_LTO=ON \
+            -DSPICE_VERSION="${{ github.ref_name }}" \
+            -DSPICE_BUILT_BY="ghactions" \
+            ..
+          cmake --build . --target spice
+
+      - name: Process build output
+        working-directory: build
+        run: |
+          mv ./src/spice spice
+          chmod +x spice
+
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: spice-macos-x64
+          path: ./build/spice**
+
   build-artifacts:
     name: Build artifacts
     needs: [
       build-compiler-linux-x86,
       build-compiler-linux-aarch64,
       build-compiler-windows-x86,
-      build-compiler-macos-aarch64
+      build-compiler-macos-aarch64,
+      build-compiler-macos-x86
     ]
     runs-on: ubuntu-latest
     env:
@@ -505,6 +610,7 @@ jobs:
           mv spice-windows-static-x64 spice-windows-amd64
           mv spice-linux-x64 spice-linux-amd64
           mv spice-macos-arm64 spice-darwin-arm64
+          mv spice-macos-x64 spice-darwin-amd64
           chmod -R +x ./
 
       - name: Run GoReleaser

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -336,110 +336,6 @@ jobs:
           name: spice-windows-static-x64
           path: ./build/spice**
 
-  build-compiler-macos-aarch64:
-    name: Build compiler - MacOS/AArch64
-    runs-on: macos-26
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          submodules: recursive
-
-      - name: Setup Java
-        uses: actions/setup-java@v5
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
-      - name: Setup Mold
-        uses: rui314/setup-mold@v1
-
-      - name: Setup Dependencies
-        run: |
-          brew install ccache
-          mkdir -p ~/.cache/ccache
-
-      - name: Restore CCache
-        uses: actions/cache/restore@v5
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
-          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Clone LLVM
-        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
-
-      - name: Cache LLVM
-        id: cache-llvm
-        uses: actions/cache@v5
-        with:
-          path: ${{ github.workspace }}/llvm/build
-          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-all-targets
-
-      - name: Build LLVM
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
-        working-directory: llvm
-        run: |
-          mkdir ./build
-          cd ./build
-          cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-            -DCMAKE_C_COMPILER=gcc \
-            -DCMAKE_CXX_COMPILER=g++ \
-            -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
-            -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
-            -DLLVM_BUILD_TOOLS=OFF \
-            -DLLVM_INCLUDE_TESTS=OFF \
-            -DLLVM_INCLUDE_EXAMPLES=OFF \
-            -DLLVM_INCLUDE_BENCHMARKS=OFF \
-            -Wno-dev \
-            -Wattributes \
-            ../llvm
-          cmake --build .
-
-      - name: Download Libs
-        run: ./setup-deps.sh
-
-      - name: Build compiler
-        env:
-          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
-        run: |
-          mkdir ./build
-          cd ./build
-          cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_C_COMPILER=gcc \
-            -DCMAKE_CXX_COMPILER=g++ \
-            -DSPICE_ALL_TARGETS=ON \
-            -DSPICE_LTO=ON \
-            -DSPICE_VERSION="${{ github.ref_name }}" \
-            -DSPICE_BUILT_BY="ghactions" \
-            ..
-          cmake --build . --target spice
-
-      - name: Process build output
-        working-directory: build
-        run: |
-          mv ./src/spice spice
-          chmod +x spice
-
-      - name: Save CCache
-        uses: actions/cache/save@v5
-        if: always()
-        with:
-          path: ~/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: spice-macos-arm64
-          path: ./build/spice**
-
   build-compiler-macos-x86:
     name: Build compiler - MacOS/x86_64
     runs-on: macos-26-intel
@@ -542,6 +438,110 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: spice-macos-x64
+          path: ./build/spice**
+
+  build-compiler-macos-aarch64:
+    name: Build compiler - MacOS/AArch64
+    runs-on: macos-26
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: zulu
+          java-version: 25
+          java-package: jre
+
+      - name: Setup Mold
+        uses: rui314/setup-mold@v1
+
+      - name: Setup Dependencies
+        run: |
+          brew install ccache
+          mkdir -p ~/.cache/ccache
+
+      - name: Restore CCache
+        uses: actions/cache/restore@v5
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v5
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-macos-aarch64-all-targets
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
+            -DLLVM_TARGETS_TO_BUILD="AArch64;AMDGPU;ARM;Mips;NVPTX;PowerPC;RISCV;WebAssembly;X86" \
+            -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            -Wno-dev \
+            -Wattributes \
+            ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: ./setup-deps.sh
+
+      - name: Build compiler
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DSPICE_ALL_TARGETS=ON \
+            -DSPICE_LTO=ON \
+            -DSPICE_VERSION="${{ github.ref_name }}" \
+            -DSPICE_BUILT_BY="ghactions" \
+            ..
+          cmake --build . --target spice
+
+      - name: Process build output
+        working-directory: build
+        run: |
+          mv ./src/spice spice
+          chmod +x spice
+
+      - name: Save CCache
+        uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: spice-macos-arm64
           path: ./build/spice**
 
   build-artifacts:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,9 +16,6 @@ builds:
       # Only offer amd64 support on Windows
       - goos: windows
         goarch: arm64
-      # Only offer arm64 support on macOS
-      - goos: darwin
-        goarch: amd64
     hooks:
       post:
         - "mv ./bin/spice-{{ .Os }}-{{ .Arch }}/spice{{ .Ext }} {{ .Path }}"

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ There are downloadable packages available for all supported platforms:
 | **Ubuntu (deb)**            | [download](https://github.com/spicelang/spice/releases/latest/download/spice_amd64.deb)         | [download](https://github.com/spicelang/spice/releases/latest/download/spice_arm64.deb)           |
 | **Windows Installer (msi)** | [download](https://github.com/spicelang/spice/releases/latest/download/spice_x64_setup.msi)     | -                                                                                                 |
 | **Windows Portable (zip)**  | [download](https://github.com/spicelang/spice/releases/latest/download/spice_windows_amd64.zip) | -                                                                                                 |
-| **MacOS / Darwin (tar.gz)** | -                                                                                               | [download](https://github.com/spicelang/spice/releases/latest/download/spice_darwin_arm64.tar.gz) |
+| **MacOS / Darwin (tar.gz)** | [download](https://github.com/spicelang/spice/releases/latest/download/spice_darwin_amd64.tar.gz) | [download](https://github.com/spicelang/spice/releases/latest/download/spice_darwin_arm64.tar.gz) |
 
 
 ## Setup guide for contributors
@@ -82,7 +82,7 @@ There is also a batch/shell script to rebuild Spice. Use the following command t
 You can find the build output in the `build` subdirectory.
 
 ## Available target platforms
-Currently, Spice only offers stable support for linux/x86_64, linux/aarch64, windows/x86_64, darwin/aarch64 and webassembly.
+Currently, Spice only offers stable support for linux/x86_64, linux/aarch64, windows/x86_64, darwin/x86_64, darwin/aarch64 and webassembly.
 But you can try to compile to the following architectures without any stability promises:
 
 `aarch64`, `amdgpu`, `armv5`, `armv6`, `armv7`, `mips`, `nvptx`, `powerpc`, `riscv`, `webassembly`, `x86`, `x86_64`

--- a/docs/docs/install/macos.md
+++ b/docs/docs/install/macos.md
@@ -20,15 +20,15 @@ To upgrade to the latest release later, run:
 brew upgrade --cask spice
 ```
 
-!!! info "Apple Silicon only"
-    The Homebrew cask currently only ships an ARM64 (Apple Silicon) build. On Intel Macs, please use the archive file
-    below or build from source.
+The cask ships builds for both Apple Silicon (ARM64) and Intel (x86_64) Macs, and Homebrew automatically selects the
+one matching your machine.
 
 ### Install from archive file
-Currently, it is only possible to install spice on macOS via the tar.gz archive, uploaded to the GitHub release.
+Alternatively, you can install Spice on macOS via the tar.gz archive, uploaded to the GitHub release.
 This archive file contains all resources that Spice needs to run.
 
 [Download ARM64](https://github.com/spicelang/spice/releases/latest/download/spice_darwin_arm64.tar.gz){ .md-button .md-button--primary .md-button--small }
+[Download x86_64](https://github.com/spicelang/spice/releases/latest/download/spice_darwin_amd64.tar.gz){ .md-button .md-button--primary .md-button--small }
 
 ### Use
 ```sh


### PR DESCRIPTION
## What changed
- Add a `build-compiler-macos-x86` job (runs on `macos-26-intel`) that builds the Spice compiler for darwin/amd64 and uploads it as `spice-macos-x64`.
- Wire the new artifact into `build-artifacts`: add it to `needs`, rename `spice-macos-x64` → `spice-darwin-amd64`, and drop the `darwin/amd64` ignore rule in `.goreleaser.yml` so archives, checksums, and the Homebrew cask include it.
- Update the macOS install docs to note the cask now ships both ARM64 and Intel builds, with an added x86_64 archive download link.

## Why
Previously the release pipeline only produced a macOS arm64 build, leaving Intel Mac users to build from source. This publishes a native x86_64 artifact through the same release flow.

## How it was validated
- CI-only change; no local build/test run. The new build job mirrors the existing `build-compiler-macos-aarch64` job and will be exercised by the release workflow on the next tag.

## Follow-up / known limitations
- Runner label `macos-26-intel` is assumed available to the org; adjust if a different Intel image is preferred.
- The Homebrew cask will now generate both arm64 and amd64 variants automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
