### PR TITLE
Add -b/--build-type argument to build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,9 +1,19 @@
 #!/usr/bin/env python3
 """Build the Spice compiler and test runner into the build/ directory."""
+import argparse
 import os
 import subprocess
 import sys
 from pathlib import Path
+
+parser = argparse.ArgumentParser(description="Build the Spice compiler and test runner.")
+parser.add_argument(
+    "-b", "--build-type",
+    choices=["Release", "Debug", "DebWithRelInfo"],
+    default="Release",
+    help="CMake build type (default: Release)",
+)
+args = parser.parse_args()
 
 build_dir = Path("build")
 build_dir.mkdir(exist_ok=True)
@@ -11,7 +21,7 @@ build_dir.mkdir(exist_ok=True)
 os.environ.setdefault("LLVM_DIR", str(Path("llvm/build-release/lib/cmake/llvm").resolve()))
 
 subprocess.run(
-    ["cmake", "-DCMAKE_BUILD_TYPE=Release", "-GNinja", ".."],
+    ["cmake", f"-DCMAKE_BUILD_TYPE={args.build_type}", "-GNinja", ".."],
     cwd=build_dir,
     check=True,
 )


### PR DESCRIPTION
## What changed
- Added `-b`/`--build-type` CLI argument to `build.py` using `argparse`
- Accepted values: `Release` (default), `Debug`, `DebWithRelInfo`
- The chosen value is passed directly to `-DCMAKE_BUILD_TYPE` in the CMake configure step

## Why
Makes it easy to produce debug or profiling builds without manually editing the script.

## How it was validated
- Inspected the script change — argument wiring is straightforward
- No test suite changes required (build script only)

## Follow-up / known limitations
None