### PR TITLE
Fix #dbg_declare ordering: emit before initializer stores

### DIFF
--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -112,6 +112,8 @@ llvm::Value *IRGenerator::getUpcastedStructPtr(llvm::Value *structPtr, const Qua
 }
 
 void IRGenerator::generateScopeCleanup(const StmtLstNode *node) {
+  diGenerator.setSourceLocation(node->closingBraceCodeLoc);
+
   // Do not clean up if the block is already terminated
   if (blockAlreadyTerminated)
     return;
@@ -331,10 +333,10 @@ llvm::Function *IRGenerator::generateImplicitFunction(const std::function<void()
     llvm::Value *thisAddress = insertAlloca(paramTypes.front(), THIS_VARIABLE_NAME);
     // Update the symbol table entry
     updateAddress(thisEntry, thisAddress);
-    // Store the value at the new address
-    insertStore(fct->arg_begin(), thisAddress);
     // Generate debug info
     diGenerator.generateLocalVarDebugInfo(THIS_VARIABLE_NAME, thisAddress, 1);
+    // Store the value at the new address
+    insertStore(fct->arg_begin(), thisAddress);
   }
 
   // Generate body
@@ -430,10 +432,10 @@ llvm::Function *IRGenerator::generateImplicitProcedure(const std::function<void(
     llvm::Value *thisAddress = insertAlloca(paramTypes.front(), THIS_VARIABLE_NAME);
     // Update the symbol table entry
     updateAddress(thisEntry, thisAddress);
-    // Store the value at the new address
-    insertStore(fct->arg_begin(), thisAddress);
     // Generate debug info
     diGenerator.generateLocalVarDebugInfo(THIS_VARIABLE_NAME, thisAddress, 1);
+    // Store the value at the new address
+    insertStore(fct->arg_begin(), thisAddress);
   }
 
   // Generate body

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -23,7 +23,6 @@ std::any IRGenerator::visitStmtLst(const StmtLstNode *node) {
   }
 
   // Generate cleanup code of this scope, e.g. dtor calls for struct instances
-  diGenerator.setSourceLocation(node->getNextOuterStmtLst()->closingBraceCodeLoc);
   generateScopeCleanup(node);
 
   return nullptr;
@@ -51,6 +50,8 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
       // Allocate memory
       varAddress = insertAlloca(varTy);
       updateAddress(varEntry, varAddress);
+      // Generate debug info for variable declaration
+      diGenerator.generateLocalVarDebugInfo(node->varName, varAddress);
       // Call copy ctor
       llvm::Value *rhsAddress = resolveAddress(node->assignExpr);
       assert(rhsAddress != nullptr);
@@ -67,6 +68,9 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
     varAddress = insertAlloca(varTy);
     updateAddress(varEntry, varAddress);
 
+    // Generate debug info for variable declaration
+    diGenerator.generateLocalVarDebugInfo(node->varName, varAddress);
+
     if (node->calledInitCtor) {
       // Call no-args constructor
       generateCtorOrDtorCall(varEntry, node->calledInitCtor, {});
@@ -82,10 +86,6 @@ std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
 
   // Attach the variable name to the LLVM value.
   varAddress->setName(varEntry->name);
-
-  // Generate debug info for variable declaration
-  diGenerator.setSourceLocation(node);
-  diGenerator.generateLocalVarDebugInfo(node->varName, varAddress);
 
   return nullptr;
 }

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -110,10 +110,10 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
     llvm::Value *paramAddress = insertAlloca(paramSymbol->getQualType(), paramName);
     // Update the symbol table entry
     updateAddress(paramSymbol, paramAddress);
-    // Store the value at the new address
-    insertStore(&arg, paramAddress);
     // Generate debug info
     diGenerator.generateLocalVarDebugInfo(paramName, paramAddress, argNumber + 1);
+    // Store the value at the new address
+    insertStore(&arg, paramAddress);
   }
 
   // Visit function body
@@ -253,10 +253,10 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
       updateAddress(paramSymbol, paramAddress);
       // Set source location
       diGenerator.setSourceLocation(paramSymbol->declNode);
-      // Store the value at the new address
-      insertStore(&arg, paramAddress);
       // Generate debug info to declare variable
       diGenerator.generateLocalVarDebugInfo(paramName, paramAddress, argNumber + 1);
+      // Store the value at the new address
+      insertStore(&arg, paramAddress);
     }
 
     // Store the default values for optional function args
@@ -396,10 +396,10 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
       updateAddress(paramSymbol, paramAddress);
       // Set source location
       diGenerator.setSourceLocation(paramSymbol->declNode);
-      // Store the value at the new address
-      insertStore(&arg, paramAddress);
       // Generate debug info to declare variable
       diGenerator.generateLocalVarDebugInfo(paramName, paramAddress, argNumber + 1);
+      // Store the value at the new address
+      insertStore(&arg, paramAddress);
     }
 
     // Store the default values for optional procedure args

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -590,11 +590,11 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
       captureStructPtrPtr = paramAddress;
     else
       updateAddress(paramSymbol, paramAddress);
-    // Store the value at the new address
-    insertStore(&arg, paramAddress);
     // Generate debug info
     if (!isCapturesStruct)
       diGenerator.generateLocalVarDebugInfo(paramName, paramAddress, argNumber + 1);
+    // Store the value at the new address
+    insertStore(&arg, paramAddress);
   }
 
   // Store the default values for optional function args
@@ -734,11 +734,11 @@ std::any IRGenerator::visitLambdaProc(const LambdaProcNode *node) {
       captureStructPtrPtr = paramAddress;
     else
       updateAddress(paramSymbol, paramAddress);
-    // Store the value at the new address
-    insertStore(&arg, paramAddress);
     // Generate debug info
     if (!isCapturesStruct)
       diGenerator.generateLocalVarDebugInfo(paramName, paramAddress, argNumber + 1);
+    // Store the value at the new address
+    insertStore(&arg, paramAddress);
   }
 
   // Store the default values for optional function args
@@ -880,11 +880,11 @@ std::any IRGenerator::visitLambdaExpr(const LambdaExprNode *node) {
       captureStructPtrPtr = paramAddress;
     else
       updateAddress(paramSymbol, paramAddress);
-    // Store the value at the new address
-    insertStore(&arg, paramAddress);
     // Generate debug info
     if (!isCapturesStruct)
       diGenerator.generateLocalVarDebugInfo(paramName, paramAddress, argNumber + 1);
+    // Store the value at the new address
+    insertStore(&arg, paramAddress);
   }
 
   // Store the default values for optional function args

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -69,7 +69,7 @@ std::any IRGenerator::visitEntry(const EntryNode *node) {
 llvm::AllocaInst *IRGenerator::insertAlloca(llvm::Type *llvmType, const std::string &varName) {
   if (allocaInsertInst != nullptr) { // If there is already an alloca inst, insert right after that
     llvm::AllocaInst *allocaInst = builder.CreateAlloca(llvmType, nullptr, varName);
-    allocaInst->setDebugLoc(llvm::DebugLoc());
+    allocaInst->dropLocation(); // Part of prologue
     allocaInst->moveAfter(allocaInsertInst);
     allocaInsertInst = allocaInst;
   } else { // This is the first alloca inst in the current function -> insert at the entry block
@@ -79,7 +79,7 @@ llvm::AllocaInst *IRGenerator::insertAlloca(llvm::Type *llvmType, const std::str
 
     // Allocate the size of the given LLVM type
     allocaInsertInst = builder.CreateAlloca(llvmType, nullptr, varName);
-    allocaInsertInst->setDebugLoc(llvm::DebugLoc());
+    allocaInsertInst->dropLocation(); // Part of prologue
 
     // Restore old basic block
     builder.SetInsertPoint(currentBlock);
@@ -363,7 +363,6 @@ void IRGenerator::switchToBlock(llvm::BasicBlock *block, llvm::Function *parentF
 }
 
 void IRGenerator::terminateBlock(const StmtLstNode *stmtLstNode) {
-  diGenerator.setSourceLocation(stmtLstNode->closingBraceCodeLoc);
   generateScopeCleanup(stmtLstNode);
   blockAlreadyTerminated = true;
 }
@@ -440,13 +439,16 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, const SymbolTa
   if (isRefAssign) {
     assert(lhsEntry != nullptr);
     if (isDecl) { // Reference gets initially assigned
-      // Get address of right side
-      llvm::Value *rhsAddress = resolveAddress(rhs);
-      assert(rhsAddress != nullptr);
-
       // Store lhs pointer to rhs
       llvm::Value *refAddress = insertAlloca(builder.getPtrTy());
       updateAddress(lhsEntry, refAddress);
+
+      // Generate debug info for variable declaration
+      diGenerator.generateLocalVarDebugInfo(lhsEntry->name, refAddress);
+
+      // Get address of right side
+      llvm::Value *rhsAddress = resolveAddress(rhs);
+      assert(rhsAddress != nullptr);
       insertStore(rhsAddress, refAddress);
 
       return LLVMExprResult{.value = rhsAddress, .ptr = refAddress, .entry = lhsEntry};
@@ -478,6 +480,8 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, const SymbolTa
     llvm::Value *rhsAddress = resolveAddress(rhs);
     updateAddress(lhsEntry, rhsAddress);
     rhs.entry = lhsEntry;
+    // Generate debug info for variable declaration
+    diGenerator.generateLocalVarDebugInfo(lhsEntry->name, rhsAddress);
     return rhs;
   }
 
@@ -486,6 +490,8 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, const SymbolTa
     assert(lhsEntry != nullptr);
     lhsAddress = insertAlloca(lhsEntry->getQualType());
     updateAddress(lhsEntry, lhsAddress);
+    // Generate debug info for variable declaration
+    diGenerator.generateLocalVarDebugInfo(lhsEntry->name, lhsAddress);
   }
 
   // Check if we try to assign an array by value to a pointer. Here we have to store the address of the first element to the lhs

--- a/test/test-files/irgenerator/instrumentation/success-asan-and-dbg-info/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/instrumentation/success-asan-and-dbg-info/ir-code-macos-amd64.ll
@@ -71,80 +71,80 @@ define dso_local noundef i32 @main() #0 !dbg !10 {
   %34 = add i64 %17, 4, !dbg !18
   %35 = inttoptr i64 %34 to ptr, !dbg !18
   store i8 0, ptr %35, align 1, !dbg !18
+    #dbg_declare(ptr %asan_local_stack_base, !20, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32), !18)
   store ptr %20, ptr %12, align 8, !dbg !18
-    #dbg_declare(ptr %asan_local_stack_base, !20, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32), !22)
-  %36 = load ptr, ptr %12, align 8, !dbg !23
-  %37 = ptrtoint ptr %36 to i64, !dbg !24
-  %38 = lshr i64 %37, 3, !dbg !24
-  %39 = or i64 %38, 17592186044416, !dbg !24
-  %40 = inttoptr i64 %39 to ptr, !dbg !24
-  %41 = load i8, ptr %40, align 1, !dbg !24
-  %42 = icmp ne i8 %41, 0, !dbg !24
-  br i1 %42, label %43, label %49, !dbg !24, !prof !19
+  %36 = load ptr, ptr %12, align 8, !dbg !22
+  %37 = ptrtoint ptr %36 to i64, !dbg !23
+  %38 = lshr i64 %37, 3, !dbg !23
+  %39 = or i64 %38, 17592186044416, !dbg !23
+  %40 = inttoptr i64 %39 to ptr, !dbg !23
+  %41 = load i8, ptr %40, align 1, !dbg !23
+  %42 = icmp ne i8 %41, 0, !dbg !23
+  br i1 %42, label %43, label %49, !dbg !23, !prof !19
 
 43:                                               ; preds = %33
-  %44 = and i64 %37, 7, !dbg !24
-  %45 = add i64 %44, 3, !dbg !24
-  %46 = trunc i64 %45 to i8, !dbg !24
-  %47 = icmp sge i8 %46, %41, !dbg !24
-  br i1 %47, label %48, label %49, !dbg !24
+  %44 = and i64 %37, 7, !dbg !23
+  %45 = add i64 %44, 3, !dbg !23
+  %46 = trunc i64 %45 to i8, !dbg !23
+  %47 = icmp sge i8 %46, %41, !dbg !23
+  br i1 %47, label %48, label %49, !dbg !23
 
 48:                                               ; preds = %43
-  call void @__asan_report_store4(i64 %37) #4, !dbg !24
+  call void @__asan_report_store4(i64 %37) #4, !dbg !23
   unreachable
 
 49:                                               ; preds = %43, %33
-  store i32 123, ptr %36, align 4, !dbg !24
-  call void @_Z8sDeallocRPh(ptr noundef %12), !dbg !25
-  %50 = load ptr, ptr %12, align 8, !dbg !27
-  %51 = ptrtoint ptr %50 to i64, !dbg !28
-  %52 = lshr i64 %51, 3, !dbg !28
-  %53 = or i64 %52, 17592186044416, !dbg !28
-  %54 = inttoptr i64 %53 to ptr, !dbg !28
-  %55 = load i8, ptr %54, align 1, !dbg !28
-  %56 = icmp ne i8 %55, 0, !dbg !28
-  br i1 %56, label %57, label %63, !dbg !28, !prof !19
+  store i32 123, ptr %36, align 4, !dbg !23
+  call void @_Z8sDeallocRPh(ptr noundef %12), !dbg !24
+  %50 = load ptr, ptr %12, align 8, !dbg !26
+  %51 = ptrtoint ptr %50 to i64, !dbg !27
+  %52 = lshr i64 %51, 3, !dbg !27
+  %53 = or i64 %52, 17592186044416, !dbg !27
+  %54 = inttoptr i64 %53 to ptr, !dbg !27
+  %55 = load i8, ptr %54, align 1, !dbg !27
+  %56 = icmp ne i8 %55, 0, !dbg !27
+  br i1 %56, label %57, label %63, !dbg !27, !prof !19
 
 57:                                               ; preds = %49
-  %58 = and i64 %51, 7, !dbg !28
-  %59 = add i64 %58, 3, !dbg !28
-  %60 = trunc i64 %59 to i8, !dbg !28
-  %61 = icmp sge i8 %60, %55, !dbg !28
-  br i1 %61, label %62, label %63, !dbg !28
+  %58 = and i64 %51, 7, !dbg !27
+  %59 = add i64 %58, 3, !dbg !27
+  %60 = trunc i64 %59 to i8, !dbg !27
+  %61 = icmp sge i8 %60, %55, !dbg !27
+  br i1 %61, label %62, label %63, !dbg !27
 
 62:                                               ; preds = %57
-  call void @__asan_report_store4(i64 %51) #4, !dbg !28
+  call void @__asan_report_store4(i64 %51) #4, !dbg !27
   unreachable
 
 63:                                               ; preds = %57, %49
-  store i32 321, ptr %50, align 4, !dbg !28
-  call void @_Z8sDeallocRPh(ptr %12), !dbg !29
-  %64 = add i64 %17, 4, !dbg !29
-  %65 = inttoptr i64 %64 to ptr, !dbg !29
-  store i8 -8, ptr %65, align 1, !dbg !29
-  %66 = load i32, ptr %result, align 4, !dbg !29
-  store i64 1172321806, ptr %11, align 8, !dbg !29
-  %67 = icmp ne i64 %6, 0, !dbg !29
-  br i1 %67, label %68, label %74, !dbg !29
+  store i32 321, ptr %50, align 4, !dbg !27
+  call void @_Z8sDeallocRPh(ptr %12), !dbg !28
+  %64 = add i64 %17, 4, !dbg !28
+  %65 = inttoptr i64 %64 to ptr, !dbg !28
+  store i8 -8, ptr %65, align 1, !dbg !28
+  %66 = load i32, ptr %result, align 4, !dbg !28
+  store i64 1172321806, ptr %11, align 8, !dbg !28
+  %67 = icmp ne i64 %6, 0, !dbg !28
+  br i1 %67, label %68, label %74, !dbg !28
 
 68:                                               ; preds = %63
-  %69 = add i64 %17, 0, !dbg !29
-  %70 = inttoptr i64 %69 to ptr, !dbg !29
-  store i64 -723401728380766731, ptr %70, align 1, !dbg !29
-  %71 = getelementptr i8, ptr %7, i64 56, !dbg !29
-  %72 = load i64, ptr %71, align 8, !dbg !29
-  %73 = inttoptr i64 %72 to ptr, !dbg !29
-  store i8 0, ptr %73, align 1, !dbg !29
-  br label %77, !dbg !29
+  %69 = add i64 %17, 0, !dbg !28
+  %70 = inttoptr i64 %69 to ptr, !dbg !28
+  store i64 -723401728380766731, ptr %70, align 1, !dbg !28
+  %71 = getelementptr i8, ptr %7, i64 56, !dbg !28
+  %72 = load i64, ptr %71, align 8, !dbg !28
+  %73 = inttoptr i64 %72 to ptr, !dbg !28
+  store i8 0, ptr %73, align 1, !dbg !28
+  br label %77, !dbg !28
 
 74:                                               ; preds = %63
-  %75 = add i64 %17, 0, !dbg !29
-  %76 = inttoptr i64 %75 to ptr, !dbg !29
-  store i64 0, ptr %76, align 1, !dbg !29
-  br label %77, !dbg !29
+  %75 = add i64 %17, 0, !dbg !28
+  %76 = inttoptr i64 %75 to ptr, !dbg !28
+  store i64 0, ptr %76, align 1, !dbg !28
+  br label %77, !dbg !28
 
 77:                                               ; preds = %74, %68
-  ret i32 %66, !dbg !29
+  ret i32 %66, !dbg !28
 }
 
 ; Function Attrs: nobuiltin nocallback nofree nosync nounwind willreturn
@@ -408,11 +408,10 @@ attributes #4 = { nomerge }
 !19 = !{!"branch_weights", i32 1, i32 1048575}
 !20 = !DILocalVariable(name: "iPtr", scope: !10, file: !11, line: 4, type: !21)
 !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !14, size: 64)
-!22 = !DILocation(line: 4, column: 5, scope: !10)
-!23 = !DILocation(line: 5, column: 6, scope: !10)
-!24 = !DILocation(line: 5, column: 13, scope: !10)
-!25 = !DILocation(line: 7, column: 35, scope: !26)
-!26 = distinct !DILexicalBlock(scope: !10, file: !11, line: 6, column: 5)
-!27 = !DILocation(line: 9, column: 6, scope: !10)
-!28 = !DILocation(line: 9, column: 13, scope: !10)
-!29 = !DILocation(line: 10, column: 1, scope: !10)
+!22 = !DILocation(line: 5, column: 6, scope: !10)
+!23 = !DILocation(line: 5, column: 13, scope: !10)
+!24 = !DILocation(line: 7, column: 35, scope: !25)
+!25 = distinct !DILexicalBlock(scope: !10, file: !11, line: 6, column: 5)
+!26 = !DILocation(line: 9, column: 6, scope: !10)
+!27 = !DILocation(line: 9, column: 13, scope: !10)
+!28 = !DILocation(line: 10, column: 1, scope: !10)

--- a/test/test-files/irgenerator/instrumentation/success-asan-and-dbg-info/ir-code-windows.ll
+++ b/test/test-files/irgenerator/instrumentation/success-asan-and-dbg-info/ir-code-windows.ll
@@ -73,80 +73,80 @@ define dso_local noundef i32 @main() #0 !dbg !10 {
   %35 = add i64 %18, 4, !dbg !18
   %36 = inttoptr i64 %35 to ptr, !dbg !18
   store i8 0, ptr %36, align 1, !dbg !18
+    #dbg_declare(ptr %asan_local_stack_base, !20, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32), !18)
   store ptr %21, ptr %13, align 8, !dbg !18
-    #dbg_declare(ptr %asan_local_stack_base, !20, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32), !22)
-  %37 = load ptr, ptr %13, align 8, !dbg !23
-  %38 = ptrtoint ptr %37 to i64, !dbg !24
-  %39 = lshr i64 %38, 3, !dbg !24
-  %40 = add i64 %39, %1, !dbg !24
-  %41 = inttoptr i64 %40 to ptr, !dbg !24
-  %42 = load i8, ptr %41, align 1, !dbg !24
-  %43 = icmp ne i8 %42, 0, !dbg !24
-  br i1 %43, label %44, label %50, !dbg !24, !prof !19
+  %37 = load ptr, ptr %13, align 8, !dbg !22
+  %38 = ptrtoint ptr %37 to i64, !dbg !23
+  %39 = lshr i64 %38, 3, !dbg !23
+  %40 = add i64 %39, %1, !dbg !23
+  %41 = inttoptr i64 %40 to ptr, !dbg !23
+  %42 = load i8, ptr %41, align 1, !dbg !23
+  %43 = icmp ne i8 %42, 0, !dbg !23
+  br i1 %43, label %44, label %50, !dbg !23, !prof !19
 
 44:                                               ; preds = %34
-  %45 = and i64 %38, 7, !dbg !24
-  %46 = add i64 %45, 3, !dbg !24
-  %47 = trunc i64 %46 to i8, !dbg !24
-  %48 = icmp sge i8 %47, %42, !dbg !24
-  br i1 %48, label %49, label %50, !dbg !24
+  %45 = and i64 %38, 7, !dbg !23
+  %46 = add i64 %45, 3, !dbg !23
+  %47 = trunc i64 %46 to i8, !dbg !23
+  %48 = icmp sge i8 %47, %42, !dbg !23
+  br i1 %48, label %49, label %50, !dbg !23
 
 49:                                               ; preds = %44
-  call void @__asan_report_store4(i64 %38) #4, !dbg !24
+  call void @__asan_report_store4(i64 %38) #4, !dbg !23
   unreachable
 
 50:                                               ; preds = %44, %34
-  store i32 123, ptr %37, align 4, !dbg !24
-  call void @_Z8sDeallocRPh(ptr noundef %13), !dbg !25
-  %51 = load ptr, ptr %13, align 8, !dbg !27
-  %52 = ptrtoint ptr %51 to i64, !dbg !28
-  %53 = lshr i64 %52, 3, !dbg !28
-  %54 = add i64 %53, %1, !dbg !28
-  %55 = inttoptr i64 %54 to ptr, !dbg !28
-  %56 = load i8, ptr %55, align 1, !dbg !28
-  %57 = icmp ne i8 %56, 0, !dbg !28
-  br i1 %57, label %58, label %64, !dbg !28, !prof !19
+  store i32 123, ptr %37, align 4, !dbg !23
+  call void @_Z8sDeallocRPh(ptr noundef %13), !dbg !24
+  %51 = load ptr, ptr %13, align 8, !dbg !26
+  %52 = ptrtoint ptr %51 to i64, !dbg !27
+  %53 = lshr i64 %52, 3, !dbg !27
+  %54 = add i64 %53, %1, !dbg !27
+  %55 = inttoptr i64 %54 to ptr, !dbg !27
+  %56 = load i8, ptr %55, align 1, !dbg !27
+  %57 = icmp ne i8 %56, 0, !dbg !27
+  br i1 %57, label %58, label %64, !dbg !27, !prof !19
 
 58:                                               ; preds = %50
-  %59 = and i64 %52, 7, !dbg !28
-  %60 = add i64 %59, 3, !dbg !28
-  %61 = trunc i64 %60 to i8, !dbg !28
-  %62 = icmp sge i8 %61, %56, !dbg !28
-  br i1 %62, label %63, label %64, !dbg !28
+  %59 = and i64 %52, 7, !dbg !27
+  %60 = add i64 %59, 3, !dbg !27
+  %61 = trunc i64 %60 to i8, !dbg !27
+  %62 = icmp sge i8 %61, %56, !dbg !27
+  br i1 %62, label %63, label %64, !dbg !27
 
 63:                                               ; preds = %58
-  call void @__asan_report_store4(i64 %52) #4, !dbg !28
+  call void @__asan_report_store4(i64 %52) #4, !dbg !27
   unreachable
 
 64:                                               ; preds = %58, %50
-  store i32 321, ptr %51, align 4, !dbg !28
-  call void @_Z8sDeallocRPh(ptr %13), !dbg !29
-  %65 = add i64 %18, 4, !dbg !29
-  %66 = inttoptr i64 %65 to ptr, !dbg !29
-  store i8 -8, ptr %66, align 1, !dbg !29
-  %67 = load i32, ptr %result, align 4, !dbg !29
-  store i64 1172321806, ptr %12, align 8, !dbg !29
-  %68 = icmp ne i64 %7, 0, !dbg !29
-  br i1 %68, label %69, label %75, !dbg !29
+  store i32 321, ptr %51, align 4, !dbg !27
+  call void @_Z8sDeallocRPh(ptr %13), !dbg !28
+  %65 = add i64 %18, 4, !dbg !28
+  %66 = inttoptr i64 %65 to ptr, !dbg !28
+  store i8 -8, ptr %66, align 1, !dbg !28
+  %67 = load i32, ptr %result, align 4, !dbg !28
+  store i64 1172321806, ptr %12, align 8, !dbg !28
+  %68 = icmp ne i64 %7, 0, !dbg !28
+  br i1 %68, label %69, label %75, !dbg !28
 
 69:                                               ; preds = %64
-  %70 = add i64 %18, 0, !dbg !29
-  %71 = inttoptr i64 %70 to ptr, !dbg !29
-  store i64 -723401728380766731, ptr %71, align 1, !dbg !29
-  %72 = getelementptr i8, ptr %8, i64 56, !dbg !29
-  %73 = load i64, ptr %72, align 8, !dbg !29
-  %74 = inttoptr i64 %73 to ptr, !dbg !29
-  store i8 0, ptr %74, align 1, !dbg !29
-  br label %78, !dbg !29
+  %70 = add i64 %18, 0, !dbg !28
+  %71 = inttoptr i64 %70 to ptr, !dbg !28
+  store i64 -723401728380766731, ptr %71, align 1, !dbg !28
+  %72 = getelementptr i8, ptr %8, i64 56, !dbg !28
+  %73 = load i64, ptr %72, align 8, !dbg !28
+  %74 = inttoptr i64 %73 to ptr, !dbg !28
+  store i8 0, ptr %74, align 1, !dbg !28
+  br label %78, !dbg !28
 
 75:                                               ; preds = %64
-  %76 = add i64 %18, 0, !dbg !29
-  %77 = inttoptr i64 %76 to ptr, !dbg !29
-  store i64 0, ptr %77, align 1, !dbg !29
-  br label %78, !dbg !29
+  %76 = add i64 %18, 0, !dbg !28
+  %77 = inttoptr i64 %76 to ptr, !dbg !28
+  store i64 0, ptr %77, align 1, !dbg !28
+  br label %78, !dbg !28
 
 78:                                               ; preds = %75, %69
-  ret i32 %67, !dbg !29
+  ret i32 %67, !dbg !28
 }
 
 ; Function Attrs: nobuiltin nocallback nofree nosync nounwind willreturn
@@ -410,11 +410,10 @@ attributes #4 = { nomerge }
 !19 = !{!"branch_weights", i32 1, i32 1048575}
 !20 = !DILocalVariable(name: "iPtr", scope: !10, file: !11, line: 4, type: !21)
 !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !14, size: 64)
-!22 = !DILocation(line: 4, column: 5, scope: !10)
-!23 = !DILocation(line: 5, column: 6, scope: !10)
-!24 = !DILocation(line: 5, column: 13, scope: !10)
-!25 = !DILocation(line: 7, column: 35, scope: !26)
-!26 = distinct !DILexicalBlock(scope: !10, file: !11, line: 6, column: 5)
-!27 = !DILocation(line: 9, column: 6, scope: !10)
-!28 = !DILocation(line: 9, column: 13, scope: !10)
-!29 = !DILocation(line: 10, column: 1, scope: !10)
+!22 = !DILocation(line: 5, column: 6, scope: !10)
+!23 = !DILocation(line: 5, column: 13, scope: !10)
+!24 = !DILocation(line: 7, column: 35, scope: !25)
+!25 = distinct !DILexicalBlock(scope: !10, file: !11, line: 6, column: 5)
+!26 = !DILocation(line: 9, column: 6, scope: !10)
+!27 = !DILocation(line: 9, column: 13, scope: !10)
+!28 = !DILocation(line: 10, column: 1, scope: !10)

--- a/test/test-files/irgenerator/instrumentation/success-asan-and-dbg-info/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-asan-and-dbg-info/ir-code.ll
@@ -76,80 +76,80 @@ define dso_local noundef i32 @main() #0 !dbg !10 {
   %34 = add i64 %17, 4, !dbg !18
   %35 = inttoptr i64 %34 to ptr, !dbg !18
   store i8 0, ptr %35, align 1, !dbg !18
+    #dbg_declare(ptr %asan_local_stack_base, !20, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32), !18)
   store ptr %20, ptr %12, align 8, !dbg !18
-    #dbg_declare(ptr %asan_local_stack_base, !20, !DIExpression(DW_OP_deref, DW_OP_plus_uconst, 32), !22)
-  %36 = load ptr, ptr %12, align 8, !dbg !23
-  %37 = ptrtoint ptr %36 to i64, !dbg !24
-  %38 = lshr i64 %37, 3, !dbg !24
-  %39 = add i64 %38, 2147450880, !dbg !24
-  %40 = inttoptr i64 %39 to ptr, !dbg !24
-  %41 = load i8, ptr %40, align 1, !dbg !24
-  %42 = icmp ne i8 %41, 0, !dbg !24
-  br i1 %42, label %43, label %49, !dbg !24, !prof !19
+  %36 = load ptr, ptr %12, align 8, !dbg !22
+  %37 = ptrtoint ptr %36 to i64, !dbg !23
+  %38 = lshr i64 %37, 3, !dbg !23
+  %39 = add i64 %38, 2147450880, !dbg !23
+  %40 = inttoptr i64 %39 to ptr, !dbg !23
+  %41 = load i8, ptr %40, align 1, !dbg !23
+  %42 = icmp ne i8 %41, 0, !dbg !23
+  br i1 %42, label %43, label %49, !dbg !23, !prof !19
 
 43:                                               ; preds = %33
-  %44 = and i64 %37, 7, !dbg !24
-  %45 = add i64 %44, 3, !dbg !24
-  %46 = trunc i64 %45 to i8, !dbg !24
-  %47 = icmp sge i8 %46, %41, !dbg !24
-  br i1 %47, label %48, label %49, !dbg !24
+  %44 = and i64 %37, 7, !dbg !23
+  %45 = add i64 %44, 3, !dbg !23
+  %46 = trunc i64 %45 to i8, !dbg !23
+  %47 = icmp sge i8 %46, %41, !dbg !23
+  br i1 %47, label %48, label %49, !dbg !23
 
 48:                                               ; preds = %43
-  call void @__asan_report_store4(i64 %37) #4, !dbg !24
+  call void @__asan_report_store4(i64 %37) #4, !dbg !23
   unreachable
 
 49:                                               ; preds = %43, %33
-  store i32 123, ptr %36, align 4, !dbg !24
-  call void @_Z8sDeallocRPh(ptr noundef %12), !dbg !25
-  %50 = load ptr, ptr %12, align 8, !dbg !27
-  %51 = ptrtoint ptr %50 to i64, !dbg !28
-  %52 = lshr i64 %51, 3, !dbg !28
-  %53 = add i64 %52, 2147450880, !dbg !28
-  %54 = inttoptr i64 %53 to ptr, !dbg !28
-  %55 = load i8, ptr %54, align 1, !dbg !28
-  %56 = icmp ne i8 %55, 0, !dbg !28
-  br i1 %56, label %57, label %63, !dbg !28, !prof !19
+  store i32 123, ptr %36, align 4, !dbg !23
+  call void @_Z8sDeallocRPh(ptr noundef %12), !dbg !24
+  %50 = load ptr, ptr %12, align 8, !dbg !26
+  %51 = ptrtoint ptr %50 to i64, !dbg !27
+  %52 = lshr i64 %51, 3, !dbg !27
+  %53 = add i64 %52, 2147450880, !dbg !27
+  %54 = inttoptr i64 %53 to ptr, !dbg !27
+  %55 = load i8, ptr %54, align 1, !dbg !27
+  %56 = icmp ne i8 %55, 0, !dbg !27
+  br i1 %56, label %57, label %63, !dbg !27, !prof !19
 
 57:                                               ; preds = %49
-  %58 = and i64 %51, 7, !dbg !28
-  %59 = add i64 %58, 3, !dbg !28
-  %60 = trunc i64 %59 to i8, !dbg !28
-  %61 = icmp sge i8 %60, %55, !dbg !28
-  br i1 %61, label %62, label %63, !dbg !28
+  %58 = and i64 %51, 7, !dbg !27
+  %59 = add i64 %58, 3, !dbg !27
+  %60 = trunc i64 %59 to i8, !dbg !27
+  %61 = icmp sge i8 %60, %55, !dbg !27
+  br i1 %61, label %62, label %63, !dbg !27
 
 62:                                               ; preds = %57
-  call void @__asan_report_store4(i64 %51) #4, !dbg !28
+  call void @__asan_report_store4(i64 %51) #4, !dbg !27
   unreachable
 
 63:                                               ; preds = %57, %49
-  store i32 321, ptr %50, align 4, !dbg !28
-  call void @_Z8sDeallocRPh(ptr %12), !dbg !29
-  %64 = add i64 %17, 4, !dbg !29
-  %65 = inttoptr i64 %64 to ptr, !dbg !29
-  store i8 -8, ptr %65, align 1, !dbg !29
-  %66 = load i32, ptr %result, align 4, !dbg !29
-  store i64 1172321806, ptr %11, align 8, !dbg !29
-  %67 = icmp ne i64 %6, 0, !dbg !29
-  br i1 %67, label %68, label %74, !dbg !29
+  store i32 321, ptr %50, align 4, !dbg !27
+  call void @_Z8sDeallocRPh(ptr %12), !dbg !28
+  %64 = add i64 %17, 4, !dbg !28
+  %65 = inttoptr i64 %64 to ptr, !dbg !28
+  store i8 -8, ptr %65, align 1, !dbg !28
+  %66 = load i32, ptr %result, align 4, !dbg !28
+  store i64 1172321806, ptr %11, align 8, !dbg !28
+  %67 = icmp ne i64 %6, 0, !dbg !28
+  br i1 %67, label %68, label %74, !dbg !28
 
 68:                                               ; preds = %63
-  %69 = add i64 %17, 0, !dbg !29
-  %70 = inttoptr i64 %69 to ptr, !dbg !29
-  store i64 -723401728380766731, ptr %70, align 1, !dbg !29
-  %71 = getelementptr i8, ptr %7, i64 56, !dbg !29
-  %72 = load i64, ptr %71, align 8, !dbg !29
-  %73 = inttoptr i64 %72 to ptr, !dbg !29
-  store i8 0, ptr %73, align 1, !dbg !29
-  br label %77, !dbg !29
+  %69 = add i64 %17, 0, !dbg !28
+  %70 = inttoptr i64 %69 to ptr, !dbg !28
+  store i64 -723401728380766731, ptr %70, align 1, !dbg !28
+  %71 = getelementptr i8, ptr %7, i64 56, !dbg !28
+  %72 = load i64, ptr %71, align 8, !dbg !28
+  %73 = inttoptr i64 %72 to ptr, !dbg !28
+  store i8 0, ptr %73, align 1, !dbg !28
+  br label %77, !dbg !28
 
 74:                                               ; preds = %63
-  %75 = add i64 %17, 0, !dbg !29
-  %76 = inttoptr i64 %75 to ptr, !dbg !29
-  store i64 0, ptr %76, align 1, !dbg !29
-  br label %77, !dbg !29
+  %75 = add i64 %17, 0, !dbg !28
+  %76 = inttoptr i64 %75 to ptr, !dbg !28
+  store i64 0, ptr %76, align 1, !dbg !28
+  br label %77, !dbg !28
 
 77:                                               ; preds = %74, %68
-  ret i32 %66, !dbg !29
+  ret i32 %66, !dbg !28
 }
 
 ; Function Attrs: nobuiltin nocallback nofree nosync nounwind willreturn
@@ -414,11 +414,10 @@ attributes #4 = { nomerge }
 !19 = !{!"branch_weights", i32 1, i32 1048575}
 !20 = !DILocalVariable(name: "iPtr", scope: !10, file: !11, line: 4, type: !21)
 !21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !14, size: 64)
-!22 = !DILocation(line: 4, column: 5, scope: !10)
-!23 = !DILocation(line: 5, column: 6, scope: !10)
-!24 = !DILocation(line: 5, column: 13, scope: !10)
-!25 = !DILocation(line: 7, column: 35, scope: !26)
-!26 = distinct !DILexicalBlock(scope: !10, file: !11, line: 6, column: 5)
-!27 = !DILocation(line: 9, column: 6, scope: !10)
-!28 = !DILocation(line: 9, column: 13, scope: !10)
-!29 = !DILocation(line: 10, column: 1, scope: !10)
+!22 = !DILocation(line: 5, column: 6, scope: !10)
+!23 = !DILocation(line: 5, column: 13, scope: !10)
+!24 = !DILocation(line: 7, column: 35, scope: !25)
+!25 = distinct !DILexicalBlock(scope: !10, file: !11, line: 6, column: 5)
+!26 = !DILocation(line: 9, column: 6, scope: !10)
+!27 = !DILocation(line: 9, column: 13, scope: !10)
+!28 = !DILocation(line: 10, column: 1, scope: !10)

--- a/test/test-files/irgenerator/instrumentation/success-dbg-info-complex/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-dbg-info-complex/ir-code.ll
@@ -59,384 +59,386 @@ define dso_local noundef i32 @main(i32 %0, ptr %1) #0 !dbg !14 {
   %12 = alloca ptr, align 8
     #dbg_declare(ptr %result, !22, !DIExpression(), !23)
   store i32 0, ptr %result, align 4, !dbg !23
-  store i32 %0, ptr %_argc, align 4, !dbg !23
     #dbg_declare(ptr %_argc, !24, !DIExpression(), !23)
-  store ptr %1, ptr %_argv, align 8, !dbg !23
+  store i32 %0, ptr %_argc, align 4, !dbg !23
     #dbg_declare(ptr %_argv, !25, !DIExpression(), !23)
+  store ptr %1, ptr %_argv, align 8, !dbg !23
   call void @_ZN6VectorIiE4ctorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !26
-    #dbg_declare(ptr %vi, !27, !DIExpression(), !35)
-  store i32 123, ptr %3, align 4, !dbg !36
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %3), !dbg !36
-  store i32 4321, ptr %4, align 4, !dbg !37
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %4), !dbg !37
-  store i32 9876, ptr %5, align 4, !dbg !38
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %5), !dbg !38
-  %13 = call noundef i64 @_ZN6VectorIiE7getSizeEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !39
-  %14 = icmp eq i64 %13, 3, !dbg !40
-  br i1 %14, label %assert.exit.L12, label %assert.then.L12, !dbg !40, !prof !41
+    #dbg_declare(ptr %vi, !27, !DIExpression(), !26)
+  store i32 123, ptr %3, align 4, !dbg !35
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %3), !dbg !35
+  store i32 4321, ptr %4, align 4, !dbg !36
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %4), !dbg !36
+  store i32 9876, ptr %5, align 4, !dbg !37
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %5), !dbg !37
+  %13 = call noundef i64 @_ZN6VectorIiE7getSizeEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !38
+  %14 = icmp eq i64 %13, 3, !dbg !39
+  br i1 %14, label %assert.exit.L12, label %assert.then.L12, !dbg !39, !prof !40
 
 assert.then.L12:                                  ; preds = %2
-  %15 = call i32 (ptr, ...) @printf(ptr @anon.string.0), !dbg !40
-  call void @exit(i32 1), !dbg !40
-  unreachable, !dbg !40
+  %15 = call i32 (ptr, ...) @printf(ptr @anon.string.0), !dbg !39
+  call void @exit(i32 1), !dbg !39
+  unreachable, !dbg !39
 
 assert.exit.L12:                                  ; preds = %2
-  %16 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !42
-  store %struct.VectorIterator %16, ptr %it, align 8, !dbg !42
-    #dbg_declare(ptr %it, !43, !DIExpression(), !49)
-  %17 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !50
-  br i1 %17, label %assert.exit.L16, label %assert.then.L16, !dbg !50, !prof !41
+  %16 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !41
+  store %struct.VectorIterator %16, ptr %it, align 8, !dbg !41
+    #dbg_declare(ptr %it, !42, !DIExpression(), !41)
+  %17 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !48
+  br i1 %17, label %assert.exit.L16, label %assert.then.L16, !dbg !48, !prof !40
 
 assert.then.L16:                                  ; preds = %assert.exit.L12
-  %18 = call i32 (ptr, ...) @printf(ptr @anon.string.1), !dbg !50
+  %18 = call i32 (ptr, ...) @printf(ptr @anon.string.1), !dbg !48
+  call void @exit(i32 1), !dbg !48
+  unreachable, !dbg !48
+
+assert.exit.L16:                                  ; preds = %assert.exit.L12
+  %19 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !49
+  %20 = load i32, ptr %19, align 4, !dbg !50
+  %21 = icmp eq i32 %20, 123, !dbg !50
+  br i1 %21, label %assert.exit.L17, label %assert.then.L17, !dbg !50, !prof !40
+
+assert.then.L17:                                  ; preds = %assert.exit.L16
+  %22 = call i32 (ptr, ...) @printf(ptr @anon.string.2), !dbg !50
   call void @exit(i32 1), !dbg !50
   unreachable, !dbg !50
 
-assert.exit.L16:                                  ; preds = %assert.exit.L12
-  %19 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !51
-  %20 = load i32, ptr %19, align 4, !dbg !52
-  %21 = icmp eq i32 %20, 123, !dbg !52
-  br i1 %21, label %assert.exit.L17, label %assert.then.L17, !dbg !52, !prof !41
+assert.exit.L17:                                  ; preds = %assert.exit.L16
+  %23 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !51
+  %24 = load i32, ptr %23, align 4, !dbg !52
+  %25 = icmp eq i32 %24, 123, !dbg !52
+  br i1 %25, label %assert.exit.L18, label %assert.then.L18, !dbg !52, !prof !40
 
-assert.then.L17:                                  ; preds = %assert.exit.L16
-  %22 = call i32 (ptr, ...) @printf(ptr @anon.string.2), !dbg !52
+assert.then.L18:                                  ; preds = %assert.exit.L17
+  %26 = call i32 (ptr, ...) @printf(ptr @anon.string.3), !dbg !52
   call void @exit(i32 1), !dbg !52
   unreachable, !dbg !52
 
-assert.exit.L17:                                  ; preds = %assert.exit.L16
-  %23 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !53
-  %24 = load i32, ptr %23, align 4, !dbg !54
-  %25 = icmp eq i32 %24, 123, !dbg !54
-  br i1 %25, label %assert.exit.L18, label %assert.then.L18, !dbg !54, !prof !41
-
-assert.then.L18:                                  ; preds = %assert.exit.L17
-  %26 = call i32 (ptr, ...) @printf(ptr @anon.string.3), !dbg !54
-  call void @exit(i32 1), !dbg !54
-  unreachable, !dbg !54
-
 assert.exit.L18:                                  ; preds = %assert.exit.L17
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !55
-  %27 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !56
-  %28 = load i32, ptr %27, align 4, !dbg !57
-  %29 = icmp eq i32 %28, 4321, !dbg !57
-  br i1 %29, label %assert.exit.L20, label %assert.then.L20, !dbg !57, !prof !41
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !53
+  %27 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !54
+  %28 = load i32, ptr %27, align 4, !dbg !55
+  %29 = icmp eq i32 %28, 4321, !dbg !55
+  br i1 %29, label %assert.exit.L20, label %assert.then.L20, !dbg !55, !prof !40
 
 assert.then.L20:                                  ; preds = %assert.exit.L18
-  %30 = call i32 (ptr, ...) @printf(ptr @anon.string.4), !dbg !57
-  call void @exit(i32 1), !dbg !57
-  unreachable, !dbg !57
+  %30 = call i32 (ptr, ...) @printf(ptr @anon.string.4), !dbg !55
+  call void @exit(i32 1), !dbg !55
+  unreachable, !dbg !55
 
 assert.exit.L20:                                  ; preds = %assert.exit.L18
-  %31 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !58
-  br i1 %31, label %assert.exit.L21, label %assert.then.L21, !dbg !58, !prof !41
+  %31 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !56
+  br i1 %31, label %assert.exit.L21, label %assert.then.L21, !dbg !56, !prof !40
 
 assert.then.L21:                                  ; preds = %assert.exit.L20
-  %32 = call i32 (ptr, ...) @printf(ptr @anon.string.5), !dbg !58
-  call void @exit(i32 1), !dbg !58
-  unreachable, !dbg !58
+  %32 = call i32 (ptr, ...) @printf(ptr @anon.string.5), !dbg !56
+  call void @exit(i32 1), !dbg !56
+  unreachable, !dbg !56
 
 assert.exit.L21:                                  ; preds = %assert.exit.L20
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !59
-  %33 = call noundef %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !60
-  store %struct.Pair %33, ptr %pair, align 8, !dbg !60
-    #dbg_declare(ptr %pair, !61, !DIExpression(), !67)
-  %34 = call noundef ptr @_ZN4PairImRiE8getFirstEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !68
-  %35 = load i64, ptr %34, align 8, !dbg !69
-  %36 = icmp eq i64 %35, 2, !dbg !69
-  br i1 %36, label %assert.exit.L24, label %assert.then.L24, !dbg !69, !prof !41
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !57
+  %33 = call noundef %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !58
+  store %struct.Pair %33, ptr %pair, align 8, !dbg !58
+    #dbg_declare(ptr %pair, !59, !DIExpression(), !58)
+  %34 = call noundef ptr @_ZN4PairImRiE8getFirstEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !65
+  %35 = load i64, ptr %34, align 8, !dbg !66
+  %36 = icmp eq i64 %35, 2, !dbg !66
+  br i1 %36, label %assert.exit.L24, label %assert.then.L24, !dbg !66, !prof !40
 
 assert.then.L24:                                  ; preds = %assert.exit.L21
-  %37 = call i32 (ptr, ...) @printf(ptr @anon.string.6), !dbg !69
-  call void @exit(i32 1), !dbg !69
-  unreachable, !dbg !69
+  %37 = call i32 (ptr, ...) @printf(ptr @anon.string.6), !dbg !66
+  call void @exit(i32 1), !dbg !66
+  unreachable, !dbg !66
 
 assert.exit.L24:                                  ; preds = %assert.exit.L21
-  %38 = call noundef ptr @_ZN4PairImRiE9getSecondEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !70
-  %39 = load i32, ptr %38, align 4, !dbg !71
-  %40 = icmp eq i32 %39, 9876, !dbg !71
-  br i1 %40, label %assert.exit.L25, label %assert.then.L25, !dbg !71, !prof !41
+  %38 = call noundef ptr @_ZN4PairImRiE9getSecondEv(ptr noundef nonnull align 8 dereferenceable(16) %pair), !dbg !67
+  %39 = load i32, ptr %38, align 4, !dbg !68
+  %40 = icmp eq i32 %39, 9876, !dbg !68
+  br i1 %40, label %assert.exit.L25, label %assert.then.L25, !dbg !68, !prof !40
 
 assert.then.L25:                                  ; preds = %assert.exit.L24
-  %41 = call i32 (ptr, ...) @printf(ptr @anon.string.7), !dbg !71
-  call void @exit(i32 1), !dbg !71
-  unreachable, !dbg !71
+  %41 = call i32 (ptr, ...) @printf(ptr @anon.string.7), !dbg !68
+  call void @exit(i32 1), !dbg !68
+  unreachable, !dbg !68
 
 assert.exit.L25:                                  ; preds = %assert.exit.L24
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !72
-  %42 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !73
-  %43 = xor i1 %42, true, !dbg !73
-  br i1 %43, label %assert.exit.L27, label %assert.then.L27, !dbg !73, !prof !41
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !69
+  %42 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !70
+  %43 = xor i1 %42, true, !dbg !70
+  br i1 %43, label %assert.exit.L27, label %assert.then.L27, !dbg !70, !prof !40
 
 assert.then.L27:                                  ; preds = %assert.exit.L25
-  %44 = call i32 (ptr, ...) @printf(ptr @anon.string.8), !dbg !73
+  %44 = call i32 (ptr, ...) @printf(ptr @anon.string.8), !dbg !70
+  call void @exit(i32 1), !dbg !70
+  unreachable, !dbg !70
+
+assert.exit.L27:                                  ; preds = %assert.exit.L25
+  store i32 321, ptr %6, align 4, !dbg !71
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %6), !dbg !71
+  store i32 -99, ptr %7, align 4, !dbg !72
+  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %7), !dbg !72
+  %45 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !73
+  br i1 %45, label %assert.exit.L32, label %assert.then.L32, !dbg !73, !prof !40
+
+assert.then.L32:                                  ; preds = %assert.exit.L27
+  %46 = call i32 (ptr, ...) @printf(ptr @anon.string.9), !dbg !73
   call void @exit(i32 1), !dbg !73
   unreachable, !dbg !73
 
-assert.exit.L27:                                  ; preds = %assert.exit.L25
-  store i32 321, ptr %6, align 4, !dbg !74
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %6), !dbg !74
-  store i32 -99, ptr %7, align 4, !dbg !75
-  call void @_ZN6VectorIiE8pushBackERKi(ptr noundef nonnull align 8 dereferenceable(32) %vi, ptr noundef %7), !dbg !75
-  %45 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !76
-  br i1 %45, label %assert.exit.L32, label %assert.then.L32, !dbg !76, !prof !41
+assert.exit.L32:                                  ; preds = %assert.exit.L27
+  call void @_Z13op.minusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 3), !dbg !74
+  %47 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !75
+  %48 = load i32, ptr %47, align 4, !dbg !76
+  %49 = icmp eq i32 %48, 123, !dbg !76
+  br i1 %49, label %assert.exit.L36, label %assert.then.L36, !dbg !76, !prof !40
 
-assert.then.L32:                                  ; preds = %assert.exit.L27
-  %46 = call i32 (ptr, ...) @printf(ptr @anon.string.9), !dbg !76
+assert.then.L36:                                  ; preds = %assert.exit.L32
+  %50 = call i32 (ptr, ...) @printf(ptr @anon.string.10), !dbg !76
   call void @exit(i32 1), !dbg !76
   unreachable, !dbg !76
 
-assert.exit.L32:                                  ; preds = %assert.exit.L27
-  call void @_Z13op.minusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 3), !dbg !77
-  %47 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !78
-  %48 = load i32, ptr %47, align 4, !dbg !79
-  %49 = icmp eq i32 %48, 123, !dbg !79
-  br i1 %49, label %assert.exit.L36, label %assert.then.L36, !dbg !79, !prof !41
-
-assert.then.L36:                                  ; preds = %assert.exit.L32
-  %50 = call i32 (ptr, ...) @printf(ptr @anon.string.10), !dbg !79
-  call void @exit(i32 1), !dbg !79
-  unreachable, !dbg !79
-
 assert.exit.L36:                                  ; preds = %assert.exit.L32
-  %51 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !80
-  br i1 %51, label %assert.exit.L37, label %assert.then.L37, !dbg !80, !prof !41
+  %51 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !77
+  br i1 %51, label %assert.exit.L37, label %assert.then.L37, !dbg !77, !prof !40
 
 assert.then.L37:                                  ; preds = %assert.exit.L36
-  %52 = call i32 (ptr, ...) @printf(ptr @anon.string.11), !dbg !80
+  %52 = call i32 (ptr, ...) @printf(ptr @anon.string.11), !dbg !77
+  call void @exit(i32 1), !dbg !77
+  unreachable, !dbg !77
+
+assert.exit.L37:                                  ; preds = %assert.exit.L36
+  %53 = load %struct.VectorIterator, ptr %it, align 8, !dbg !78
+  call void @_Z16op.plusplus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !78
+  %54 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !79
+  %55 = load i32, ptr %54, align 4, !dbg !80
+  %56 = icmp eq i32 %55, 4321, !dbg !80
+  br i1 %56, label %assert.exit.L39, label %assert.then.L39, !dbg !80, !prof !40
+
+assert.then.L39:                                  ; preds = %assert.exit.L37
+  %57 = call i32 (ptr, ...) @printf(ptr @anon.string.12), !dbg !80
   call void @exit(i32 1), !dbg !80
   unreachable, !dbg !80
 
-assert.exit.L37:                                  ; preds = %assert.exit.L36
-  %53 = load %struct.VectorIterator, ptr %it, align 8, !dbg !81
-  call void @_Z16op.plusplus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !81
-  %54 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !82
-  %55 = load i32, ptr %54, align 4, !dbg !83
-  %56 = icmp eq i32 %55, 4321, !dbg !83
-  br i1 %56, label %assert.exit.L39, label %assert.then.L39, !dbg !83, !prof !41
+assert.exit.L39:                                  ; preds = %assert.exit.L37
+  %58 = load %struct.VectorIterator, ptr %it, align 8, !dbg !81
+  call void @_Z18op.minusminus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !81
+  %59 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !82
+  %60 = load i32, ptr %59, align 4, !dbg !83
+  %61 = icmp eq i32 %60, 123, !dbg !83
+  br i1 %61, label %assert.exit.L41, label %assert.then.L41, !dbg !83, !prof !40
 
-assert.then.L39:                                  ; preds = %assert.exit.L37
-  %57 = call i32 (ptr, ...) @printf(ptr @anon.string.12), !dbg !83
+assert.then.L41:                                  ; preds = %assert.exit.L39
+  %62 = call i32 (ptr, ...) @printf(ptr @anon.string.13), !dbg !83
   call void @exit(i32 1), !dbg !83
   unreachable, !dbg !83
 
-assert.exit.L39:                                  ; preds = %assert.exit.L37
-  %58 = load %struct.VectorIterator, ptr %it, align 8, !dbg !84
-  call void @_Z18op.minusminus.postIiEvR14VectorIteratorIiE(ptr %it), !dbg !84
-  %59 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !85
-  %60 = load i32, ptr %59, align 4, !dbg !86
-  %61 = icmp eq i32 %60, 123, !dbg !86
-  br i1 %61, label %assert.exit.L41, label %assert.then.L41, !dbg !86, !prof !41
+assert.exit.L41:                                  ; preds = %assert.exit.L39
+  call void @_Z12op.plusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 4), !dbg !84
+  %63 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !85
+  %64 = load i32, ptr %63, align 4, !dbg !86
+  %65 = icmp eq i32 %64, -99, !dbg !86
+  br i1 %65, label %assert.exit.L43, label %assert.then.L43, !dbg !86, !prof !40
 
-assert.then.L41:                                  ; preds = %assert.exit.L39
-  %62 = call i32 (ptr, ...) @printf(ptr @anon.string.13), !dbg !86
+assert.then.L43:                                  ; preds = %assert.exit.L41
+  %66 = call i32 (ptr, ...) @printf(ptr @anon.string.14), !dbg !86
   call void @exit(i32 1), !dbg !86
   unreachable, !dbg !86
 
-assert.exit.L41:                                  ; preds = %assert.exit.L39
-  call void @_Z12op.plusequalIiiEvR14VectorIteratorIiEi(ptr %it, i32 4), !dbg !87
-  %63 = call noundef ptr @_ZN14VectorIteratorIiE3getEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !88
-  %64 = load i32, ptr %63, align 4, !dbg !89
-  %65 = icmp eq i32 %64, -99, !dbg !89
-  br i1 %65, label %assert.exit.L43, label %assert.then.L43, !dbg !89, !prof !41
-
-assert.then.L43:                                  ; preds = %assert.exit.L41
-  %66 = call i32 (ptr, ...) @printf(ptr @anon.string.14), !dbg !89
-  call void @exit(i32 1), !dbg !89
-  unreachable, !dbg !89
-
 assert.exit.L43:                                  ; preds = %assert.exit.L41
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !90
-  %67 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !91
-  %68 = xor i1 %67, true, !dbg !91
-  br i1 %68, label %assert.exit.L45, label %assert.then.L45, !dbg !91, !prof !41
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !87
+  %67 = call noundef zeroext i1 @_ZN14VectorIteratorIiE7isValidEv(ptr noundef nonnull align 8 dereferenceable(24) %it), !dbg !88
+  %68 = xor i1 %67, true, !dbg !88
+  br i1 %68, label %assert.exit.L45, label %assert.then.L45, !dbg !88, !prof !40
 
 assert.then.L45:                                  ; preds = %assert.exit.L43
-  %69 = call i32 (ptr, ...) @printf(ptr @anon.string.15), !dbg !91
-  call void @exit(i32 1), !dbg !91
-  unreachable, !dbg !91
+  %69 = call i32 (ptr, ...) @printf(ptr @anon.string.15), !dbg !88
+  call void @exit(i32 1), !dbg !88
+  unreachable, !dbg !88
 
 assert.exit.L45:                                  ; preds = %assert.exit.L43
-  %70 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !92
-  store %struct.VectorIterator %70, ptr %8, align 8, !dbg !92
-    #dbg_declare(ptr %item, !94, !DIExpression(), !95)
-  br label %foreach.head.L48, !dbg !95
+  %70 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !89
+  store %struct.VectorIterator %70, ptr %8, align 8, !dbg !89
+    #dbg_declare(ptr %item, !91, !DIExpression(), !92)
+  br label %foreach.head.L48, !dbg !92
 
 foreach.head.L48:                                 ; preds = %foreach.tail.L48, %assert.exit.L45
-  %71 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %8), !dbg !95
-  br i1 %71, label %foreach.body.L48, label %foreach.exit.L48, !dbg !95
+  %71 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %8), !dbg !92
+  br i1 %71, label %foreach.body.L48, label %foreach.exit.L48, !dbg !92
 
 foreach.body.L48:                                 ; preds = %foreach.head.L48
-  %72 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %8), !dbg !95
-  %73 = load i32, ptr %72, align 4, !dbg !95
-  store i32 %73, ptr %item, align 4, !dbg !95
-  %74 = load i32, ptr %item, align 4, !dbg !96
-  %75 = add nsw i32 %74, 1, !dbg !96
-  store i32 %75, ptr %item, align 4, !dbg !96
-  br label %foreach.tail.L48, !dbg !97
+  %72 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %8), !dbg !92
+  %73 = load i32, ptr %72, align 4, !dbg !92
+  store i32 %73, ptr %item, align 4, !dbg !92
+  %74 = load i32, ptr %item, align 4, !dbg !93
+  %75 = add nsw i32 %74, 1, !dbg !93
+  store i32 %75, ptr %item, align 4, !dbg !93
+  br label %foreach.tail.L48, !dbg !94
 
 foreach.tail.L48:                                 ; preds = %foreach.body.L48
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %8), !dbg !97
-  br label %foreach.head.L48, !dbg !97
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %8), !dbg !94
+  br label %foreach.head.L48, !dbg !94
 
 foreach.exit.L48:                                 ; preds = %foreach.head.L48
-  %76 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !98
-  %77 = load i32, ptr %76, align 4, !dbg !99
-  %78 = icmp eq i32 %77, 123, !dbg !99
-  br i1 %78, label %assert.exit.L51, label %assert.then.L51, !dbg !99, !prof !41
+  %76 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !95
+  %77 = load i32, ptr %76, align 4, !dbg !96
+  %78 = icmp eq i32 %77, 123, !dbg !96
+  br i1 %78, label %assert.exit.L51, label %assert.then.L51, !dbg !96, !prof !40
 
 assert.then.L51:                                  ; preds = %foreach.exit.L48
-  %79 = call i32 (ptr, ...) @printf(ptr @anon.string.16), !dbg !99
-  call void @exit(i32 1), !dbg !99
-  unreachable, !dbg !99
+  %79 = call i32 (ptr, ...) @printf(ptr @anon.string.16), !dbg !96
+  call void @exit(i32 1), !dbg !96
+  unreachable, !dbg !96
 
 assert.exit.L51:                                  ; preds = %foreach.exit.L48
-  %80 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !100
-  %81 = load i32, ptr %80, align 4, !dbg !101
-  %82 = icmp eq i32 %81, 4321, !dbg !101
-  br i1 %82, label %assert.exit.L52, label %assert.then.L52, !dbg !101, !prof !41
+  %80 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !97
+  %81 = load i32, ptr %80, align 4, !dbg !98
+  %82 = icmp eq i32 %81, 4321, !dbg !98
+  br i1 %82, label %assert.exit.L52, label %assert.then.L52, !dbg !98, !prof !40
 
 assert.then.L52:                                  ; preds = %assert.exit.L51
-  %83 = call i32 (ptr, ...) @printf(ptr @anon.string.17), !dbg !101
-  call void @exit(i32 1), !dbg !101
-  unreachable, !dbg !101
+  %83 = call i32 (ptr, ...) @printf(ptr @anon.string.17), !dbg !98
+  call void @exit(i32 1), !dbg !98
+  unreachable, !dbg !98
 
 assert.exit.L52:                                  ; preds = %assert.exit.L51
-  %84 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !102
-  %85 = load i32, ptr %84, align 4, !dbg !103
-  %86 = icmp eq i32 %85, 9876, !dbg !103
-  br i1 %86, label %assert.exit.L53, label %assert.then.L53, !dbg !103, !prof !41
+  %84 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !99
+  %85 = load i32, ptr %84, align 4, !dbg !100
+  %86 = icmp eq i32 %85, 9876, !dbg !100
+  br i1 %86, label %assert.exit.L53, label %assert.then.L53, !dbg !100, !prof !40
 
 assert.then.L53:                                  ; preds = %assert.exit.L52
-  %87 = call i32 (ptr, ...) @printf(ptr @anon.string.18), !dbg !103
-  call void @exit(i32 1), !dbg !103
-  unreachable, !dbg !103
+  %87 = call i32 (ptr, ...) @printf(ptr @anon.string.18), !dbg !100
+  call void @exit(i32 1), !dbg !100
+  unreachable, !dbg !100
 
 assert.exit.L53:                                  ; preds = %assert.exit.L52
-  %88 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !104
-  store %struct.VectorIterator %88, ptr %9, align 8, !dbg !104
-    #dbg_declare(ptr %item1, !106, !DIExpression(), !107)
-  br label %foreach.head.L56, !dbg !107
+  %88 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !101
+  store %struct.VectorIterator %88, ptr %9, align 8, !dbg !101
+    #dbg_declare(ptr %item1, !103, !DIExpression(), !104)
+  br label %foreach.head.L56, !dbg !104
 
 foreach.head.L56:                                 ; preds = %foreach.tail.L56, %assert.exit.L53
-  %89 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %9), !dbg !107
-  br i1 %89, label %foreach.body.L56, label %foreach.exit.L56, !dbg !107
+  %89 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %9), !dbg !104
+  br i1 %89, label %foreach.body.L56, label %foreach.exit.L56, !dbg !104
 
 foreach.body.L56:                                 ; preds = %foreach.head.L56
-  %90 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %9), !dbg !107
-  store ptr %90, ptr %10, align 8, !dbg !107
-  %91 = load ptr, ptr %10, align 8, !dbg !108
-  %92 = load i32, ptr %91, align 4, !dbg !108
-  %93 = add nsw i32 %92, 1, !dbg !108
-  store i32 %93, ptr %91, align 4, !dbg !108
-  br label %foreach.tail.L56, !dbg !109
+  %90 = call ptr @_ZN14VectorIteratorIiE3getEv(ptr %9), !dbg !104
+    #dbg_declare(ptr %10, !103, !DIExpression(), !104)
+  store ptr %90, ptr %10, align 8, !dbg !104
+  %91 = load ptr, ptr %10, align 8, !dbg !105
+  %92 = load i32, ptr %91, align 4, !dbg !105
+  %93 = add nsw i32 %92, 1, !dbg !105
+  store i32 %93, ptr %91, align 4, !dbg !105
+  br label %foreach.tail.L56, !dbg !106
 
 foreach.tail.L56:                                 ; preds = %foreach.body.L56
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %9), !dbg !109
-  br label %foreach.head.L56, !dbg !109
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %9), !dbg !106
+  br label %foreach.head.L56, !dbg !106
 
 foreach.exit.L56:                                 ; preds = %foreach.head.L56
-  %94 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !110
-  %95 = load i32, ptr %94, align 4, !dbg !111
-  %96 = icmp eq i32 %95, 124, !dbg !111
-  br i1 %96, label %assert.exit.L59, label %assert.then.L59, !dbg !111, !prof !41
+  %94 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !107
+  %95 = load i32, ptr %94, align 4, !dbg !108
+  %96 = icmp eq i32 %95, 124, !dbg !108
+  br i1 %96, label %assert.exit.L59, label %assert.then.L59, !dbg !108, !prof !40
 
 assert.then.L59:                                  ; preds = %foreach.exit.L56
-  %97 = call i32 (ptr, ...) @printf(ptr @anon.string.19), !dbg !111
-  call void @exit(i32 1), !dbg !111
-  unreachable, !dbg !111
+  %97 = call i32 (ptr, ...) @printf(ptr @anon.string.19), !dbg !108
+  call void @exit(i32 1), !dbg !108
+  unreachable, !dbg !108
 
 assert.exit.L59:                                  ; preds = %foreach.exit.L56
-  %98 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !112
-  %99 = load i32, ptr %98, align 4, !dbg !113
-  %100 = icmp eq i32 %99, 4322, !dbg !113
-  br i1 %100, label %assert.exit.L60, label %assert.then.L60, !dbg !113, !prof !41
+  %98 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !109
+  %99 = load i32, ptr %98, align 4, !dbg !110
+  %100 = icmp eq i32 %99, 4322, !dbg !110
+  br i1 %100, label %assert.exit.L60, label %assert.then.L60, !dbg !110, !prof !40
 
 assert.then.L60:                                  ; preds = %assert.exit.L59
-  %101 = call i32 (ptr, ...) @printf(ptr @anon.string.20), !dbg !113
-  call void @exit(i32 1), !dbg !113
-  unreachable, !dbg !113
+  %101 = call i32 (ptr, ...) @printf(ptr @anon.string.20), !dbg !110
+  call void @exit(i32 1), !dbg !110
+  unreachable, !dbg !110
 
 assert.exit.L60:                                  ; preds = %assert.exit.L59
-  %102 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !114
-  %103 = load i32, ptr %102, align 4, !dbg !115
-  %104 = icmp eq i32 %103, 9877, !dbg !115
-  br i1 %104, label %assert.exit.L61, label %assert.then.L61, !dbg !115, !prof !41
+  %102 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !111
+  %103 = load i32, ptr %102, align 4, !dbg !112
+  %104 = icmp eq i32 %103, 9877, !dbg !112
+  br i1 %104, label %assert.exit.L61, label %assert.then.L61, !dbg !112, !prof !40
 
 assert.then.L61:                                  ; preds = %assert.exit.L60
-  %105 = call i32 (ptr, ...) @printf(ptr @anon.string.21), !dbg !115
-  call void @exit(i32 1), !dbg !115
-  unreachable, !dbg !115
+  %105 = call i32 (ptr, ...) @printf(ptr @anon.string.21), !dbg !112
+  call void @exit(i32 1), !dbg !112
+  unreachable, !dbg !112
 
 assert.exit.L61:                                  ; preds = %assert.exit.L60
-  %106 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !116
-  store %struct.VectorIterator %106, ptr %11, align 8, !dbg !116
-  store i64 0, ptr %idx, align 8, !dbg !118
-    #dbg_declare(ptr %idx, !119, !DIExpression(), !118)
-    #dbg_declare(ptr %item2, !121, !DIExpression(), !122)
-  br label %foreach.head.L63, !dbg !122
+  %106 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !113
+  store %struct.VectorIterator %106, ptr %11, align 8, !dbg !113
+    #dbg_declare(ptr %idx, !115, !DIExpression(), !117)
+  store i64 0, ptr %idx, align 8, !dbg !117
+    #dbg_declare(ptr %item2, !118, !DIExpression(), !119)
+  br label %foreach.head.L63, !dbg !119
 
 foreach.head.L63:                                 ; preds = %foreach.tail.L63, %assert.exit.L61
-  %107 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !122
-  br i1 %107, label %foreach.body.L63, label %foreach.exit.L63, !dbg !122
+  %107 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !119
+  br i1 %107, label %foreach.body.L63, label %foreach.exit.L63, !dbg !119
 
 foreach.body.L63:                                 ; preds = %foreach.head.L63
-  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %11), !dbg !122
-  store %struct.Pair %pair3, ptr %pair.addr, align 8, !dbg !122
-  %108 = load i64, ptr %pair.addr, align 8, !dbg !122
-  store i64 %108, ptr %idx, align 8, !dbg !122
-  %item.addr = getelementptr inbounds nuw %struct.Pair, ptr %pair.addr, i32 0, i32 1, !dbg !122
-  %109 = load ptr, ptr %item.addr, align 8, !dbg !122
-  store ptr %109, ptr %12, align 8, !dbg !122
-  %110 = load i64, ptr %idx, align 8, !dbg !123
-  %111 = trunc i64 %110 to i32, !dbg !123
-  %112 = load ptr, ptr %12, align 8, !dbg !123
-  %113 = load i32, ptr %112, align 4, !dbg !123
-  %114 = add nsw i32 %113, %111, !dbg !123
-  store i32 %114, ptr %112, align 4, !dbg !123
-  br label %foreach.tail.L63, !dbg !124
+  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %11), !dbg !119
+  store %struct.Pair %pair3, ptr %pair.addr, align 8, !dbg !119
+  %108 = load i64, ptr %pair.addr, align 8, !dbg !119
+  store i64 %108, ptr %idx, align 8, !dbg !119
+  %item.addr = getelementptr inbounds nuw %struct.Pair, ptr %pair.addr, i32 0, i32 1, !dbg !119
+    #dbg_declare(ptr %12, !118, !DIExpression(), !119)
+  %109 = load ptr, ptr %item.addr, align 8, !dbg !119
+  store ptr %109, ptr %12, align 8, !dbg !119
+  %110 = load i64, ptr %idx, align 8, !dbg !120
+  %111 = trunc i64 %110 to i32, !dbg !120
+  %112 = load ptr, ptr %12, align 8, !dbg !120
+  %113 = load i32, ptr %112, align 4, !dbg !120
+  %114 = add nsw i32 %113, %111, !dbg !120
+  store i32 %114, ptr %112, align 4, !dbg !120
+  br label %foreach.tail.L63, !dbg !121
 
 foreach.tail.L63:                                 ; preds = %foreach.body.L63
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !124
-  br label %foreach.head.L63, !dbg !124
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !121
+  br label %foreach.head.L63, !dbg !121
 
 foreach.exit.L63:                                 ; preds = %foreach.head.L63
-  %115 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !125
-  %116 = load i32, ptr %115, align 4, !dbg !126
-  %117 = icmp eq i32 %116, 124, !dbg !126
-  br i1 %117, label %assert.exit.L66, label %assert.then.L66, !dbg !126, !prof !41
+  %115 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !122
+  %116 = load i32, ptr %115, align 4, !dbg !123
+  %117 = icmp eq i32 %116, 124, !dbg !123
+  br i1 %117, label %assert.exit.L66, label %assert.then.L66, !dbg !123, !prof !40
 
 assert.then.L66:                                  ; preds = %foreach.exit.L63
-  %118 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !126
-  call void @exit(i32 1), !dbg !126
-  unreachable, !dbg !126
+  %118 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !123
+  call void @exit(i32 1), !dbg !123
+  unreachable, !dbg !123
 
 assert.exit.L66:                                  ; preds = %foreach.exit.L63
-  %119 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !127
-  %120 = load i32, ptr %119, align 4, !dbg !128
-  %121 = icmp eq i32 %120, 4323, !dbg !128
-  br i1 %121, label %assert.exit.L67, label %assert.then.L67, !dbg !128, !prof !41
+  %119 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !124
+  %120 = load i32, ptr %119, align 4, !dbg !125
+  %121 = icmp eq i32 %120, 4323, !dbg !125
+  br i1 %121, label %assert.exit.L67, label %assert.then.L67, !dbg !125, !prof !40
 
 assert.then.L67:                                  ; preds = %assert.exit.L66
-  %122 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !128
-  call void @exit(i32 1), !dbg !128
-  unreachable, !dbg !128
+  %122 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !125
+  call void @exit(i32 1), !dbg !125
+  unreachable, !dbg !125
 
 assert.exit.L67:                                  ; preds = %assert.exit.L66
-  %123 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !129
-  %124 = load i32, ptr %123, align 4, !dbg !130
-  %125 = icmp eq i32 %124, 9879, !dbg !130
-  br i1 %125, label %assert.exit.L68, label %assert.then.L68, !dbg !130, !prof !41
+  %123 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !126
+  %124 = load i32, ptr %123, align 4, !dbg !127
+  %125 = icmp eq i32 %124, 9879, !dbg !127
+  br i1 %125, label %assert.exit.L68, label %assert.then.L68, !dbg !127, !prof !40
 
 assert.then.L68:                                  ; preds = %assert.exit.L67
-  %126 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !130
-  call void @exit(i32 1), !dbg !130
-  unreachable, !dbg !130
+  %126 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !127
+  call void @exit(i32 1), !dbg !127
+  unreachable, !dbg !127
 
 assert.exit.L68:                                  ; preds = %assert.exit.L67
-  %127 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !131
-  call void @_ZN6VectorIiE4dtorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !132
-  %128 = load i32, ptr %result, align 4, !dbg !132
-  ret i32 %128, !dbg !132
+  %127 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !128
+  call void @_ZN6VectorIiE4dtorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !129
+  %128 = load i32, ptr %result, align 4, !dbg !129
+  ret i32 %128, !dbg !129
 }
 
 declare void @_ZN6VectorIiE4ctorEv(ptr)
@@ -520,101 +522,98 @@ attributes #2 = { cold noreturn nounwind }
 !32 = !DIDerivedType(tag: DW_TAG_member, name: "capacity", scope: !28, file: !5, line: 27, baseType: !33, size: 64, offset: 128)
 !33 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
 !34 = !DIDerivedType(tag: DW_TAG_member, name: "size", scope: !28, file: !5, line: 28, baseType: !33, size: 64, offset: 192)
-!35 = !DILocation(line: 8, column: 5, scope: !14)
-!36 = !DILocation(line: 9, column: 17, scope: !14)
-!37 = !DILocation(line: 10, column: 17, scope: !14)
-!38 = !DILocation(line: 11, column: 17, scope: !14)
-!39 = !DILocation(line: 12, column: 12, scope: !14)
-!40 = !DILocation(line: 12, column: 28, scope: !14)
-!41 = !{!"branch_weights", i32 1048575, i32 1}
-!42 = !DILocation(line: 15, column: 14, scope: !14)
-!43 = !DILocalVariable(name: "it", scope: !14, file: !5, line: 15, type: !44)
-!44 = !DICompositeType(tag: DW_TAG_structure_type, name: "VectorIterator", scope: !5, file: !5, line: 364, size: 192, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !45, identifier: "struct.VectorIterator")
-!45 = !{!46, !48}
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "vector", scope: !44, file: !5, line: 365, baseType: !47, size: 64, offset: 64)
-!47 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !28, size: 64)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "cursor", scope: !44, file: !5, line: 366, baseType: !33, size: 64, offset: 128)
-!49 = !DILocation(line: 15, column: 5, scope: !14)
-!50 = !DILocation(line: 16, column: 12, scope: !14)
-!51 = !DILocation(line: 17, column: 12, scope: !14)
-!52 = !DILocation(line: 17, column: 24, scope: !14)
-!53 = !DILocation(line: 18, column: 12, scope: !14)
-!54 = !DILocation(line: 18, column: 24, scope: !14)
-!55 = !DILocation(line: 19, column: 5, scope: !14)
-!56 = !DILocation(line: 20, column: 12, scope: !14)
-!57 = !DILocation(line: 20, column: 24, scope: !14)
-!58 = !DILocation(line: 21, column: 12, scope: !14)
-!59 = !DILocation(line: 22, column: 5, scope: !14)
-!60 = !DILocation(line: 23, column: 16, scope: !14)
-!61 = !DILocalVariable(name: "pair", scope: !14, file: !5, line: 23, type: !62)
-!62 = !DICompositeType(tag: DW_TAG_structure_type, name: "Pair", scope: !5, file: !5, line: 8, size: 128, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !63, identifier: "struct.Pair")
-!63 = !{!64, !65}
-!64 = !DIDerivedType(tag: DW_TAG_member, name: "first", scope: !62, file: !5, line: 9, baseType: !33, size: 64)
-!65 = !DIDerivedType(tag: DW_TAG_member, name: "second", scope: !62, file: !5, line: 10, baseType: !66, size: 64, offset: 64)
-!66 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !17, size: 64)
-!67 = !DILocation(line: 23, column: 5, scope: !14)
-!68 = !DILocation(line: 24, column: 12, scope: !14)
-!69 = !DILocation(line: 24, column: 31, scope: !14)
-!70 = !DILocation(line: 25, column: 12, scope: !14)
-!71 = !DILocation(line: 25, column: 32, scope: !14)
-!72 = !DILocation(line: 26, column: 5, scope: !14)
-!73 = !DILocation(line: 27, column: 13, scope: !14)
-!74 = !DILocation(line: 30, column: 17, scope: !14)
-!75 = !DILocation(line: 31, column: 17, scope: !14)
-!76 = !DILocation(line: 32, column: 12, scope: !14)
-!77 = !DILocation(line: 35, column: 5, scope: !14)
-!78 = !DILocation(line: 36, column: 12, scope: !14)
-!79 = !DILocation(line: 36, column: 24, scope: !14)
-!80 = !DILocation(line: 37, column: 12, scope: !14)
-!81 = !DILocation(line: 38, column: 5, scope: !14)
-!82 = !DILocation(line: 39, column: 12, scope: !14)
-!83 = !DILocation(line: 39, column: 24, scope: !14)
-!84 = !DILocation(line: 40, column: 5, scope: !14)
-!85 = !DILocation(line: 41, column: 12, scope: !14)
-!86 = !DILocation(line: 41, column: 24, scope: !14)
-!87 = !DILocation(line: 42, column: 5, scope: !14)
-!88 = !DILocation(line: 43, column: 12, scope: !14)
-!89 = !DILocation(line: 43, column: 24, scope: !14)
-!90 = !DILocation(line: 44, column: 5, scope: !14)
-!91 = !DILocation(line: 45, column: 13, scope: !14)
-!92 = !DILocation(line: 48, column: 24, scope: !93)
-!93 = distinct !DILexicalBlock(scope: !14, file: !5, line: 48, column: 5)
-!94 = !DILocalVariable(name: "item", scope: !93, file: !5, line: 48, type: !17)
-!95 = !DILocation(line: 48, column: 13, scope: !93)
-!96 = !DILocation(line: 49, column: 9, scope: !93)
-!97 = !DILocation(line: 50, column: 5, scope: !93)
-!98 = !DILocation(line: 51, column: 19, scope: !14)
-!99 = !DILocation(line: 51, column: 25, scope: !14)
-!100 = !DILocation(line: 52, column: 19, scope: !14)
-!101 = !DILocation(line: 52, column: 25, scope: !14)
-!102 = !DILocation(line: 53, column: 19, scope: !14)
-!103 = !DILocation(line: 53, column: 25, scope: !14)
-!104 = !DILocation(line: 56, column: 25, scope: !105)
-!105 = distinct !DILexicalBlock(scope: !14, file: !5, line: 56, column: 5)
-!106 = !DILocalVariable(name: "item", scope: !105, file: !5, line: 56, type: !66)
-!107 = !DILocation(line: 56, column: 13, scope: !105)
-!108 = !DILocation(line: 57, column: 9, scope: !105)
-!109 = !DILocation(line: 58, column: 5, scope: !105)
-!110 = !DILocation(line: 59, column: 19, scope: !14)
-!111 = !DILocation(line: 59, column: 25, scope: !14)
-!112 = !DILocation(line: 60, column: 19, scope: !14)
-!113 = !DILocation(line: 60, column: 25, scope: !14)
-!114 = !DILocation(line: 61, column: 19, scope: !14)
-!115 = !DILocation(line: 61, column: 25, scope: !14)
-!116 = !DILocation(line: 63, column: 35, scope: !117)
-!117 = distinct !DILexicalBlock(scope: !14, file: !5, line: 63, column: 5)
-!118 = !DILocation(line: 63, column: 13, scope: !117)
-!119 = !DILocalVariable(name: "idx", scope: !117, file: !5, line: 63, type: !120)
-!120 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!121 = !DILocalVariable(name: "item", scope: !117, file: !5, line: 63, type: !66)
-!122 = !DILocation(line: 63, column: 23, scope: !117)
-!123 = !DILocation(line: 64, column: 9, scope: !117)
-!124 = !DILocation(line: 65, column: 5, scope: !117)
-!125 = !DILocation(line: 66, column: 19, scope: !14)
-!126 = !DILocation(line: 66, column: 25, scope: !14)
-!127 = !DILocation(line: 67, column: 19, scope: !14)
-!128 = !DILocation(line: 67, column: 25, scope: !14)
-!129 = !DILocation(line: 68, column: 19, scope: !14)
-!130 = !DILocation(line: 68, column: 25, scope: !14)
-!131 = !DILocation(line: 70, column: 5, scope: !14)
-!132 = !DILocation(line: 71, column: 1, scope: !14)
+!35 = !DILocation(line: 9, column: 17, scope: !14)
+!36 = !DILocation(line: 10, column: 17, scope: !14)
+!37 = !DILocation(line: 11, column: 17, scope: !14)
+!38 = !DILocation(line: 12, column: 12, scope: !14)
+!39 = !DILocation(line: 12, column: 28, scope: !14)
+!40 = !{!"branch_weights", i32 1048575, i32 1}
+!41 = !DILocation(line: 15, column: 14, scope: !14)
+!42 = !DILocalVariable(name: "it", scope: !14, file: !5, line: 15, type: !43)
+!43 = !DICompositeType(tag: DW_TAG_structure_type, name: "VectorIterator", scope: !5, file: !5, line: 364, size: 192, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !44, identifier: "struct.VectorIterator")
+!44 = !{!45, !47}
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "vector", scope: !43, file: !5, line: 365, baseType: !46, size: 64, offset: 64)
+!46 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !28, size: 64)
+!47 = !DIDerivedType(tag: DW_TAG_member, name: "cursor", scope: !43, file: !5, line: 366, baseType: !33, size: 64, offset: 128)
+!48 = !DILocation(line: 16, column: 12, scope: !14)
+!49 = !DILocation(line: 17, column: 12, scope: !14)
+!50 = !DILocation(line: 17, column: 24, scope: !14)
+!51 = !DILocation(line: 18, column: 12, scope: !14)
+!52 = !DILocation(line: 18, column: 24, scope: !14)
+!53 = !DILocation(line: 19, column: 5, scope: !14)
+!54 = !DILocation(line: 20, column: 12, scope: !14)
+!55 = !DILocation(line: 20, column: 24, scope: !14)
+!56 = !DILocation(line: 21, column: 12, scope: !14)
+!57 = !DILocation(line: 22, column: 5, scope: !14)
+!58 = !DILocation(line: 23, column: 16, scope: !14)
+!59 = !DILocalVariable(name: "pair", scope: !14, file: !5, line: 23, type: !60)
+!60 = !DICompositeType(tag: DW_TAG_structure_type, name: "Pair", scope: !5, file: !5, line: 8, size: 128, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !61, identifier: "struct.Pair")
+!61 = !{!62, !63}
+!62 = !DIDerivedType(tag: DW_TAG_member, name: "first", scope: !60, file: !5, line: 9, baseType: !33, size: 64)
+!63 = !DIDerivedType(tag: DW_TAG_member, name: "second", scope: !60, file: !5, line: 10, baseType: !64, size: 64, offset: 64)
+!64 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !17, size: 64)
+!65 = !DILocation(line: 24, column: 12, scope: !14)
+!66 = !DILocation(line: 24, column: 31, scope: !14)
+!67 = !DILocation(line: 25, column: 12, scope: !14)
+!68 = !DILocation(line: 25, column: 32, scope: !14)
+!69 = !DILocation(line: 26, column: 5, scope: !14)
+!70 = !DILocation(line: 27, column: 13, scope: !14)
+!71 = !DILocation(line: 30, column: 17, scope: !14)
+!72 = !DILocation(line: 31, column: 17, scope: !14)
+!73 = !DILocation(line: 32, column: 12, scope: !14)
+!74 = !DILocation(line: 35, column: 5, scope: !14)
+!75 = !DILocation(line: 36, column: 12, scope: !14)
+!76 = !DILocation(line: 36, column: 24, scope: !14)
+!77 = !DILocation(line: 37, column: 12, scope: !14)
+!78 = !DILocation(line: 38, column: 5, scope: !14)
+!79 = !DILocation(line: 39, column: 12, scope: !14)
+!80 = !DILocation(line: 39, column: 24, scope: !14)
+!81 = !DILocation(line: 40, column: 5, scope: !14)
+!82 = !DILocation(line: 41, column: 12, scope: !14)
+!83 = !DILocation(line: 41, column: 24, scope: !14)
+!84 = !DILocation(line: 42, column: 5, scope: !14)
+!85 = !DILocation(line: 43, column: 12, scope: !14)
+!86 = !DILocation(line: 43, column: 24, scope: !14)
+!87 = !DILocation(line: 44, column: 5, scope: !14)
+!88 = !DILocation(line: 45, column: 13, scope: !14)
+!89 = !DILocation(line: 48, column: 24, scope: !90)
+!90 = distinct !DILexicalBlock(scope: !14, file: !5, line: 48, column: 5)
+!91 = !DILocalVariable(name: "item", scope: !90, file: !5, line: 48, type: !17)
+!92 = !DILocation(line: 48, column: 13, scope: !90)
+!93 = !DILocation(line: 49, column: 9, scope: !90)
+!94 = !DILocation(line: 50, column: 5, scope: !90)
+!95 = !DILocation(line: 51, column: 19, scope: !14)
+!96 = !DILocation(line: 51, column: 25, scope: !14)
+!97 = !DILocation(line: 52, column: 19, scope: !14)
+!98 = !DILocation(line: 52, column: 25, scope: !14)
+!99 = !DILocation(line: 53, column: 19, scope: !14)
+!100 = !DILocation(line: 53, column: 25, scope: !14)
+!101 = !DILocation(line: 56, column: 25, scope: !102)
+!102 = distinct !DILexicalBlock(scope: !14, file: !5, line: 56, column: 5)
+!103 = !DILocalVariable(name: "item", scope: !102, file: !5, line: 56, type: !64)
+!104 = !DILocation(line: 56, column: 13, scope: !102)
+!105 = !DILocation(line: 57, column: 9, scope: !102)
+!106 = !DILocation(line: 58, column: 5, scope: !102)
+!107 = !DILocation(line: 59, column: 19, scope: !14)
+!108 = !DILocation(line: 59, column: 25, scope: !14)
+!109 = !DILocation(line: 60, column: 19, scope: !14)
+!110 = !DILocation(line: 60, column: 25, scope: !14)
+!111 = !DILocation(line: 61, column: 19, scope: !14)
+!112 = !DILocation(line: 61, column: 25, scope: !14)
+!113 = !DILocation(line: 63, column: 35, scope: !114)
+!114 = distinct !DILexicalBlock(scope: !14, file: !5, line: 63, column: 5)
+!115 = !DILocalVariable(name: "idx", scope: !114, file: !5, line: 63, type: !116)
+!116 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!117 = !DILocation(line: 63, column: 13, scope: !114)
+!118 = !DILocalVariable(name: "item", scope: !114, file: !5, line: 63, type: !64)
+!119 = !DILocation(line: 63, column: 23, scope: !114)
+!120 = !DILocation(line: 64, column: 9, scope: !114)
+!121 = !DILocation(line: 65, column: 5, scope: !114)
+!122 = !DILocation(line: 66, column: 19, scope: !14)
+!123 = !DILocation(line: 66, column: 25, scope: !14)
+!124 = !DILocation(line: 67, column: 19, scope: !14)
+!125 = !DILocation(line: 67, column: 25, scope: !14)
+!126 = !DILocation(line: 68, column: 19, scope: !14)
+!127 = !DILocation(line: 68, column: 25, scope: !14)
+!128 = !DILocation(line: 70, column: 5, scope: !14)
+!129 = !DILocation(line: 71, column: 1, scope: !14)

--- a/test/test-files/irgenerator/instrumentation/success-dbg-info-simple/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-dbg-info-simple/ir-code.ll
@@ -12,12 +12,12 @@ source_filename = "source.spice"
 ; Function Attrs: mustprogress noinline nounwind optnone uwtable
 define void @_ZN10TestStruct4dtorEv(ptr noundef nonnull align 8 dereferenceable(40) %0) #0 !dbg !23 {
   %this = alloca ptr, align 8
-  store ptr %0, ptr %this, align 8, !dbg !43
-    #dbg_declare(ptr %this, !44, !DIExpression(), !43)
-  %2 = load ptr, ptr %this, align 8, !dbg !43
-  %3 = getelementptr inbounds nuw %struct.TestStruct, ptr %2, i32 0, i32 1, !dbg !43
-  call void @_ZN6String4dtorEv(ptr noundef nonnull align 8 dereferenceable(24) %3), !dbg !43
-  ret void, !dbg !43
+    #dbg_declare(ptr %this, !43, !DIExpression(), !45)
+  store ptr %0, ptr %this, align 8, !dbg !45
+  %2 = load ptr, ptr %this, align 8, !dbg !45
+  %3 = getelementptr inbounds nuw %struct.TestStruct, ptr %2, i32 0, i32 1, !dbg !45
+  call void @_ZN6String4dtorEv(ptr noundef nonnull align 8 dereferenceable(24) %3), !dbg !45
+  ret void, !dbg !45
 }
 
 declare void @_ZN6String4dtorEv(ptr noundef nonnull align 8 dereferenceable(24))
@@ -28,8 +28,8 @@ define private noundef %struct.TestStruct @_Z3fctRi(ptr noundef %0) !dbg !46 {
   %2 = alloca %struct.String, align 8
   %ts = alloca %struct.TestStruct, align 8
     #dbg_declare(ptr %result, !50, !DIExpression(), !51)
-  store ptr %0, ptr %ref, align 8, !dbg !52
-    #dbg_declare(ptr %ref, !53, !DIExpression(), !52)
+    #dbg_declare(ptr %ref, !52, !DIExpression(), !53)
+  store ptr %0, ptr %ref, align 8, !dbg !53
   call void @_ZN6String4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(24) %2, ptr noundef @anon.string.0), !dbg !54
   store i64 6, ptr %ts, align 8, !dbg !55
   %3 = load %struct.String, ptr %2, align 8, !dbg !55
@@ -39,37 +39,37 @@ define private noundef %struct.TestStruct @_Z3fctRi(ptr noundef %0) !dbg !46 {
   %6 = load i32, ptr %5, align 4, !dbg !55
   %7 = getelementptr inbounds nuw %struct.TestStruct, ptr %ts, i32 0, i32 2, !dbg !55
   store i32 %6, ptr %7, align 4, !dbg !55
-    #dbg_declare(ptr %ts, !56, !DIExpression(), !57)
-  %8 = load %struct.TestStruct, ptr %ts, align 8, !dbg !58
-  ret %struct.TestStruct %8, !dbg !59
+    #dbg_declare(ptr %ts, !56, !DIExpression(), !55)
+  %8 = load %struct.TestStruct, ptr %ts, align 8, !dbg !57
+  ret %struct.TestStruct %8, !dbg !58
 }
 
 declare void @_ZN6String4ctorEPKc(ptr, ptr)
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
-define dso_local noundef i32 @main() #1 !dbg !60 {
+define dso_local noundef i32 @main() #1 !dbg !59 {
   %result = alloca i32, align 4
   %test = alloca i32, align 4
   %res = alloca %struct.TestStruct, align 8
-    #dbg_declare(ptr %result, !63, !DIExpression(), !64)
-  store i32 0, ptr %result, align 4, !dbg !64
+    #dbg_declare(ptr %result, !62, !DIExpression(), !63)
+  store i32 0, ptr %result, align 4, !dbg !63
+    #dbg_declare(ptr %test, !64, !DIExpression(), !65)
   store i32 987654, ptr %test, align 4, !dbg !65
-    #dbg_declare(ptr %test, !66, !DIExpression(), !67)
-  %1 = call noundef %struct.TestStruct @_Z3fctRi(ptr noundef %test), !dbg !68
-  store %struct.TestStruct %1, ptr %res, align 8, !dbg !68
-    #dbg_declare(ptr %res, !69, !DIExpression(), !70)
-  %lng.addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !71
-  %2 = load i64, ptr %lng.addr, align 8, !dbg !71
-  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 noundef %2), !dbg !71
-  %4 = getelementptr inbounds nuw %struct.TestStruct, ptr %res, i32 0, i32 1, !dbg !72
-  %5 = call noundef ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !72
-  %6 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr noundef %5), !dbg !72
-  %i.addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !73
-  %7 = load i32, ptr %i.addr, align 4, !dbg !73
-  %8 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 noundef %7), !dbg !73
-  call void @_ZN10TestStruct4dtorEv(ptr noundef nonnull align 8 dereferenceable(40) %res), !dbg !74
-  %9 = load i32, ptr %result, align 4, !dbg !74
-  ret i32 %9, !dbg !74
+  %1 = call noundef %struct.TestStruct @_Z3fctRi(ptr noundef %test), !dbg !66
+  store %struct.TestStruct %1, ptr %res, align 8, !dbg !66
+    #dbg_declare(ptr %res, !67, !DIExpression(), !66)
+  %lng.addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 0, !dbg !68
+  %2 = load i64, ptr %lng.addr, align 8, !dbg !68
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i64 noundef %2), !dbg !68
+  %4 = getelementptr inbounds nuw %struct.TestStruct, ptr %res, i32 0, i32 1, !dbg !69
+  %5 = call noundef ptr @_ZN6String6getRawEv(ptr noundef nonnull align 8 dereferenceable(24) %4), !dbg !69
+  %6 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, ptr noundef %5), !dbg !69
+  %i.addr = getelementptr inbounds %struct.TestStruct, ptr %res, i64 0, i32 2, !dbg !70
+  %7 = load i32, ptr %i.addr, align 4, !dbg !70
+  %8 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 noundef %7), !dbg !70
+  call void @_ZN10TestStruct4dtorEv(ptr noundef nonnull align 8 dereferenceable(40) %res), !dbg !71
+  %9 = load i32, ptr %result, align 4, !dbg !71
+  ret i32 %9, !dbg !71
 }
 
 ; Function Attrs: nofree nounwind
@@ -128,35 +128,32 @@ attributes #2 = { nofree nounwind }
 !40 = !DIDerivedType(tag: DW_TAG_member, name: "i", scope: !27, file: !7, line: 6, baseType: !41, size: 32, offset: 256)
 !41 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
 !42 = !{}
-!43 = !DILocation(line: 3, column: 1, scope: !23)
-!44 = !DILocalVariable(name: "this", arg: 1, scope: !23, file: !7, line: 3, type: !45)
-!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!43 = !DILocalVariable(name: "this", arg: 1, scope: !23, file: !7, line: 3, type: !44)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!45 = !DILocation(line: 3, column: 1, scope: !23)
 !46 = distinct !DISubprogram(name: "fct", linkageName: "_Z3fctRi", scope: !7, file: !7, line: 9, type: !47, scopeLine: 9, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
 !47 = !DISubroutineType(types: !48)
 !48 = !{!27, !49}
 !49 = !DIDerivedType(tag: DW_TAG_reference_type, baseType: !41, size: 64)
 !50 = !DILocalVariable(name: "result", scope: !46, file: !7, line: 9, type: !27)
 !51 = !DILocation(line: 9, column: 1, scope: !46)
-!52 = !DILocation(line: 9, column: 19, scope: !46)
-!53 = !DILocalVariable(name: "ref", arg: 1, scope: !46, file: !7, line: 9, type: !49)
+!52 = !DILocalVariable(name: "ref", arg: 1, scope: !46, file: !7, line: 9, type: !49)
+!53 = !DILocation(line: 9, column: 19, scope: !46)
 !54 = !DILocation(line: 10, column: 44, scope: !46)
 !55 = !DILocation(line: 10, column: 60, scope: !46)
 !56 = !DILocalVariable(name: "ts", scope: !46, file: !7, line: 10, type: !27)
-!57 = !DILocation(line: 10, column: 5, scope: !46)
-!58 = !DILocation(line: 11, column: 12, scope: !46)
-!59 = !DILocation(line: 12, column: 1, scope: !46)
-!60 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !7, file: !7, line: 14, type: !61, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
-!61 = !DISubroutineType(types: !62)
-!62 = !{!41}
-!63 = !DILocalVariable(name: "result", scope: !60, file: !7, line: 14, type: !41)
-!64 = !DILocation(line: 14, column: 1, scope: !60)
-!65 = !DILocation(line: 15, column: 16, scope: !60)
-!66 = !DILocalVariable(name: "test", scope: !60, file: !7, line: 15, type: !41)
-!67 = !DILocation(line: 15, column: 5, scope: !60)
-!68 = !DILocation(line: 16, column: 32, scope: !60)
-!69 = !DILocalVariable(name: "res", scope: !60, file: !7, line: 16, type: !27)
-!70 = !DILocation(line: 16, column: 5, scope: !60)
-!71 = !DILocation(line: 17, column: 26, scope: !60)
-!72 = !DILocation(line: 18, column: 28, scope: !60)
-!73 = !DILocation(line: 19, column: 25, scope: !60)
-!74 = !DILocation(line: 20, column: 1, scope: !60)
+!57 = !DILocation(line: 11, column: 12, scope: !46)
+!58 = !DILocation(line: 12, column: 1, scope: !46)
+!59 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !7, file: !7, line: 14, type: !60, scopeLine: 14, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !42)
+!60 = !DISubroutineType(types: !61)
+!61 = !{!41}
+!62 = !DILocalVariable(name: "result", scope: !59, file: !7, line: 14, type: !41)
+!63 = !DILocation(line: 14, column: 1, scope: !59)
+!64 = !DILocalVariable(name: "test", scope: !59, file: !7, line: 15, type: !41)
+!65 = !DILocation(line: 15, column: 16, scope: !59)
+!66 = !DILocation(line: 16, column: 32, scope: !59)
+!67 = !DILocalVariable(name: "res", scope: !59, file: !7, line: 16, type: !27)
+!68 = !DILocation(line: 17, column: 26, scope: !59)
+!69 = !DILocation(line: 18, column: 28, scope: !59)
+!70 = !DILocation(line: 19, column: 25, scope: !59)
+!71 = !DILocation(line: 20, column: 1, scope: !59)

--- a/test/test-files/irgenerator/instrumentation/success-tsan-and-dbg-info/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-tsan-and-dbg-info/ir-code.ll
@@ -13,81 +13,81 @@ define private void @_Z6workerv() #0 !dbg !15 {
   %1 = call ptr @llvm.returnaddress(i32 0), !dbg !20
   call void @__tsan_func_entry(ptr %1), !dbg !20
   %i = alloca i32, align 4
-  store i32 0, ptr %i, align 4, !dbg !21
-    #dbg_declare(ptr %i, !23, !DIExpression(), !24)
-  br label %for.head.L8, !dbg !24
+    #dbg_declare(ptr %i, !21, !DIExpression(), !23)
+  store i32 0, ptr %i, align 4, !dbg !23
+  br label %for.head.L8, !dbg !23
 
 for.head.L8:                                      ; preds = %for.tail.L8, %0
-  %2 = load i32, ptr %i, align 4, !dbg !25
-  %3 = icmp slt i32 %2, 1000000, !dbg !25
-  br i1 %3, label %for.body.L8, label %for.exit.L8, !dbg !25
+  %2 = load i32, ptr %i, align 4, !dbg !24
+  %3 = icmp slt i32 %2, 1000000, !dbg !24
+  br i1 %3, label %for.body.L8, label %for.exit.L8, !dbg !24
 
 for.body.L8:                                      ; preds = %for.head.L8
-  %4 = load i32, ptr @COUNTER, align 4, !dbg !26
-  %5 = add nsw i32 %4, 1, !dbg !26
-  call void @__tsan_write4(ptr @COUNTER), !dbg !26
-  store i32 %5, ptr @COUNTER, align 4, !dbg !26
-  br label %for.tail.L8, !dbg !27
+  %4 = load i32, ptr @COUNTER, align 4, !dbg !25
+  %5 = add nsw i32 %4, 1, !dbg !25
+  call void @__tsan_write4(ptr @COUNTER), !dbg !25
+  store i32 %5, ptr @COUNTER, align 4, !dbg !25
+  br label %for.tail.L8, !dbg !26
 
 for.tail.L8:                                      ; preds = %for.body.L8
-  %6 = load i32, ptr %i, align 4, !dbg !28
-  %7 = add nsw i32 %6, 1, !dbg !28
-  store i32 %7, ptr %i, align 4, !dbg !28
-  br label %for.head.L8, !dbg !28
+  %6 = load i32, ptr %i, align 4, !dbg !27
+  %7 = add nsw i32 %6, 1, !dbg !27
+  store i32 %7, ptr %i, align 4, !dbg !27
+  br label %for.head.L8, !dbg !27
 
 for.exit.L8:                                      ; preds = %for.head.L8
-  call void @__tsan_func_exit(), !dbg !29
-  ret void, !dbg !29
+  call void @__tsan_func_exit(), !dbg !28
+  ret void, !dbg !28
 }
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone sanitize_thread uwtable
-define dso_local noundef i32 @main() #1 !dbg !30 {
-  %1 = call ptr @llvm.returnaddress(i32 0), !dbg !33
-  call void @__tsan_func_entry(ptr %1), !dbg !33
+define dso_local noundef i32 @main() #1 !dbg !29 {
+  %1 = call ptr @llvm.returnaddress(i32 0), !dbg !32
+  call void @__tsan_func_entry(ptr %1), !dbg !32
   %result = alloca i32, align 4
   %thread1 = alloca %struct.Thread, align 8
   %fat.ptr = alloca { ptr, ptr, i64 }, align 8
   %thread2 = alloca %struct.Thread, align 8
   %fat.ptr1 = alloca { ptr, ptr, i64 }, align 8
-    #dbg_declare(ptr %result, !34, !DIExpression(), !35)
-  store i32 0, ptr %result, align 4, !dbg !35
-  store ptr @_Z6workerv.fatthunk, ptr %fat.ptr, align 8, !dbg !36
-  %2 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr, i32 0, i32 1, !dbg !36
-  store ptr null, ptr %2, align 8, !dbg !36
-  %3 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr, i32 0, i32 2, !dbg !36
-  store i64 0, ptr %3, align 8, !dbg !36
-  %4 = load { ptr, ptr, i64 }, ptr %fat.ptr, align 8, !dbg !36
-  call void @_ZN6Thread4ctorEPFvE(ptr noundef nonnull align 8 dereferenceable(48) %thread1, { ptr, ptr, i64 } noundef %4), !dbg !36
-    #dbg_declare(ptr %thread1, !37, !DIExpression(), !57)
-  store ptr @_Z6workerv.fatthunk, ptr %fat.ptr1, align 8, !dbg !58
-  %5 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr1, i32 0, i32 1, !dbg !58
-  store ptr null, ptr %5, align 8, !dbg !58
-  %6 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr1, i32 0, i32 2, !dbg !58
-  store i64 0, ptr %6, align 8, !dbg !58
-  %7 = load { ptr, ptr, i64 }, ptr %fat.ptr1, align 8, !dbg !58
-  call void @_ZN6Thread4ctorEPFvE(ptr noundef nonnull align 8 dereferenceable(48) %thread2, { ptr, ptr, i64 } noundef %7), !dbg !58
-    #dbg_declare(ptr %thread2, !59, !DIExpression(), !60)
-  call void @_ZN6Thread3runEv(ptr noundef nonnull align 8 dereferenceable(48) %thread1), !dbg !61
-  call void @_ZN6Thread3runEv(ptr noundef nonnull align 8 dereferenceable(48) %thread2), !dbg !62
-  call void @_ZN6Thread4joinEv(ptr noundef nonnull align 8 dereferenceable(48) %thread1), !dbg !63
-  call void @_ZN6Thread4joinEv(ptr noundef nonnull align 8 dereferenceable(48) %thread2), !dbg !64
-  call void @_ZN6Thread4dtorEv(ptr noundef nonnull align 8 dereferenceable(48) %thread2), !dbg !65
-  call void @_ZN6Thread4dtorEv(ptr noundef nonnull align 8 dereferenceable(48) %thread1), !dbg !65
-  %8 = load i32, ptr %result, align 4, !dbg !65
-  call void @__tsan_func_exit(), !dbg !65
-  ret i32 %8, !dbg !65
+    #dbg_declare(ptr %result, !33, !DIExpression(), !34)
+  store i32 0, ptr %result, align 4, !dbg !34
+  store ptr @_Z6workerv.fatthunk, ptr %fat.ptr, align 8, !dbg !35
+  %2 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr, i32 0, i32 1, !dbg !35
+  store ptr null, ptr %2, align 8, !dbg !35
+  %3 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr, i32 0, i32 2, !dbg !35
+  store i64 0, ptr %3, align 8, !dbg !35
+  %4 = load { ptr, ptr, i64 }, ptr %fat.ptr, align 8, !dbg !35
+  call void @_ZN6Thread4ctorEPFvE(ptr noundef nonnull align 8 dereferenceable(48) %thread1, { ptr, ptr, i64 } noundef %4), !dbg !35
+    #dbg_declare(ptr %thread1, !36, !DIExpression(), !35)
+  store ptr @_Z6workerv.fatthunk, ptr %fat.ptr1, align 8, !dbg !56
+  %5 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr1, i32 0, i32 1, !dbg !56
+  store ptr null, ptr %5, align 8, !dbg !56
+  %6 = getelementptr inbounds nuw { ptr, ptr, i64 }, ptr %fat.ptr1, i32 0, i32 2, !dbg !56
+  store i64 0, ptr %6, align 8, !dbg !56
+  %7 = load { ptr, ptr, i64 }, ptr %fat.ptr1, align 8, !dbg !56
+  call void @_ZN6Thread4ctorEPFvE(ptr noundef nonnull align 8 dereferenceable(48) %thread2, { ptr, ptr, i64 } noundef %7), !dbg !56
+    #dbg_declare(ptr %thread2, !57, !DIExpression(), !56)
+  call void @_ZN6Thread3runEv(ptr noundef nonnull align 8 dereferenceable(48) %thread1), !dbg !58
+  call void @_ZN6Thread3runEv(ptr noundef nonnull align 8 dereferenceable(48) %thread2), !dbg !59
+  call void @_ZN6Thread4joinEv(ptr noundef nonnull align 8 dereferenceable(48) %thread1), !dbg !60
+  call void @_ZN6Thread4joinEv(ptr noundef nonnull align 8 dereferenceable(48) %thread2), !dbg !61
+  call void @_ZN6Thread4dtorEv(ptr noundef nonnull align 8 dereferenceable(48) %thread2), !dbg !62
+  call void @_ZN6Thread4dtorEv(ptr noundef nonnull align 8 dereferenceable(48) %thread1), !dbg !62
+  %8 = load i32, ptr %result, align 4, !dbg !62
+  call void @__tsan_func_exit(), !dbg !62
+  ret i32 %8, !dbg !62
 }
 
 define private void @_Z6workerv.fatthunk(ptr %0) personality ptr @__gcc_personality_v0 {
 entry:
-  %1 = call ptr @llvm.returnaddress(i32 0), !dbg !36
-  call void @__tsan_func_entry(ptr %1), !dbg !36
+  %1 = call ptr @llvm.returnaddress(i32 0), !dbg !35
+  call void @__tsan_func_entry(ptr %1), !dbg !35
   invoke void @_Z6workerv()
-          to label %.noexc unwind label %tsan_cleanup, !dbg !36
+          to label %.noexc unwind label %tsan_cleanup, !dbg !35
 
 .noexc:                                           ; preds = %entry
-  call void @__tsan_func_exit(), !dbg !36
-  ret void, !dbg !36
+  call void @__tsan_func_exit(), !dbg !35
+  ret void, !dbg !35
 
 tsan_cleanup:                                     ; preds = %entry
   %cleanup.lpad = landingpad { ptr, i32 }
@@ -481,48 +481,45 @@ attributes #4 = { nocallback nofree nosync nounwind willreturn memory(none) }
 !18 = !DIBasicType(name: "void", encoding: DW_ATE_unsigned)
 !19 = !{}
 !20 = !DILocation(line: 0, scope: !15)
-!21 = !DILocation(line: 8, column: 17, scope: !22)
+!21 = !DILocalVariable(name: "i", scope: !22, file: !5, line: 8, type: !6)
 !22 = distinct !DILexicalBlock(scope: !15, file: !5, line: 8, column: 5)
-!23 = !DILocalVariable(name: "i", scope: !22, file: !5, line: 8, type: !6)
-!24 = !DILocation(line: 8, column: 9, scope: !22)
-!25 = !DILocation(line: 8, column: 24, scope: !22)
-!26 = !DILocation(line: 9, column: 9, scope: !22)
-!27 = !DILocation(line: 10, column: 5, scope: !22)
-!28 = !DILocation(line: 8, column: 33, scope: !22)
-!29 = !DILocation(line: 11, column: 1, scope: !15)
-!30 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !5, file: !5, line: 13, type: !31, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !19)
-!31 = !DISubroutineType(types: !32)
-!32 = !{!6}
-!33 = !DILocation(line: 0, scope: !30)
-!34 = !DILocalVariable(name: "result", scope: !30, file: !5, line: 13, type: !6)
-!35 = !DILocation(line: 13, column: 1, scope: !30)
-!36 = !DILocation(line: 14, column: 29, scope: !30)
-!37 = !DILocalVariable(name: "thread1", scope: !30, file: !5, line: 14, type: !38)
-!38 = !DICompositeType(tag: DW_TAG_structure_type, name: "Thread", scope: !5, file: !5, line: 23, size: 384, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !39, identifier: "struct.Thread")
-!39 = !{!40, !55}
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "threadRoutine", scope: !38, file: !5, line: 24, baseType: !41, size: 320, align: 8)
-!41 = !DICompositeType(tag: DW_TAG_structure_type, name: "Lambda", scope: !5, file: !5, line: 31, size: 320, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !42, identifier: "struct.Lambda")
-!42 = !{!43, !51, !54}
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "native", scope: !41, file: !5, line: 32, baseType: !44, size: 192, align: 8)
-!44 = !DICompositeType(tag: DW_TAG_structure_type, name: "_lambda", scope: !5, file: !5, size: 192, align: 8, flags: DIFlagTypePassByValue | DIFlagNonTrivial, elements: !45, identifier: "_lambda")
-!45 = !{!46, !48, !49}
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "fct", scope: !44, file: !5, baseType: !47, size: 64, align: 8)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64, align: 8)
-!48 = !DIDerivedType(tag: DW_TAG_member, name: "captures", scope: !44, file: !5, baseType: !47, size: 64, align: 8, offset: 64)
-!49 = !DIDerivedType(tag: DW_TAG_member, name: "captureSize", scope: !44, file: !5, baseType: !50, size: 64, align: 8, offset: 128)
-!50 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
-!51 = !DIDerivedType(tag: DW_TAG_member, name: "ownedCaptures", scope: !41, file: !5, line: 33, baseType: !52, size: 64, offset: 192)
-!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
-!53 = !DIBasicType(name: "byte", size: 8, encoding: DW_ATE_unsigned)
-!54 = !DIDerivedType(tag: DW_TAG_member, name: "captureSize", scope: !41, file: !5, line: 34, baseType: !50, size: 64, offset: 256)
-!55 = !DIDerivedType(tag: DW_TAG_member, name: "threadId", scope: !38, file: !5, line: 25, baseType: !56, size: 64, offset: 320)
-!56 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!57 = !DILocation(line: 14, column: 5, scope: !30)
-!58 = !DILocation(line: 15, column: 29, scope: !30)
-!59 = !DILocalVariable(name: "thread2", scope: !30, file: !5, line: 15, type: !38)
-!60 = !DILocation(line: 15, column: 5, scope: !30)
-!61 = !DILocation(line: 16, column: 5, scope: !30)
-!62 = !DILocation(line: 17, column: 5, scope: !30)
-!63 = !DILocation(line: 18, column: 5, scope: !30)
-!64 = !DILocation(line: 19, column: 5, scope: !30)
-!65 = !DILocation(line: 20, column: 1, scope: !30)
+!23 = !DILocation(line: 8, column: 17, scope: !22)
+!24 = !DILocation(line: 8, column: 24, scope: !22)
+!25 = !DILocation(line: 9, column: 9, scope: !22)
+!26 = !DILocation(line: 10, column: 5, scope: !22)
+!27 = !DILocation(line: 8, column: 33, scope: !22)
+!28 = !DILocation(line: 11, column: 1, scope: !15)
+!29 = distinct !DISubprogram(name: "main", linkageName: "_Z4mainv", scope: !5, file: !5, line: 13, type: !30, scopeLine: 13, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !2, retainedNodes: !19)
+!30 = !DISubroutineType(types: !31)
+!31 = !{!6}
+!32 = !DILocation(line: 0, scope: !29)
+!33 = !DILocalVariable(name: "result", scope: !29, file: !5, line: 13, type: !6)
+!34 = !DILocation(line: 13, column: 1, scope: !29)
+!35 = !DILocation(line: 14, column: 29, scope: !29)
+!36 = !DILocalVariable(name: "thread1", scope: !29, file: !5, line: 14, type: !37)
+!37 = !DICompositeType(tag: DW_TAG_structure_type, name: "Thread", scope: !5, file: !5, line: 23, size: 384, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !38, identifier: "struct.Thread")
+!38 = !{!39, !54}
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "threadRoutine", scope: !37, file: !5, line: 24, baseType: !40, size: 320, align: 8)
+!40 = !DICompositeType(tag: DW_TAG_structure_type, name: "Lambda", scope: !5, file: !5, line: 31, size: 320, align: 8, flags: DIFlagTypePassByReference | DIFlagNonTrivial, elements: !41, identifier: "struct.Lambda")
+!41 = !{!42, !50, !53}
+!42 = !DIDerivedType(tag: DW_TAG_member, name: "native", scope: !40, file: !5, line: 32, baseType: !43, size: 192, align: 8)
+!43 = !DICompositeType(tag: DW_TAG_structure_type, name: "_lambda", scope: !5, file: !5, size: 192, align: 8, flags: DIFlagTypePassByValue | DIFlagNonTrivial, elements: !44, identifier: "_lambda")
+!44 = !{!45, !47, !48}
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "fct", scope: !43, file: !5, baseType: !46, size: 64, align: 8)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !18, size: 64, align: 8)
+!47 = !DIDerivedType(tag: DW_TAG_member, name: "captures", scope: !43, file: !5, baseType: !46, size: 64, align: 8, offset: 64)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "captureSize", scope: !43, file: !5, baseType: !49, size: 64, align: 8, offset: 128)
+!49 = !DIBasicType(name: "unsigned long", size: 64, encoding: DW_ATE_unsigned)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "ownedCaptures", scope: !40, file: !5, line: 33, baseType: !51, size: 64, offset: 192)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DIBasicType(name: "byte", size: 8, encoding: DW_ATE_unsigned)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "captureSize", scope: !40, file: !5, line: 34, baseType: !49, size: 64, offset: 256)
+!54 = !DIDerivedType(tag: DW_TAG_member, name: "threadId", scope: !37, file: !5, line: 25, baseType: !55, size: 64, offset: 320)
+!55 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!56 = !DILocation(line: 15, column: 29, scope: !29)
+!57 = !DILocalVariable(name: "thread2", scope: !29, file: !5, line: 15, type: !37)
+!58 = !DILocation(line: 16, column: 5, scope: !29)
+!59 = !DILocation(line: 17, column: 5, scope: !29)
+!60 = !DILocation(line: 18, column: 5, scope: !29)
+!61 = !DILocation(line: 19, column: 5, scope: !29)
+!62 = !DILocation(line: 20, column: 1, scope: !29)

--- a/test/test-files/irgenerator/instrumentation/success-tysan-and-dbg-info/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/instrumentation/success-tysan-and-dbg-info/ir-code-macos-amd64.ll
@@ -29,22 +29,22 @@ define dso_local noundef i32 @main() #0 !dbg !9 {
   call void @__tysan_instrument_mem_inst(ptr %ptr, ptr null, i64 8, i1 false), !dbg !17
   call void @__tysan_instrument_with_shadow_update(ptr %result, ptr @__tysan_v1_int_o_0, i1 true, i64 4, i32 2), !dbg !17
   store i32 0, ptr %result, align 4, !dbg !17, !tbaa !20
-  call void @__tysan_instrument_with_shadow_update(ptr %l, ptr @__tysan_v1_long_o_0, i1 true, i64 8, i32 2), !dbg !24
-  store i64 100, ptr %l, align 8, !dbg !24, !tbaa !25
-    #dbg_declare(ptr %l, !27, !DIExpression(), !29)
-  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr @__tysan_v1_double_2a_o_0, i1 true, i64 8, i32 2), !dbg !30
-  store ptr %l, ptr %ptr, align 8, !dbg !30, !tbaa !32
-    #dbg_declare(ptr %ptr, !34, !DIExpression(), !37)
-  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr null, i1 true, i64 8, i32 1), !dbg !38
-  %1 = load ptr, ptr %ptr, align 8, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr @__tysan_v1_double_o_0, i1 true, i64 8, i32 1), !dbg !38
-  %2 = load double, ptr %1, align 8, !dbg !38, !tbaa !39
-  %3 = fadd double %2, 2.000000e+00, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr null, i1 true, i64 8, i32 2), !dbg !38
-  store double %3, ptr %1, align 8, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %result, ptr null, i1 true, i64 4, i32 1), !dbg !41
-  %4 = load i32, ptr %result, align 4, !dbg !41
-  ret i32 %4, !dbg !41
+    #dbg_declare(ptr %l, !24, !DIExpression(), !26)
+  call void @__tysan_instrument_with_shadow_update(ptr %l, ptr @__tysan_v1_long_o_0, i1 true, i64 8, i32 2), !dbg !26
+  store i64 100, ptr %l, align 8, !dbg !26, !tbaa !27
+    #dbg_declare(ptr %ptr, !29, !DIExpression(), !33)
+  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr @__tysan_v1_double_2a_o_0, i1 true, i64 8, i32 2), !dbg !33
+  store ptr %l, ptr %ptr, align 8, !dbg !33, !tbaa !34
+  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr null, i1 true, i64 8, i32 1), !dbg !36
+  %1 = load ptr, ptr %ptr, align 8, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr @__tysan_v1_double_o_0, i1 true, i64 8, i32 1), !dbg !36
+  %2 = load double, ptr %1, align 8, !dbg !36, !tbaa !37
+  %3 = fadd double %2, 2.000000e+00, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr null, i1 true, i64 8, i32 2), !dbg !36
+  store double %3, ptr %1, align 8, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %result, ptr null, i1 true, i64 4, i32 1), !dbg !39
+  %4 = load i32, ptr %result, align 4, !dbg !39
+  ret i32 %4, !dbg !39
 }
 
 declare void @__tysan_init()
@@ -99,21 +99,19 @@ attributes #2 = { nounwind }
 !21 = !{!"int", !22, i64 0}
 !22 = !{!"omnipotent byte", !23, i64 0}
 !23 = !{!"Simple Spice TBAA"}
-!24 = !DILocation(line: 4, column: 14, scope: !9)
-!25 = !{!26, !26, i64 0}
-!26 = !{!"long", !22, i64 0}
-!27 = !DILocalVariable(name: "l", scope: !9, file: !10, line: 4, type: !28)
-!28 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!29 = !DILocation(line: 4, column: 5, scope: !9)
-!30 = !DILocation(line: 6, column: 37, scope: !31)
-!31 = distinct !DILexicalBlock(scope: !9, file: !10, line: 5, column: 5)
-!32 = !{!33, !33, i64 0}
-!33 = !{!"double*", !22, i64 0}
-!34 = !DILocalVariable(name: "ptr", scope: !31, file: !10, line: 6, type: !35)
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
-!37 = !DILocation(line: 6, column: 8, scope: !31)
-!38 = !DILocation(line: 7, column: 9, scope: !31)
-!39 = !{!40, !40, i64 0}
-!40 = !{!"double", !22, i64 0}
-!41 = !DILocation(line: 9, column: 1, scope: !9)
+!24 = !DILocalVariable(name: "l", scope: !9, file: !10, line: 4, type: !25)
+!25 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!26 = !DILocation(line: 4, column: 14, scope: !9)
+!27 = !{!28, !28, i64 0}
+!28 = !{!"long", !22, i64 0}
+!29 = !DILocalVariable(name: "ptr", scope: !30, file: !10, line: 6, type: !31)
+!30 = distinct !DILexicalBlock(scope: !9, file: !10, line: 5, column: 5)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
+!33 = !DILocation(line: 6, column: 37, scope: !30)
+!34 = !{!35, !35, i64 0}
+!35 = !{!"double*", !22, i64 0}
+!36 = !DILocation(line: 7, column: 9, scope: !30)
+!37 = !{!38, !38, i64 0}
+!38 = !{!"double", !22, i64 0}
+!39 = !DILocation(line: 9, column: 1, scope: !9)

--- a/test/test-files/irgenerator/instrumentation/success-tysan-and-dbg-info/ir-code-windows.ll
+++ b/test/test-files/irgenerator/instrumentation/success-tysan-and-dbg-info/ir-code-windows.ll
@@ -29,22 +29,22 @@ define dso_local noundef i32 @main() #0 !dbg !9 {
   call void @__tysan_instrument_mem_inst(ptr %ptr, ptr null, i64 8, i1 false), !dbg !17
   call void @__tysan_instrument_with_shadow_update(ptr %result, ptr @__tysan_v1_int_o_0, i1 true, i64 4, i32 2), !dbg !17
   store i32 0, ptr %result, align 4, !dbg !17, !tbaa !20
-  call void @__tysan_instrument_with_shadow_update(ptr %l, ptr @__tysan_v1_long_o_0, i1 true, i64 8, i32 2), !dbg !24
-  store i64 100, ptr %l, align 8, !dbg !24, !tbaa !25
-    #dbg_declare(ptr %l, !27, !DIExpression(), !29)
-  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr @__tysan_v1_double_2a_o_0, i1 true, i64 8, i32 2), !dbg !30
-  store ptr %l, ptr %ptr, align 8, !dbg !30, !tbaa !32
-    #dbg_declare(ptr %ptr, !34, !DIExpression(), !37)
-  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr null, i1 true, i64 8, i32 1), !dbg !38
-  %1 = load ptr, ptr %ptr, align 8, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr @__tysan_v1_double_o_0, i1 true, i64 8, i32 1), !dbg !38
-  %2 = load double, ptr %1, align 8, !dbg !38, !tbaa !39
-  %3 = fadd double %2, 2.000000e+00, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr null, i1 true, i64 8, i32 2), !dbg !38
-  store double %3, ptr %1, align 8, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %result, ptr null, i1 true, i64 4, i32 1), !dbg !41
-  %4 = load i32, ptr %result, align 4, !dbg !41
-  ret i32 %4, !dbg !41
+    #dbg_declare(ptr %l, !24, !DIExpression(), !26)
+  call void @__tysan_instrument_with_shadow_update(ptr %l, ptr @__tysan_v1_long_o_0, i1 true, i64 8, i32 2), !dbg !26
+  store i64 100, ptr %l, align 8, !dbg !26, !tbaa !27
+    #dbg_declare(ptr %ptr, !29, !DIExpression(), !33)
+  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr @__tysan_v1_double_2a_o_0, i1 true, i64 8, i32 2), !dbg !33
+  store ptr %l, ptr %ptr, align 8, !dbg !33, !tbaa !34
+  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr null, i1 true, i64 8, i32 1), !dbg !36
+  %1 = load ptr, ptr %ptr, align 8, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr @__tysan_v1_double_o_0, i1 true, i64 8, i32 1), !dbg !36
+  %2 = load double, ptr %1, align 8, !dbg !36, !tbaa !37
+  %3 = fadd double %2, 2.000000e+00, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr null, i1 true, i64 8, i32 2), !dbg !36
+  store double %3, ptr %1, align 8, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %result, ptr null, i1 true, i64 4, i32 1), !dbg !39
+  %4 = load i32, ptr %result, align 4, !dbg !39
+  ret i32 %4, !dbg !39
 }
 
 declare void @__tysan_init()
@@ -99,21 +99,19 @@ attributes #2 = { nounwind }
 !21 = !{!"int", !22, i64 0}
 !22 = !{!"omnipotent byte", !23, i64 0}
 !23 = !{!"Simple Spice TBAA"}
-!24 = !DILocation(line: 4, column: 14, scope: !9)
-!25 = !{!26, !26, i64 0}
-!26 = !{!"long", !22, i64 0}
-!27 = !DILocalVariable(name: "l", scope: !9, file: !10, line: 4, type: !28)
-!28 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!29 = !DILocation(line: 4, column: 5, scope: !9)
-!30 = !DILocation(line: 6, column: 37, scope: !31)
-!31 = distinct !DILexicalBlock(scope: !9, file: !10, line: 5, column: 5)
-!32 = !{!33, !33, i64 0}
-!33 = !{!"double*", !22, i64 0}
-!34 = !DILocalVariable(name: "ptr", scope: !31, file: !10, line: 6, type: !35)
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
-!37 = !DILocation(line: 6, column: 8, scope: !31)
-!38 = !DILocation(line: 7, column: 9, scope: !31)
-!39 = !{!40, !40, i64 0}
-!40 = !{!"double", !22, i64 0}
-!41 = !DILocation(line: 9, column: 1, scope: !9)
+!24 = !DILocalVariable(name: "l", scope: !9, file: !10, line: 4, type: !25)
+!25 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!26 = !DILocation(line: 4, column: 14, scope: !9)
+!27 = !{!28, !28, i64 0}
+!28 = !{!"long", !22, i64 0}
+!29 = !DILocalVariable(name: "ptr", scope: !30, file: !10, line: 6, type: !31)
+!30 = distinct !DILexicalBlock(scope: !9, file: !10, line: 5, column: 5)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
+!33 = !DILocation(line: 6, column: 37, scope: !30)
+!34 = !{!35, !35, i64 0}
+!35 = !{!"double*", !22, i64 0}
+!36 = !DILocation(line: 7, column: 9, scope: !30)
+!37 = !{!38, !38, i64 0}
+!38 = !{!"double", !22, i64 0}
+!39 = !DILocation(line: 9, column: 1, scope: !9)

--- a/test/test-files/irgenerator/instrumentation/success-tysan-and-dbg-info/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-tysan-and-dbg-info/ir-code.ll
@@ -49,22 +49,22 @@ define dso_local noundef i32 @main() #0 !dbg !9 {
   call void @__tysan_instrument_mem_inst(ptr %ptr, ptr null, i64 8, i1 false), !dbg !17
   call void @__tysan_instrument_with_shadow_update(ptr %result, ptr @__tysan_v1_int_o_0, i1 true, i64 4, i32 2), !dbg !17
   store i32 0, ptr %result, align 4, !dbg !17, !tbaa !20
-  call void @__tysan_instrument_with_shadow_update(ptr %l, ptr @__tysan_v1_long_o_0, i1 true, i64 8, i32 2), !dbg !24
-  store i64 100, ptr %l, align 8, !dbg !24, !tbaa !25
-    #dbg_declare(ptr %l, !27, !DIExpression(), !29)
-  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr @__tysan_v1_double_2a_o_0, i1 true, i64 8, i32 2), !dbg !30
-  store ptr %l, ptr %ptr, align 8, !dbg !30, !tbaa !32
-    #dbg_declare(ptr %ptr, !34, !DIExpression(), !37)
-  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr null, i1 true, i64 8, i32 1), !dbg !38
-  %1 = load ptr, ptr %ptr, align 8, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr @__tysan_v1_double_o_0, i1 true, i64 8, i32 1), !dbg !38
-  %2 = load double, ptr %1, align 8, !dbg !38, !tbaa !39
-  %3 = fadd double %2, 2.000000e+00, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr null, i1 true, i64 8, i32 2), !dbg !38
-  store double %3, ptr %1, align 8, !dbg !38
-  call void @__tysan_instrument_with_shadow_update(ptr %result, ptr null, i1 true, i64 4, i32 1), !dbg !41
-  %4 = load i32, ptr %result, align 4, !dbg !41
-  ret i32 %4, !dbg !41
+    #dbg_declare(ptr %l, !24, !DIExpression(), !26)
+  call void @__tysan_instrument_with_shadow_update(ptr %l, ptr @__tysan_v1_long_o_0, i1 true, i64 8, i32 2), !dbg !26
+  store i64 100, ptr %l, align 8, !dbg !26, !tbaa !27
+    #dbg_declare(ptr %ptr, !29, !DIExpression(), !33)
+  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr @__tysan_v1_double_2a_o_0, i1 true, i64 8, i32 2), !dbg !33
+  store ptr %l, ptr %ptr, align 8, !dbg !33, !tbaa !34
+  call void @__tysan_instrument_with_shadow_update(ptr %ptr, ptr null, i1 true, i64 8, i32 1), !dbg !36
+  %1 = load ptr, ptr %ptr, align 8, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr @__tysan_v1_double_o_0, i1 true, i64 8, i32 1), !dbg !36
+  %2 = load double, ptr %1, align 8, !dbg !36, !tbaa !37
+  %3 = fadd double %2, 2.000000e+00, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %1, ptr null, i1 true, i64 8, i32 2), !dbg !36
+  store double %3, ptr %1, align 8, !dbg !36
+  call void @__tysan_instrument_with_shadow_update(ptr %result, ptr null, i1 true, i64 4, i32 1), !dbg !39
+  %4 = load i32, ptr %result, align 4, !dbg !39
+  ret i32 %4, !dbg !39
 }
 
 declare void @__tysan_init()
@@ -119,21 +119,19 @@ attributes #2 = { nounwind }
 !21 = !{!"int", !22, i64 0}
 !22 = !{!"omnipotent byte", !23, i64 0}
 !23 = !{!"Simple Spice TBAA"}
-!24 = !DILocation(line: 4, column: 14, scope: !9)
-!25 = !{!26, !26, i64 0}
-!26 = !{!"long", !22, i64 0}
-!27 = !DILocalVariable(name: "l", scope: !9, file: !10, line: 4, type: !28)
-!28 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!29 = !DILocation(line: 4, column: 5, scope: !9)
-!30 = !DILocation(line: 6, column: 37, scope: !31)
-!31 = distinct !DILexicalBlock(scope: !9, file: !10, line: 5, column: 5)
-!32 = !{!33, !33, i64 0}
-!33 = !{!"double*", !22, i64 0}
-!34 = !DILocalVariable(name: "ptr", scope: !31, file: !10, line: 6, type: !35)
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
-!37 = !DILocation(line: 6, column: 8, scope: !31)
-!38 = !DILocation(line: 7, column: 9, scope: !31)
-!39 = !{!40, !40, i64 0}
-!40 = !{!"double", !22, i64 0}
-!41 = !DILocation(line: 9, column: 1, scope: !9)
+!24 = !DILocalVariable(name: "l", scope: !9, file: !10, line: 4, type: !25)
+!25 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
+!26 = !DILocation(line: 4, column: 14, scope: !9)
+!27 = !{!28, !28, i64 0}
+!28 = !{!"long", !22, i64 0}
+!29 = !DILocalVariable(name: "ptr", scope: !30, file: !10, line: 6, type: !31)
+!30 = distinct !DILexicalBlock(scope: !9, file: !10, line: 5, column: 5)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "double", size: 64, encoding: DW_ATE_float)
+!33 = !DILocation(line: 6, column: 37, scope: !30)
+!34 = !{!35, !35, i64 0}
+!35 = !{!"double*", !22, i64 0}
+!36 = !DILocation(line: 7, column: 9, scope: !30)
+!37 = !{!38, !38, i64 0}
+!38 = !{!"double", !22, i64 0}
+!39 = !DILocation(line: 9, column: 1, scope: !9)


### PR DESCRIPTION
## What changed

Move `generateLocalVarDebugInfo` (which emits the `#dbg_declare` intrinsic) to immediately follow `insertAlloca`, before any `insertStore`, at every alloca site in the IR generator:

- **`GenStatements.cpp`** — `visitDeclStmt`: copy-ctor path and default-value path
- **`IRGenerator.cpp`** — `doAssignment`: reference-decl, temp-steal, and plain alloca paths
- **`GenTopLevelDefinitions.cpp`** — main function and `visitFctDef`/`visitProcDef` parameter prologues
- **`GenValues.cpp`** — lambda function/procedure/expression parameter prologues
- **`GenImplicit.cpp`** — implicit function/procedure `this`-pointer setup

Also consolidates the `setSourceLocation` call for scope cleanup: removed the duplicated call from `visitStmtLst` and `terminateBlock`, centralising it in `generateScopeCleanup`.

Updated all affected reference IR files under `test/test-files/irgenerator/instrumentation/`.

## Why

LLVM and DWARF debuggers require `llvm.dbg.declare` to appear before the first store to a variable so that the variable is considered live from its declaration point. Previously `#dbg_declare` was emitted after the initializer store, so stepping into a freshly-entered function in a debugger would not show local variables on the first line.

Clang emits:
```llvm
#dbg_declare(ptr %i, ...)   ; declare — before any store
store i32 1, ptr %i, ...    ; initialise
```

Spice was emitting:
```llvm
store i32 1, ptr %i, ...    ; initialise — declare comes too late
#dbg_declare(ptr %i, ...)
```

## How it was validated

- Built with `cmake --build cmake-build-debug --target spice spicetest`
- Manually verified corrected IR ordering with `spice build -O0 -ir --debug-info`; all `#dbg_declare` intrinsics now precede their corresponding stores
- `cmake-build-debug/test/spicetest` passed all non-environment-dependent tests

## Follow-up

The remaining debug info differences noted during analysis (per-sub-expression DILocations, `result` variable marked artificial) are tracked separately.