### PR TITLE
Constify SymbolTableEntry* throughout the IRGenerator

### DIFF
--- a/src-bootstrap/irgenerator/ir-generator.spice
+++ b/src-bootstrap/irgenerator/ir-generator.spice
@@ -29,7 +29,7 @@ public type IRGenerator struct {
     bool blockAlreadyTerminated = false
     //Vector<DeferredLogic> deferredVTableInitializations
     // IR-side state: separate from semantic objects to keep the type-checker model clean
-    UnorderedMap<SymbolTableEntry*, Stack<llvm::Value*>> addressMap
+    UnorderedMap<const SymbolTableEntry*, Stack<llvm::Value*>> addressMap
     UnorderedMap<const Function*, llvm::Function*> llvmFunctions
 }
 
@@ -87,7 +87,7 @@ public p IRGenerator.insertStore(llvm::Value value, llvm::Value ptr, bool isVola
  * @param entry Symbol table entry
  * @return IR address, or nil if not yet allocated
  */
-public f<llvm::Value*> IRGenerator.getAddress(SymbolTableEntry* entry) {
+public f<llvm::Value*> IRGenerator.getAddress(const SymbolTableEntry* entry) {
     if !this.addressMap.contains(entry) { return nil<llvm::Value*>; }
     Stack<llvm::Value*>& stack = this.addressMap.get(entry);
     return stack.isEmpty() ? nil<llvm::Value*> : stack.top();
@@ -101,7 +101,7 @@ public f<llvm::Value*> IRGenerator.getAddress(SymbolTableEntry* entry) {
  * @param entry Symbol table entry
  * @param address IR address to record
  */
-public p IRGenerator.updateAddress(SymbolTableEntry* entry, llvm::Value* address) {
+public p IRGenerator.updateAddress(const SymbolTableEntry* entry, llvm::Value* address) {
     assert address != nil<llvm::Value*>;
     if !this.addressMap.contains(entry) {
         Stack<llvm::Value*> stack;
@@ -125,7 +125,7 @@ public p IRGenerator.updateAddress(SymbolTableEntry* entry, llvm::Value* address
  * @param entry Symbol table entry
  * @param address IR address to push
  */
-public p IRGenerator.pushAddress(SymbolTableEntry* entry, llvm::Value* address) {
+public p IRGenerator.pushAddress(const SymbolTableEntry* entry, llvm::Value* address) {
     assert address != nil<llvm::Value*>;
     if !this.addressMap.contains(entry) {
         Stack<llvm::Value*> stack;
@@ -140,7 +140,7 @@ public p IRGenerator.pushAddress(SymbolTableEntry* entry, llvm::Value* address) 
  *
  * @param entry Symbol table entry
  */
-public p IRGenerator.popAddress(SymbolTableEntry* entry) {
+public p IRGenerator.popAddress(const SymbolTableEntry* entry) {
     assert this.addressMap.contains(entry);
     Stack<llvm::Value*>& stack = this.addressMap.get(entry);
     assert !stack.isEmpty();

--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -175,7 +175,7 @@ llvm::DICompositeType *DebugInfoGenerator::generateCaptureStructDebugInfo(const 
 
   // Get LLVM type for struct
   std::vector<llvm::Type *> fieldTypes;
-  std::vector<SymbolTableEntry *> fieldEntries;
+  std::vector<const SymbolTableEntry *> fieldEntries;
   QualTypeList fieldSymbolTypes;
   for (const auto &capture : captures | std::views::values) {
     QualType captureType = capture.capturedSymbol->getQualType();

--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -115,7 +115,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
     iteratorPtr = resolveAddress(callResult);
 
     // If an anonymous symbol exists, set its address
-    if (SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(iteratorAssignNode))
+    if (const SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(iteratorAssignNode))
       updateAddress(returnSymbol, iteratorPtr);
   } else { // The iteratorAssignExpr is of type Iterator
     iteratorPtr = resolveAddress(iteratorAssignNode);
@@ -129,7 +129,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
   const QualType itemRefSTy = hasIdx ? node->getIdxFct->returnType : node->getFct->returnType;
 
   // Visit idx variable declaration if required
-  SymbolTableEntry *idxEntry = nullptr;
+  const SymbolTableEntry *idxEntry = nullptr;
   llvm::Value *idxAddress = nullptr;
   if (hasIdx) {
     visit(idxDeclNode);
@@ -143,7 +143,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
   const DeclStmtNode *itemDeclNode = node->itemVarDecl;
   visit(itemDeclNode);
   // Get address of item variable
-  SymbolTableEntry *itemEntry = itemDeclNode->entries.at(manIdx);
+  const SymbolTableEntry *itemEntry = itemDeclNode->entries.at(manIdx);
   llvm::Value *itemAddress = getAddress(itemEntry);
   assert(itemAddress != nullptr);
 

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -100,7 +100,7 @@ std::any IRGenerator::visitTernaryExpr(const TernaryExprNode *node) {
 
   llvm::Value *resultValue = nullptr;
   llvm::Value *resultPtr = nullptr;
-  SymbolTableEntry *anonymousSymbol = nullptr;
+  const SymbolTableEntry *anonymousSymbol = nullptr;
   if (trueNode->hasCompileTimeValue(manIdx) && falseNode->hasCompileTimeValue(manIdx)) {
     // If both are constants, we can simply emit a selection instruction
     llvm::Value *trueValue = resolveValue(trueNode);

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -266,7 +266,7 @@ llvm::Function *IRGenerator::generateImplicitFunction(const std::function<void()
 
   // Get 'this' entry
   std::vector<llvm::Type *> paramTypes;
-  SymbolTableEntry *thisEntry = nullptr;
+  const SymbolTableEntry *thisEntry = nullptr;
   if (spiceFunc->isMethod()) {
     thisEntry = spiceFunc->bodyScope->lookupStrict(THIS_VARIABLE_NAME);
     assert(thisEntry != nullptr);
@@ -366,7 +366,7 @@ llvm::Function *IRGenerator::generateImplicitProcedure(const std::function<void(
 
   // Get 'this' entry
   std::vector<llvm::Type *> paramTypes;
-  SymbolTableEntry *thisEntry = nullptr;
+  const SymbolTableEntry *thisEntry = nullptr;
   if (spiceProc->isMethod()) {
     thisEntry = spiceProc->bodyScope->lookupStrict(THIS_VARIABLE_NAME);
     assert(thisEntry != nullptr);

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -37,7 +37,7 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
   diGenerator.setSourceLocation(node);
 
   // Get variable entry
-  SymbolTableEntry *varEntry = node->entries.at(manIdx);
+  const SymbolTableEntry *varEntry = node->entries.at(manIdx);
   assert(varEntry != nullptr);
   const QualType varSymbolType = varEntry->getQualType();
 

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -28,7 +28,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
   assert(currentScope != nullptr);
 
   // Visit parameters
-  std::vector<std::pair<std::string, SymbolTableEntry *>> paramInfoList;
+  std::vector<std::pair<std::string, const SymbolTableEntry *>> paramInfoList;
   QualTypeList paramSymbolTypes;
   std::vector<llvm::Type *> paramTypes;
   if (node->takesArgs) {
@@ -38,7 +38,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
     paramTypes.reserve(numOfParams);
     for (DeclStmtNode *param : node->paramLst->params) {
       // Get symbol table entry of param
-      SymbolTableEntry *paramSymbol = node->bodyScope->lookupStrict(param->varName);
+      const SymbolTableEntry *paramSymbol = node->bodyScope->lookupStrict(param->varName);
       assert(paramSymbol != nullptr);
       // Retrieve type of param
       auto paramType = any_cast<llvm::Type *>(visit(param->dataType));
@@ -92,7 +92,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
   // Allocate result variable
   llvm::Value *resultAddress = insertAlloca(QualType(TY_INT), RETURN_VARIABLE_NAME);
   // Update the symbol table entry
-  SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
+  const SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
   assert(resultEntry != nullptr);
   updateAddress(resultEntry, resultAddress);
   // Generate debug info
@@ -164,10 +164,10 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
     assert(currentScope != nullptr);
 
     // Get 'this' entry
-    std::vector<std::pair<std::string, SymbolTableEntry *>> paramInfoList;
+    std::vector<std::pair<std::string, const SymbolTableEntry *>> paramInfoList;
     std::vector<llvm::Type *> paramTypes;
     if (manifestation->isMethod()) {
-      SymbolTableEntry *thisEntry = currentScope->lookupStrict(THIS_VARIABLE_NAME);
+      const SymbolTableEntry *thisEntry = currentScope->lookupStrict(THIS_VARIABLE_NAME);
       assert(thisEntry != nullptr);
       paramInfoList.emplace_back(THIS_VARIABLE_NAME, thisEntry);
       paramTypes.push_back(builder.getPtrTy());
@@ -182,7 +182,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
       for (; argIdx < numOfParams; argIdx++) {
         const DeclStmtNode *param = node->paramLst->params.at(argIdx);
         // Get symbol table entry of param
-        SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
+        const SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
         assert(paramSymbol != nullptr);
         const QualType paramSymbolType = manifestation->getParamTypes().at(argIdx);
         // Retrieve type of param
@@ -235,7 +235,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
 
     // Declare result variable
     llvm::Value *resultAddr = insertAlloca(manifestation->returnType, RETURN_VARIABLE_NAME);
-    SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
+    const SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
     assert(resultEntry != nullptr);
     updateAddress(resultEntry, resultAddr);
     // Generate debug info
@@ -321,10 +321,10 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
     assert(currentScope != nullptr);
 
     // Get 'this' entry
-    std::vector<std::pair<std::string, SymbolTableEntry *>> paramInfoList;
+    std::vector<std::pair<std::string, const SymbolTableEntry *>> paramInfoList;
     std::vector<llvm::Type *> paramTypes;
     if (manifestation->isMethod()) {
-      SymbolTableEntry *thisEntry = currentScope->lookupStrict(THIS_VARIABLE_NAME);
+      const SymbolTableEntry *thisEntry = currentScope->lookupStrict(THIS_VARIABLE_NAME);
       assert(thisEntry != nullptr);
       paramInfoList.emplace_back(THIS_VARIABLE_NAME, thisEntry);
       paramTypes.push_back(builder.getPtrTy());
@@ -339,7 +339,7 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
       for (; argIdx < numOfParams; argIdx++) {
         const DeclStmtNode *param = node->paramLst->params.at(argIdx);
         // Get symbol table entry of param
-        SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
+        const SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
         assert(paramSymbol != nullptr);
         const QualType paramSymbolType = manifestation->getParamTypes().at(argIdx);
         // Retrieve type of param

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -71,7 +71,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
     mangledName = spiceFunc->getMangledName();
 
   // Get entry of the first fragment
-  SymbolTableEntry *firstFragEntry = currentScope->lookup(node->functionNameFragments.front());
+  const SymbolTableEntry *firstFragEntry = currentScope->lookup(node->functionNameFragments.front());
 
   // Get this type
   std::vector<llvm::Value *> argValues;
@@ -96,7 +96,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
     for (size_t i = 1; i < node->functionNameFragments.size() - 1; i++) {
       const std::string identifier = node->functionNameFragments.at(i);
       // Retrieve field entry
-      SymbolTableEntry *fieldEntry = structScope->lookupStrict(identifier);
+      const SymbolTableEntry *fieldEntry = structScope->lookupStrict(identifier);
       assert(fieldEntry != nullptr);
       QualType fieldEntryType = fieldEntry->getQualType();
       assert(fieldEntryType.getBase().isOneOf({TY_STRUCT, TY_INTERFACE}));
@@ -177,7 +177,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
           llvm::Value *newValue = insertLoad(valueType, valueCopyPtr);
 
           // Attach address of copy to anonymous symbol
-          SymbolTableEntry *anonymousSymbol = currentScope->symbolTable.lookupAnonymous(argNode, SIZE_MAX);
+          const SymbolTableEntry *anonymousSymbol = currentScope->symbolTable.lookupAnonymous(argNode, SIZE_MAX);
           updateAddress(anonymousSymbol, valueCopyPtr);
 
           argValues.push_back(newValue);
@@ -273,7 +273,7 @@ std::any IRGenerator::visitFctCall(const FctCallNode *node) {
   }
 
   // Attach address to anonymous symbol to keep track of de-allocation
-  SymbolTableEntry *anonymousSymbol = nullptr;
+  const SymbolTableEntry *anonymousSymbol = nullptr;
   llvm::Value *resultPtr = nullptr;
   if (returnSType.is(TY_STRUCT) || data.isCtorCall()) {
     anonymousSymbol = currentScope->symbolTable.lookupAnonymous(node);
@@ -473,7 +473,7 @@ std::any IRGenerator::visitStructInstantiation(const StructInstantiationNode *no
     }
 
     // Attach address to anonymous symbol to keep track of de-allocation
-    SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(node);
+    const SymbolTableEntry *returnSymbol = currentScope->symbolTable.lookupAnonymous(node);
     if (returnSymbol != nullptr)
       updateAddress(returnSymbol, structAddr);
 
@@ -508,7 +508,7 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
     for (; argIdx < numOfParams; argIdx++) {
       const DeclStmtNode *param = node->paramLst->params.at(argIdx);
       // Get symbol table entry of param
-      SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
+      const SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
       assert(paramSymbol != nullptr);
       // Retrieve type of param
       llvm::Type *paramType = spiceFunc.getParamTypes().at(argIdx).toLLVMType(sourceFile);
@@ -558,7 +558,7 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
   allocaInsertInst = nullptr;
 
   // Declare result variable
-  SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
+  const SymbolTableEntry *resultEntry = currentScope->lookupStrict(RETURN_VARIABLE_NAME);
   assert(resultEntry != nullptr);
   llvm::Value *resultAddr = insertAlloca(returnType, RETURN_VARIABLE_NAME);
   updateAddress(resultEntry, resultAddr);
@@ -663,7 +663,7 @@ std::any IRGenerator::visitLambdaProc(const LambdaProcNode *node) {
     for (; argIdx < numOfParams; argIdx++) {
       const DeclStmtNode *param = node->paramLst->params.at(argIdx);
       // Get symbol table entry of param
-      SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
+      const SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
       assert(paramSymbol != nullptr);
       // Retrieve type of param
       llvm::Type *paramType = spiceFunc.getParamTypes().at(argIdx).toLLVMType(sourceFile);
@@ -805,7 +805,7 @@ std::any IRGenerator::visitLambdaExpr(const LambdaExprNode *node) {
     for (; argIdx < numOfParams; argIdx++) {
       const DeclStmtNode *param = node->paramLst->params.at(argIdx);
       // Get symbol table entry of param
-      SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
+      const SymbolTableEntry *paramSymbol = currentScope->lookupStrict(param->varName);
       assert(paramSymbol != nullptr);
       // Retrieve type of param
       llvm::Type *paramType = spiceFunc.getParamTypes().at(argIdx).toLLVMType(sourceFile);

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -413,12 +413,12 @@ void IRGenerator::verifyModule(const CodeLoc &codeLoc) const {
 LLVMExprResult IRGenerator::doAssignment(const ASTNode *lhsNode, const ExprNode *rhsNode, const ASTNode *node) {
   // Get entry of left side
   auto exprResult = std::any_cast<LLVMExprResult>(visit(lhsNode));
-  SymbolTableEntry *entry = exprResult.entry;
+  const SymbolTableEntry *entry = exprResult.entry;
   llvm::Value *lhsAddress = entry != nullptr && entry->getQualType().isRef() ? exprResult.refPtr : resolveAddress(exprResult);
   return doAssignment(lhsAddress, entry, rhsNode, node);
 }
 
-LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, const ExprNode *rhsNode,
+LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, const SymbolTableEntry *lhsEntry, const ExprNode *rhsNode,
                                          const ASTNode *node, bool isDecl) {
   // Get symbol type of right side
   const QualType &rhsSType = rhsNode->getEvaluatedSymbolType(manIdx);
@@ -426,7 +426,7 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEnt
   return doAssignment(lhsAddress, lhsEntry, rhs, rhsSType, node, isDecl);
 }
 
-LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, LLVMExprResult &rhs,
+LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, const SymbolTableEntry *lhsEntry, LLVMExprResult &rhs,
                                          const QualType &rhsSType, const ASTNode *node, bool isDecl) {
   // Deduce some information about the assignment
   const bool isRefAssign = lhsEntry != nullptr && lhsEntry->getQualType().isRef();
@@ -684,7 +684,7 @@ llvm::Value *IRGenerator::getAddress(const SymbolTableEntry *entry) {
   return it->second.top();
 }
 
-void IRGenerator::updateAddress(SymbolTableEntry *entry, llvm::Value *address) {
+void IRGenerator::updateAddress(const SymbolTableEntry *entry, llvm::Value *address) {
   assert(address != nullptr);
   assert(address->getType()->isPointerTy());
   auto &stack = addressMap[entry];
@@ -694,12 +694,12 @@ void IRGenerator::updateAddress(SymbolTableEntry *entry, llvm::Value *address) {
     stack.top() = address;
 }
 
-void IRGenerator::pushAddress(SymbolTableEntry *entry, llvm::Value *address) {
+void IRGenerator::pushAddress(const SymbolTableEntry *entry, llvm::Value *address) {
   assert(address != nullptr);
   addressMap[entry].push(address);
 }
 
-void IRGenerator::popAddress(SymbolTableEntry *entry) {
+void IRGenerator::popAddress(const SymbolTableEntry *entry) {
   auto it = addressMap.find(entry);
   assert(it != addressMap.end() && !it->second.empty());
   it->second.pop();

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -39,7 +39,7 @@ class SourceFile;
 class IRGenerator final : CompilerPass, public ParallelizableASTVisitor {
 public:
   // Type definitions
-  using ParamInfoList = std::vector<std::pair<std::string, SymbolTableEntry *>>;
+  using ParamInfoList = std::vector<std::pair<std::string, const SymbolTableEntry *>>;
 
   // Constructors
   IRGenerator(GlobalResourceManager &resourceManager, SourceFile *sourceFile);
@@ -139,9 +139,9 @@ public:
   [[nodiscard]] static std::string getIRString(llvm::Module *llvmModule, const CliOptions &cliOptions);
   // Address management for symbol table entries
   [[nodiscard]] llvm::Value *getAddress(const SymbolTableEntry *entry);
-  void updateAddress(SymbolTableEntry *entry, llvm::Value *address);
-  void pushAddress(SymbolTableEntry *entry, llvm::Value *address);
-  void popAddress(SymbolTableEntry *entry);
+  void updateAddress(const SymbolTableEntry *entry, llvm::Value *address);
+  void pushAddress(const SymbolTableEntry *entry, llvm::Value *address);
+  void popAddress(const SymbolTableEntry *entry);
   // LLVM function management for Spice functions
   [[nodiscard]] llvm::Function *getLLVMFunction(const Function *spiceFunc);
   void setLLVMFunction(const Function *spiceFunc, llvm::Function *llvmFunction);
@@ -167,10 +167,10 @@ private:
   void verifyFunction(const llvm::Function *fct, const CodeLoc &codeLoc) const;
   void verifyModule(const CodeLoc &codeLoc) const;
   LLVMExprResult doAssignment(const ASTNode *lhsNode, const ExprNode *rhsNode, const ASTNode *node);
-  LLVMExprResult doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, const ExprNode *rhsNode, const ASTNode *node,
-                              bool isDecl = false);
-  LLVMExprResult doAssignment(llvm::Value *lhsAddress, SymbolTableEntry *lhsEntry, LLVMExprResult &rhs, const QualType &rhsSType,
-                              const ASTNode *node, bool isDecl);
+  LLVMExprResult doAssignment(llvm::Value *lhsAddress, const SymbolTableEntry *lhsEntry, const ExprNode *rhsNode,
+                              const ASTNode *node, bool isDecl = false);
+  LLVMExprResult doAssignment(llvm::Value *lhsAddress, const SymbolTableEntry *lhsEntry, LLVMExprResult &rhs,
+                              const QualType &rhsSType, const ASTNode *node, bool isDecl);
   void generateShallowCopy(llvm::Value *oldAddress, llvm::Type *varType, llvm::Value *targetAddress, bool isVolatile) const;
   void autoDeReferencePtr(llvm::Value *&ptr, QualType &symbolType);
   llvm::GlobalVariable *createGlobalConst(const std::string &baseName, llvm::Constant *constant) const;

--- a/src/irgenerator/LLVMExprResult.h
+++ b/src/irgenerator/LLVMExprResult.h
@@ -21,7 +21,7 @@ struct LLVMExprResult {
   llvm::Constant *constant = nullptr;
   llvm::Value *ptr = nullptr;
   llvm::Value *refPtr = nullptr;
-  SymbolTableEntry *entry = nullptr;
+  const SymbolTableEntry *entry = nullptr;
   const ExprNode *node = nullptr;
 
   [[nodiscard]] bool isTemporary() const { return entry == nullptr || entry->anonymous; }

--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -1755,7 +1755,7 @@ LLVMExprResult OpRuleConversionManager::callOperatorOverloadFct(const ASTNode *n
     return {.constant = builder.getTrue()};
 
   // Attach address to anonymous symbol to keep track of de-allocation
-  SymbolTableEntry *anonymousSymbol = nullptr;
+  const SymbolTableEntry *anonymousSymbol = nullptr;
   llvm::Value *resultPtr = nullptr;
   if (opFct->returnType.is(TY_STRUCT)) {
     anonymousSymbol = irGenerator->currentScope->symbolTable.lookupAnonymous(node, opIdx);


### PR DESCRIPTION
## What changed

All `SymbolTableEntry*` usages in the IRGenerator are now `const SymbolTableEntry*`. Specifically:

- `LLVMExprResult::entry` field
- `IRGenerator::ParamInfoList` typedef (vector element type)
- `updateAddress`, `pushAddress`, `popAddress`, `doAssignment` (×2) parameter types
- All local variables in `GenTopLevelDefinitions`, `GenStatements`, `GenControlStructures`, `GenExpressions`, `GenImplicit`, `GenValues`, `OpRuleConversionManager`, and `DebugInfoGenerator`

## Why it changed

This is the final step in a three-part refactor to make `SymbolTableEntry` immutable from the IRGenerator's perspective (the "decorated AST" pattern used by Clang and others):

1. **#1228** — Moved LLVM IR state (`memAddress`, `llvmFunction`) out of semantic objects into IRGenerator-owned side maps
2. **#1231** — Moved lambda-capture param annotation from IRGenerator to TypeChecker (the last `updateType` call in codegen)
3. **This PR** — Constify all `SymbolTableEntry*` usages, enforcing the immutability at the type level

The IRGenerator now acts as a pure reader of the semantic model: it looks up symbol entries and reads their types/qualifiers, but never mutates them. All semantic annotations are completed by the TypeChecker before codegen begins.

## How it was validated

- `cmake --build cmake-build-debug --target spice` — clean build, zero errors or warnings
- Full test suite (`spicetest`) — same 22 pre-existing failures as `main` baseline, no regressions

## Dependencies

Depends on #1231 (move lambda-capture annotation to TypeChecker) being merged first.