### PR TITLE
Run the test suite in parallel via gtest-parallel

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -96,17 +96,16 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_ASAN=ON \
+            -DSPICE_TEST_ARGS="--is-github-actions;--skip-sanitizer-tests" \
             -Wattributes \
             ..
           cmake --build . --target spicetest
 
       - name: Run Test target with ASAN
-        working-directory: build/test
+        working-directory: build
+        # spicetest_parallel derives SPICE_STD_DIR / SPICE_BOOTSTRAP_DIR / LLVM_LIB_DIR / LLVM_INCLUDE_DIR itself; ASAN_OPTIONS is
+        # forwarded through gtest-parallel to each spicetest process. --is-github-actions / --skip-sanitizer-tests are passed via
+        # SPICE_TEST_ARGS.
         env:
-          LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
           ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:abort_on_error=1:print_summary=1"
-        run: ./spicetest --is-github-actions --skip-sanitizer-tests
+        run: cmake --build . --target spicetest_parallel

--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -103,9 +103,6 @@ jobs:
 
       - name: Run Test target with ASAN
         working-directory: build
-        # spicetest_parallel derives SPICE_STD_DIR / SPICE_BOOTSTRAP_DIR / LLVM_LIB_DIR / LLVM_INCLUDE_DIR itself; ASAN_OPTIONS is
-        # forwarded through gtest-parallel to each spicetest process. --is-github-actions / --skip-sanitizer-tests are passed via
-        # SPICE_TEST_ARGS.
         env:
           ASAN_OPTIONS: "detect_leaks=1:halt_on_error=1:abort_on_error=1:print_summary=1"
         run: cmake --build . --target spicetest_parallel

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -133,7 +133,6 @@ jobs:
         env:
           LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib
           LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
           SPICE_STD_DIR: ${{ github.workspace }}/std
           SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
         run: ./spicetest --is-github-actions
@@ -144,7 +143,6 @@ jobs:
 #        env:
 #          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
 #          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-#          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
 #          SPICE_STD_DIR: ${{ github.workspace }}/spice/std
 #          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/spice/src-bootstrap
 #        run: valgrind -q --leak-check=full ./spicetest --is-github-actions --leak-detection
@@ -262,8 +260,6 @@ jobs:
 
       - name: Run Test target
         working-directory: build
-        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
-        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
         run: cmake --build . --target spicetest_parallel
 
       - name: Save CCache
@@ -357,8 +353,6 @@ jobs:
 
       - name: Run Test target
         working-directory: build
-        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
-        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
         run: |
           cmake --build . --target spicetest_parallel
 
@@ -451,8 +445,6 @@ jobs:
 
       - name: Run Test target
         working-directory: build
-        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
-        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
         run: cmake --build . --target spicetest_parallel
 
       - name: Save CCache
@@ -544,8 +536,6 @@ jobs:
 
       - name: Run Test target
         working-directory: build
-        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
-        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
         run: cmake --build . --target spicetest_parallel
 
       - name: Save CCache

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -255,19 +255,16 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
+            -DSPICE_TEST_ARGS=--is-github-actions \
             -Wattributes \
             ..
           cmake --build . --target spicetest
 
       - name: Run Test target
-        working-directory: build/test
-        env:
-          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
-        run: ./spicetest --is-github-actions
+        working-directory: build
+        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
+        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
+        run: cmake --build . --target spicetest_parallel
 
       - name: Save CCache
         uses: actions/cache/save@v5
@@ -353,20 +350,17 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DSPICE_BUILT_BY="ghactions" `
+            -DSPICE_TEST_ARGS=--is-github-actions `
             -Wattributes `
             ..
           cmake --build . --target spicetest
 
       - name: Run Test target
-        working-directory: build/test
-        env:
-          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
+        working-directory: build
+        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
+        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
         run: |
-          ./spicetest --is-github-actions
+          cmake --build . --target spicetest_parallel
 
       - name: Save CCache
         uses: actions/cache/save@v5
@@ -450,19 +444,16 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
+            -DSPICE_TEST_ARGS=--is-github-actions \
             -Wattributes \
             ..
           cmake --build . --target spicetest
 
       - name: Run Test target
-        working-directory: build/test
-        env:
-          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
-        run: ./spicetest --is-github-actions
+        working-directory: build
+        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
+        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
+        run: cmake --build . --target spicetest_parallel
 
       - name: Save CCache
         uses: actions/cache/save@v5
@@ -546,19 +537,16 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
+            -DSPICE_TEST_ARGS=--is-github-actions \
             -Wattributes \
             ..
           cmake --build . --target spicetest
 
       - name: Run Test target
-        working-directory: build/test
-        env:
-          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
-          LLVM_BUILD_INCLUDE_DIR: ${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
-        run: ./spicetest --is-github-actions
+        working-directory: build
+        # The spicetest_parallel target runs the suite via gtest-parallel and injects the required runtime env vars itself
+        # (SPICE_STD_DIR, SPICE_BOOTSTRAP_DIR, LLVM_LIB_DIR). --is-github-actions is forwarded to spicetest via SPICE_TEST_ARGS.
+        run: cmake --build . --target spicetest_parallel
 
       - name: Save CCache
         uses: actions/cache/save@v5

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -132,7 +132,7 @@ jobs:
         working-directory: build/test
         env:
           LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
+          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
           SPICE_STD_DIR: ${{ github.workspace }}/std
           SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
         run: ./spicetest --is-github-actions
@@ -142,7 +142,7 @@ jobs:
 #        working-directory: build/test
 #        env:
 #          LLVM_LIB_DIR: ${{ github.workspace }}/llvm/build/lib
-#          LLVM_INCLUDE_DIR: ${{ github.workspace }}/llvm/llvm/include
+#          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
 #          SPICE_STD_DIR: ${{ github.workspace }}/spice/std
 #          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/spice/src-bootstrap
 #        run: valgrind -q --leak-check=full ./spicetest --is-github-actions --leak-detection

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -251,7 +251,7 @@ jobs:
           mkdir ./build
           cd ./build
           cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
@@ -349,7 +349,7 @@ jobs:
           mkdir ./build
           cd ./build
           cmake -GNinja `
-            -DCMAKE_BUILD_TYPE=Debug `
+            -DCMAKE_BUILD_TYPE=Release `
             -DCMAKE_C_COMPILER_LAUNCHER=ccache `
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DSPICE_BUILT_BY="ghactions" `
@@ -446,7 +446,7 @@ jobs:
           mkdir ./build
           cd ./build
           cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
@@ -542,7 +542,7 @@ jobs:
           mkdir ./build
           cd ./build
           cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -100,11 +100,11 @@ jobs:
           mkdir ./build
           cd ./build
           cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_BUILD_TYPE=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'Debug' || 'Release' }} \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
-            -DSPICE_RUN_COVERAGE=ON \
+            -DSPICE_RUN_COVERAGE=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'ON' || 'OFF' }} \
             -Wattributes \
             ..
           cmake --build . --target spicetest

--- a/.gitmodules
+++ b/.gitmodules
@@ -11,3 +11,6 @@
 [submodule "deps/googletest"]
 	path = deps/googletest
 	url = https://github.com/google/googletest.git
+[submodule "deps/gtest-parallel"]
+	path = deps/gtest-parallel
+	url = https://github.com/google/gtest-parallel.git

--- a/.run/spice build.run.xml
+++ b/.run/spice build.run.xml
@@ -1,8 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O0 -g -d ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
-      <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
-      <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spice build.run.xml
+++ b/.run/spice build.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spice build" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="build -O0 -g -d ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
-      <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
+      <env name="LLVM_INCLUDE_DIRS" value="-I$PROJECT_DIR$/../llvm-project-latest/llvm/include -I$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />
       <env name="SPICE_BOOTSTRAP_DIR" value="$PROJECT_DIR$/src-bootstrap" />

--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
-      <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
+      <env name="LLVM_INCLUDE_DIRS" value="-I$PROJECT_DIR$/../llvm-project-latest/llvm/include -I$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />
       <env name="SPICE_BOOTSTRAP_DIR" value="$PROJECT_DIR$/src-bootstrap" />

--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,8 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
-      <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
-      <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spice test.run.xml
+++ b/.run/spice test.run.xml
@@ -1,8 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spice test" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="test -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
-      <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
-      <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="SPICE_BOOTSTRAP_DIR" value="$PROJECT_DIR$/src-bootstrap" />

--- a/.run/spice test.run.xml
+++ b/.run/spice test.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spice test" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="test -O0 -d -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
-      <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
+      <env name="LLVM_INCLUDE_DIRS" value="-I$PROJECT_DIR$/../llvm-project-latest/llvm/include -I$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="SPICE_BOOTSTRAP_DIR" value="$PROJECT_DIR$/src-bootstrap" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,8 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
     <envs>
-      <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
-      <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="RUN_TESTS" value="ON" />

--- a/.run/spicetest.run.xml
+++ b/.run/spicetest.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spicetest" type="CMakeGoogleTestRunConfigurationType" factoryName="Google Test" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest" TEST_MODE="SUITE_TEST">
     <envs>
-      <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
+      <env name="LLVM_INCLUDE_DIRS" value="-I$PROJECT_DIR$/../llvm-project-latest/llvm/include -I$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="RUN_TESTS" value="ON" />
       <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />

--- a/.run/spicetest_parallel.run.xml
+++ b/.run/spicetest_parallel.run.xml
@@ -1,11 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spicetest_parallel" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest_parallel" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest">
     <envs>
-      <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
-      <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="RUN_TESTS" value="ON" />
-      <env name="SPICE_BOOTSTRAP_DIR" value="$PROJECT_DIR$/src-bootstrap" />
-      <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />
     </envs>
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />

--- a/.run/spicetest_parallel.run.xml
+++ b/.run/spicetest_parallel.run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="spicetest_parallel" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest_parallel" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest">
+    <envs>
+      <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
+      <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />
+      <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
+      <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
+      <env name="RUN_TESTS" value="ON" />
+      <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />
+      <env name="SPICE_BOOTSTRAP_DIR" value="$PROJECT_DIR$/src-bootstrap" />
+    </envs>
+    <method v="2">
+      <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/spicetest_parallel.run.xml
+++ b/.run/spicetest_parallel.run.xml
@@ -1,13 +1,11 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="spicetest_parallel" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="--update-refs=false" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spicetest_parallel" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spicetest">
     <envs>
-      <env name="LLVM_ADDITIONAL_FLAGS" value="-lole32 -lws2_32" />
-      <env name="LLVM_BUILD_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/include" />
       <env name="LLVM_INCLUDE_DIR" value="$PROJECT_DIR$/../llvm-project-latest/llvm/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />
       <env name="RUN_TESTS" value="ON" />
-      <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />
       <env name="SPICE_BOOTSTRAP_DIR" value="$PROJECT_DIR$/src-bootstrap" />
+      <env name="SPICE_STD_DIR" value="$PROJECT_DIR$/std" />
     </envs>
     <method v="2">
       <option name="com.jetbrains.cidr.execution.CidrBuildBeforeRunTaskProvider$BuildBeforeRunTask" enabled="true" />

--- a/src-bootstrap/util/save-and-restore.spice
+++ b/src-bootstrap/util/save-and-restore.spice
@@ -1,0 +1,68 @@
+// Generic type defs
+type T dyn;
+
+/**
+ * RAII helper to save a value and restore it when the object of this class goes out of scope
+ *
+ * @tparam T Value type
+ */
+public type SaveAndRestore<T> struct {
+    T& value
+    T oldValue
+}
+
+public p SaveAndRestore.ctor(T& value) {
+    this.value = value;
+    this.oldValue = value;
+}
+
+public p SaveAndRestore.ctor(T& value, const T& newValue) {
+    this.value = value;
+    this.oldValue = value;
+    T newValueCopy = newValue;
+    value = newValueCopy;
+}
+
+public p SaveAndRestore.dtor() {
+    this.value = this.oldValue;
+}
+
+#[test, test.name="Single-arg ctor restores the original value on scope exit"]
+public f<bool> testSaveAndRestoreRestoreOriginalValue() {
+    int value = 5;
+    {
+        SaveAndRestore<int> guard = SaveAndRestore<int>(value);
+        assert value == 5;
+        value = 42;
+        assert value == 42;
+    }
+    assert value == 5;
+    return true;
+}
+
+#[test, test.name="Two-arg ctor applies the new value and restores the old one"]
+public f<bool> testSaveAndRestoreApplyAndRestoreNewValue() {
+    int value = 7;
+    {
+        SaveAndRestore<int> guard = SaveAndRestore<int>(value, 99);
+        assert value == 99;
+    }
+    assert value == 7;
+    return true;
+}
+
+#[test, test.name="Nested guards restore values in reverse order"]
+public f<bool> testSaveAndRestoreNestedGuards() {
+    int value = 1;
+    {
+        SaveAndRestore<int> outer = SaveAndRestore<int>(value, 2);
+        assert value == 2;
+        {
+            SaveAndRestore<int> inner = SaveAndRestore<int>(value, 3);
+            assert value == 3;
+        }
+        assert value == 2;
+    }
+    assert value == 1;
+    return true;
+}

--- a/src-bootstrap/util/save-and-restore.spice
+++ b/src-bootstrap/util/save-and-restore.spice
@@ -31,7 +31,7 @@ public p SaveAndRestore.dtor() {
 public f<bool> testSaveAndRestoreRestoreOriginalValue() {
     int value = 5;
     {
-        SaveAndRestore<int> guard = SaveAndRestore<int>(value);
+        SaveAndRestore<int>(value);
         assert value == 5;
         value = 42;
         assert value == 42;
@@ -44,7 +44,7 @@ public f<bool> testSaveAndRestoreRestoreOriginalValue() {
 public f<bool> testSaveAndRestoreApplyAndRestoreNewValue() {
     int value = 7;
     {
-        SaveAndRestore<int> guard = SaveAndRestore<int>(value, 99);
+        SaveAndRestore<int>(value, 99);
         assert value == 99;
     }
     assert value == 7;
@@ -55,10 +55,10 @@ public f<bool> testSaveAndRestoreApplyAndRestoreNewValue() {
 public f<bool> testSaveAndRestoreNestedGuards() {
     int value = 1;
     {
-        SaveAndRestore<int> outer = SaveAndRestore<int>(value, 2);
+        SaveAndRestore<int>(value, 2);
         assert value == 2;
         {
-            SaveAndRestore<int> inner = SaveAndRestore<int>(value, 3);
+            SaveAndRestore<int>(value, 3);
             assert value == 3;
         }
         assert value == 2;

--- a/src-bootstrap/visualizer/ast-visualizer.spice
+++ b/src-bootstrap/visualizer/ast-visualizer.spice
@@ -52,7 +52,7 @@ f<Any> ASTVisualizer.buildNode<T>(const T* node) {
     }
 
     // Set parentNodeId for children
-    
+    dyn restoreParentNodeId = SaveAndRestore(this.parentNodeId, nodeId);
 
     // Visit all the children
     const Vector<ASTNode*> children/* = node.getChildren()*/;

--- a/src-bootstrap/visualizer/ast-visualizer.spice
+++ b/src-bootstrap/visualizer/ast-visualizer.spice
@@ -9,6 +9,7 @@ import "bootstrap/ast/ast-nodes";
 import "bootstrap/ast/ast-node-intf";
 import "bootstrap/ast/abstract-ast-visitor";
 import "bootstrap/reader/code-loc";
+import "bootstrap/util/save-and-restore";
 
 // Generic type defs
 type T dyn;
@@ -52,7 +53,7 @@ f<Any> ASTVisualizer.buildNode<T>(const T* node) {
     }
 
     // Set parentNodeId for children
-    dyn restoreParentNodeId = SaveAndRestore(this.parentNodeId, nodeId);
+    SaveAndRestore<String>(this.parentNodeId, nodeId);
 
     // Visit all the children
     const Vector<ASTNode*> children/* = node.getChildren()*/;

--- a/src/util/SaveAndRestore.h
+++ b/src/util/SaveAndRestore.h
@@ -20,9 +20,6 @@ template <typename T> struct SaveAndRestore {
   // Destructor
   ~SaveAndRestore() { value = std::move(oldValue); }
 
-  // Public methods
-  const T &get() { return oldValue; }
-
 private:
   // Private members
   T &value;

--- a/src/visualizer/ASTVisualizer.h
+++ b/src/visualizer/ASTVisualizer.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <string>
-#include <vector>
 
 #include <CompilerPass.h>
 #include <ast/ASTNodes.h>

--- a/std/bindings/llvm/linker-flags.spice
+++ b/std/bindings/llvm/linker-flags.spice
@@ -1,7 +1,6 @@
 #![
     // Paths - Linux
     core.linux.linker.flag = "-L$LLVM_LIB_DIR",
-    core.linux.linker.flag = "-I$LLVM_BUILD_INCLUDE_DIR",
     core.linux.linker.flag = "-I$LLVM_INCLUDE_DIR",
     core.linux.linker.flag = "-lm", // math
     core.linux.linker.flag = "-lz", // zlib
@@ -10,7 +9,6 @@
     core.linux.linker.flag = "-luuid", // uuid
     // Paths - macOS
     core.darwin.linker.flag = "-L$LLVM_LIB_DIR",
-    core.darwin.linker.flag = "-I$LLVM_BUILD_INCLUDE_DIR",
     core.darwin.linker.flag = "-I$LLVM_INCLUDE_DIR",
     core.darwin.linker.flag = "-L/opt/homebrew/lib",
     core.darwin.linker.flag = "-lm", // math
@@ -19,7 +17,6 @@
     core.darwin.linker.flag = "-lzstd", // zstd
     // Paths - Windows
     core.windows.linker.flag = "-L%LLVM_LIB_DIR%",           // e.g.: D:/LLVM/build-release/lib
-    core.windows.linker.flag = "-I%LLVM_BUILD_INCLUDE_DIR%", // e.g.: D:/LLVM/build-release/include
     core.windows.linker.flag = "-I%LLVM_INCLUDE_DIR%",       // e.g.: D:/LLVM/llvm/include
     // Additional libs for Windows (taken from llvm/lib/Support/CMakeLists.txt)
     core.windows.linker.flag = "-lole32", // COM

--- a/std/bindings/llvm/linker-flags.spice
+++ b/std/bindings/llvm/linker-flags.spice
@@ -1,7 +1,8 @@
 #![
     // Paths - Linux
     core.linux.linker.flag = "-L$LLVM_LIB_DIR",
-    core.linux.linker.flag = "-I$LLVM_INCLUDE_DIR",
+    // Holds one or more "-I<dir>" flags (space-separated); shell word-splitting forwards each as a separate include dir
+    core.linux.linker.flag = "$LLVM_INCLUDE_DIRS",
     core.linux.linker.flag = "-lm", // math
     core.linux.linker.flag = "-lz", // zlib
     core.linux.linker.flag = "-ltinfo", // ncurses
@@ -9,15 +10,17 @@
     core.linux.linker.flag = "-luuid", // uuid
     // Paths - macOS
     core.darwin.linker.flag = "-L$LLVM_LIB_DIR",
-    core.darwin.linker.flag = "-I$LLVM_INCLUDE_DIR",
+    // Holds one or more "-I<dir>" flags (space-separated); shell word-splitting forwards each as a separate include dir
+    core.darwin.linker.flag = "$LLVM_INCLUDE_DIRS",
     core.darwin.linker.flag = "-L/opt/homebrew/lib",
     core.darwin.linker.flag = "-lm", // math
     core.darwin.linker.flag = "-lz", // zlib
     core.darwin.linker.flag = "-lncurses", // ncurses
     core.darwin.linker.flag = "-lzstd", // zstd
     // Paths - Windows
-    core.windows.linker.flag = "-L%LLVM_LIB_DIR%",           // e.g.: D:/LLVM/build-release/lib
-    core.windows.linker.flag = "-I%LLVM_INCLUDE_DIR%",       // e.g.: D:/LLVM/llvm/include
+    core.windows.linker.flag = "-L%LLVM_LIB_DIR%", // e.g.: D:/LLVM/build-release/lib
+    // Holds one or more "-I<dir>" flags (space-separated), e.g.: -ID:/LLVM/build-release/include -ID:/LLVM/llvm/include
+    core.windows.linker.flag = "%LLVM_INCLUDE_DIRS%",
     // Additional libs for Windows (taken from llvm/lib/Support/CMakeLists.txt)
     core.windows.linker.flag = "-lole32", // COM
     core.windows.linker.flag = "-lws2_32", // WinSock

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,23 +41,16 @@ add_custom_target(spicetest_leakcheck COMMAND valgrind --leak-check=full --error
 set(SPICE_TEST_ARGS "" CACHE STRING "Arguments forwarded to spicetest when run via the spicetest_parallel target")
 find_program(PYTHON3_EXECUTABLE NAMES python3 python)
 if (PYTHON3_EXECUTABLE)
-    set(_llvm_build_include "${LLVM_BINARY_DIR}/include")
-    set(LLVM_INCLUDE_DIR_VALUE "")
-    foreach (_dir IN LISTS LLVM_INCLUDE_DIRS)
-        if (NOT _dir STREQUAL _llvm_build_include)
-            set(LLVM_INCLUDE_DIR_VALUE "${_dir}")
-        endif ()
-    endforeach ()
-    if (NOT LLVM_INCLUDE_DIR_VALUE)
-        set(LLVM_INCLUDE_DIR_VALUE "${_llvm_build_include}")
-    endif ()
-
+    # Collect all LLVM include dirs into a single "-I<dir> -I<dir> ..." string forwarded as one env var.
+    SET(LLVM_INCLUDE_FLAGS ${LLVM_INCLUDE_DIRS})
+    list(TRANSFORM LLVM_INCLUDE_FLAGS PREPEND "-I")
+    list(JOIN LLVM_INCLUDE_FLAGS " " LLVM_INCLUDE_FLAGS)
     add_custom_target(spicetest_parallel
             COMMAND ${CMAKE_COMMAND} -E env
             SPICE_STD_DIR=${CMAKE_SOURCE_DIR}/std
             SPICE_BOOTSTRAP_DIR=${CMAKE_SOURCE_DIR}/src-bootstrap
             LLVM_LIB_DIR=${LLVM_LIBRARY_DIRS}
-            LLVM_INCLUDE_DIR=${LLVM_INCLUDE_DIR_VALUE}
+            LLVM_INCLUDE_DIRS=${LLVM_INCLUDE_FLAGS}
             ${PYTHON3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/deps/gtest-parallel/gtest-parallel $<TARGET_FILE:spicetest> -- ${SPICE_TEST_ARGS}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS spicetest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,15 +41,23 @@ add_custom_target(spicetest_leakcheck COMMAND valgrind --leak-check=full --error
 set(SPICE_TEST_ARGS "" CACHE STRING "Arguments forwarded to spicetest when run via the spicetest_parallel target")
 find_program(PYTHON3_EXECUTABLE NAMES python3 python)
 if (PYTHON3_EXECUTABLE)
-    # The test runner needs a few environment variables at runtime: the compiler reads SPICE_STD_DIR / SPICE_BOOTSTRAP_DIR via
-    # SystemUtil, and the bootstrap-compiler tests shell-expand LLVM_LIB_DIR in their linker command. add_custom_target has no
-    # ENVIRONMENT property, so the env is injected into the command itself via "cmake -E env" to make sure it reaches the
-    # spicetest child processes spawned by gtest-parallel. Arguments after "--" are forwarded to each spicetest process.
+    set(_llvm_build_include "${LLVM_BINARY_DIR}/include")
+    set(LLVM_INCLUDE_DIR_VALUE "")
+    foreach (_dir IN LISTS LLVM_INCLUDE_DIRS)
+        if (NOT _dir STREQUAL _llvm_build_include)
+            set(LLVM_INCLUDE_DIR_VALUE "${_dir}")
+        endif ()
+    endforeach ()
+    if (NOT LLVM_INCLUDE_DIR_VALUE)
+        set(LLVM_INCLUDE_DIR_VALUE "${_llvm_build_include}")
+    endif ()
+
     add_custom_target(spicetest_parallel
             COMMAND ${CMAKE_COMMAND} -E env
             SPICE_STD_DIR=${CMAKE_SOURCE_DIR}/std
             SPICE_BOOTSTRAP_DIR=${CMAKE_SOURCE_DIR}/src-bootstrap
             LLVM_LIB_DIR=${LLVM_LIBRARY_DIRS}
+            LLVM_INCLUDE_DIR=${LLVM_INCLUDE_DIR_VALUE}
             ${PYTHON3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/deps/gtest-parallel/gtest-parallel $<TARGET_FILE:spicetest> -- ${SPICE_TEST_ARGS}
             WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
             DEPENDS spicetest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,3 +32,27 @@ file(CREATE_LINK ${CMAKE_SOURCE_DIR}/src-bootstrap ${CMAKE_CURRENT_BINARY_DIR}/b
 ################# spicetest_leakcheck ################
 
 add_custom_target(spicetest_leakcheck COMMAND valgrind --leak-check=full --error-exitcode=1 ./spicetest DEPENDS spicetest)
+
+################# spicetest_parallel #################
+
+# Run the integration/unit test suite in parallel via gtest-parallel (one process per test case). The test runner writes its
+# build artifacts to a per-test directory (see TestUtil::prepareArtifactDir), which makes the cases safe to run concurrently.
+# Arguments forwarded to each spicetest process spawned by gtest-parallel (e.g. "--is-github-actions" in CI).
+set(SPICE_TEST_ARGS "" CACHE STRING "Arguments forwarded to spicetest when run via the spicetest_parallel target")
+find_program(PYTHON3_EXECUTABLE NAMES python3 python)
+if (PYTHON3_EXECUTABLE)
+    # The test runner needs a few environment variables at runtime: the compiler reads SPICE_STD_DIR / SPICE_BOOTSTRAP_DIR via
+    # SystemUtil, and the bootstrap-compiler tests shell-expand LLVM_LIB_DIR in their linker command. add_custom_target has no
+    # ENVIRONMENT property, so the env is injected into the command itself via "cmake -E env" to make sure it reaches the
+    # spicetest child processes spawned by gtest-parallel. Arguments after "--" are forwarded to each spicetest process.
+    add_custom_target(spicetest_parallel
+            COMMAND ${CMAKE_COMMAND} -E env
+            SPICE_STD_DIR=${CMAKE_SOURCE_DIR}/std
+            SPICE_BOOTSTRAP_DIR=${CMAKE_SOURCE_DIR}/src-bootstrap
+            LLVM_LIB_DIR=${LLVM_LIBRARY_DIRS}
+            ${PYTHON3_EXECUTABLE} ${CMAKE_SOURCE_DIR}/deps/gtest-parallel/gtest-parallel $<TARGET_FILE:spicetest> -- ${SPICE_TEST_ARGS}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            DEPENDS spicetest
+            USES_TERMINAL
+            COMMENT "Running spicetest in parallel via gtest-parallel")
+endif ()

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -116,6 +116,15 @@ void execTestCase(const TestCase &testCase) {
   if (explicitlySelectedTarget)
     cliOptions.isNativeTarget = false;
 
+  // Redirect all build artifacts to a per-test directory. Driver::enrich() resets these to shared paths (e.g. "./" and a
+  // shared temp cache dir), which would cause concurrently running test processes to clobber each other's object files and
+  // executables. Using a unique directory per test keeps parallel runs (e.g. via gtest-parallel) collision-free.
+  const std::filesystem::path artifactDir = TestUtil::prepareArtifactDir(testCase);
+  const std::filesystem::path executablePath = TestUtil::getExecutablePath(artifactDir);
+  cliOptions.outputDir = artifactDir;
+  cliOptions.cacheDir = artifactDir / "cache";
+  std::filesystem::create_directories(cliOptions.cacheDir);
+
   // Instantiate GlobalResourceManager
   GlobalResourceManager resourceManager(cliOptions);
 
@@ -238,7 +247,7 @@ void execTestCase(const TestCase &testCase) {
       mainSourceFile->concludeCompilation();
 
       // Prepare linker
-      resourceManager.linker.outputPath = TestUtil::getDefaultExecutableName();
+      resourceManager.linker.outputPath = executablePath;
 
       // Prepare and run linker
       resourceManager.linker.prepare();
@@ -266,7 +275,7 @@ void execTestCase(const TestCase &testCase) {
       std::stringstream cmd;
       if (testDriverCliOptions.enableLeakDetection)
         cmd << "valgrind -q --leak-check=full --num-callers=100 --error-exitcode=1 ";
-      cmd << TestUtil::getDefaultExecutableName();
+      cmd << executablePath.string();
       if (exists(cliFlagsFile))
         cmd << " " << TestUtil::getFileContentLinesVector(cliFlagsFile).at(0);
       const auto [output, exitCode] = SystemUtil::exec(cmd.str(), checkExecutionOutput);
@@ -296,7 +305,7 @@ void execTestCase(const TestCase &testCase) {
             std::filesystem::path gdbScriptPath = testCase.testPath / CTL_DEBUG_SCRIPT;
             EXPECT_TRUE(std::filesystem::exists(gdbScriptPath)) << "Debug output requested, but debug script not found";
             gdbScriptPath.make_preferred();
-            const std::string cmd = "gdb -x " + gdbScriptPath.string() + " " + TestUtil::getDefaultExecutableName();
+            const std::string cmd = "gdb -x " + gdbScriptPath.string() + " " + executablePath.string();
             const auto [output, exitCode] = SystemUtil::exec(cmd);
 
 #if not OS_WINDOWS // Windows does not give us the exit code, so we cannot check it on Windows

--- a/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/cout.out
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/source.spice
+++ b/test/test-files/bootstrap-compiler/unit-wrapper-save-and-restore/source.spice
@@ -1,0 +1,9 @@
+import "bootstrap/util/save-and-restore";
+
+// Wrapper for 'spice test' unit test
+f<int> main() {
+    assert testSaveAndRestoreRestoreOriginalValue();
+    assert testSaveAndRestoreApplyAndRestoreNewValue();
+    assert testSaveAndRestoreNestedGuards();
+    printf("All assertions passed!");
+}

--- a/test/util/TestUtil.cpp
+++ b/test/util/TestUtil.cpp
@@ -239,10 +239,15 @@ std::filesystem::path TestUtil::prepareArtifactDir(const TestCase &testCase) {
  */
 std::filesystem::path TestUtil::getExecutablePath(const std::filesystem::path &artifactDir) {
 #if OS_WINDOWS
-  return artifactDir / "source.exe";
+  std::filesystem::path executablePath = artifactDir / "source.exe";
 #else
-  return artifactDir / "source";
+  std::filesystem::path executablePath = artifactDir / "source";
 #endif
+  // Normalize to native separators. The artifact dir is built from a literal "./test-tmp" prefix, so the path string still
+  // contains forward slashes. When the executable is later run through a shell, the Windows command interpreter treats '/' as
+  // an option switch and fails with "'.' is not recognized as an internal or external command".
+  executablePath.make_preferred();
+  return executablePath;
 }
 
 /**

--- a/test/util/TestUtil.cpp
+++ b/test/util/TestUtil.cpp
@@ -215,6 +215,37 @@ std::string TestUtil::toCamelCase(std::string input) {
 }
 
 /**
+ * Create a clean, per-test directory for build artifacts (object files, compiler cache and the linked executable).
+ * The directory name is derived from the unique test suite/case name, so concurrently running test processes (e.g. when the
+ * suite is driven by gtest-parallel) never write to the same files.
+ *
+ * @param testCase Test case to prepare the artifact directory for
+ * @return Path to the prepared artifact directory
+ */
+std::filesystem::path TestUtil::prepareArtifactDir(const TestCase &testCase) {
+  const std::string dirName = toCamelCase(testCase.testSuite) + "_" + toCamelCase(testCase.testName);
+  const std::filesystem::path artifactDir = std::filesystem::path("./test-tmp") / dirName;
+  std::error_code ec;
+  std::filesystem::remove_all(artifactDir, ec); // Clean up leftovers from a previous run
+  std::filesystem::create_directories(artifactDir);
+  return artifactDir;
+}
+
+/**
+ * Get the path of the linked test executable inside the given per-test artifact directory.
+ *
+ * @param artifactDir Per-test artifact directory
+ * @return Path to the executable
+ */
+std::filesystem::path TestUtil::getExecutablePath(const std::filesystem::path &artifactDir) {
+#if OS_WINDOWS
+  return artifactDir / "source.exe";
+#else
+  return artifactDir / "source";
+#endif
+}
+
+/**
  * Check if the provided test case is disabled
  *
  * @param testCase Test case to check
@@ -249,11 +280,14 @@ bool TestUtil::isDisabled(const TestCase &testCase) {
  * @param gdbOutput GDB output to modify
  */
 void TestUtil::eraseGDBHeader(std::string &gdbOutput) {
-  // Remove header
+  // Remove the header up to and including the "Reading symbols from <path>" line. The executable lives in a per-test artifact
+  // directory, so its path is not stable across runs and must not be part of the comparison.
   size_t pos = gdbOutput.find(GDB_READING_SYMBOLS_MESSAGE);
   if (pos != std::string::npos) {
-    if (const size_t lineStart = gdbOutput.rfind('\n', pos); lineStart != std::string::npos)
-      gdbOutput.erase(0, lineStart + 1);
+    if (const size_t lineEnd = gdbOutput.find('\n', pos); lineEnd != std::string::npos)
+      gdbOutput.erase(0, lineEnd + 1);
+    else
+      gdbOutput.clear();
   }
 
   // Remove inferior message

--- a/test/util/TestUtil.h
+++ b/test/util/TestUtil.h
@@ -75,13 +75,11 @@ public:
   static std::vector<std::string> getSubdirs(const std::filesystem::path &basePath);
   static std::vector<std::string> getFileContentLinesVector(const std::filesystem::path &filePath);
   static std::string toCamelCase(std::string input);
-  static consteval const char *getDefaultExecutableName() {
-#if OS_WINDOWS
-    return ".\\source.exe";
-#else
-    return "./source";
-#endif
-  }
+  /// Create (and clean) a per-test directory for build artifacts (object files, cache, executable). Using a unique directory
+  /// per test case keeps concurrently running test processes (e.g. via gtest-parallel) from clobbering each other's files.
+  static std::filesystem::path prepareArtifactDir(const TestCase &testCase);
+  /// Path of the linked test executable inside the given per-test artifact directory.
+  static std::filesystem::path getExecutablePath(const std::filesystem::path &artifactDir);
   static bool isDisabled(const TestCase &testCase);
   static void eraseGDBHeader(std::string &gdbOutput);
   static void eraseLinesBySubstring(std::string &irCode, const char *needle);


### PR DESCRIPTION
## Summary

Speeds up CI by running the `spicetest` integration/unit suite in parallel, with the supporting infrastructure and fixes needed to make the cases safe to run concurrently.

- **Parallel test target**: adds a `spicetest_parallel` CMake target driven by `gtest-parallel` (vendored as a submodule under `deps/`), one process per test case. CI (`ci-cpp.yml`, `ci-asan.yml`) now runs the suite through it.
- **Per-test artifact isolation**: each test writes its build artifacts (object files, compiler cache, linked executable) to a unique per-test directory (`TestUtil::prepareArtifactDir`), so concurrent processes no longer clobber each other's output.
- **Simplified LLVM include forwarding**: the two separate include-dir env vars are collapsed into a single `LLVM_INCLUDE_DIRS` var that can hold multiple `-I<dir>` flags (`linker-flags.spice`), with the test harness/CI building the value accordingly.
- **Windows execution fix**: the per-test artifact path is built from a literal `./test-tmp` prefix, which kept forward slashes in the path string. Windows `cmd` treats `/` as an option switch, so running a compiled test binary failed with `'.' is not recognized as an internal or external command`. `getExecutablePath` now calls `make_preferred()` to normalize separators.
- **Build-type tuning**: CI test targets build with `RelWithDebInfo`/`Release` (Debug only for coverage on `main`) for faster runs.
- **Bootstrap**: ports `SaveAndRestore` to `src-bootstrap` with a wrapper test, and a small `ast-visualizer` fix.

## Test plan

- CI runs the full suite via `spicetest_parallel` on Linux, ASAN, and Windows.
- Windows runner now executes compiled test binaries without the `cmd` path error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)