### PR TITLE
Fix ccache misses caused by global build-info compile definitions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -97,6 +97,7 @@ jobs:
             -DSPICE_LINK_STATIC=ON \
             -DSPICE_LTO=ON \
             -DSPICE_VERSION="${{ github.ref_name }}" \
+            -DSPICE_GIT_HASH="${{ github.sha }}" \
             -DSPICE_BUILT_BY="ghactions" \
             ..
           cmake --build . --target spice
@@ -210,6 +211,7 @@ jobs:
             -DSPICE_LINK_STATIC=ON \
             -DSPICE_LTO=ON \
             -DSPICE_VERSION="${{ github.ref_name }}" \
+            -DSPICE_GIT_HASH="${{ github.sha }}" \
             -DSPICE_BUILT_BY="ghactions" \
             ..
           cmake --build . --target spice
@@ -315,6 +317,7 @@ jobs:
             -DSPICE_ALL_TARGETS=ON `
             -DSPICE_LINK_STATIC=ON `
             -DSPICE_VERSION="${{ github.ref_name }}" `
+            -DSPICE_GIT_HASH="${{ github.sha }}" `
             -DSPICE_BUILT_BY="ghactions" `
             ..
           cmake --build . --target spice
@@ -417,6 +420,7 @@ jobs:
             -DSPICE_ALL_TARGETS=ON \
             -DSPICE_LTO=ON \
             -DSPICE_VERSION="${{ github.ref_name }}" \
+            -DSPICE_GIT_HASH="${{ github.sha }}" \
             -DSPICE_BUILT_BY="ghactions" \
             ..
           cmake --build . --target spice
@@ -521,6 +525,7 @@ jobs:
             -DSPICE_ALL_TARGETS=ON \
             -DSPICE_LTO=ON \
             -DSPICE_VERSION="${{ github.ref_name }}" \
+            -DSPICE_GIT_HASH="${{ github.sha }}" \
             -DSPICE_BUILT_BY="ghactions" \
             ..
           cmake --build . --target spice

--- a/Options.cmake
+++ b/Options.cmake
@@ -39,21 +39,11 @@ endif ()
 
 # Spice version
 set(SPICE_VERSION "dev" CACHE STRING "Spice build version")
-add_definitions(-DSPICE_VERSION="${SPICE_VERSION}")
 message(STATUS "Spice: Build version is set to '${SPICE_VERSION}'")
 
-# Spice Git hash (defaults to current Git hash)
-execute_process(
-        COMMAND git rev-parse HEAD
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-        OUTPUT_VARIABLE SPICE_GIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-)
-if (NOT SPICE_GIT_HASH)
-    set(SPICE_GIT_HASH "dev" CACHE STRING "Spice Git hash")
-endif ()
-add_definitions(-DSPICE_GIT_HASH="${SPICE_GIT_HASH}")
+# Spice Git hash — not resolved here to avoid busting ccache on every commit;
+# passed as a per-file compile definition in src/CMakeLists.txt instead.
+set(SPICE_GIT_HASH "dev" CACHE STRING "Spice Git hash")
 message(STATUS "Spice: Git hash is set to '${SPICE_GIT_HASH}'")
 
 # Spice built by
@@ -65,7 +55,6 @@ else ()
     set(SPICE_BUILT_BY "unknown")
 endif ()
 set(SPICE_BUILT_BY "${SPICE_BUILT_BY}" CACHE STRING "Spice built by person")
-add_definitions(-DSPICE_BUILT_BY="${SPICE_BUILT_BY}")
 message(STATUS "Spice: Built by is set to '${SPICE_BUILT_BY}'")
 
 # Unity builds

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,14 @@ separate_arguments(LLVM_DEFINITIONS_LIST NATIVE_COMMAND ${LLVM_DEFINITIONS})
 target_compile_definitions(spicecore PRIVATE ${LLVM_DEFINITIONS_LIST})
 # Enable pedantic warnings
 target_compile_options(spicecore PRIVATE -Wpedantic -Wall -Werror -Wno-unknown-pragmas ${SPICE_EXTRA_COMPILE_OPTIONS})
+# Scope volatile build-info defines to the two TUs that actually use them, so ccache isn't busted on every commit.
+set(_SPICE_BUILD_INFO_DEFS
+    -DSPICE_VERSION="${SPICE_VERSION}"
+    -DSPICE_GIT_HASH="${SPICE_GIT_HASH}"
+    -DSPICE_BUILT_BY="${SPICE_BUILT_BY}"
+)
+set_property(SOURCE util/CommonUtil.cpp APPEND PROPERTY COMPILE_OPTIONS ${_SPICE_BUILD_INFO_DEFS})
+set_property(SOURCE irgenerator/IRGenerator.cpp APPEND PROPERTY COMPILE_OPTIONS ${_SPICE_BUILD_INFO_DEFS})
 # RawStringOStream derives from the polymorphic LLVM type llvm::raw_pwrite_stream. Compiling it with
 # RTTI emits a type_info that references "typeinfo for llvm::raw_pwrite_stream", which does not exist
 # when LLVM is built without RTTI (the default). The class is never used with dynamic_cast/typeid, so

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -14,6 +14,8 @@
 
 namespace spice::compiler {
 
+const std::string PRODUCER_STRING = "spice version " + std::string(SPICE_VERSION) + " (https://github.com/spicelang/spice)";
+
 IRGenerator::IRGenerator(GlobalResourceManager &resourceManager, SourceFile *sourceFile)
     : CompilerPass(resourceManager, sourceFile), context(cliOptions.useLTO ? resourceManager.ltoContext : sourceFile->context),
       builder(sourceFile->builder), module(sourceFile->llvmModule.get()), conversionManager(sourceFile, this),

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -25,8 +25,7 @@ class Function;
 const char *const ANON_GLOBAL_STRING_NAME = "anon.string.";
 const char *const ANON_GLOBAL_ARRAY_NAME = "anon.array.";
 const char *const CAPTURES_PARAM_NAME = "captures";
-static const std::string PRODUCER_STRING =
-    "spice version " + std::string(SPICE_VERSION) + " (https://github.com/spicelang/spice)";
+extern const std::string PRODUCER_STRING;
 
 enum class Likelihood : uint8_t {
   UNSPECIFIED,


### PR DESCRIPTION
## What changed

- **Options.cmake**: Removed `add_definitions` for `SPICE_VERSION`, `SPICE_GIT_HASH`, and `SPICE_BUILT_BY`. Also removed the `execute_process(git rev-parse HEAD)` call. The variables are still settable via `-D` on the cmake command line; they just no longer pollute every TU's compile flags.
- **src/irgenerator/IRGenerator.h**: Replaced the `static const std::string PRODUCER_STRING = "spice version " + std::string(SPICE_VERSION) + ...` definition (which dragged `SPICE_VERSION` into ~17 TUs via the header) with `extern const std::string PRODUCER_STRING`.
- **src/irgenerator/IRGenerator.cpp**: Added the actual `PRODUCER_STRING` definition here, where `SPICE_VERSION` is now scoped.
- **src/CMakeLists.txt**: Added `set_property(SOURCE ... COMPILE_OPTIONS ...)` to inject the three defines only on `util/CommonUtil.cpp` and `irgenerator/IRGenerator.cpp` — the only files that reference them.
- **.github/workflows/publish.yml**: Added `-DSPICE_GIT_HASH="${{ github.sha }}"` to all five "Build compiler" cmake invocations so release builds still embed the real commit hash.

## Why it changed

`add_definitions` is global — it appended `-DSPICE_GIT_HASH="<sha>"` to the compiler flags of **every** translation unit. Since the hash changes on every commit, ccache saw different flags for all ~100 TUs and produced a 100% miss rate, causing the test executable to be rebuilt from scratch on every CI run (~11 minutes).

## How it was validated

- Diffed all changed files to confirm no accidental removals.
- Verified with `grep` that no other source files reference `SPICE_GIT_HASH` or `SPICE_BUILT_BY`, and that `SPICE_VERSION` is now only reachable via the two scoped TUs.
- Confirmed all five publish targets have `-DSPICE_GIT_HASH` set.

## Follow-up / known limitations

None. In CI workflows (`ci-cpp.yml`, `ci-asan.yml`, `valgrind.yml`) the hash defaults to the cache string `"dev"`, which is stable across commits — exactly what we want for maximum ccache reuse.