### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -98,7 +98,6 @@ jobs:
             -DSPICE_ENABLE_TPDE=ON \
             -DSPICE_ASAN=ON \
             -DSPICE_TEST_ARGS="--is-github-actions;--skip-sanitizer-tests" \
-            -Wattributes \
             ..
           cmake --build . --target spicetest
 

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -101,7 +101,6 @@ jobs:
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_ENABLE_TPDE=ON \
             -DSPICE_RUN_COVERAGE=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'ON' || 'OFF' }} \
-            -Wattributes \
             ..
           cmake --build . --target spicetest
 
@@ -222,7 +221,6 @@ jobs:
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_ENABLE_TPDE=ON \
             -DSPICE_TEST_ARGS=--is-github-actions \
-            -Wattributes \
             ..
           cmake --build . --target spicetest
 
@@ -315,7 +313,6 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache `
             -DSPICE_BUILT_BY="ghactions" `
             -DSPICE_TEST_ARGS=--is-github-actions `
-            -Wattributes `
             ..
           cmake --build . --target spicetest
 
@@ -407,7 +404,6 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_TEST_ARGS=--is-github-actions \
-            -Wattributes \
             ..
           cmake --build . --target spicetest
 
@@ -498,7 +494,6 @@ jobs:
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_TEST_ARGS=--is-github-actions \
-            -Wattributes \
             ..
           cmake --build . --target spicetest
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -95,7 +95,6 @@ jobs:
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_ENABLE_TPDE=ON \
             -DSPICE_LINK_STATIC=OFF \
-            -Wattributes \
             ..
           cmake --build . --target spicetest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,8 +75,6 @@ jobs:
             -DLLVM_INCLUDE_BENCHMARKS=OFF \
             -DLLVM_ENABLE_ZLIB=OFF \
             -DLLVM_ENABLE_ZSTD=OFF \
-            -Wno-dev \
-            -Wattributes \
             ../llvm
           cmake --build .
 
@@ -189,8 +187,6 @@ jobs:
             -DLLVM_INCLUDE_BENCHMARKS=OFF \
             -DLLVM_ENABLE_ZLIB=OFF \
             -DLLVM_ENABLE_ZSTD=OFF \
-            -Wno-dev \
-            -Wattributes \
             ../llvm
           cmake --build .
 
@@ -294,8 +290,6 @@ jobs:
             -DLLVM_INCLUDE_TESTS=OFF `
             -DLLVM_INCLUDE_EXAMPLES=OFF `
             -DLLVM_INCLUDE_BENCHMARKS=OFF `
-            -Wno-dev `
-            -Wattributes `
             ../llvm
           cmake --build .
 
@@ -399,8 +393,6 @@ jobs:
             -DLLVM_INCLUDE_TESTS=OFF \
             -DLLVM_INCLUDE_EXAMPLES=OFF \
             -DLLVM_INCLUDE_BENCHMARKS=OFF \
-            -Wno-dev \
-            -Wattributes \
             ../llvm
           cmake --build .
 
@@ -504,8 +496,6 @@ jobs:
             -DLLVM_INCLUDE_TESTS=OFF \
             -DLLVM_INCLUDE_EXAMPLES=OFF \
             -DLLVM_INCLUDE_BENCHMARKS=OFF \
-            -Wno-dev \
-            -Wattributes \
             ../llvm
           cmake --build .
 

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -83,7 +83,6 @@ jobs:
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
-            -Wattributes \
             ..
           cmake --build . --target spicetest
 


### PR DESCRIPTION
CMake was upgraded to versoin 4.4 for many runner images. This version removes/deprecates the `-W` cli flags.