### PR TITLE
Add workflow to auto-assign milestone to new PRs

### DIFF
--- a/.github/workflows/assign-milestone.yml
+++ b/.github/workflows/assign-milestone.yml
@@ -1,0 +1,48 @@
+name: Assign Milestone
+
+on:
+  pull_request:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  assign-milestone:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            // Determine the next minor version from the latest release tag
+            const { data: latestRelease } = await github.rest.repos.getLatestRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const match = latestRelease.tag_name.match(/^v?(\d+)\.(\d+)\.\d+$/);
+            if (!match) {
+              core.warning(`Could not parse latest release tag: ${latestRelease.tag_name}`);
+              return;
+            }
+            const nextMilestone = `${match[1]}.${parseInt(match[2]) + 1}.0`;
+
+            const { data: milestones } = await github.rest.issues.listMilestones({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+
+            const target = milestones.find(m => m.title === nextMilestone);
+            if (!target) {
+              core.warning(`Milestone ${nextMilestone} not found or not open`);
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              milestone: target.number,
+            });


### PR DESCRIPTION
## What changed
- Added `.github/workflows/assign-milestone.yml` that runs on `pull_request: opened` against `main`

## Why
Automates milestone assignment so new PRs are always tagged with the correct upcoming release milestone without manual effort.

## How it works
1. Fetches the latest release tag (e.g. `v0.27.3`)
2. Increments the minor version to compute the next milestone name (e.g. `0.28.0`)
3. Looks up that milestone by name among open milestones and assigns it to the PR
4. Logs a warning and exits cleanly if the release tag can't be parsed or the milestone doesn't exist

## How it was validated
- Workflow syntax verified locally; no build or test suite is required for a CI-only change

## Follow-up / known limitations
- Only increments the minor version; a major version bump would need manual milestone creation as usual