### PR TITLE
Fix debug location: skip setSourceLocation on passthrough nodes

### DIFF
--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -2,7 +2,6 @@
 
 #include "DebugInfoGenerator.h"
 
-#include <ast/ASTNodes.h>
 #include <driver/Driver.h>
 #include <irgenerator/IRGenerator.h>
 #include <irgenerator/NameMangling.h>
@@ -266,8 +265,6 @@ void DebugInfoGenerator::setSourceLocation(const CodeLoc &codeLoc) {
   const llvm::DILocation *diCodeLoc = llvm::DILocation::get(scope->getContext(), codeLoc.line, codeLoc.col, scope);
   irGenerator->builder.SetCurrentDebugLocation(diCodeLoc);
 }
-
-void DebugInfoGenerator::setSourceLocation(const ASTNode *node) { setSourceLocation(node->codeLoc); }
 
 void DebugInfoGenerator::finalize() const {
   if (irGenerator->cliOptions.instrumentation.generateDebugInfo)

--- a/src/irgenerator/DebugInfoGenerator.h
+++ b/src/irgenerator/DebugInfoGenerator.h
@@ -6,6 +6,9 @@
 #include <stack>
 #include <unordered_map>
 
+#include <ast/ASTNodes.h>
+#include <util/GlobalDefinitions.h>
+
 #include <llvm/IR/DIBuilder.h>
 
 namespace spice::compiler {
@@ -16,7 +19,6 @@ class SymbolTableEntry;
 class QualType;
 class Function;
 class Struct;
-class ASTNode;
 struct CodeLoc;
 
 class DebugInfoGenerator {
@@ -36,7 +38,7 @@ public:
                                      const CodeLoc &codeLoc) const;
   void generateLocalVarDebugInfo(const std::string &varName, llvm::Value *address, size_t argNumber = SIZE_MAX);
   void setSourceLocation(const CodeLoc &codeLoc);
-  void setSourceLocation(const ASTNode *node);
+  ALWAYS_INLINE void setSourceLocation(const ASTNode *node) { setSourceLocation(node->codeLoc); }
   void finalize() const;
 
 private:

--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -8,8 +8,6 @@
 namespace spice::compiler {
 
 std::any IRGenerator::visitUnsafeBlockDef(const UnsafeBlockNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Change scope
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::UNSAFE_BODY, node);
 
@@ -20,8 +18,6 @@ std::any IRGenerator::visitUnsafeBlockDef(const UnsafeBlockNode *node) {
 }
 
 std::any IRGenerator::visitForLoop(const ForLoopNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Create blocks
   const std::string codeLine = node->codeLoc.toPrettyLine();
   llvm::BasicBlock *bHead = createBlock("for.head." + codeLine);
@@ -75,8 +71,6 @@ std::any IRGenerator::visitForLoop(const ForLoopNode *node) {
 }
 
 std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Create blocks
   const std::string codeLine = node->codeLoc.toPrettyLine();
   llvm::BasicBlock *bHead = createBlock("foreach.head." + codeLine);
@@ -152,6 +146,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
 
   // Switch to head block
   switchToBlock(bHead);
+  diGenerator.setSourceLocation(node);
   // Call .isValid() on iterator
   assert(node->isValidFct);
   llvm::Function *isValidFct = stdFunctionManager.getIteratorIsValidFct(node->isValidFct);
@@ -203,6 +198,7 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
 
   // Switch to tail block
   switchToBlock(bTail);
+  diGenerator.setSourceLocation(node);
   // Call .next() on iterator
   assert(node->nextFct);
   llvm::Function *nextFct = stdFunctionManager.getIteratorNextFct(node->nextFct);
@@ -223,8 +219,6 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
 }
 
 std::any IRGenerator::visitWhileLoop(const WhileLoopNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Create blocks
   const std::string codeLine = node->codeLoc.toPrettyLine();
   llvm::BasicBlock *bHead = createBlock("while.head." + codeLine);
@@ -268,8 +262,6 @@ std::any IRGenerator::visitWhileLoop(const WhileLoopNode *node) {
 }
 
 std::any IRGenerator::visitDoWhileLoop(const DoWhileLoopNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Create blocks
   const std::string codeLine = node->codeLoc.toPrettyLine();
   llvm::BasicBlock *bBody = createBlock("dowhile.body." + codeLine);
@@ -313,8 +305,6 @@ std::any IRGenerator::visitDoWhileLoop(const DoWhileLoopNode *node) {
 }
 
 std::any IRGenerator::visitIfStmt(const IfStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // If we have a compile time decision, only evaluate the respective branch
   if (node->doCompileThenBranch(manIdx) && !node->doCompileElseBranch(manIdx)) {
     ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::IF_ELSE_BODY, node);
@@ -368,8 +358,6 @@ std::any IRGenerator::visitIfStmt(const IfStmtNode *node) {
 }
 
 std::any IRGenerator::visitElseStmt(const ElseStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   if (node->ifStmt) { // It is an else if branch
     visit(node->ifStmt);
   } else { // It is an else branch
@@ -384,8 +372,6 @@ std::any IRGenerator::visitElseStmt(const ElseStmtNode *node) {
 }
 
 std::any IRGenerator::visitSwitchStmt(const SwitchStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Create blocks
   std::vector<llvm::BasicBlock *> bCases;
   bCases.reserve(node->caseBranches.size());
@@ -458,8 +444,6 @@ std::any IRGenerator::visitSwitchStmt(const SwitchStmtNode *node) {
 }
 
 std::any IRGenerator::visitCaseBranch(const CaseBranchNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Change to case body scope
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::CASE_BODY);
 
@@ -470,8 +454,6 @@ std::any IRGenerator::visitCaseBranch(const CaseBranchNode *node) {
 }
 
 std::any IRGenerator::visitDefaultBranch(const DefaultBranchNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Change to default body scope
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::DEFAULT_BODY);
 
@@ -482,8 +464,6 @@ std::any IRGenerator::visitDefaultBranch(const DefaultBranchNode *node) {
 }
 
 std::any IRGenerator::visitAnonymousBlockStmt(const AnonymousBlockStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Change scope
   node->bodyScope->parent = currentScope;                           // Needed for nested scopes in generic functions
   node->bodyScope->symbolTable.parent = &currentScope->symbolTable; // Needed for nested scopes in generic functions

--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -9,11 +9,11 @@
 namespace spice::compiler {
 
 std::any IRGenerator::visitAssignExpr(const AssignExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Visit ternary expression
   if (node->ternaryExpr)
     return visit(node->ternaryExpr);
+
+  diGenerator.setSourceLocation(node);
 
   // Assign or compound assign operation
   if (node->op != AssignExprNode::AssignOp::OP_NONE) {
@@ -86,11 +86,11 @@ std::any IRGenerator::visitAssignExpr(const AssignExprNode *node) {
 }
 
 std::any IRGenerator::visitTernaryExpr(const TernaryExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (!node->falseExpr)
     return visit(node->condition);
+
+  diGenerator.setSourceLocation(node);
 
   // It is a ternary
   // Retrieve the condition value
@@ -186,11 +186,11 @@ std::any IRGenerator::visitTernaryExpr(const TernaryExprNode *node) {
 }
 
 std::any IRGenerator::visitLogicalOrExpr(const LogicalOrExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is a logical or expression
   // Create exit block for short-circuiting
@@ -240,11 +240,11 @@ std::any IRGenerator::visitLogicalOrExpr(const LogicalOrExprNode *node) {
 }
 
 std::any IRGenerator::visitLogicalAndExpr(const LogicalAndExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is a logical and expression
   // Create exit block for short-circuiting
@@ -294,11 +294,11 @@ std::any IRGenerator::visitLogicalAndExpr(const LogicalAndExprNode *node) {
 }
 
 std::any IRGenerator::visitBitwiseOrExpr(const BitwiseOrExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is a bitwise or expression
   // Evaluate first operand
@@ -320,11 +320,11 @@ std::any IRGenerator::visitBitwiseOrExpr(const BitwiseOrExprNode *node) {
 }
 
 std::any IRGenerator::visitBitwiseXorExpr(const BitwiseXorExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is a bitwise xor expression
   // Evaluate first operand
@@ -346,11 +346,11 @@ std::any IRGenerator::visitBitwiseXorExpr(const BitwiseXorExprNode *node) {
 }
 
 std::any IRGenerator::visitBitwiseAndExpr(const BitwiseAndExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is a bitwise and expression
   // Evaluate first operand
@@ -372,11 +372,11 @@ std::any IRGenerator::visitBitwiseAndExpr(const BitwiseAndExprNode *node) {
 }
 
 std::any IRGenerator::visitEqualityExpr(const EqualityExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is an equality expression
   // Evaluate lhs
@@ -406,11 +406,11 @@ std::any IRGenerator::visitEqualityExpr(const EqualityExprNode *node) {
 }
 
 std::any IRGenerator::visitRelationalExpr(const RelationalExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is a relational expression
   // Evaluate lhs
@@ -446,11 +446,11 @@ std::any IRGenerator::visitRelationalExpr(const RelationalExprNode *node) {
 }
 
 std::any IRGenerator::visitShiftExpr(const ShiftExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is a shift expression
   // Evaluate first operand
@@ -491,11 +491,11 @@ std::any IRGenerator::visitShiftExpr(const ShiftExprNode *node) {
 }
 
 std::any IRGenerator::visitAdditiveExpr(const AdditiveExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is an additive expression
   // Evaluate first operand
@@ -536,11 +536,11 @@ std::any IRGenerator::visitAdditiveExpr(const AdditiveExprNode *node) {
 }
 
 std::any IRGenerator::visitMultiplicativeExpr(const MultiplicativeExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (node->operands.size() == 1)
     return visit(node->operands.front());
+
+  diGenerator.setSourceLocation(node);
 
   // It is an additive expression
   // Evaluate first operand
@@ -583,11 +583,11 @@ std::any IRGenerator::visitMultiplicativeExpr(const MultiplicativeExprNode *node
 }
 
 std::any IRGenerator::visitCastExpr(const CastExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if only one operand is present -> loop through
   if (!node->isCast)
     return visit(node->prefixUnaryExpr);
+
+  diGenerator.setSourceLocation(node);
 
   // It is a cast expression
   // Retrieve target symbol type
@@ -606,11 +606,11 @@ std::any IRGenerator::visitCastExpr(const CastExprNode *node) {
 }
 
 std::any IRGenerator::visitPrefixUnaryExpr(const PrefixUnaryExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // If no operator is applied, simply visit the atomic expression
   if (node->op == PrefixUnaryExprNode::PrefixUnaryOp::OP_NONE)
     return visit(node->postfixUnaryExpr);
+
+  diGenerator.setSourceLocation(node);
 
   // Evaluate lhs
   const ExprNode *lhsNode = node->prefixUnaryExpr;
@@ -702,11 +702,11 @@ std::any IRGenerator::visitPrefixUnaryExpr(const PrefixUnaryExprNode *node) {
 }
 
 std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // If no operator is applied, simply visit the atomic expression
   if (node->op == PostfixUnaryExprNode::PostfixUnaryOp::OP_NONE)
     return visit(node->atomicExpr);
+
+  diGenerator.setSourceLocation(node);
 
   // Evaluate lhs
   const ExprNode *lhsNode = node->postfixUnaryExpr;
@@ -847,8 +847,6 @@ std::any IRGenerator::visitPostfixUnaryExpr(const PostfixUnaryExprNode *node) {
 }
 
 std::any IRGenerator::visitAtomicExpr(const AtomicExprNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // If constant
   if (node->constant) {
     const auto constantValue = std::any_cast<llvm::Constant *>(visit(node->constant));
@@ -862,6 +860,8 @@ std::any IRGenerator::visitAtomicExpr(const AtomicExprNode *node) {
   // Is assign expression
   if (node->assignExpr)
     return visit(node->assignExpr);
+
+  diGenerator.setSourceLocation(node);
 
   // Identifier (local or global variable access)
   assert(!node->identifierFragments.empty());

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -13,11 +13,13 @@ namespace spice::compiler {
 std::any IRGenerator::visitStmtLst(const StmtLstNode *node) {
   // Generate instructions in the scope
   for (const StmtNode *stmt : node->statements) {
-    if (!stmt)
-      continue;
     // Check if we can cancel generating instructions for this code branch
     if (blockAlreadyTerminated || stmt->unreachable)
       break;
+
+    // Set source location for debug info
+    diGenerator.setSourceLocation(stmt);
+
     // Visit child
     visit(stmt);
   }
@@ -33,8 +35,6 @@ std::any IRGenerator::visitTypeAltsLst(const TypeAltsLstNode *node) {
 }
 
 std::any IRGenerator::visitDeclStmt(const DeclStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Get variable entry
   const SymbolTableEntry *varEntry = node->entries.at(manIdx);
   assert(varEntry != nullptr);
@@ -111,8 +111,6 @@ std::any IRGenerator::visitCaseConstant(const CaseConstantNode *node) {
 }
 
 std::any IRGenerator::visitReturnStmt(const ReturnStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   llvm::Value *returnValue = nullptr;
   if (node->hasReturnValue) { // Return value is attached to the return statement
     const ExprNode *returnExpr = node->assignExpr;
@@ -151,8 +149,6 @@ std::any IRGenerator::visitReturnStmt(const ReturnStmtNode *node) {
 }
 
 std::any IRGenerator::visitBreakStmt(const BreakStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Jump to destination block
   const size_t blockIdx = breakBlocks.size() - node->breakTimes;
   insertJump(breakBlocks.at(blockIdx));
@@ -161,8 +157,6 @@ std::any IRGenerator::visitBreakStmt(const BreakStmtNode *node) {
 }
 
 std::any IRGenerator::visitContinueStmt(const ContinueStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Jump to destination block
   const size_t blockIdx = continueBlocks.size() - node->continueTimes;
   insertJump(continueBlocks.at(blockIdx));
@@ -171,8 +165,6 @@ std::any IRGenerator::visitContinueStmt(const ContinueStmtNode *node) {
 }
 
 std::any IRGenerator::visitFallthroughStmt(const FallthroughStmtNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Jump to destination block
   insertJump(fallthroughBlocks.top());
 
@@ -183,8 +175,6 @@ std::any IRGenerator::visitAssertStmt(const AssertStmtNode *node) {
   // Do not generate assertions in release mode
   if (cliOptions.buildMode == BuildMode::RELEASE)
     return nullptr;
-
-  diGenerator.setSourceLocation(node);
 
   // Create blocks
   const std::string &codeLine = node->codeLoc.toPrettyLine();

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -51,12 +51,12 @@ std::any IRGenerator::visitValue(const ValueNode *node) {
 }
 
 std::any IRGenerator::visitConstant(const ConstantNode *node) {
+  if (currentScope != rootScope)
+    diGenerator.setSourceLocation(node);
   return getConst(node->getCompileTimeValue(manIdx), node->getEvaluatedSymbolType(manIdx), node);
 }
 
 std::any IRGenerator::visitFctCall(const FctCallNode *node) {
-  diGenerator.setSourceLocation(node);
-
   // Check if this is a builtin call
   for (const auto &[builtinFctName, _] : BUILTIN_FUNCTIONS)
     if (node->fqFunctionName == builtinFctName)
@@ -931,9 +931,6 @@ std::any IRGenerator::visitLambdaExpr(const LambdaExprNode *node) {
 }
 
 std::any IRGenerator::visitDataType(const DataTypeNode *node) {
-  // Only set the source location if this is not the root scope
-  if (currentScope != rootScope && !node->isParamType && !node->isReturnType && !node->isFieldType)
-    diGenerator.setSourceLocation(node);
   // Retrieve symbol type
   const QualType symbolType = node->getEvaluatedSymbolType(manIdx);
   assert(!symbolType.is(TY_DYN)); // Symbol type should not be dyn anymore at this point

--- a/test/test-files/irgenerator/instrumentation/success-dbg-info-complex/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-dbg-info-complex/ir-code.ll
@@ -258,8 +258,8 @@ assert.then.L45:                                  ; preds = %assert.exit.L43
 assert.exit.L45:                                  ; preds = %assert.exit.L43
   %70 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !89
   store %struct.VectorIterator %70, ptr %8, align 8, !dbg !89
-    #dbg_declare(ptr %item, !91, !DIExpression(), !92)
-  br label %foreach.head.L48, !dbg !92
+    #dbg_declare(ptr %item, !91, !DIExpression(), !89)
+  br label %foreach.head.L48, !dbg !89
 
 foreach.head.L48:                                 ; preds = %foreach.tail.L48, %assert.exit.L45
   %71 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %8), !dbg !92
@@ -275,8 +275,8 @@ foreach.body.L48:                                 ; preds = %foreach.head.L48
   br label %foreach.tail.L48, !dbg !94
 
 foreach.tail.L48:                                 ; preds = %foreach.body.L48
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %8), !dbg !94
-  br label %foreach.head.L48, !dbg !94
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %8), !dbg !92
+  br label %foreach.head.L48, !dbg !92
 
 foreach.exit.L48:                                 ; preds = %foreach.head.L48
   %76 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !95
@@ -314,8 +314,8 @@ assert.then.L53:                                  ; preds = %assert.exit.L52
 assert.exit.L53:                                  ; preds = %assert.exit.L52
   %88 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !101
   store %struct.VectorIterator %88, ptr %9, align 8, !dbg !101
-    #dbg_declare(ptr %item1, !103, !DIExpression(), !104)
-  br label %foreach.head.L56, !dbg !104
+    #dbg_declare(ptr %item1, !103, !DIExpression(), !101)
+  br label %foreach.head.L56, !dbg !101
 
 foreach.head.L56:                                 ; preds = %foreach.tail.L56, %assert.exit.L53
   %89 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %9), !dbg !104
@@ -332,8 +332,8 @@ foreach.body.L56:                                 ; preds = %foreach.head.L56
   br label %foreach.tail.L56, !dbg !106
 
 foreach.tail.L56:                                 ; preds = %foreach.body.L56
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %9), !dbg !106
-  br label %foreach.head.L56, !dbg !106
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %9), !dbg !104
+  br label %foreach.head.L56, !dbg !104
 
 foreach.exit.L56:                                 ; preds = %foreach.head.L56
   %94 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !107
@@ -371,74 +371,74 @@ assert.then.L61:                                  ; preds = %assert.exit.L60
 assert.exit.L61:                                  ; preds = %assert.exit.L60
   %106 = call noundef %struct.VectorIterator @_ZN6VectorIiE11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !113
   store %struct.VectorIterator %106, ptr %11, align 8, !dbg !113
-    #dbg_declare(ptr %idx, !115, !DIExpression(), !117)
-  store i64 0, ptr %idx, align 8, !dbg !117
-    #dbg_declare(ptr %item2, !118, !DIExpression(), !119)
-  br label %foreach.head.L63, !dbg !119
+    #dbg_declare(ptr %idx, !115, !DIExpression(), !113)
+  store i64 0, ptr %idx, align 8, !dbg !113
+    #dbg_declare(ptr %item2, !117, !DIExpression(), !113)
+  br label %foreach.head.L63, !dbg !113
 
 foreach.head.L63:                                 ; preds = %foreach.tail.L63, %assert.exit.L61
-  %107 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !119
-  br i1 %107, label %foreach.body.L63, label %foreach.exit.L63, !dbg !119
+  %107 = call i1 @_ZN14VectorIteratorIiE7isValidEv(ptr %11), !dbg !118
+  br i1 %107, label %foreach.body.L63, label %foreach.exit.L63, !dbg !118
 
 foreach.body.L63:                                 ; preds = %foreach.head.L63
-  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %11), !dbg !119
-  store %struct.Pair %pair3, ptr %pair.addr, align 8, !dbg !119
-  %108 = load i64, ptr %pair.addr, align 8, !dbg !119
-  store i64 %108, ptr %idx, align 8, !dbg !119
-  %item.addr = getelementptr inbounds nuw %struct.Pair, ptr %pair.addr, i32 0, i32 1, !dbg !119
-    #dbg_declare(ptr %12, !118, !DIExpression(), !119)
-  %109 = load ptr, ptr %item.addr, align 8, !dbg !119
-  store ptr %109, ptr %12, align 8, !dbg !119
-  %110 = load i64, ptr %idx, align 8, !dbg !120
-  %111 = trunc i64 %110 to i32, !dbg !120
-  %112 = load ptr, ptr %12, align 8, !dbg !120
-  %113 = load i32, ptr %112, align 4, !dbg !120
-  %114 = add nsw i32 %113, %111, !dbg !120
-  store i32 %114, ptr %112, align 4, !dbg !120
-  br label %foreach.tail.L63, !dbg !121
+  %pair3 = call %struct.Pair @_ZN14VectorIteratorIiE6getIdxEv(ptr %11), !dbg !118
+  store %struct.Pair %pair3, ptr %pair.addr, align 8, !dbg !118
+  %108 = load i64, ptr %pair.addr, align 8, !dbg !118
+  store i64 %108, ptr %idx, align 8, !dbg !118
+  %item.addr = getelementptr inbounds nuw %struct.Pair, ptr %pair.addr, i32 0, i32 1, !dbg !118
+    #dbg_declare(ptr %12, !117, !DIExpression(), !118)
+  %109 = load ptr, ptr %item.addr, align 8, !dbg !118
+  store ptr %109, ptr %12, align 8, !dbg !118
+  %110 = load i64, ptr %idx, align 8, !dbg !119
+  %111 = trunc i64 %110 to i32, !dbg !119
+  %112 = load ptr, ptr %12, align 8, !dbg !119
+  %113 = load i32, ptr %112, align 4, !dbg !119
+  %114 = add nsw i32 %113, %111, !dbg !119
+  store i32 %114, ptr %112, align 4, !dbg !119
+  br label %foreach.tail.L63, !dbg !120
 
 foreach.tail.L63:                                 ; preds = %foreach.body.L63
-  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !121
-  br label %foreach.head.L63, !dbg !121
+  call void @_ZN14VectorIteratorIiE4nextEv(ptr %11), !dbg !118
+  br label %foreach.head.L63, !dbg !118
 
 foreach.exit.L63:                                 ; preds = %foreach.head.L63
-  %115 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !122
-  %116 = load i32, ptr %115, align 4, !dbg !123
-  %117 = icmp eq i32 %116, 124, !dbg !123
-  br i1 %117, label %assert.exit.L66, label %assert.then.L66, !dbg !123, !prof !40
+  %115 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 0), !dbg !121
+  %116 = load i32, ptr %115, align 4, !dbg !122
+  %117 = icmp eq i32 %116, 124, !dbg !122
+  br i1 %117, label %assert.exit.L66, label %assert.then.L66, !dbg !122, !prof !40
 
 assert.then.L66:                                  ; preds = %foreach.exit.L63
-  %118 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !123
-  call void @exit(i32 1), !dbg !123
-  unreachable, !dbg !123
+  %118 = call i32 (ptr, ...) @printf(ptr @anon.string.22), !dbg !122
+  call void @exit(i32 1), !dbg !122
+  unreachable, !dbg !122
 
 assert.exit.L66:                                  ; preds = %foreach.exit.L63
-  %119 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !124
-  %120 = load i32, ptr %119, align 4, !dbg !125
-  %121 = icmp eq i32 %120, 4323, !dbg !125
-  br i1 %121, label %assert.exit.L67, label %assert.then.L67, !dbg !125, !prof !40
+  %119 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 1), !dbg !123
+  %120 = load i32, ptr %119, align 4, !dbg !124
+  %121 = icmp eq i32 %120, 4323, !dbg !124
+  br i1 %121, label %assert.exit.L67, label %assert.then.L67, !dbg !124, !prof !40
 
 assert.then.L67:                                  ; preds = %assert.exit.L66
-  %122 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !125
-  call void @exit(i32 1), !dbg !125
-  unreachable, !dbg !125
+  %122 = call i32 (ptr, ...) @printf(ptr @anon.string.23), !dbg !124
+  call void @exit(i32 1), !dbg !124
+  unreachable, !dbg !124
 
 assert.exit.L67:                                  ; preds = %assert.exit.L66
-  %123 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !126
-  %124 = load i32, ptr %123, align 4, !dbg !127
-  %125 = icmp eq i32 %124, 9879, !dbg !127
-  br i1 %125, label %assert.exit.L68, label %assert.then.L68, !dbg !127, !prof !40
+  %123 = call noundef ptr @_ZN6VectorIiE3getEj(ptr noundef nonnull align 8 dereferenceable(32) %vi, i32 noundef 2), !dbg !125
+  %124 = load i32, ptr %123, align 4, !dbg !126
+  %125 = icmp eq i32 %124, 9879, !dbg !126
+  br i1 %125, label %assert.exit.L68, label %assert.then.L68, !dbg !126, !prof !40
 
 assert.then.L68:                                  ; preds = %assert.exit.L67
-  %126 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !127
-  call void @exit(i32 1), !dbg !127
-  unreachable, !dbg !127
+  %126 = call i32 (ptr, ...) @printf(ptr @anon.string.24), !dbg !126
+  call void @exit(i32 1), !dbg !126
+  unreachable, !dbg !126
 
 assert.exit.L68:                                  ; preds = %assert.exit.L67
-  %127 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !128
-  call void @_ZN6VectorIiE4dtorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !129
-  %128 = load i32, ptr %result, align 4, !dbg !129
-  ret i32 %128, !dbg !129
+  %127 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0), !dbg !127
+  call void @_ZN6VectorIiE4dtorEv(ptr noundef nonnull align 8 dereferenceable(32) %vi), !dbg !128
+  %128 = load i32, ptr %result, align 4, !dbg !128
+  ret i32 %128, !dbg !128
 }
 
 declare void @_ZN6VectorIiE4ctorEv(ptr)
@@ -579,7 +579,7 @@ attributes #2 = { cold noreturn nounwind }
 !89 = !DILocation(line: 48, column: 24, scope: !90)
 !90 = distinct !DILexicalBlock(scope: !14, file: !5, line: 48, column: 5)
 !91 = !DILocalVariable(name: "item", scope: !90, file: !5, line: 48, type: !17)
-!92 = !DILocation(line: 48, column: 13, scope: !90)
+!92 = !DILocation(line: 48, column: 5, scope: !90)
 !93 = !DILocation(line: 49, column: 9, scope: !90)
 !94 = !DILocation(line: 50, column: 5, scope: !90)
 !95 = !DILocation(line: 51, column: 19, scope: !14)
@@ -591,7 +591,7 @@ attributes #2 = { cold noreturn nounwind }
 !101 = !DILocation(line: 56, column: 25, scope: !102)
 !102 = distinct !DILexicalBlock(scope: !14, file: !5, line: 56, column: 5)
 !103 = !DILocalVariable(name: "item", scope: !102, file: !5, line: 56, type: !64)
-!104 = !DILocation(line: 56, column: 13, scope: !102)
+!104 = !DILocation(line: 56, column: 5, scope: !102)
 !105 = !DILocation(line: 57, column: 9, scope: !102)
 !106 = !DILocation(line: 58, column: 5, scope: !102)
 !107 = !DILocation(line: 59, column: 19, scope: !14)
@@ -604,16 +604,15 @@ attributes #2 = { cold noreturn nounwind }
 !114 = distinct !DILexicalBlock(scope: !14, file: !5, line: 63, column: 5)
 !115 = !DILocalVariable(name: "idx", scope: !114, file: !5, line: 63, type: !116)
 !116 = !DIBasicType(name: "long", size: 64, encoding: DW_ATE_signed)
-!117 = !DILocation(line: 63, column: 13, scope: !114)
-!118 = !DILocalVariable(name: "item", scope: !114, file: !5, line: 63, type: !64)
-!119 = !DILocation(line: 63, column: 23, scope: !114)
-!120 = !DILocation(line: 64, column: 9, scope: !114)
-!121 = !DILocation(line: 65, column: 5, scope: !114)
-!122 = !DILocation(line: 66, column: 19, scope: !14)
-!123 = !DILocation(line: 66, column: 25, scope: !14)
-!124 = !DILocation(line: 67, column: 19, scope: !14)
-!125 = !DILocation(line: 67, column: 25, scope: !14)
-!126 = !DILocation(line: 68, column: 19, scope: !14)
-!127 = !DILocation(line: 68, column: 25, scope: !14)
-!128 = !DILocation(line: 70, column: 5, scope: !14)
-!129 = !DILocation(line: 71, column: 1, scope: !14)
+!117 = !DILocalVariable(name: "item", scope: !114, file: !5, line: 63, type: !64)
+!118 = !DILocation(line: 63, column: 5, scope: !114)
+!119 = !DILocation(line: 64, column: 9, scope: !114)
+!120 = !DILocation(line: 65, column: 5, scope: !114)
+!121 = !DILocation(line: 66, column: 19, scope: !14)
+!122 = !DILocation(line: 66, column: 25, scope: !14)
+!123 = !DILocation(line: 67, column: 19, scope: !14)
+!124 = !DILocation(line: 67, column: 25, scope: !14)
+!125 = !DILocation(line: 68, column: 19, scope: !14)
+!126 = !DILocation(line: 68, column: 25, scope: !14)
+!127 = !DILocation(line: 70, column: 5, scope: !14)
+!128 = !DILocation(line: 71, column: 1, scope: !14)


### PR DESCRIPTION
## What changed
- Moved `diGenerator.setSourceLocation()` calls past early-return passthrough guards in all expression visitors (`visitAssignExpr`, `visitTernaryExpr`, `visitLogicalOrExpr`, etc.) so debug locations are only set when the node actually generates IR
- Consolidated statement-level `setSourceLocation` calls from individual statement visitors (`visitDeclStmt`, `visitReturnStmt`, `visitBreakStmt`, etc.) into `visitStmtLst`, eliminating the duplication
- Inlined the `ASTNode*` overload of `setSourceLocation` as `ALWAYS_INLINE` in the header, removing a tiny but unnecessary call indirection
- Also fixed `visitForeachLoop` to set the location on the head/tail blocks rather than at the top of the function, and removed the no-op call from `visitDataType`

## Why
Previously, `setSourceLocation` was called at the very top of every visitor — including on passthrough nodes that delegate immediately to a child and generate no IR themselves. This meant debug location metadata was emitted for nodes that produce no instructions, which could result in incorrect or misleading source-location annotations in the debug info. The fix ensures the debug location is only set when the visitor is about to emit actual IR.

## How it was validated
- Updated reference file `test/test-files/irgenerator/instrumentation/success-dbg-info-complex/ir-code.ll` reflects the corrected debug locations
- Build: `cmake --build cmake-build-debug --target spice spicetest`
- Tests: `cmake-build-debug/test/spicetest --gtest_filter='IRGeneratorTests*'`

## Follow-up / known limitations
None known.