### PR TITLE
Add test for generic substantiation in circular import scenarios

### DIFF
--- a/test/test-files/typechecker/imports/success-circular-generics/a.spice
+++ b/test/test-files/typechecker/imports/success-circular-generics/a.spice
@@ -1,0 +1,26 @@
+import "b" as b;
+
+type T dyn;
+
+public type Box<T> struct {
+    public T value
+}
+
+public p Box.ctor(T val) {
+    this.value = val;
+}
+
+// Reads the item from a Container of the same type T across the circular import boundary.
+public f<T> Box.take(Container<T>* c) {
+    return c.item;
+}
+
+// Swaps: returns a new Box whose value is taken from c, leaving this box's value.
+public f<Box<T>> Box.swapWith(Container<T>* c) {
+    return Box<T>{c.item};
+}
+
+// Generic free function: transfers the item from a Container into a new Box.
+public f<Box<T>> boxOf<T>(Container<T>* c) {
+    return Box<T>{c.item};
+}

--- a/test/test-files/typechecker/imports/success-circular-generics/b.spice
+++ b/test/test-files/typechecker/imports/success-circular-generics/b.spice
@@ -1,0 +1,24 @@
+import "a" as a;
+
+type T dyn;
+
+// Container is the type referenced by a.spice's generic Box methods. b.spice does NOT
+// reference Box<T> in its own method signatures: when b.spice is first loaded, a.spice
+// is mid-processing (typeCheckerPreRunning), so its generic types are not yet declared.
+// The circular dependency is still load-bearing: type identity between Container<int>
+// resolved through a.spice and through b.spice must be the same type.
+public type Container<T> struct {
+    public T item
+}
+
+public p Container.ctor(T val) {
+    this.item = val;
+}
+
+public f<T> Container.get() {
+    return this.item;
+}
+
+public p Container.set(T val) {
+    this.item = val;
+}

--- a/test/test-files/typechecker/imports/success-circular-generics/cout.out
+++ b/test/test-files/typechecker/imports/success-circular-generics/cout.out
@@ -1,0 +1,7 @@
+intBox.take(intContainer) = 32
+intBox.swapWith(intContainer).value = 32
+boxOf(intContainer).value = 32
+intContainer.get() = 32
+after set(99): intBox.take(intContainer) = 99
+dblBox.take(dblContainer) = 2.5
+boxOf(dblContainer).value = 2.5

--- a/test/test-files/typechecker/imports/success-circular-generics/source.spice
+++ b/test/test-files/typechecker/imports/success-circular-generics/source.spice
@@ -1,0 +1,39 @@
+import "a" as a;
+import "b" as b;
+
+f<int> main() {
+    // Substantiate Box<int> and Container<int> across the circular import boundary.
+    // Box is defined in a.spice (which imports b.spice), Container in b.spice (which imports a.spice).
+    Box<int> intBox = Box<int>(10);
+    Container<int> intContainer = Container<int>(32);
+
+    // Box.take() and Box.swapWith() cross the import boundary: their method bodies reference
+    // Container<T> from b.spice. The generic parameter T is substantiated with int here.
+    int taken = intBox.take(&intContainer);
+    Box<int> swapped = intBox.swapWith(&intContainer);
+    // boxOf<int>() is a generic free function in a.spice that also references Container<T>.
+    Box<int> boxed = boxOf<int>(&intContainer);
+
+    printf("intBox.take(intContainer) = %d\n", taken);
+    printf("intBox.swapWith(intContainer).value = %d\n", swapped.value);
+    printf("boxOf(intContainer).value = %d\n", boxed.value);
+    printf("intContainer.get() = %d\n", intContainer.get());
+
+    // Mutate via Container.set and re-read through Box.take to verify the mutation is visible
+    // across the generic type boundary (the Container<int> instance must share type identity
+    // with the Container<int> seen from inside Box.take).
+    intContainer.set(99);
+    int takenAfterSet = intBox.take(&intContainer);
+    printf("after set(99): intBox.take(intContainer) = %d\n", takenAfterSet);
+
+    // Substantiate with double to verify independent re-instantiation of both generic types.
+    Box<double> dblBox = Box<double>(1.5);
+    Container<double> dblContainer = Container<double>(2.5);
+    double takenDbl = dblBox.take(&dblContainer);
+    Box<double> boxedDbl = boxOf<double>(&dblContainer);
+
+    printf("dblBox.take(dblContainer) = %.1f\n", takenDbl);
+    printf("boxOf(dblContainer).value = %.1f\n", boxedDbl.value);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

- Adds `test/test-files/typechecker/imports/success-circular-generics/` — a new TypeChecker integration test covering generic type substantiation across a circular import boundary
- The cycle: `a.spice` (defines `Box<T>`) imports `b.spice` (defines `Container<T>`), which imports `a.spice` back
- Tests two concrete instantiations (`int`, `double`), cross-file generic methods (`Box.take`, `Box.swapWith`), a generic free function (`boxOf<T>`), and mutation visibility across the type-identity boundary

## What changed

Four new reference files under `test/test-files/typechecker/imports/success-circular-generics/`:

| File | Role |
|------|------|
| `a.spice` | Defines `Box<T>` with methods that reference `Container<T>` from `b.spice` |
| `b.spice` | Defines `Container<T>` with `get`/`set`; imports `a.spice` to close the cycle |
| `source.spice` | Substantiates both generics with `int` and `double`; exercises all cross-file paths |
| `cout.out` | Expected execution output |

## Why it changed

The circular import support landed in #1237 and #1239 but had no test exercising generic type parameters across the cycle — only concrete structs, methods, enums, interfaces, and aliases were covered. This closes that gap.

## Validation

```
# Build
cmake --build cmake-build-debug --target spicetest

# Run the new test case only
cd test && ../cmake-build-debug/test/spicetest --gtest_filter='*imports_successCircularGenerics*'
```

Result: `[ PASSED ] 1 test.`

All other circular-import success tests continue to pass (`imports_successCircularEnum`, `…Import`, `…Methods`, `…Struct`, `…ThreeStructs`, `…Alias`).

## Follow-up

The `typeCheckerPreRunning` guard means b.spice cannot reference `Box<T>` in its own method _signatures_ at the time it is first processed — only in bodies via the post-run fixpoint. A future test could verify the error path when someone attempts that pattern.