### PR TITLE
Fix macOS ccache cache directory in CI

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -353,12 +353,12 @@ jobs:
         run: |
           brew update
           brew install ccache graphviz
-          mkdir -p ~/.cache/ccache
+          mkdir -p ~/Library/Caches/ccache
 
       - name: Restore CCache
         uses: actions/cache/restore@v6
         with:
-          path: ~/.cache/ccache
+          path: ~/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
@@ -417,7 +417,7 @@ jobs:
         uses: actions/cache/save@v6
         if: always()
         with:
-          path: ~/.cache/ccache
+          path: ~/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
 
   build-macos-aarch64:
@@ -444,12 +444,12 @@ jobs:
         run: |
           brew update
           brew install ccache graphviz
-          mkdir -p ~/.cache/ccache
+          mkdir -p ~/Library/Caches/ccache
 
       - name: Restore CCache
         uses: actions/cache/restore@v6
         with:
-          path: ~/.cache/ccache
+          path: ~/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
 
@@ -508,5 +508,5 @@ jobs:
         uses: actions/cache/save@v6
         if: always()
         with:
-          path: ~/.cache/ccache
+          path: ~/Library/Caches/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}


### PR DESCRIPTION
## What changed
- Both macOS jobs (`build-macos-x86`, `build-macos-aarch64`) in `ci-cpp.yml` now cache `~/Library/Caches/ccache` instead of `~/.cache/ccache`.

## Why
ccache ≥4.0 defaults to `~/Library/Caches/ccache` on macOS — `~/.cache/ccache` is the Linux default, not macOS's. The workflow was restoring/saving an empty directory on every macOS run (confirmed via `gh api repos/spicelang/spice/actions/caches`: both `ccache-macOS-*` entries were ~200 bytes, vs. hundreds of MB for the other platforms), so macOS builds always recompiled from scratch.

## How it was validated
- Confirmed via the GitHub Actions cache API that the existing macOS ccache entries are empty (~200 bytes) while Linux/Windows entries contain real data (100s of MB).
- Could not run the local build/test suite in this environment — local builds are blocked by a sandbox symlink-privilege issue with the antlr/googletest submodules (unrelated to this change).
- This is a CI-only workflow change; correctness will be visible from the next few `ci-cpp.yml` runs on this PR, where the macOS jobs' ccache cache size should jump from ~200 bytes to real content and subsequent runs should get faster "Build test target" steps.

## Follow-up / known limitations
- Linux/x86_64 and Windows restore real (non-empty) ccache data but still show much lower effective hit rates than Linux/AArch64 in this repo's CI history. Root cause not yet isolated — flagged separately, not addressed in this PR.