### PR TITLE
Constify Function* in irgenerator

### DIFF
--- a/src-bootstrap/irgenerator/ir-generator.spice
+++ b/src-bootstrap/irgenerator/ir-generator.spice
@@ -30,7 +30,7 @@ public type IRGenerator struct {
     //Vector<DeferredLogic> deferredVTableInitializations
     // IR-side state: separate from semantic objects to keep the type-checker model clean
     UnorderedMap<SymbolTableEntry*, Stack<llvm::Value*>> addressMap
-    UnorderedMap<Function*, llvm::Function*> llvmFunctions
+    UnorderedMap<const Function*, llvm::Function*> llvmFunctions
 }
 
 public p IRGenerator.ctor(GlobalResourceManager& resourceManager, SourceFile* sourceFile) {
@@ -153,7 +153,7 @@ public p IRGenerator.popAddress(SymbolTableEntry* entry) {
  * @param spiceFunc Spice function
  * @return LLVM function, or nil if not yet generated
  */
-public f<llvm::Function*> IRGenerator.getLLVMFunction(Function* spiceFunc) {
+public f<llvm::Function*> IRGenerator.getLLVMFunction(const Function* spiceFunc) {
     return this.llvmFunctions.contains(spiceFunc) ? this.llvmFunctions.get(spiceFunc) : nil<llvm::Function*>;
 }
 
@@ -163,7 +163,7 @@ public f<llvm::Function*> IRGenerator.getLLVMFunction(Function* spiceFunc) {
  * @param spiceFunc Spice function
  * @param llvmFunction Generated LLVM function
  */
-public p IRGenerator.setLLVMFunction(Function* spiceFunc, llvm::Function* llvmFunction) {
+public p IRGenerator.setLLVMFunction(const Function* spiceFunc, llvm::Function* llvmFunction) {
     assert llvmFunction != nil<llvm::Function*>;
     this.llvmFunctions.upsert(spiceFunc, llvmFunction);
 }

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -2005,7 +2005,7 @@ public:
     QualTypeList templateTypes;
     QualType thisType = QualType(TY_DYN); // Is filled if method or ctor call
     ArgList args;
-    Function *callee = nullptr; // Stays nullptr if function pointer call
+    const Function *callee = nullptr; // Stays nullptr if function pointer call
     Scope *calleeParentScope = nullptr;
     CompileTimeValue compileTimeValue;
     bool compileTimeValueSet = false;

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -141,7 +141,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
 std::any IRGenerator::visitFctDef(const FctDefNode *node) {
   // Loop through manifestations
   manIdx = 0; // Reset the symbolTypeIndex
-  for (Function *manifestation : node->manifestations) {
+  for (const Function *manifestation : node->manifestations) {
     assert(manifestation->entry != nullptr);
 
     // Check if the manifestation is substantiated or not public and not used by anybody
@@ -300,7 +300,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
 std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
   // Loop through manifestations
   manIdx = 0; // Reset the symbolTypeIndex
-  for (Function *manifestation : node->manifestations) {
+  for (const Function *manifestation : node->manifestations) {
     assert(manifestation->entry != nullptr);
 
     // Check if the manifestation is substantiated or not public and not used by anybody

--- a/src/irgenerator/GenVTable.cpp
+++ b/src/irgenerator/GenVTable.cpp
@@ -93,7 +93,7 @@ llvm::Constant *IRGenerator::generateTypeInfo(StructBase *spiceStruct) const {
 
 llvm::Constant *IRGenerator::generateVTable(StructBase *spiceStruct) const {
   // Retrieve virtual method count
-  const std::vector<Function *> virtualMethods = spiceStruct->scope->getVirtualMethods();
+  const std::vector<const Function *> virtualMethods = spiceStruct->scope->getVirtualMethods();
   const size_t virtualMethodCount = virtualMethods.size();
   const size_t arrayElementCount = virtualMethodCount + 2; // +2 for nullptr and TypeInfo
 
@@ -124,7 +124,7 @@ llvm::Constant *IRGenerator::generateVTable(StructBase *spiceStruct) const {
 void IRGenerator::generateVTableInitializer(const StructBase *spiceStruct) {
   // Retrieve virtual method count
   assert(spiceStruct->scope);
-  const std::vector<Function *> virtualMethods = spiceStruct->scope->getVirtualMethods();
+  const std::vector<const Function *> virtualMethods = spiceStruct->scope->getVirtualMethods();
   const size_t virtualMethodCount = virtualMethods.size();
   const size_t arrayElementCount = virtualMethodCount + 2; // +2 for nullptr and TypeInfo
 
@@ -137,7 +137,7 @@ void IRGenerator::generateVTableInitializer(const StructBase *spiceStruct) {
   std::vector<llvm::Constant *> arrayValues;
   arrayValues.push_back(llvm::Constant::getNullValue(ptrTy)); // nullptr as safety guard
   arrayValues.push_back(spiceStruct->vTableData.typeInfo);    // TypeInfo to identify the type for the VTable
-  for (Function *virtualMethod : virtualMethods) {
+  for (const Function *virtualMethod : virtualMethods) {
     llvm::Function *llvmFunc = getLLVMFunction(virtualMethod);
     assert(spiceStruct->scope->type == ScopeType::INTERFACE || llvmFunc != nullptr);
     arrayValues.push_back(llvmFunc ? llvmFunc : llvm::Constant::getNullValue(ptrTy));

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -64,7 +64,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
 
   const FctCallNode::FctCallData &data = node->data.at(manIdx);
 
-  Function *spiceFunc = data.callee;
+  const Function *spiceFunc = data.callee;
   assert(data.isFctPtrCall() || spiceFunc != nullptr); // If not a function pointer call, we must have a function
   std::string mangledName;
   if (!data.isFctPtrCall())

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -276,11 +276,11 @@ size_t Scope::getFieldCount() const {
  *
  * @return List of virtual method pointers
  */
-std::vector<Function *> Scope::getVirtualMethods() {
+std::vector<const Function *> Scope::getVirtualMethods() {
   assert(type == ScopeType::STRUCT || type == ScopeType::INTERFACE);
 
   // Collect all virtual methods
-  std::vector<Function *> methods;
+  std::vector<const Function *> methods;
   for (auto &[fctId, manifestationList] : functions) {
     assert(!manifestationList.empty());
     for (auto &[mangledName, function] : manifestationList)

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -94,7 +94,7 @@ public:
   void collectWarnings(std::vector<CompilerWarning> &warnings) const;
   void ensureSuccessfulTypeInference() const;
   [[nodiscard]] size_t getFieldCount() const;
-  [[nodiscard]] std::vector<Function *> getVirtualMethods();
+  [[nodiscard]] std::vector<const Function *> getVirtualMethods();
   [[nodiscard]] std::vector<const Struct *> getAllStructManifestationsInDeclarationOrder() const;
   [[nodiscard]] unsigned int getLoopNestingDepth() const;
   [[nodiscard]] bool isInCaseBranch() const;


### PR DESCRIPTION
## Summary

The IRGenerator never mutates `Function` objects — all semantic state on `Function` is written by the TypeChecker before IRGen runs. This PR enforces that invariant by making all `Function` pointers `const` throughout the IR generation layer.

Changes:

- **`ASTNodes.h`** — `FctCallData::callee` field: `Function*` → `const Function*`
- **`GenTopLevelDefinitions.cpp`** — for-each loop variables over `node->manifestations` in `visitFctDef` / `visitProcDef`: `Function*` → `const Function*`
- **`GenVTable.cpp`** — `virtualMethods` vector and loop variable: `vector<Function*>` → `vector<const Function*>`
- **`GenValues.cpp`** — local `spiceFunc` variable in `visitFctCall`: `Function*` → `const Function*`
- **`Scope.h` / `Scope.cpp`** — `Scope::getVirtualMethods()` return type: `vector<Function*>` → `vector<const Function*>`

## Why

This is a follow-up to #1228 which moved LLVM IR state out of the semantic model. With that done, `Function` objects produced by the TypeChecker are fully immutable by the time IRGen starts. Making the pointers `const` encodes that guarantee in the type system, so any future attempt to mutate a `Function` from IRGen will be caught at compile time rather than silently succeeding.

The one remaining obstacle to full `const`-correctness on `SymbolTableEntry*` is `paramSymbol->updateType(...getWithLambdaCaptures(), true)` in `visitFctDef`/`visitProcDef` — that annotation belongs in the TypeChecker and will be addressed in a follow-up.

## Validation

```
cmake --build cmake-build-debug --target spice
# → clean build, 0 errors
```