### PR TITLE
Add post-TypeChecker annotation verifier (debug builds only)

### DIFF
--- a/media/specs/compile-stages.md
+++ b/media/specs/compile-stages.md
@@ -15,6 +15,7 @@ graph TD;
     ImportCollector-->
     SymbolTableBuilder-->
     TypeChecker-->
+    PostTypeCheckingVerifier-->
     DepGraphVisualizer-->
     IRGenerator-->
     DefaultIROptimizer-->
@@ -63,20 +64,26 @@ graph TD;
     Input/Output: AST -> AST <br>
     Note: Checks if all types match, performs type inference, fill types in symbol table
 
-9.  **Dependency Graph Visualizer** <br>
+9.  **Post-TypeChecker Annotation Verifier** *(debug builds only)* <br>
+    Input/Output: AST -> AST <br>
+    Note: Asserts that the TypeChecker has fully annotated the AST before codegen begins — entry pointers are non-null,
+    per-manifestation vectors are correctly sized, and every non-function-pointer call has a resolved callee. Compiled
+    out in release builds (`NDEBUG`).
+
+10. **Dependency Graph Visualizer** <br>
     Input/Output: AST -> AST <br>
     Note: Prints the compile unit dependency graph (DAG) as Dot code
 
-10. **IR Generator** <br>
+11. **IR Generator** <br>
     Input/Output: AST -> IR <br>
     Additional used resources: Symbol Table <br>
     Note: Uses several helper modules to generate IR from the information of AST and Symbol Table.
 
-11. **IR Optimizer** <br>
+12. **IR Optimizer** <br>
     Input/Output: IR -> IR <br>
     Note: Uses the stated optimization level to call the LLVM optimizer. In case of -O0, the IR Optimizer is not invoked.
 
-12. **Object Emitter** <br>
+13. **Object Emitter** <br>
     Input/Output: IR -> Object file <br>
     Note: Calls LLVM to emit an object file from the generated IR.
 
@@ -118,15 +125,18 @@ Source file A imports B and C.
 13. Type Checker for A (check)
 14. Type Checker for B (check)
 15. Type Checker for C (check)
-16. IR Generator for B
-17. IR Optimizer for B
-18. Object Emitter for B
-19. IR Generator for C
-20. IR Optimizer for C 
-21. Object Emitter for C 
-22. IR Generator for A 
-23. IR Optimizer for A 
-24. Object Emitter for A
+16. Post-TypeChecker Annotation Verifier for A *(debug only)*
+17. Post-TypeChecker Annotation Verifier for B *(debug only)*
+18. Post-TypeChecker Annotation Verifier for C *(debug only)*
+19. IR Generator for B
+20. IR Optimizer for B
+21. Object Emitter for B
+22. IR Generator for C
+23. IR Optimizer for C 
+24. Object Emitter for C 
+25. IR Generator for A 
+26. IR Optimizer for A 
+27. Object Emitter for A
 
 ## Note for parallelization:
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ set(SOURCES
         typechecker/StructManager.cpp
         typechecker/InterfaceManager.cpp
         typechecker/TypeMatcher.cpp
+        typechecker/PostTypeCheckingVerifier.cpp
         # Dependency graph visualizer
         visualizer/DependencyGraphVisualizer.cpp
         # IR generator

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -21,6 +21,7 @@
 #include <typechecker/FunctionManager.h>
 #include <typechecker/InterfaceManager.h>
 #include <typechecker/MacroDefs.h>
+#include <typechecker/PostTypeCheckingVerifier.h>
 #include <typechecker/StructManager.h>
 #include <typechecker/TypeChecker.h>
 #include <util/CompilerWarning.h>
@@ -324,6 +325,11 @@ void SourceFile::runTypeCheckerPost() { // NOLINT(misc-no-recursion)
   // Check if all dyn variables were type-inferred successfully
   globalScope->ensureSuccessfulTypeInference();
 
+#ifndef NDEBUG
+  // In debug builds, verify that the TypeChecker fully annotated the AST
+  runPostTypeCheckingVerifier();
+#endif
+
   previousStage = TYPE_CHECKER_POST;
   timer.stop();
   printStatusMessage("Type Checker Post", IO_AST, IO_AST, compilerOutput.times.typeCheckerPost, typeCheckerRuns);
@@ -335,6 +341,11 @@ void SourceFile::runTypeCheckerPost() { // NOLINT(misc-no-recursion)
   // Dump symbol table
   if (cliOptions.dump.dumpSymbolTable)
     dumpOutput(compilerOutput.symbolTableString, "Symbol Table", "symbol-table.json");
+}
+
+void SourceFile::runPostTypeCheckingVerifier() {
+  PostTypeCheckingVerifier verifier(resourceManager, this);
+  verifier.verify(ast);
 }
 
 void SourceFile::runDependencyGraphVisualizer() {

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -134,6 +134,7 @@ public:
 private:
   void runTypeCheckerPre();
   void runTypeCheckerPost();
+  void runPostTypeCheckingVerifier();
 
 public:
   void runDependencyGraphVisualizer();

--- a/src/typechecker/PostTypeCheckingVerifier.cpp
+++ b/src/typechecker/PostTypeCheckingVerifier.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#include "PostTypeCheckingVerifier.h"
+
+#include <cassert>
+
+#include <ast/ASTNodes.h>
+
+namespace spice::compiler {
+
+PostTypeCheckingVerifier::PostTypeCheckingVerifier(GlobalResourceManager &resourceManager, SourceFile *sourceFile)
+    : CompilerPass(resourceManager, sourceFile) {}
+
+void PostTypeCheckingVerifier::verify(ASTNode *ast) { visit(ast); }
+
+std::any PostTypeCheckingVerifier::visitFctDef(FctDefNode *node) {
+  assert(node->entry != nullptr);
+  assert(!node->manifestations.empty());
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitProcDef(ProcDefNode *node) {
+  assert(node->entry != nullptr);
+  assert(!node->manifestations.empty());
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitStructDef(StructDefNode *node) {
+  assert(node->entry != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitInterfaceDef(InterfaceDefNode *node) {
+  assert(node->entry != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitEnumDef(EnumDefNode *node) {
+  assert(node->entry != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitEnumItem(EnumItemNode *node) {
+  assert(node->entry != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitAliasDef(AliasDefNode *node) {
+  assert(node->entry != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitGlobalVarDef(GlobalVarDefNode *node) {
+  assert(node->entry != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitSignature(SignatureNode *node) {
+  assert(node->entry != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitDeclStmt(DeclStmtNode *node) {
+  if (!node->isForEachItem) {
+    // For regular declarations the per-manifestation entries vector must be fully populated
+    assert(!node->entries.empty());
+    for (const SymbolTableEntry *entry : node->entries)
+      assert(entry != nullptr);
+  }
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitFctCall(FctCallNode *node) {
+  assert(!node->data.empty());
+  for (const FctCallNode::FctCallData &d : node->data) {
+    // Function pointer calls do not have a statically-resolved callee
+    if (!d.isFctPtrCall())
+      assert(d.callee != nullptr);
+    assert(d.calleeParentScope != nullptr);
+  }
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitAtomicExpr(AtomicExprNode *node) {
+  // data is only populated for identifier accesses (not for constants / nested exprs)
+  if (!node->identifierFragments.empty()) {
+    assert(!node->data.empty());
+    for (const AtomicExprNode::VarAccessData &d : node->data)
+      assert(d.entry != nullptr);
+  }
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitStructInstantiation(StructInstantiationNode *node) {
+  assert(!node->instantiatedStructs.empty());
+  for (const Struct *s : node->instantiatedStructs)
+    assert(s != nullptr);
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitLambdaFunc(LambdaFuncNode *node) {
+  assert(!node->manifestations.empty());
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitLambdaProc(LambdaProcNode *node) {
+  assert(!node->manifestations.empty());
+  return visitChildren(node);
+}
+
+std::any PostTypeCheckingVerifier::visitLambdaExpr(LambdaExprNode *node) {
+  assert(!node->manifestations.empty());
+  return visitChildren(node);
+}
+
+} // namespace spice::compiler

--- a/src/typechecker/PostTypeCheckingVerifier.cpp
+++ b/src/typechecker/PostTypeCheckingVerifier.cpp
@@ -2,7 +2,9 @@
 
 #include "PostTypeCheckingVerifier.h"
 
+#include <algorithm>
 #include <cassert>
+#include <ranges>
 
 #include <ast/ASTNodes.h>
 
@@ -64,20 +66,17 @@ std::any PostTypeCheckingVerifier::visitDeclStmt(DeclStmtNode *node) {
   if (!node->isForEachItem) {
     // For regular declarations the per-manifestation entries vector must be fully populated
     assert(!node->entries.empty());
-    for ([[maybe_unused]] const SymbolTableEntry *entry : node->entries)
-      assert(entry != nullptr);
+    assert(std::ranges::all_of(node->entries, [](const SymbolTableEntry *e) { return e != nullptr; }));
   }
   return visitChildren(node);
 }
 
 std::any PostTypeCheckingVerifier::visitFctCall(FctCallNode *node) {
   assert(!node->data.empty());
-  for ([[maybe_unused]] const FctCallNode::FctCallData &d : node->data) {
+  assert(std::ranges::all_of(node->data, [](const FctCallNode::FctCallData &d) {
     // Function pointer calls do not have a statically-resolved callee
-    if (!d.isFctPtrCall())
-      assert(d.callee != nullptr);
-    assert(d.calleeParentScope != nullptr);
-  }
+    return (d.isFctPtrCall() || d.callee != nullptr) && d.calleeParentScope != nullptr;
+  }));
   return visitChildren(node);
 }
 
@@ -85,16 +84,14 @@ std::any PostTypeCheckingVerifier::visitAtomicExpr(AtomicExprNode *node) {
   // data is only populated for identifier accesses (not for constants / nested exprs)
   if (!node->identifierFragments.empty()) {
     assert(!node->data.empty());
-    for ([[maybe_unused]] const AtomicExprNode::VarAccessData &d : node->data)
-      assert(d.entry != nullptr);
+    assert(std::ranges::all_of(node->data, [](const AtomicExprNode::VarAccessData &d) { return d.entry != nullptr; }));
   }
   return visitChildren(node);
 }
 
 std::any PostTypeCheckingVerifier::visitStructInstantiation(StructInstantiationNode *node) {
   assert(!node->instantiatedStructs.empty());
-  for ([[maybe_unused]] const Struct *s : node->instantiatedStructs)
-    assert(s != nullptr);
+  assert(std::ranges::all_of(node->instantiatedStructs, [](const Struct *s) { return s != nullptr; }));
   return visitChildren(node);
 }
 

--- a/src/typechecker/PostTypeCheckingVerifier.cpp
+++ b/src/typechecker/PostTypeCheckingVerifier.cpp
@@ -64,7 +64,7 @@ std::any PostTypeCheckingVerifier::visitDeclStmt(DeclStmtNode *node) {
   if (!node->isForEachItem) {
     // For regular declarations the per-manifestation entries vector must be fully populated
     assert(!node->entries.empty());
-    for (const SymbolTableEntry *entry : node->entries)
+    for ([[maybe_unused]] const SymbolTableEntry *entry : node->entries)
       assert(entry != nullptr);
   }
   return visitChildren(node);
@@ -72,7 +72,7 @@ std::any PostTypeCheckingVerifier::visitDeclStmt(DeclStmtNode *node) {
 
 std::any PostTypeCheckingVerifier::visitFctCall(FctCallNode *node) {
   assert(!node->data.empty());
-  for (const FctCallNode::FctCallData &d : node->data) {
+  for ([[maybe_unused]] const FctCallNode::FctCallData &d : node->data) {
     // Function pointer calls do not have a statically-resolved callee
     if (!d.isFctPtrCall())
       assert(d.callee != nullptr);
@@ -85,7 +85,7 @@ std::any PostTypeCheckingVerifier::visitAtomicExpr(AtomicExprNode *node) {
   // data is only populated for identifier accesses (not for constants / nested exprs)
   if (!node->identifierFragments.empty()) {
     assert(!node->data.empty());
-    for (const AtomicExprNode::VarAccessData &d : node->data)
+    for ([[maybe_unused]] const AtomicExprNode::VarAccessData &d : node->data)
       assert(d.entry != nullptr);
   }
   return visitChildren(node);
@@ -93,7 +93,7 @@ std::any PostTypeCheckingVerifier::visitAtomicExpr(AtomicExprNode *node) {
 
 std::any PostTypeCheckingVerifier::visitStructInstantiation(StructInstantiationNode *node) {
   assert(!node->instantiatedStructs.empty());
-  for (const Struct *s : node->instantiatedStructs)
+  for ([[maybe_unused]] const Struct *s : node->instantiatedStructs)
     assert(s != nullptr);
   return visitChildren(node);
 }

--- a/src/typechecker/PostTypeCheckingVerifier.h
+++ b/src/typechecker/PostTypeCheckingVerifier.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <CompilerPass.h>
+#include <ast/ASTVisitor.h>
+
+namespace spice::compiler {
+
+/**
+ * Verifies that the TypeChecker has fully annotated the AST before codegen begins.
+ *
+ * Runs only in debug builds (guarded by #ifndef NDEBUG in SourceFile.cpp). Asserts
+ * that every field the IRGenerator reads — entry pointers, per-manifestation vectors,
+ * FctCallData::callee — is non-null and correctly sized. A failure here means a TC
+ * regression left a gap in the semantic model, which would otherwise surface as a
+ * cryptic null-dereference inside the IRGenerator.
+ */
+class PostTypeCheckingVerifier final : CompilerPass, public ASTVisitor {
+public:
+  // Constructors
+  PostTypeCheckingVerifier(GlobalResourceManager &resourceManager, SourceFile *sourceFile);
+
+  // Public methods
+  void verify(ASTNode *ast);
+
+private:
+  // Visitor methods
+  std::any visitFctDef(FctDefNode *node) override;
+  std::any visitProcDef(ProcDefNode *node) override;
+  std::any visitStructDef(StructDefNode *node) override;
+  std::any visitInterfaceDef(InterfaceDefNode *node) override;
+  std::any visitEnumDef(EnumDefNode *node) override;
+  std::any visitEnumItem(EnumItemNode *node) override;
+  std::any visitAliasDef(AliasDefNode *node) override;
+  std::any visitGlobalVarDef(GlobalVarDefNode *node) override;
+  std::any visitSignature(SignatureNode *node) override;
+  std::any visitDeclStmt(DeclStmtNode *node) override;
+  std::any visitFctCall(FctCallNode *node) override;
+  std::any visitAtomicExpr(AtomicExprNode *node) override;
+  std::any visitStructInstantiation(StructInstantiationNode *node) override;
+  std::any visitLambdaFunc(LambdaFuncNode *node) override;
+  std::any visitLambdaProc(LambdaProcNode *node) override;
+  std::any visitLambdaExpr(LambdaExprNode *node) override;
+};
+
+} // namespace spice::compiler


### PR DESCRIPTION
## What changed

Adds `PostTypeCheckingVerifier` — a new compiler pass (`src/typechecker/PostTypeCheckingVerifier.h/.cpp`) that walks the AST immediately after `runTypeCheckerPost()` completes and asserts that every field the IRGenerator reads is non-null and properly sized.

The pass is invoked in `SourceFile::runTypeCheckerPost()` under `#ifndef NDEBUG`, so it runs in Debug builds (where `assert()` is active) and has zero cost in Release builds.

## Why it changed

The IRGenerator is now a pure reader of the semantic model (see #1228, #1229, #1231, #1232). The implicit contract is that the TypeChecker fully populates all AST annotation fields before codegen begins. Without an explicit check, a TypeChecker regression that leaves a `nullptr` entry or an empty per-manifestation vector will silently produce wrong IR or crash deep inside the IRGenerator with a cryptic null-dereference.

This verifier enforces the contract at the boundary, producing a clear `assert()` failure pointing at the exact field that was missed.

## Fields verified

| Node | Field | Invariant |
|------|-------|-----------|
| `FctDefNode` / `ProcDefNode` | `entry`, `manifestations` | non-null, non-empty |
| `StructDefNode`, `InterfaceDefNode`, `EnumDefNode`, `EnumItemNode`, `AliasDefNode`, `GlobalVarDefNode`, `SignatureNode` | `entry` | non-null |
| `DeclStmtNode` | `entries` | non-empty, each element non-null |
| `FctCallNode` | `data`, `data[i].callee` (non-fct-ptr), `data[i].calleeParentScope` | non-empty, non-null |
| `AtomicExprNode` (identifier access) | `data`, `data[i].entry` | non-empty, non-null |
| `StructInstantiationNode` | `instantiatedStructs` | non-empty, each non-null |
| `LambdaFuncNode` / `LambdaProcNode` / `LambdaExprNode` | `manifestations` | non-empty |

Note: `MainFctDefNode::entry` is intentionally not asserted — it is never set by the TypeChecker (the symbol lives in the root scope, looked up by name). This is a pre-existing pattern documented in the verifier with a comment.

## How it was validated

- `cmake --build cmake-build-debug --target spice spicetest` — clean build
- `cmake-build-debug/test/spicetest` — same 22 pre-existing failures, no new assertion failures or regressions