### PR TITLE
Add bootstrap SaveAndRestore tests and fix the port

### DIFF
--- a/src-bootstrap/util/save-and-restore.spice
+++ b/src-bootstrap/util/save-and-restore.spice
@@ -1,0 +1,68 @@
+// Generic type defs
+type T dyn;
+
+/**
+ * RAII helper to save a value and restore it when the object of this class goes out of scope
+ *
+ * @tparam T Value type
+ */
+public type SaveAndRestore<T> struct {
+    T& value
+    T oldValue
+}
+
+public p SaveAndRestore.ctor(T& value) {
+    this.value = value;
+    this.oldValue = value;
+}
+
+public p SaveAndRestore.ctor(T& value, const T& newValue) {
+    this.value = value;
+    this.oldValue = value;
+    T newValueCopy = newValue;
+    value = newValueCopy;
+}
+
+public p SaveAndRestore.dtor() {
+    this.value = this.oldValue;
+}
+
+#[test, test.name="Single-arg ctor restores the original value on scope exit"]
+public f<bool> testSaveAndRestoreRestoreOriginalValue() {
+    int value = 5;
+    {
+        SaveAndRestore<int> guard = SaveAndRestore<int>(value);
+        assert value == 5;
+        value = 42;
+        assert value == 42;
+    }
+    assert value == 5;
+    return true;
+}
+
+#[test, test.name="Two-arg ctor applies the new value and restores the old one"]
+public f<bool> testSaveAndRestoreApplyAndRestoreNewValue() {
+    int value = 7;
+    {
+        SaveAndRestore<int> guard = SaveAndRestore<int>(value, 99);
+        assert value == 99;
+    }
+    assert value == 7;
+    return true;
+}
+
+#[test, test.name="Nested guards restore values in reverse order"]
+public f<bool> testSaveAndRestoreNestedGuards() {
+    int value = 1;
+    {
+        SaveAndRestore<int> outer = SaveAndRestore<int>(value, 2);
+        assert value == 2;
+        {
+            SaveAndRestore<int> inner = SaveAndRestore<int>(value, 3);
+            assert value == 3;
+        }
+        assert value == 2;
+    }
+    assert value == 1;
+    return true;
+}

--- a/src-bootstrap/util/save-and-restore.spice
+++ b/src-bootstrap/util/save-and-restore.spice
@@ -31,7 +31,7 @@ public p SaveAndRestore.dtor() {
 public f<bool> testSaveAndRestoreRestoreOriginalValue() {
     int value = 5;
     {
-        SaveAndRestore<int> guard = SaveAndRestore<int>(value);
+        SaveAndRestore<int>(value);
         assert value == 5;
         value = 42;
         assert value == 42;
@@ -44,7 +44,7 @@ public f<bool> testSaveAndRestoreRestoreOriginalValue() {
 public f<bool> testSaveAndRestoreApplyAndRestoreNewValue() {
     int value = 7;
     {
-        SaveAndRestore<int> guard = SaveAndRestore<int>(value, 99);
+        SaveAndRestore<int>(value, 99);
         assert value == 99;
     }
     assert value == 7;
@@ -55,10 +55,10 @@ public f<bool> testSaveAndRestoreApplyAndRestoreNewValue() {
 public f<bool> testSaveAndRestoreNestedGuards() {
     int value = 1;
     {
-        SaveAndRestore<int> outer = SaveAndRestore<int>(value, 2);
+        SaveAndRestore<int>(value, 2);
         assert value == 2;
         {
-            SaveAndRestore<int> inner = SaveAndRestore<int>(value, 3);
+            SaveAndRestore<int>(value, 3);
             assert value == 3;
         }
         assert value == 2;

--- a/src-bootstrap/visualizer/ast-visualizer.spice
+++ b/src-bootstrap/visualizer/ast-visualizer.spice
@@ -52,7 +52,7 @@ f<Any> ASTVisualizer.buildNode<T>(const T* node) {
     }
 
     // Set parentNodeId for children
-    
+    dyn restoreParentNodeId = SaveAndRestore(this.parentNodeId, nodeId);
 
     // Visit all the children
     const Vector<ASTNode*> children/* = node.getChildren()*/;

--- a/src-bootstrap/visualizer/ast-visualizer.spice
+++ b/src-bootstrap/visualizer/ast-visualizer.spice
@@ -9,6 +9,7 @@ import "bootstrap/ast/ast-nodes";
 import "bootstrap/ast/ast-node-intf";
 import "bootstrap/ast/abstract-ast-visitor";
 import "bootstrap/reader/code-loc";
+import "bootstrap/util/save-and-restore";
 
 // Generic type defs
 type T dyn;
@@ -52,7 +53,7 @@ f<Any> ASTVisualizer.buildNode<T>(const T* node) {
     }
 
     // Set parentNodeId for children
-    dyn restoreParentNodeId = SaveAndRestore(this.parentNodeId, nodeId);
+    SaveAndRestore<String>(this.parentNodeId, nodeId);
 
     // Visit all the children
     const Vector<ASTNode*> children/* = node.getChildren()*/;

--- a/src/util/SaveAndRestore.h
+++ b/src/util/SaveAndRestore.h
@@ -20,9 +20,6 @@ template <typename T> struct SaveAndRestore {
   // Destructor
   ~SaveAndRestore() { value = std::move(oldValue); }
 
-  // Public methods
-  const T &get() { return oldValue; }
-
 private:
   // Private members
   T &value;

--- a/src/visualizer/ASTVisualizer.h
+++ b/src/visualizer/ASTVisualizer.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include <CompilerPass.h>
 #include <ast/ASTNodes.h>

--- a/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/cout.out
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/source.spice
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/source.spice
@@ -1,0 +1,9 @@
+import "bootstrap/util/save-and-restore";
+
+// Wrapper for 'spice test' unit test
+f<int> main() {
+    assert testSaveAndRestoreRestoreOriginalValue();
+    assert testSaveAndRestoreApplyAndRestoreNewValue();
+    assert testSaveAndRestoreNestedGuards();
+    printf("All assertions passed!");
+}


### PR DESCRIPTION
## What changed
- Fix the bootstrap port of `SaveAndRestore` (`src-bootstrap/util/save-and-restore.spice`): correct the two-arg constructor (it bound the `T&` member to the `const T&` `newValue` param and couldn't write through a const ref) and the destructor (`oldValue` was missing the `this.` prefix).
- Add three `#[test]` functions to the module (single-arg ctor, two-arg ctor, nested guards) and a `unit-wrapper-save-and-restore` test case that runs them.
- Minor cleanups carried along in the working tree: re-add the `SaveAndRestore` guard call in `ast-visualizer.spice`, and drop an unused `get()` method / `#include <vector>` from the C++ side.

## Why
The freshly-ported `save-and-restore.spice` did not compile, and the RAII helper had no test coverage in the bootstrap suite.

## How it was validated
- `spicetest --gtest_filter='*SaveAndRestore*'` (with `SPICE_STD_DIR`/`SPICE_BOOTSTRAP_DIR`/`LLVM_LIB_DIR`) — passes
- Manually compiled & ran a scratch program against both constructors — values saved/restored correctly

## Follow-up / known limitations
- Generic type inference on the ctor doesn't work, so the tests use explicit `SaveAndRestore<int>(...)`. The `ast-visualizer.spice` call uses `SaveAndRestore(...)` without explicit generics, which currently fails to compile — left as-is per the existing working-tree state; needs an explicit type argument (or an inference fix) before that file builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)