### PR TITLE
Harden Linux release binaries: full RELRO, FORTIFY_SOURCE, PIE

### DIFF
--- a/Conditionals.cmake
+++ b/Conditionals.cmake
@@ -8,6 +8,18 @@ if (LINKER_SUPPORTS_GC_SECTIONS)
     set(GC_SECTIONS_FLAG "-Wl,-gc-sections")
 endif()
 
+# Check if linker supports full RELRO (-z relro -z now). ELF-specific, so only probe on Linux;
+# macOS/Windows linkers don't share this semantics.
+set(RELRO_NOW_FLAG "")
+if (UNIX AND NOT APPLE)
+    set(CMAKE_REQUIRED_FLAGS "-Wl,-z,relro,-z,now")
+    check_cxx_compiler_flag("" LINKER_SUPPORTS_RELRO_NOW)
+    if (LINKER_SUPPORTS_RELRO_NOW)
+        set(RELRO_NOW_FLAG "-Wl,-z,relro,-z,now")
+    endif()
+    unset(CMAKE_REQUIRED_FLAGS)
+endif()
+
 # GCC 16's driver spec emits virtual library names like gcc_s_asneeded and
 # atomic_asneeded. CMake captures these into CMAKE_<LANG>_IMPLICIT_LINK_LIBRARIES,
 # and LLVM bakes them into its exported INTERFACE_LINK_LIBRARIES when it is built
@@ -23,6 +35,13 @@ endforeach ()
 
 # Set release flags
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3 -fdata-sections -ffunction-sections ${GC_SECTIONS_FLAG} -fvisibility=hidden")
+set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} ${RELRO_NOW_FLAG}")
+
+# Harden Linux release binaries: full RELRO (above) + fortify source. Requires -O1+, which the
+# release flags above already provide. macOS/Windows toolchains don't share glibc's *_chk symbols.
+if (UNIX AND NOT APPLE)
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -D_FORTIFY_SOURCE=2")
+endif()
 
 # On macOS, libc++ marks std::wstring_convert (used by CLI11) as deprecated. Keep it a warning, not an error.
 set(SPICE_EXTRA_COMPILE_OPTIONS "")

--- a/Options.cmake
+++ b/Options.cmake
@@ -126,7 +126,21 @@ if (SPICE_LINK_STATIC)
     endif ()
     message(STATUS "Spice: Static linking for Spice is enabled.")
     set(BUILD_SHARED_LIBS OFF)
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++")
+    if (WIN32)
+        # MinGW/PE has no -static-pie equivalent; PE binaries get ASLR via /DYNAMICBASE
+        # regardless of static linking, so plain -static is fine here.
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++")
+    else ()
+        # Use -static-pie instead of plain -static: keeps the binary fully self-contained (no
+        # runtime dependency on shared libc/libstdc++) while still producing a position-independent
+        # executable (ASLR-capable), which plain -static cannot do. Note: -static-pie already
+        # implies a full static link (libgcc/libstdc++ included) — combining it with the separate
+        # -static-libgcc/-static-libstdc++ flags confuses the gcc driver's spec logic and silently
+        # produces a dynamically-linked, crashing binary instead, so those flags are deliberately
+        # omitted here.
+        set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-pie")
+    endif ()
 else ()
     message(STATUS "Spice: Static linking for Spice is disabled.")
 endif ()


### PR DESCRIPTION
checksec flagged the published Linux binaries as partial RELRO, no
PIE, and no FORTIFY_SOURCE. Root cause: the static release build
(-DSPICE_LINK_STATIC=ON) linked with plain -static, which forces a
non-PIE EXEC binary, skips -z now, and never defines
_FORTIFY_SOURCE.

- Add full RELRO (-Wl,-z,relro,-z,now) to Linux release linker flags,
  gated behind a compiler-flag-support check.
- Define -D_FORTIFY_SOURCE=2 for Linux release builds (already at
  -O3, satisfying the -O1+ requirement).
- Switch the Linux static-link path from -static to -static-pie,
  which keeps the binary fully self-contained while producing a
  position-independent (ASLR-capable) executable. Windows keeps
  plain -static since MinGW/PE has no -static-pie equivalent and
  gets ASLR via /DYNAMICBASE regardless.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UnTYo4fChVVsrsk3hY5w5Y