### PR TITLE
Move lambda-capture param annotation from IRGenerator to TypeChecker

### DIFF
--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -185,9 +185,6 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
         SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
         assert(paramSymbol != nullptr);
         const QualType paramSymbolType = manifestation->getParamTypes().at(argIdx);
-        // Pass the information if captures are taken for function/procedure types
-        if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures())
-          paramSymbol->updateType(paramSymbol->getQualType().getWithLambdaCaptures(), true);
         // Retrieve type of param
         llvm::Type *paramType = paramSymbolType.toLLVMType(sourceFile);
         // Add it to the lists
@@ -345,9 +342,6 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
         SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
         assert(paramSymbol != nullptr);
         const QualType paramSymbolType = manifestation->getParamTypes().at(argIdx);
-        // Pass the information if captures are taken for function/procedure types
-        if (paramSymbolType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramSymbolType.hasLambdaCaptures())
-          paramSymbol->updateType(paramSymbol->getQualType().getWithLambdaCaptures(), true);
         // Retrieve type of param
         llvm::Type *paramType = paramSymbolType.toLLVMType(sourceFile);
         // Add it to the lists

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -65,8 +65,20 @@ std::any TypeChecker::visitFctDefCheck(FctDefNode *node) {
 
     // Visit parameters
     // This happens once in the type checker prepare stage. This second time is only required if we have a generic function
-    if (node->hasParams)
+    if (node->hasParams) {
       visit(node->paramLst);
+      // Annotate function/procedure-typed params with lambda-capture info from the resolved manifestation type.
+      // This must happen in the TypeChecker so that the IRGenerator can treat SymbolTableEntry as immutable.
+      for (size_t i = 0; i < manifestation->paramList.size(); i++) {
+        const DeclStmtNode *param = node->paramLst->params.at(i);
+        const QualType paramType = manifestation->getParamTypes().at(i);
+        if (paramType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramType.hasLambdaCaptures()) {
+          SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
+          assert(paramSymbol != nullptr);
+          paramSymbol->updateType(paramSymbol->getQualType().getWithLambdaCaptures(), true);
+        }
+      }
+    }
 
     // Visit statements in new scope
     visit(node->body);
@@ -115,8 +127,20 @@ std::any TypeChecker::visitProcDefCheck(ProcDefNode *node) {
 
     // Visit parameters
     // This happens once in the type checker prepare stage. This second time is only required if we have a generic procedure
-    if (node->hasParams)
+    if (node->hasParams) {
       visit(node->paramLst);
+      // Annotate function/procedure-typed params with lambda-capture info from the resolved manifestation type.
+      // This must happen in the TypeChecker so that the IRGenerator can treat SymbolTableEntry as immutable.
+      for (size_t i = 0; i < manifestation->paramList.size(); i++) {
+        const DeclStmtNode *param = node->paramLst->params.at(i);
+        const QualType paramType = manifestation->getParamTypes().at(i);
+        if (paramType.isOneOf({TY_FUNCTION, TY_PROCEDURE}) && paramType.hasLambdaCaptures()) {
+          SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
+          assert(paramSymbol != nullptr);
+          paramSymbol->updateType(paramSymbol->getQualType().getWithLambdaCaptures(), true);
+        }
+      }
+    }
 
     // Prepare generation of special ctor preamble to store VTable, default field values, etc. if required
     if (node->isCtor)


### PR DESCRIPTION
## What changed

The lambda-capture flag on function/procedure-typed parameters was being applied in the IRGenerator (`visitFctDef`/`visitProcDef` in `GenTopLevelDefinitions.cpp`), which required mutating `SymbolTableEntry` during codegen — the last remaining `updateType` call on a symbol entry inside the IRGenerator.

The annotation is now applied in the TypeChecker (`visitFctDefCheck`/`visitProcDefCheck` in `TypeCheckerTopLevelDefinitionsCheck.cpp`), right after `visit(node->paramLst)` where:
- The function body scope is active, so `lookupStrict` finds the correct param symbol
- The manifestation's param types are fully resolved and authoritative

## Why it changed

This is part of a broader effort to make `SymbolTableEntry` immutable from the IRGenerator's perspective (Clang's "decorated AST" pattern). The IRGenerator should be a pure consumer of the semantic model — not a mutator. With this change, the IRGenerator no longer calls `updateType` on any symbol table entry at all, which unblocks making all `SymbolTableEntry*` parameters and locals in the IRGenerator `const`.

## How it was validated

- `cmake --build cmake-build-debug --target spice` — clean build, no errors or warnings
- Full test suite (`spicetest`) — same 22 pre-existing failures as `main` baseline, no regressions

## Follow-up

The next step is the mechanical `const SymbolTableEntry*` cascade across the IRGenerator (all local variables, `ParamInfoList` typedef, `doAssignment` signatures, `LLVMExprResult::entry`, `updateAddress`/`pushAddress`/`popAddress` parameters).