### PR TITLE
Decouple LLVM IR state from semantic model objects

### DIFF
--- a/src-bootstrap/irgenerator/ir-generator.spice
+++ b/src-bootstrap/irgenerator/ir-generator.spice
@@ -1,9 +1,12 @@
 // Std imports
 import "std/data/vector";
 import "std/data/stack";
+import "std/data/unordered-map";
 
 // Own imports
 import "src/bindings/llvm/llvm" as llvm;
+import "bootstrap/model/function";
+import "bootstrap/symboltablebuilder/symbol-table-entry";
 
 type CommonLLVMTypes struct {
     llvm::StructType fatPtrType
@@ -25,6 +28,9 @@ public type IRGenerator struct {
     llvm::Instruction* allocaInsertInst = nil<llvm::Instruction*>
     bool blockAlreadyTerminated = false
     //Vector<DeferredLogic> deferredVTableInitializations
+    // IR-side state: separate from semantic objects to keep the type-checker model clean
+    UnorderedMap<SymbolTableEntry*, Stack<llvm::Value*>> addressMap
+    UnorderedMap<Function*, llvm::Function*> llvmFunctions
 }
 
 public p IRGenerator.ctor(GlobalResourceManager& resourceManager, SourceFile* sourceFile) {
@@ -73,4 +79,91 @@ public f<llvm::Value> IRGenerator.insertLoad(llvm::Type llvmType, llvm::Value pt
 public p IRGenerator.insertStore(llvm::Value value, llvm::Value ptr, bool isVolatile) {
     assert ptr.getType().isPointerTy();
     this.builder.createStore(value, ptr, isVolatile);
+}
+
+/**
+ * Retrieve the current IR address of a symbol table entry
+ *
+ * @param entry Symbol table entry
+ * @return IR address, or nil if not yet allocated
+ */
+public f<llvm::Value*> IRGenerator.getAddress(SymbolTableEntry* entry) {
+    if !this.addressMap.contains(entry) { return nil<llvm::Value*>; }
+    Stack<llvm::Value*>& stack = this.addressMap.get(entry);
+    return stack.isEmpty() ? nil<llvm::Value*> : stack.top();
+}
+
+/**
+ * Set or update the IR address of a symbol table entry.
+ * If no address has been recorded yet, the address is pushed onto a new stack;
+ * otherwise the top of the existing stack is replaced.
+ *
+ * @param entry Symbol table entry
+ * @param address IR address to record
+ */
+public p IRGenerator.updateAddress(SymbolTableEntry* entry, llvm::Value* address) {
+    assert address != nil<llvm::Value*>;
+    if !this.addressMap.contains(entry) {
+        Stack<llvm::Value*> stack;
+        stack.push(address);
+        this.addressMap.upsert(entry, stack);
+    } else {
+        Stack<llvm::Value*>& stack = this.addressMap.get(entry);
+        if stack.isEmpty() {
+            stack.push(address);
+        } else {
+            stack.pop();
+            stack.push(address);
+        }
+    }
+}
+
+/**
+ * Push a new IR address onto the stack for a symbol table entry.
+ * Used for lambda captures that temporarily shadow an outer address.
+ *
+ * @param entry Symbol table entry
+ * @param address IR address to push
+ */
+public p IRGenerator.pushAddress(SymbolTableEntry* entry, llvm::Value* address) {
+    assert address != nil<llvm::Value*>;
+    if !this.addressMap.contains(entry) {
+        Stack<llvm::Value*> stack;
+        this.addressMap.upsert(entry, stack);
+    }
+    this.addressMap.get(entry).push(address);
+}
+
+/**
+ * Pop the top IR address from the stack for a symbol table entry.
+ * Used to restore the outer address after a lambda capture scope exits.
+ *
+ * @param entry Symbol table entry
+ */
+public p IRGenerator.popAddress(SymbolTableEntry* entry) {
+    assert this.addressMap.contains(entry);
+    Stack<llvm::Value*>& stack = this.addressMap.get(entry);
+    assert !stack.isEmpty();
+    stack.pop();
+}
+
+/**
+ * Retrieve the LLVM function for a Spice function
+ *
+ * @param spiceFunc Spice function
+ * @return LLVM function, or nil if not yet generated
+ */
+public f<llvm::Function*> IRGenerator.getLLVMFunction(Function* spiceFunc) {
+    return this.llvmFunctions.contains(spiceFunc) ? this.llvmFunctions.get(spiceFunc) : nil<llvm::Function*>;
+}
+
+/**
+ * Register the LLVM function generated for a Spice function
+ *
+ * @param spiceFunc Spice function
+ * @param llvmFunction Generated LLVM function
+ */
+public p IRGenerator.setLLVMFunction(Function* spiceFunc, llvm::Function* llvmFunction) {
+    assert llvmFunction != nil<llvm::Function*>;
+    this.llvmFunctions.upsert(spiceFunc, llvmFunction);
 }

--- a/src-bootstrap/model/function.spice
+++ b/src-bootstrap/model/function.spice
@@ -1,7 +1,6 @@
 // Std imports
 import "std/data/vector";
 import "std/text/stringstream";
-import "std/bindings/llvm/llvm" as llvm;
 
 // Own imports
 import "bootstrap/ast/ast-nodes";
@@ -51,7 +50,6 @@ public type Function struct {
     public bool implicitDefault = false
     public bool isVirtual = false
     public bool isNewlyInserted = false
-    public llvm::Function* llvmFunction = nil<llvm::Function*>
     public unsigned long vtableIndex = 0ul
 }
 

--- a/src-bootstrap/symboltablebuilder/symbol-table-entry.spice
+++ b/src-bootstrap/symboltablebuilder/symbol-table-entry.spice
@@ -1,6 +1,4 @@
 // Std imports
-import "std/data/stack";
-import "std/bindings/llvm/llvm" as llvm;
 
 // Own imports
 import "bootstrap/ast/ast-nodes";
@@ -33,7 +31,6 @@ public type SymbolTableEntry struct {
     public bool isImplicitField = false
     // Private fields
     QualType qualType
-    Stack<llvm::Value*> memAddress
     Lifecycle lifecycle
 }
 
@@ -99,54 +96,6 @@ public p SymbolTableEntry.updateState(const LifecycleState& newState, ASTNode* n
  */
 public f<const CodeLoc &> SymbolTableEntry.getDeclCodeLoc() {
     return this.declNode.codeLoc;
-}
-
-/**
- * Retrieve the address of the assigned value
- *
- * @return Address of the value in memory
- */
-public f<llvm::Value*> SymbolTableEntry.getAddress() {
-    return this.memAddress.isEmpty() ? nil<llvm::Value*> : this.memAddress.top();
-}
-
-/**
- * Update the address of a symbol. This is used to save the allocated address where the symbol lives.
- *
- * @param address Address of the symbol in memory
- */
-public p SymbolTableEntry.updateAddress(llvm::Value* address) {
-    assert address != nil<llvm::Value*>;
-    // Ensure that structs fields get no addresses assigned, as the addresses are meant for the struct instances
-    const ScopeType currentScopeType = this.scope.getScopeType();
-    const dyn fctOptions = [SuperType::TY_FUNCTION, SuperType::TY_PROCEDURE];
-    assert (currentScopeType != ScopeType::STRUCT && currentScopeType != ScopeType::INTERFACE) || this.qualType.isOneOf(fctOptions, len(fctOptions));
-    if this.memAddress.isEmpty() {
-        this.memAddress.push(address);
-    } else {
-        // Replace the top element. The host compiler does not treat a reference returned from a method call
-        // (Stack.top()) as an assignable lvalue, so we pop and push instead of `this.memAddress.top() = address`.
-        this.memAddress.pop();
-        this.memAddress.push(address);
-    }
-}
-
-/**
- * Push a new address to the stack
- *
- * @param address Address to push
- */
-public p SymbolTableEntry.pushAddress(llvm::Value* address) {
-    assert address != nil<llvm::Value*>;
-    this.memAddress.push(address);
-}
-
-/**
- * Remove the last address from the stack
- */
-public p SymbolTableEntry.popAddress() {
-    assert !this.memAddress.isEmpty();
-    this.memAddress.pop();
 }
 
 /**

--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -116,7 +116,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
 
     // If an anonymous symbol exists, set its address
     if (SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(iteratorAssignNode))
-      returnSymbol->updateAddress(iteratorPtr);
+      updateAddress(returnSymbol, iteratorPtr);
   } else { // The iteratorAssignExpr is of type Iterator
     iteratorPtr = resolveAddress(iteratorAssignNode);
   }
@@ -135,7 +135,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
     visit(idxDeclNode);
     // Get address of idx variable
     idxEntry = idxDeclNode->entries.at(manIdx);
-    idxAddress = idxEntry->getAddress();
+    idxAddress = getAddress(idxEntry);
     assert(idxAddress != nullptr);
   }
 
@@ -144,7 +144,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
   visit(itemDeclNode);
   // Get address of item variable
   SymbolTableEntry *itemEntry = itemDeclNode->entries.at(manIdx);
-  llvm::Value *itemAddress = itemEntry->getAddress();
+  llvm::Value *itemAddress = getAddress(itemEntry);
   assert(itemAddress != nullptr);
 
   // Create jump from original to head block

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -72,7 +72,7 @@ std::any IRGenerator::visitAssignExpr(const AssignExprNode *node) {
 
     if (result.ptr) { // The operation allocated more memory
       if (lhs.entry)
-        lhs.entry->updateAddress(result.ptr);
+        updateAddress(lhs.entry, result.ptr);
     } else if (result.value) { // The operation only updated the value
       // Store the result
       lhs.value = result.value;
@@ -178,7 +178,7 @@ std::any IRGenerator::visitTernaryExpr(const TernaryExprNode *node) {
         resultPtr = insertAlloca(anonymousSymbol->getQualType());
         insertStore(resultValue, resultPtr);
       }
-      anonymousSymbol->updateAddress(resultPtr);
+      updateAddress(anonymousSymbol, resultPtr);
     }
   }
 
@@ -877,7 +877,7 @@ std::any IRGenerator::visitAtomicExpr(const AtomicExprNode *node) {
   if (entry->global && accessScope->isImportedBy(rootScope)) {
     // External global variables need to be declared and allocated in the current module
     llvm::Value *varAddress = module->getOrInsertGlobal(entry->name, varType);
-    entry->updateAddress(varAddress);
+    updateAddress(entry, varAddress);
   }
 
   // Check if enum item
@@ -887,7 +887,7 @@ std::any IRGenerator::visitAtomicExpr(const AtomicExprNode *node) {
     return LLVMExprResult{.constant = constantItemValue, .entry = entry};
   }
 
-  llvm::Value *address = entry->getAddress();
+  llvm::Value *address = getAddress(entry);
   assert(address != nullptr);
 
   // If this is a function/procedure reference, return it as value. The fat pointer must point at a thunk that

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -111,7 +111,7 @@ llvm::Value *IRGenerator::getUpcastedStructPtr(llvm::Value *structPtr, const Qua
   return structPtr;
 }
 
-void IRGenerator::generateScopeCleanup(const StmtLstNode *node) const {
+void IRGenerator::generateScopeCleanup(const StmtLstNode *node) {
   // Do not clean up if the block is already terminated
   if (blockAlreadyTerminated)
     return;
@@ -123,12 +123,12 @@ void IRGenerator::generateScopeCleanup(const StmtLstNode *node) const {
 
   // Deallocate all heap variables that go out of scope and are currently owned
   for (const SymbolTableEntry *entry : heapVarsToFree)
-    generateDeallocCall(entry->getAddress());
+    generateDeallocCall(getAddress(entry));
 
   // Generate lifetime end markers
   if (cliOptions.useLifetimeMarkers) {
     for (const SymbolTableEntry *var : currentScope->getVarsGoingOutOfScope()) {
-      llvm::Value *address = var->getAddress();
+      llvm::Value *address = getAddress(var);
       if (address != nullptr)
         builder.CreateLifetimeEnd(address);
     }
@@ -205,7 +205,7 @@ void IRGenerator::generateProcDeclAndCall(const Function *proc, const std::vecto
 }
 
 void IRGenerator::generateCtorOrDtorCall(const SymbolTableEntry *entry, const Function *ctorOrDtor,
-                                         const std::vector<llvm::Value *> &args) const {
+                                         const std::vector<llvm::Value *> &args) {
   // Retrieve address of the struct variable. For fields this is the 'this' variable, otherwise use the normal address
   llvm::Value *structAddr;
   if (entry->isField()) {
@@ -214,11 +214,11 @@ void IRGenerator::generateCtorOrDtorCall(const SymbolTableEntry *entry, const Fu
     assert(thisVar != nullptr);
     assert(thisVar->getQualType().isPtr() && thisVar->getQualType().getContained().is(TY_STRUCT));
     llvm::Type *thisType = thisVar->getQualType().getContained().toLLVMType(sourceFile);
-    llvm::Value *thisPtr = insertLoad(builder.getPtrTy(), thisVar->getAddress());
+    llvm::Value *thisPtr = insertLoad(builder.getPtrTy(), getAddress(thisVar));
     // Add field offset
     structAddr = insertStructGEP(thisType, thisPtr, entry->orderIndex);
   } else {
-    structAddr = entry->getAddress();
+    structAddr = getAddress(entry);
     // For optional parameter initializers we need this exception
     if (!structAddr)
       return;
@@ -330,7 +330,7 @@ llvm::Function *IRGenerator::generateImplicitFunction(const std::function<void()
     // Allocate space for the parameter
     llvm::Value *thisAddress = insertAlloca(paramTypes.front(), THIS_VARIABLE_NAME);
     // Update the symbol table entry
-    thisEntry->updateAddress(thisAddress);
+    updateAddress(thisEntry, thisAddress);
     // Store the value at the new address
     insertStore(fct->arg_begin(), thisAddress);
     // Generate debug info
@@ -429,7 +429,7 @@ llvm::Function *IRGenerator::generateImplicitProcedure(const std::function<void(
     // Allocate space for the parameter
     llvm::Value *thisAddress = insertAlloca(paramTypes.front(), THIS_VARIABLE_NAME);
     // Update the symbol table entry
-    thisEntry->updateAddress(thisAddress);
+    updateAddress(thisEntry, thisAddress);
     // Store the value at the new address
     insertStore(fct->arg_begin(), thisAddress);
     // Generate debug info
@@ -462,7 +462,7 @@ void IRGenerator::generateCtorBodyPreamble(Scope *bodyScope) {
   // Get struct address
   const SymbolTableEntry *thisEntry = bodyScope->lookupStrict(THIS_VARIABLE_NAME);
   assert(thisEntry != nullptr);
-  llvm::Value *thisPtrPtr = thisEntry->getAddress();
+  llvm::Value *thisPtrPtr = getAddress(thisEntry);
   assert(thisPtrPtr != nullptr);
   llvm::Value *thisPtr = nullptr;
   const QualType structSymbolType = thisEntry->getQualType().getBase();
@@ -540,7 +540,7 @@ void IRGenerator::generateCopyCtorBodyPreamble(const Function *copyCtorFunction)
   // Get struct address
   const SymbolTableEntry *thisEntry = copyCtorFunction->bodyScope->lookupStrict(THIS_VARIABLE_NAME);
   assert(thisEntry != nullptr);
-  llvm::Value *thisPtrPtr = thisEntry->getAddress();
+  llvm::Value *thisPtrPtr = getAddress(thisEntry);
   assert(thisPtrPtr != nullptr);
   llvm::Value *thisPtr = nullptr;
   llvm::Type *structType = thisEntry->getQualType().getBase().toLLVMType(sourceFile);
@@ -628,7 +628,7 @@ void IRGenerator::generateMoveCtorBodyPreamble(const Function *moveCtorFunction)
   // Get struct address
   const SymbolTableEntry *thisEntry = moveCtorFunction->bodyScope->lookupStrict(THIS_VARIABLE_NAME);
   assert(thisEntry != nullptr);
-  llvm::Value *thisPtrPtr = thisEntry->getAddress();
+  llvm::Value *thisPtrPtr = getAddress(thisEntry);
   assert(thisPtrPtr != nullptr);
   llvm::Value *thisPtr = nullptr;
   llvm::Type *structType = thisEntry->getQualType().getBase().toLLVMType(sourceFile);
@@ -697,7 +697,7 @@ void IRGenerator::generateDefaultMoveCtor(const Function *moveCtorFunction) {
   generateImplicitProcedure(generateBody, moveCtorFunction);
 }
 
-void IRGenerator::generateDtorBodyPreamble(const Function *dtorFunction) const {
+void IRGenerator::generateDtorBodyPreamble(const Function *dtorFunction) {
   // Retrieve struct scope
   Scope *structScope = dtorFunction->bodyScope->parent;
   assert(structScope != nullptr);
@@ -705,7 +705,7 @@ void IRGenerator::generateDtorBodyPreamble(const Function *dtorFunction) const {
   // Get struct address
   const SymbolTableEntry *thisEntry = dtorFunction->bodyScope->lookupStrict(THIS_VARIABLE_NAME);
   assert(thisEntry != nullptr);
-  llvm::Value *thisPtrPtr = thisEntry->getAddress();
+  llvm::Value *thisPtrPtr = getAddress(thisEntry);
   assert(thisPtrPtr != nullptr);
   llvm::Value *thisPtr = nullptr;
   llvm::Type *structType = thisEntry->getQualType().getBase().toLLVMType(sourceFile);

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -50,7 +50,7 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
     if (node->calledCopyCtor) {
       // Allocate memory
       varAddress = insertAlloca(varTy);
-      varEntry->updateAddress(varAddress);
+      updateAddress(varEntry, varAddress);
       // Call copy ctor
       llvm::Value *rhsAddress = resolveAddress(node->assignExpr);
       assert(rhsAddress != nullptr);
@@ -59,13 +59,13 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
       // Assign rhs to lhs
       [[maybe_unused]] const LLVMExprResult assignResult = doAssignment(varAddress, varEntry, node->assignExpr, node, true);
       assert(assignResult.entry == varEntry);
-      varAddress = varEntry->getAddress();
-      varEntry->updateAddress(varAddress);
+      varAddress = getAddress(varEntry);
+      updateAddress(varEntry, varAddress);
     }
   } else { // Default value
     // Allocate memory
     varAddress = insertAlloca(varTy);
-    varEntry->updateAddress(varAddress);
+    updateAddress(varEntry, varAddress);
 
     if (node->calledInitCtor) {
       // Call no-args constructor
@@ -130,7 +130,7 @@ std::any IRGenerator::visitReturnStmt(const ReturnStmtNode *node) {
     const SymbolTableEntry *resultEntry = currentScope->lookup(RETURN_VARIABLE_NAME);
     if (resultEntry != nullptr) {
       llvm::Type *resultSTy = resultEntry->getQualType().toLLVMType(sourceFile);
-      llvm::Value *returnValueAddr = resultEntry->getAddress();
+      llvm::Value *returnValueAddr = getAddress(resultEntry);
       returnValue = insertLoad(resultSTy, returnValueAddr);
     }
   }

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -94,7 +94,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
   // Update the symbol table entry
   SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
   assert(resultEntry != nullptr);
-  resultEntry->updateAddress(resultAddress);
+  updateAddress(resultEntry, resultAddress);
   // Generate debug info
   diGenerator.generateLocalVarDebugInfo(RETURN_VARIABLE_NAME, resultAddress);
   // Store the default result value
@@ -109,7 +109,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
     // Allocate space for it
     llvm::Value *paramAddress = insertAlloca(paramSymbol->getQualType(), paramName);
     // Update the symbol table entry
-    paramSymbol->updateAddress(paramAddress);
+    updateAddress(paramSymbol, paramAddress);
     // Store the value at the new address
     insertStore(&arg, paramAddress);
     // Generate debug info
@@ -121,7 +121,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
 
   // Create return statement if the block is not terminated yet
   if (!blockAlreadyTerminated) {
-    llvm::Value *result = insertLoad(fct->getReturnType(), resultEntry->getAddress());
+    llvm::Value *result = insertLoad(fct->getReturnType(), getAddress(resultEntry));
     builder.CreateRet(result);
   }
 
@@ -210,8 +210,8 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
     llvm::FunctionType *funcType = llvm::FunctionType::get(returnType, paramTypes, false);
     module->getOrInsertFunction(mangledName, funcType);
     llvm::Function *func = module->getFunction(mangledName);
-    node->entry->updateAddress(func);
-    manifestation->llvmFunction = func;
+    updateAddress(node->entry, func);
+    setLLVMFunction(manifestation, func);
     assert(func->empty());
 
     // Set attributes to function
@@ -240,7 +240,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
     llvm::Value *resultAddr = insertAlloca(manifestation->returnType, RETURN_VARIABLE_NAME);
     SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
     assert(resultEntry != nullptr);
-    resultEntry->updateAddress(resultAddr);
+    updateAddress(resultEntry, resultAddr);
     // Generate debug info
     diGenerator.generateLocalVarDebugInfo(RETURN_VARIABLE_NAME, resultAddr);
 
@@ -253,7 +253,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
       // Allocate space for it
       llvm::Value *paramAddress = insertAlloca(paramSymbol->getQualType(), paramName);
       // Update the symbol table entry
-      paramSymbol->updateAddress(paramAddress);
+      updateAddress(paramSymbol, paramAddress);
       // Set source location
       diGenerator.setSourceLocation(paramSymbol->declNode);
       // Store the value at the new address
@@ -274,7 +274,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
 
     // Create return statement if the block is not terminated yet
     if (!blockAlreadyTerminated) {
-      llvm::Value *result = insertLoad(returnType, resultEntry->getAddress());
+      llvm::Value *result = insertLoad(returnType, getAddress(resultEntry));
       builder.CreateRet(result);
     }
 
@@ -364,8 +364,8 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
     llvm::FunctionType *procType = llvm::FunctionType::get(returnType, paramTypes, false);
     module->getOrInsertFunction(mangledName, procType);
     llvm::Function *proc = module->getFunction(mangledName);
-    node->entry->updateAddress(proc);
-    manifestation->llvmFunction = proc;
+    updateAddress(node->entry, proc);
+    setLLVMFunction(manifestation, proc);
     assert(proc->empty());
 
     // Set attributes to procedure
@@ -399,7 +399,7 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
       // Allocate space for it
       llvm::Value *paramAddress = insertAlloca(paramSymbol->getQualType(), paramName);
       // Update the symbol table entry
-      paramSymbol->updateAddress(paramAddress);
+      updateAddress(paramSymbol, paramAddress);
       // Set source location
       diGenerator.setSourceLocation(paramSymbol->declNode);
       // Store the value at the new address
@@ -625,7 +625,7 @@ std::any IRGenerator::visitGlobalVarDef(const GlobalVarDefNode *node) {
     var->setInitializer(constantValue);
   }
 
-  node->entry->updateAddress(varAddress);
+  updateAddress(node->entry, varAddress);
 
   // Add debug info
   diGenerator.generateGlobalVarDebugInfo(var, node->entry);

--- a/src/irgenerator/GenVTable.cpp
+++ b/src/irgenerator/GenVTable.cpp
@@ -121,7 +121,7 @@ llvm::Constant *IRGenerator::generateVTable(StructBase *spiceStruct) const {
   return spiceStruct->vTableData.vtable = global;
 }
 
-void IRGenerator::generateVTableInitializer(const StructBase *spiceStruct) const {
+void IRGenerator::generateVTableInitializer(const StructBase *spiceStruct) {
   // Retrieve virtual method count
   assert(spiceStruct->scope);
   const std::vector<Function *> virtualMethods = spiceStruct->scope->getVirtualMethods();
@@ -138,8 +138,9 @@ void IRGenerator::generateVTableInitializer(const StructBase *spiceStruct) const
   arrayValues.push_back(llvm::Constant::getNullValue(ptrTy)); // nullptr as safety guard
   arrayValues.push_back(spiceStruct->vTableData.typeInfo);    // TypeInfo to identify the type for the VTable
   for (Function *virtualMethod : virtualMethods) {
-    assert(spiceStruct->scope->type == ScopeType::INTERFACE || virtualMethod->llvmFunction != nullptr);
-    arrayValues.push_back(virtualMethod->llvmFunction ? virtualMethod->llvmFunction : llvm::Constant::getNullValue(ptrTy));
+    llvm::Function *llvmFunc = getLLVMFunction(virtualMethod);
+    assert(spiceStruct->scope->type == ScopeType::INTERFACE || llvmFunc != nullptr);
+    arrayValues.push_back(llvmFunc ? llvmFunc : llvm::Constant::getNullValue(ptrTy));
   }
 
   // Generate VTable struct

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -85,7 +85,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
     Scope *structScope = baseType.getBodyScope();
 
     // Get address of the referenced variable / struct instance
-    thisPtr = firstFragEntry->getAddress();
+    thisPtr = getAddress(firstFragEntry);
 
     // Auto de-reference 'this' pointer
     QualType firstFragmentType = firstFragEntry->getQualType();
@@ -130,7 +130,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
   // site knowing statically whether it captures (e.g. when it was retrieved from the std Lambda wrapper).
   llvm::Value *fctPtr = nullptr;
   if (data.isFctPtrCall()) {
-    llvm::Value *fatPtr = firstFragEntry->getAddress();
+    llvm::Value *fatPtr = getAddress(firstFragEntry);
     // Load fctPtr
     fctPtr = insertStructGEP(llvmTypes.lambdaFatPtrType, fatPtr, 0);
     // Load the captures pointer and add it to the argument list
@@ -178,7 +178,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
 
           // Attach address of copy to anonymous symbol
           SymbolTableEntry *anonymousSymbol = currentScope->symbolTable.lookupAnonymous(argNode, SIZE_MAX);
-          anonymousSymbol->updateAddress(valueCopyPtr);
+          updateAddress(anonymousSymbol, valueCopyPtr);
 
           argValues.push_back(newValue);
         } else {
@@ -251,7 +251,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
     assert(firstFragEntry != nullptr);
     QualType firstFragType = firstFragEntry->getQualType();
     if (!fctPtr)
-      fctPtr = firstFragEntry->getAddress();
+      fctPtr = getAddress(firstFragEntry);
     autoDeReferencePtr(fctPtr, firstFragType);
     llvm::Value *fct = insertLoad(builder.getPtrTy(), fctPtr, false, "fct");
 
@@ -279,11 +279,11 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
     anonymousSymbol = currentScope->symbolTable.lookupAnonymous(node);
     if (anonymousSymbol != nullptr) {
       if (data.isCtorCall()) {
-        anonymousSymbol->updateAddress(thisPtr);
+        updateAddress(anonymousSymbol, thisPtr);
       } else {
         resultPtr = insertAlloca(callInst->getType());
         insertStore(callInst, resultPtr);
-        anonymousSymbol->updateAddress(resultPtr);
+        updateAddress(anonymousSymbol, resultPtr);
       }
     }
   }
@@ -475,7 +475,7 @@ std::any IRGenerator::visitStructInstantiation(const StructInstantiationNode *no
     // Attach address to anonymous symbol to keep track of de-allocation
     SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(node);
     if (returnSymbol != nullptr)
-      returnSymbol->updateAddress(structAddr);
+      updateAddress(returnSymbol, structAddr);
 
     return LLVMExprResult{.ptr = structAddr};
   }
@@ -561,7 +561,7 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
   SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
   assert(resultEntry != nullptr);
   llvm::Value *resultAddr = insertAlloca(returnType, RETURN_VARIABLE_NAME);
-  resultEntry->updateAddress(resultAddr);
+  updateAddress(resultEntry, resultAddr);
   // Generate debug info
   diGenerator.generateLocalVarDebugInfo(RETURN_VARIABLE_NAME, resultAddr);
 
@@ -579,7 +579,7 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
     if (isCapturesStruct)
       captureStructPtrPtr = paramAddress;
     else
-      paramSymbol->updateAddress(paramAddress);
+      updateAddress(paramSymbol, paramAddress);
     // Store the value at the new address
     insertStore(&arg, paramAddress);
     // Generate debug info
@@ -605,14 +605,14 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
 
   // Create return statement if the block is not terminated yet
   if (!blockAlreadyTerminated) {
-    llvm::Value *result = insertLoad(returnType, resultEntry->getAddress());
+    llvm::Value *result = insertLoad(returnType, getAddress(resultEntry));
     builder.CreateRet(result);
   }
 
   // Pop capture addresses
   if (hasCaptures)
     for (const auto &capture : captures | std::views::values)
-      capture.capturedSymbol->popAddress();
+      popAddress(capture.capturedSymbol);
 
   // Conclude debug info for function
   diGenerator.concludeFunctionDebugInfo();
@@ -723,7 +723,7 @@ std::any IRGenerator::visitLambdaProc(const LambdaProcNode *node) {
     if (isCapturesStruct)
       captureStructPtrPtr = paramAddress;
     else
-      paramSymbol->updateAddress(paramAddress);
+      updateAddress(paramSymbol, paramAddress);
     // Store the value at the new address
     insertStore(&arg, paramAddress);
     // Generate debug info
@@ -754,7 +754,7 @@ std::any IRGenerator::visitLambdaProc(const LambdaProcNode *node) {
   // Pop capture addresses
   if (hasCaptures)
     for (const auto &capture : captures | std::views::values)
-      capture.capturedSymbol->popAddress();
+      popAddress(capture.capturedSymbol);
 
   // Conclude debug info for function
   diGenerator.concludeFunctionDebugInfo();
@@ -869,7 +869,7 @@ std::any IRGenerator::visitLambdaExpr(const LambdaExprNode *node) {
     if (isCapturesStruct)
       captureStructPtrPtr = paramAddress;
     else
-      paramSymbol->updateAddress(paramAddress);
+      updateAddress(paramSymbol, paramAddress);
     // Store the value at the new address
     insertStore(&arg, paramAddress);
     // Generate debug info
@@ -897,7 +897,7 @@ std::any IRGenerator::visitLambdaExpr(const LambdaExprNode *node) {
   // Pop capture addresses
   if (hasCaptures)
     for (const auto &val : captures | std::views::values)
-      val.capturedSymbol->popAddress();
+      popAddress(val.capturedSymbol);
 
   // Conclude debug info for function
   diGenerator.concludeFunctionDebugInfo();
@@ -994,9 +994,9 @@ llvm::Value *IRGenerator::buildFatFctPtr(Scope *bodyScope, llvm::Type *capturesS
       const Capture &capture = captures.begin()->second;
       if (capture.getMode() == BY_VALUE) {
         llvm::Type *varType = capture.capturedSymbol->getQualType().toLLVMType(sourceFile);
-        capturesPtr = insertLoad(varType, capture.capturedSymbol->getAddress());
+        capturesPtr = insertLoad(varType, getAddress(capture.capturedSymbol));
       } else {
-        capturesPtr = capture.capturedSymbol->getAddress();
+        capturesPtr = getAddress(capture.capturedSymbol);
       }
     } else {
       capturesPtr = insertAlloca(capturesStructType, CAPTURES_PARAM_NAME);
@@ -1005,7 +1005,7 @@ llvm::Value *IRGenerator::buildFatFctPtr(Scope *bodyScope, llvm::Type *capturesS
       for (const auto &capture : bodyScope->symbolTable.captures | std::views::values) {
         const SymbolTableEntry *capturedEntry = capture.capturedSymbol;
         // Get address or value of captured variable, depending on the capturing mode
-        llvm::Value *capturedValue = capturedEntry->getAddress();
+        llvm::Value *capturedValue = getAddress(capturedEntry);
         assert(capturedValue != nullptr);
         if (capture.getMode() == BY_VALUE) {
           llvm::Type *captureType = capturedEntry->getQualType().toLLVMType(sourceFile);
@@ -1059,7 +1059,7 @@ void IRGenerator::unpackCapturesToLocalVariables(const CaptureMap &captures, llv
   if (captures.size() == 1 && (firstCapture.capturedSymbol->getQualType().isPtr() || firstCapture.getMode() == BY_REFERENCE)) {
     // Interpret capturesPtr as ptr to the first and only capture
     llvm::Value *captureAddress = val;
-    firstCapture.capturedSymbol->pushAddress(captureAddress);
+    pushAddress(firstCapture.capturedSymbol, captureAddress);
     // Generate debug info
     diGenerator.generateLocalVarDebugInfo(firstCapture.getName(), captureAddress);
   } else {
@@ -1070,7 +1070,7 @@ void IRGenerator::unpackCapturesToLocalVariables(const CaptureMap &captures, llv
     for (const auto &[name, capture] : captures) {
       const std::string valueName = capture.getMode() == BY_REFERENCE ? name + ".addr" : name;
       llvm::Value *captureAddress = insertStructGEP(structType, capturesPtr, captureIdx, valueName);
-      capture.capturedSymbol->pushAddress(captureAddress);
+      pushAddress(capture.capturedSymbol, captureAddress);
       // Generate debug info
       diGenerator.generateLocalVarDebugInfo(capture.getName(), captureAddress);
       captureIdx++;

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -5,6 +5,7 @@
 #include <SourceFile.h>
 #include <driver/Driver.h>
 #include <global/GlobalResourceManager.h>
+#include <model/Function.h>
 #include <symboltablebuilder/SymbolTableBuilder.h>
 #include <typechecker/FunctionManager.h>
 
@@ -438,7 +439,7 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
 
       // Store lhs pointer to rhs
       llvm::Value *refAddress = insertAlloca(builder.getPtrTy());
-      lhsEntry->updateAddress(refAddress);
+      updateAddress(lhsEntry, refAddress);
       insertStore(rhsAddress, refAddress);
 
       return LLVMExprResult{.value = rhsAddress, .ptr = refAddress, .entry = lhsEntry};
@@ -468,7 +469,7 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
     assert(lhsEntry != nullptr);
     // Directly set the address to the lhs entry (temp stealing)
     llvm::Value *rhsAddress = resolveAddress(rhs);
-    lhsEntry->updateAddress(rhsAddress);
+    updateAddress(lhsEntry, rhsAddress);
     rhs.entry = lhsEntry;
     return rhs;
   }
@@ -477,7 +478,7 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
   if (!lhsAddress) {
     assert(lhsEntry != nullptr);
     lhsAddress = insertAlloca(lhsEntry->getQualType());
-    lhsEntry->updateAddress(lhsAddress);
+    updateAddress(lhsEntry, lhsAddress);
   }
 
   // Check if we try to assign an array by value to a pointer. Here we have to store the address of the first element to the lhs
@@ -672,6 +673,44 @@ void IRGenerator::attachComdatToSymbol(llvm::GlobalVariable *global, const std::
   // MachO does not support comdat annotations
   if (isPublic && cliOptions.targetTriple.getObjectFormat() != llvm::Triple::MachO)
     global->setComdat(module->getOrInsertComdat(comdatName));
+}
+
+llvm::Value *IRGenerator::getAddress(const SymbolTableEntry *entry) {
+  const auto it = addressMap.find(entry);
+  if (it == addressMap.end() || it->second.empty())
+    return nullptr;
+  return it->second.top();
+}
+
+void IRGenerator::updateAddress(SymbolTableEntry *entry, llvm::Value *address) {
+  assert(address != nullptr);
+  assert(address->getType()->isPointerTy());
+  auto &stack = addressMap[entry];
+  if (stack.empty())
+    stack.push(address);
+  else
+    stack.top() = address;
+}
+
+void IRGenerator::pushAddress(SymbolTableEntry *entry, llvm::Value *address) {
+  assert(address != nullptr);
+  addressMap[entry].push(address);
+}
+
+void IRGenerator::popAddress(SymbolTableEntry *entry) {
+  auto it = addressMap.find(entry);
+  assert(it != addressMap.end() && !it->second.empty());
+  it->second.pop();
+}
+
+llvm::Function *IRGenerator::getLLVMFunction(const Function *spiceFunc) {
+  const auto it = llvmFunctions.find(spiceFunc);
+  return it != llvmFunctions.end() ? it->second : nullptr;
+}
+
+void IRGenerator::setLLVMFunction(const Function *spiceFunc, llvm::Function *llvmFunction) {
+  assert(llvmFunction != nullptr);
+  llvmFunctions[spiceFunc] = llvmFunction;
 }
 
 std::string IRGenerator::getIRString(llvm::Module *llvmModule, const CliOptions &cliOptions) {

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -2,6 +2,9 @@
 
 #pragma once
 
+#include <stack>
+#include <unordered_map>
+
 #include <CompilerPass.h>
 #include <ast/ASTNodes.h>
 #include <ast/ParallelizableASTVisitor.h>
@@ -17,6 +20,7 @@ namespace spice::compiler {
 
 // Forward declarations
 class ExprNode;
+class Function;
 
 const char *const ANON_GLOBAL_STRING_NAME = "anon.string.";
 const char *const ANON_GLOBAL_ARRAY_NAME = "anon.array.";
@@ -134,6 +138,14 @@ public:
   llvm::Value *resolveAddress(LLVMExprResult &exprResult);
   [[nodiscard]] llvm::Constant *getDefaultValueForSymbolType(const QualType &symbolType);
   [[nodiscard]] static std::string getIRString(llvm::Module *llvmModule, const CliOptions &cliOptions);
+  // Address management for symbol table entries
+  [[nodiscard]] llvm::Value *getAddress(const SymbolTableEntry *entry);
+  void updateAddress(SymbolTableEntry *entry, llvm::Value *address);
+  void pushAddress(SymbolTableEntry *entry, llvm::Value *address);
+  void popAddress(SymbolTableEntry *entry);
+  // LLVM function management for Spice functions
+  [[nodiscard]] llvm::Function *getLLVMFunction(const Function *spiceFunc);
+  void setLLVMFunction(const Function *spiceFunc, llvm::Function *llvmFunction);
 
   // Builtin function handlers
   std::any visitBuiltinCall(const FctCallNode *node);
@@ -186,13 +198,13 @@ private:
   // Generate implicit
   llvm::Value *doImplicitCast(llvm::Value *src, QualType dstSTy, QualType srcSTy);
   llvm::Value *getUpcastedStructPtr(llvm::Value *structPtr, const QualType &dstType, const QualType &srcType) const;
-  void generateScopeCleanup(const StmtLstNode *node) const;
+  void generateScopeCleanup(const StmtLstNode *node);
   void generateFctDecl(const Function *fct, const std::vector<llvm::Value *> &args) const;
   llvm::CallInst *generateFctCall(const Function *fct, const std::vector<llvm::Value *> &args) const;
   llvm::Value *generateFctDeclAndCall(const Function *fct, const std::vector<llvm::Value *> &args) const;
   void generateProcDeclAndCall(const Function *proc, const std::vector<llvm::Value *> &args) const;
   void generateCtorOrDtorCall(const SymbolTableEntry *entry, const Function *ctorOrDtor,
-                              const std::vector<llvm::Value *> &args) const;
+                              const std::vector<llvm::Value *> &args);
   void generateCtorOrDtorCall(llvm::Value *structAddr, const Function *ctorOrDtor, const std::vector<llvm::Value *> &args) const;
   void generateDeallocCall(llvm::Value *variableAddress) const;
   llvm::Function *generateImplicitFunction(const std::function<void(void)> &generateBody, const Function *spiceFunc);
@@ -203,7 +215,7 @@ private:
   void generateDefaultCopyCtor(const Function *copyCtorFunction);
   void generateMoveCtorBodyPreamble(const Function *moveCtorFunction);
   void generateDefaultMoveCtor(const Function *moveCtorFunction);
-  void generateDtorBodyPreamble(const Function *dtorFunction) const;
+  void generateDtorBodyPreamble(const Function *dtorFunction);
   void generateDefaultDtor(const Function *dtorFunction);
   void generateTestMain();
 
@@ -215,7 +227,7 @@ private:
   llvm::Constant *generateTypeInfoName(StructBase *spiceStruct) const;
   llvm::Constant *generateTypeInfo(StructBase *spiceStruct) const;
   llvm::Constant *generateVTable(StructBase *spiceStruct) const;
-  void generateVTableInitializer(const StructBase *spiceStruct) const;
+  void generateVTableInitializer(const StructBase *spiceStruct);
 
   // Generate code instrumentation
   void enableFunctionInstrumentation(llvm::Function *function) const;
@@ -239,6 +251,9 @@ private:
   bool blockAlreadyTerminated = false;
   bool isInCtorBody = false;
   std::vector<DeferredLogic> deferredVTableInitializations;
+  // IR-side state: separate from semantic objects to keep the type-checker model clean
+  std::unordered_map<const SymbolTableEntry *, std::stack<llvm::Value *>> addressMap;
+  std::unordered_map<const Function *, llvm::Function *> llvmFunctions;
 };
 
 } // namespace spice::compiler

--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -1762,7 +1762,7 @@ LLVMExprResult OpRuleConversionManager::callOperatorOverloadFct(const ASTNode *n
     if (anonymousSymbol != nullptr) {
       resultPtr = irGenerator->insertAlloca(result->getType());
       irGenerator->insertStore(result, resultPtr);
-      anonymousSymbol->updateAddress(resultPtr);
+      irGenerator->updateAddress(anonymousSymbol, resultPtr);
     }
   }
 

--- a/src/model/Function.h
+++ b/src/model/Function.h
@@ -9,8 +9,6 @@
 #include <symboltablebuilder/TypeChain.h>
 #include <util/GlobalDefinitions.h>
 
-#include <llvm/IR/Function.h>
-
 namespace spice::compiler {
 
 // Forward declarations
@@ -87,7 +85,6 @@ public:
   bool implicitDefault = false;
   bool isVirtual = false;
   bool isNewlyInserted = false;
-  llvm::Function *llvmFunction = nullptr;
   size_t vtableIndex = 0;
 };
 

--- a/src/symboltablebuilder/SymbolTableEntry.cpp
+++ b/src/symboltablebuilder/SymbolTableEntry.cpp
@@ -52,48 +52,6 @@ void SymbolTableEntry::updateState(const LifecycleState &newState, const ASTNode
 const CodeLoc &SymbolTableEntry::getDeclCodeLoc() const { return declNode->codeLoc; }
 
 /**
- * Retrieve the address of the assigned value
- *
- * @return Address of the value in memory
- */
-llvm::Value *SymbolTableEntry::getAddress() const { return memAddress.empty() ? nullptr : memAddress.top(); }
-
-/**
- * Update the address of a symbol. This is used to save the allocated address where the symbol lives.
- *
- * @param address Address of the symbol in memory
- */
-void SymbolTableEntry::updateAddress(llvm::Value *address) {
-  assert(address != nullptr);
-  assert(address->getType()->isPointerTy());
-  // Ensure that structs fields get no addresses assigned, as the addresses are meant for the struct instances
-  assert((scope->type != ScopeType::STRUCT && scope->type != ScopeType::INTERFACE) ||
-         qualType.isOneOf({TY_FUNCTION, TY_PROCEDURE}));
-  if (memAddress.empty())
-    memAddress.push(address);
-  else
-    memAddress.top() = address;
-}
-
-/**
- * Push a new address to the stack
- *
- * @param address Address to push
- */
-void SymbolTableEntry::pushAddress(llvm::Value *address) {
-  assert(address != nullptr);
-  memAddress.push(address);
-}
-
-/**
- * Remove the last address from the stack
- */
-void SymbolTableEntry::popAddress() {
-  assert(!memAddress.empty());
-  memAddress.pop();
-}
-
-/**
  * Check if this symbol is a struct field
  *
  * @return Struct field or not

--- a/src/symboltablebuilder/SymbolTableEntry.h
+++ b/src/symboltablebuilder/SymbolTableEntry.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <stack>
 #include <string>
 #include <utility>
 
@@ -12,10 +11,6 @@
 #include <nlohmann/json.hpp>
 
 // Forward declarations
-namespace llvm {
-class Value;
-} // namespace llvm
-
 namespace spice::compiler {
 
 // Forward declarations
@@ -37,10 +32,6 @@ public:
   void updateType(const QualType &newType, bool overwriteExistingType);
   void updateState(const LifecycleState &newState, const ASTNode *node);
   [[nodiscard]] const CodeLoc &getDeclCodeLoc() const;
-  [[nodiscard]] llvm::Value *getAddress() const;
-  void updateAddress(llvm::Value *address);
-  void pushAddress(llvm::Value *address);
-  void popAddress();
   [[nodiscard]] bool isField() const;
   [[nodiscard]] const Lifecycle &getLifecycle() const { return lifecycle; }
   [[nodiscard]] bool isInitialized() const { return lifecycle.isInitialized(); }
@@ -66,7 +57,6 @@ public:
 private:
   // Members
   QualType qualType;
-  std::stack<llvm::Value *> memAddress;
   Lifecycle lifecycle;
 };
 


### PR DESCRIPTION
## Summary

- **Remove `Function::llvmFunction`** and its `<llvm/IR/Function.h>` include. The `Function` class is a semantic model object owned by the type-checker; it should not carry codegen state.
- **Remove `SymbolTableEntry::memAddress`** (`std::stack<llvm::Value*>`) and its four accessor methods (`getAddress` / `updateAddress` / `pushAddress` / `popAddress`). Same principle: symbol table entries describe semantics, not IR allocations.
- **Add `IRGenerator::addressMap`** (`unordered_map<const SymbolTableEntry*, stack<llvm::Value*>>`) and **`IRGenerator::llvmFunctions`** (`unordered_map<const Function*, llvm::Function*>`), with matching accessor methods on `IRGenerator`.

This follows the Clang pattern: semantic objects are immutable once codegen starts; the codegen layer holds a separate side-table mapping semantic objects to LLVM values.

The maps are non-`mutable`. The small set of previously-`const` generate helpers that read IR addresses (`generateScopeCleanup`, `generateCtorOrDtorCall(entry,…)`, `generateDtorBodyPreamble`, `generateVTableInitializer`) are de-const-ed to restore proper const-correctness.

## Why it changed

The type-checker and IR generator previously shared mutable state through fields on `Function` and `SymbolTableEntry`. This made the TC output effectively mutable during IR generation, preventing future work like serializing the semantic model, caching type-check results, or safely parallelising compilation units.

## Validation

```
cmake --build cmake-build-debug --target spice
# → clean build, 0 errors

cmake-build-debug/src/spice run test/test-files/irgenerator/structs/success-constructors/source.spice
cmake-build-debug/src/spice run test/test-files/irgenerator/generics/success-generic-functions1/source.spice
cmake-build-debug/src/spice run test/test-files/irgenerator/generics/success-generic-structs/source.spice
SPICE_STD_DIR=std cmake-build-debug/src/spice run test/test-files/irgenerator/interfaces/success-basic-interface/source.spice
# → all produce correct output
```

## Follow-up

Two further improvements identified but out of scope for this PR:
- Replace positional `manIdx` with a stable `ManifestationKey` to make the TC/IRGen synchronisation contract order-independent.
- Add a post-TC annotation verifier (debug builds only) that asserts all `FctCallData.callee` and `VarAccessData.entry` fields are non-null before IRGen starts.