### PR TITLE
Add cast support from bool to byte, short, int and long

### DIFF
--- a/src/irgenerator/OpRuleConversionManager.cpp
+++ b/src/irgenerator/OpRuleConversionManager.cpp
@@ -1668,6 +1668,12 @@ LLVMExprResult OpRuleConversionManager::getCastInst(const ASTNode *node, QualTyp
     return {.value = builder.CreateIntCast(rhsV(), lhsT, lhsSTy.isSigned())};
   case COMB(TY_BYTE, TY_CHAR):
     return {.value = rhsV()};
+  case COMB(TY_INT, TY_BOOL):   // fallthrough
+  case COMB(TY_SHORT, TY_BOOL): // fallthrough
+  case COMB(TY_LONG, TY_BOOL):  // fallthrough
+  case COMB(TY_BYTE, TY_BOOL):
+    // Bool is always unsigned (0 or 1), so zero-extend rather than sign-extend to avoid true -> -1
+    return {.value = builder.CreateZExt(rhsV(), lhsT)};
   case COMB(TY_CHAR, TY_INT):   // fallthrough
   case COMB(TY_CHAR, TY_SHORT): // fallthrough
   case COMB(TY_CHAR, TY_LONG):

--- a/src/typechecker/OpRuleManager.h
+++ b/src/typechecker/OpRuleManager.h
@@ -570,17 +570,21 @@ static constexpr BinaryOpRule CAST_OP_RULES[] = {
     BinaryOpRule(TY_INT, TY_LONG, TY_INT, false),         // (int) long -> int
     BinaryOpRule(TY_INT, TY_BYTE, TY_INT, false),         // (int) byte -> int
     BinaryOpRule(TY_INT, TY_CHAR, TY_INT, false),         // (int) char -> int
+    BinaryOpRule(TY_INT, TY_BOOL, TY_INT, false),         // (int) bool -> int
     BinaryOpRule(TY_SHORT, TY_DOUBLE, TY_SHORT, false),   // (short) double -> short
     BinaryOpRule(TY_SHORT, TY_INT, TY_SHORT, false),      // (short) int -> short
     BinaryOpRule(TY_SHORT, TY_SHORT, TY_SHORT, false),    // (short) short -> short
     BinaryOpRule(TY_SHORT, TY_LONG, TY_SHORT, false),     // (short) long -> short
+    BinaryOpRule(TY_SHORT, TY_BOOL, TY_SHORT, false),     // (short) bool -> short
     BinaryOpRule(TY_LONG, TY_DOUBLE, TY_LONG, false),     // (long) double -> long
     BinaryOpRule(TY_LONG, TY_INT, TY_LONG, false),        // (long) int -> long
     BinaryOpRule(TY_LONG, TY_SHORT, TY_LONG, false),      // (long) short -> long
     BinaryOpRule(TY_LONG, TY_LONG, TY_LONG, false),       // (long) long -> long
+    BinaryOpRule(TY_LONG, TY_BOOL, TY_LONG, false),       // (long) bool -> long
     BinaryOpRule(TY_BYTE, TY_INT, TY_BYTE, false),        // (byte) int -> byte
     BinaryOpRule(TY_BYTE, TY_BYTE, TY_BYTE, false),       // (byte) byte -> byte
     BinaryOpRule(TY_BYTE, TY_CHAR, TY_BYTE, false),       // (byte) char -> byte
+    BinaryOpRule(TY_BYTE, TY_BOOL, TY_BYTE, false),       // (byte) bool -> byte
     BinaryOpRule(TY_CHAR, TY_INT, TY_CHAR, false),        // (char) int -> char
     BinaryOpRule(TY_CHAR, TY_SHORT, TY_CHAR, false),      // (char) short -> char
     BinaryOpRule(TY_CHAR, TY_LONG, TY_CHAR, false),       // (char) long -> char

--- a/src/typechecker/OpRuleManager.h
+++ b/src/typechecker/OpRuleManager.h
@@ -560,38 +560,38 @@ static constexpr UnaryOpRule POSTFIX_MINUS_MINUS_OP_RULES[] = {
 
 // Cast op rules
 static constexpr BinaryOpRule CAST_OP_RULES[] = {
-    BinaryOpRule(TY_DOUBLE, TY_DOUBLE, TY_DOUBLE, false), // (double) double -> double
-    BinaryOpRule(TY_DOUBLE, TY_INT, TY_DOUBLE, false),    // (double) int -> double
-    BinaryOpRule(TY_DOUBLE, TY_SHORT, TY_DOUBLE, false),  // (double) short -> double
-    BinaryOpRule(TY_DOUBLE, TY_LONG, TY_DOUBLE, false),   // (double) long -> double
-    BinaryOpRule(TY_INT, TY_DOUBLE, TY_INT, false),       // (int) double -> int
-    BinaryOpRule(TY_INT, TY_INT, TY_INT, false),          // (int) int -> int
-    BinaryOpRule(TY_INT, TY_SHORT, TY_INT, false),        // (int) short -> int
-    BinaryOpRule(TY_INT, TY_LONG, TY_INT, false),         // (int) long -> int
-    BinaryOpRule(TY_INT, TY_BYTE, TY_INT, false),         // (int) byte -> int
-    BinaryOpRule(TY_INT, TY_CHAR, TY_INT, false),         // (int) char -> int
-    BinaryOpRule(TY_INT, TY_BOOL, TY_INT, false),         // (int) bool -> int
-    BinaryOpRule(TY_SHORT, TY_DOUBLE, TY_SHORT, false),   // (short) double -> short
-    BinaryOpRule(TY_SHORT, TY_INT, TY_SHORT, false),      // (short) int -> short
-    BinaryOpRule(TY_SHORT, TY_SHORT, TY_SHORT, false),    // (short) short -> short
-    BinaryOpRule(TY_SHORT, TY_LONG, TY_SHORT, false),     // (short) long -> short
-    BinaryOpRule(TY_SHORT, TY_BOOL, TY_SHORT, false),     // (short) bool -> short
-    BinaryOpRule(TY_LONG, TY_DOUBLE, TY_LONG, false),     // (long) double -> long
-    BinaryOpRule(TY_LONG, TY_INT, TY_LONG, false),        // (long) int -> long
-    BinaryOpRule(TY_LONG, TY_SHORT, TY_LONG, false),      // (long) short -> long
-    BinaryOpRule(TY_LONG, TY_LONG, TY_LONG, false),       // (long) long -> long
-    BinaryOpRule(TY_LONG, TY_BOOL, TY_LONG, false),       // (long) bool -> long
-    BinaryOpRule(TY_BYTE, TY_INT, TY_BYTE, false),        // (byte) int -> byte
-    BinaryOpRule(TY_BYTE, TY_BYTE, TY_BYTE, false),       // (byte) byte -> byte
-    BinaryOpRule(TY_BYTE, TY_CHAR, TY_BYTE, false),       // (byte) char -> byte
-    BinaryOpRule(TY_BYTE, TY_BOOL, TY_BYTE, false),       // (byte) bool -> byte
-    BinaryOpRule(TY_CHAR, TY_INT, TY_CHAR, false),        // (char) int -> char
-    BinaryOpRule(TY_CHAR, TY_SHORT, TY_CHAR, false),      // (char) short -> char
-    BinaryOpRule(TY_CHAR, TY_LONG, TY_CHAR, false),       // (char) long -> char
-    BinaryOpRule(TY_CHAR, TY_BYTE, TY_CHAR, false),       // (char) byte -> char
-    BinaryOpRule(TY_CHAR, TY_CHAR, TY_CHAR, false),       // (char) char -> char
-    BinaryOpRule(TY_STRING, TY_STRING, TY_STRING, false), // (string) string -> string
-    BinaryOpRule(TY_BOOL, TY_BOOL, TY_BOOL, false),       // (bool) bool -> bool
+    BinaryOpRule(TY_DOUBLE, TY_DOUBLE, TY_DOUBLE, false), // cast<double>(double) -> double
+    BinaryOpRule(TY_DOUBLE, TY_INT, TY_DOUBLE, false),    // cast<double>(int) -> double
+    BinaryOpRule(TY_DOUBLE, TY_SHORT, TY_DOUBLE, false),  // cast<double>(short) -> double
+    BinaryOpRule(TY_DOUBLE, TY_LONG, TY_DOUBLE, false),   // cast<double>(long) -> double
+    BinaryOpRule(TY_INT, TY_DOUBLE, TY_INT, false),       // cast<int>(double) -> int
+    BinaryOpRule(TY_INT, TY_INT, TY_INT, false),          // cast<int>(int) -> int
+    BinaryOpRule(TY_INT, TY_SHORT, TY_INT, false),        // cast<int>(short) -> int
+    BinaryOpRule(TY_INT, TY_LONG, TY_INT, false),         // cast<int>(long) -> int
+    BinaryOpRule(TY_INT, TY_BYTE, TY_INT, false),         // cast<int>(byte) -> int
+    BinaryOpRule(TY_INT, TY_CHAR, TY_INT, false),         // cast<int>(char) -> int
+    BinaryOpRule(TY_INT, TY_BOOL, TY_INT, false),         // cast<int>(bool) -> int
+    BinaryOpRule(TY_SHORT, TY_DOUBLE, TY_SHORT, false),   // cast<short>(double) -> short
+    BinaryOpRule(TY_SHORT, TY_INT, TY_SHORT, false),      // cast<short>(int) -> short
+    BinaryOpRule(TY_SHORT, TY_SHORT, TY_SHORT, false),    // cast<short>(short) -> short
+    BinaryOpRule(TY_SHORT, TY_LONG, TY_SHORT, false),     // cast<short>(long) -> short
+    BinaryOpRule(TY_SHORT, TY_BOOL, TY_SHORT, false),     // cast<short>(bool) -> short
+    BinaryOpRule(TY_LONG, TY_DOUBLE, TY_LONG, false),     // cast<long>(double) -> long
+    BinaryOpRule(TY_LONG, TY_INT, TY_LONG, false),        // cast<long>(int) -> long
+    BinaryOpRule(TY_LONG, TY_SHORT, TY_LONG, false),      // cast<long>(short) -> long
+    BinaryOpRule(TY_LONG, TY_LONG, TY_LONG, false),       // cast<long>(long) -> long
+    BinaryOpRule(TY_LONG, TY_BOOL, TY_LONG, false),       // cast<long>(bool) -> long
+    BinaryOpRule(TY_BYTE, TY_INT, TY_BYTE, false),        // cast<byte>(int) -> byte
+    BinaryOpRule(TY_BYTE, TY_BYTE, TY_BYTE, false),       // cast<byte>(byte) -> byte
+    BinaryOpRule(TY_BYTE, TY_CHAR, TY_BYTE, false),       // cast<byte>(char) -> byte
+    BinaryOpRule(TY_BYTE, TY_BOOL, TY_BYTE, false),       // cast<byte>(bool) -> byte
+    BinaryOpRule(TY_CHAR, TY_INT, TY_CHAR, false),        // cast<char>(int) -> char
+    BinaryOpRule(TY_CHAR, TY_SHORT, TY_CHAR, false),      // cast<char>(short) -> char
+    BinaryOpRule(TY_CHAR, TY_LONG, TY_CHAR, false),       // cast<char>(long) -> char
+    BinaryOpRule(TY_CHAR, TY_BYTE, TY_CHAR, false),       // cast<char>(byte) -> char
+    BinaryOpRule(TY_CHAR, TY_CHAR, TY_CHAR, false),       // cast<char>(char) -> char
+    BinaryOpRule(TY_STRING, TY_STRING, TY_STRING, false), // cast<string>(string) -> string
+    BinaryOpRule(TY_BOOL, TY_BOOL, TY_BOOL, false),       // cast<bool>(bool) -> bool
 };
 
 /**

--- a/test/test-files/irgenerator/operators/success-operators-all-combinations-unary/source.spice
+++ b/test/test-files/irgenerator/operators/success-operators-all-combinations-unary/source.spice
@@ -174,6 +174,15 @@ p castTest() {
     castInner<char, short>(57s, '9');
     castInner<char, long>(57l, '9');
     castInner<char, byte>(cast<byte>(57), '9');
+    // Lhs bool
+    castInner<byte, bool>(true, cast<byte>(1));
+    castInner<byte, bool>(false, cast<byte>(0));
+    castInner<short, bool>(true, 1s);
+    castInner<short, bool>(false, 0s);
+    castInner<int, bool>(true, 1);
+    castInner<int, bool>(false, 0);
+    castInner<long, bool>(true, 1l);
+    castInner<long, bool>(false, 0l);
     // Special casts
     // cast<const char*>(string)
     //String str = String("test");

--- a/test/test-files/irgenerator/operators/success-operators-all-combinations-unary/source.spice
+++ b/test/test-files/irgenerator/operators/success-operators-all-combinations-unary/source.spice
@@ -158,31 +158,30 @@ p castTest() {
     castInner<int, long>(1l, 1);
     castInner<int, byte>(cast<byte>(1), 1);
     castInner<int, char>('A', 65);
+    castInner<int, bool>(true, 1);
+    castInner<int, bool>(false, 0);
     // Lhs short
     castInner<short, double>(1.0, 1s);
     castInner<short, int>(1, 1s);
     castInner<short, long>(1l, 1s);
+    castInner<short, bool>(true, 1s);
+    castInner<short, bool>(false, 0s);
     // Lhs long
     castInner<long, double>(1.0, 1l);
     castInner<long, int>(1, 1l);
     castInner<long, short>(1s, 1l);
+    castInner<long, bool>(true, 1l);
+    castInner<long, bool>(false, 0l);
     // Lhs byte
     castInner<byte, int>(56, cast<byte>(56));
     castInner<byte, char>('8', cast<byte>(56));
+    castInner<byte, bool>(true, cast<byte>(1));
+    castInner<byte, bool>(false, cast<byte>(0));
     // Lhs char
     castInner<char, int>(57, '9');
     castInner<char, short>(57s, '9');
     castInner<char, long>(57l, '9');
     castInner<char, byte>(cast<byte>(57), '9');
-    // Lhs bool
-    castInner<byte, bool>(true, cast<byte>(1));
-    castInner<byte, bool>(false, cast<byte>(0));
-    castInner<short, bool>(true, 1s);
-    castInner<short, bool>(false, 0s);
-    castInner<int, bool>(true, 1);
-    castInner<int, bool>(false, 0);
-    castInner<long, bool>(true, 1l);
-    castInner<long, bool>(false, 0l);
     // Special casts
     // cast<const char*>(string)
     //String str = String("test");


### PR DESCRIPTION
## What changed

- Added `cast<byte>(bool)`, `cast<short>(bool)`, `cast<int>(bool)` and `cast<long>(bool)` to the typechecker's `CAST_OP_RULES` table in `src/typechecker/OpRuleManager.h`.
- Added the matching IR codegen for these combinations in `OpRuleConversionManager::getCastInst` (`src/irgenerator/OpRuleConversionManager.cpp`): the bool operand is zero-extended (`CreateZExt`) rather than sign-extended to the target width.
- Reworded all `CAST_OP_RULES` comments from the old `// (T) S -> T` style to `// cast<T>(S) -> T`, matching Spice's actual cast syntax.
- Extended `test/test-files/irgenerator/operators/success-operators-all-combinations-unary/source.spice` with `true`/`false` cast cases for all four new target types, placed in their respective target-type sections (`Lhs int`/`short`/`long`/`byte`).

## Why it changed

Spice previously supported casting `bool` only to itself (`cast<bool>(bool)`); casting a `bool` to any of the other integer types was rejected by the typechecker. This adds the missing combinations.

Bool is always zero-extended rather than sign-extended when widening, since `bool` is unsigned (0 or 1) — sign-extending the single set bit of `true` (`i1`) would otherwise produce `-1` in a signed target type instead of `1`.

## How it was validated

- Careful pattern-matching of the new typechecker rules and IR codegen cases against the existing, already-tested combinations for the same target types (e.g. `cast<int>(byte)`), which follow an identical shape.
- Added exhaustive cast test cases to the existing `success-operators-all-combinations-unary` integration test.
- **Could not run a full build/test pass in this environment**: the repository pins an unreleased/custom LLVM revision (`llvmorg-23.1.0-rc2` per `dev-setup.py`) whose `llvm::Triple`/`TargetRegistry` API differs from every system-packaged LLVM available (18/20) in ways unrelated to this change (e.g. `Triple::empty()`, `Triple::normalize()`, `lookupTarget(Triple, ...)` don't exist upstream). Building the pinned LLVM from source was impractical within this session's time/disk budget, so I was unable to execute `spicetest` to confirm compilation and runtime behavior directly.

## Follow-up / known limitations

- CI should be relied on to confirm this compiles and passes `spicetest` against the project's actual pinned LLVM build, since local verification wasn't possible here.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J7r8rC5613Kbdhtz6sYPH4)_