### PR TITLE
Release JSON and XML value trees instead of leaking them

### DIFF
--- a/std/text/json-parser.spice
+++ b/std/text/json-parser.spice
@@ -14,7 +14,7 @@ import "std/type/type-conversion";
 public type JsonParser struct {
     String input
     unsigned long pos
-    String errorMessage
+    string errorMessage  // always points to a string literal, so it outlives the parser
     bool hasError
 }
 
@@ -26,6 +26,7 @@ public type JsonParser struct {
 public p JsonParser.ctor(const String& input) {
     this.input = input;
     this.pos = 0l;
+    this.errorMessage = "";
     this.hasError = false;
 }
 
@@ -38,10 +39,13 @@ public f<Result<JsonValue*>> JsonParser.parse() {
     this.skipWhitespace();
     JsonValue* value = this.parseValue();
     if this.hasError {
-        return err<JsonValue*>(Error(this.errorMessage.getRaw()));
+        // Nothing is handed out, so the partially built tree is ours to release
+        deleteJsonValue(value);
+        return err<JsonValue*>(Error(this.errorMessage));
     }
     this.skipWhitespace();
     if this.pos < this.input.getLength() {
+        deleteJsonValue(value);
         return err<JsonValue*>(Error("Trailing data after JSON value"));
     }
     return ok(value);
@@ -50,8 +54,10 @@ public f<Result<JsonValue*>> JsonParser.parse() {
 /**
  * Parse a JSON document.
  *
- * On success returns the root JsonValue (heap-allocated; the caller owns it).
- * On failure returns an error describing the first problem encountered.
+ * On success returns the root JsonValue, which the caller owns and releases
+ * again with `deleteJsonValue` from "std/text/json-value". On failure the
+ * partially built tree is released by the parser and an error describing the
+ * first problem encountered is returned.
  */
 public f<Result<JsonValue*>> parseJson(const String& input) {
     JsonParser parser = JsonParser(input);
@@ -85,7 +91,7 @@ p JsonParser.skipWhitespace() {
 
 p JsonParser.fail(string msg) {
     if !this.hasError {
-        this.errorMessage = String(msg);
+        this.errorMessage = msg;
         this.hasError = true;
     }
 }
@@ -161,9 +167,13 @@ f<JsonValue*> JsonParser.parseNumber() {
 }
 
 f<JsonValue*> JsonParser.parseStringValue() {
+    // `s` has to stay alive until the end of the scope, so that it gets cleaned up
+    JsonValue* stringValue = nil<JsonValue*>;
     const String s = this.parseStringLiteral();
-    if this.hasError { return nil<JsonValue*>; }
-    return __new<JsonValue>(s);
+    if !this.hasError {
+        stringValue = __new<JsonValue>(s);
+    }
+    return stringValue;
 }
 
 f<String> JsonParser.parseStringLiteral() {
@@ -223,7 +233,7 @@ f<String> JsonParser.parseStringLiteral() {
 
 f<JsonValue*> JsonParser.parseArray() {
     this.pos++; // consume '['
-    heap JsonValue* arr = __new<JsonValue>(JsonValueKind::JSON_ARRAY);
+    JsonValue* arr = __new<JsonValue>(JsonValueKind::JSON_ARRAY);
     this.skipWhitespace();
     if this.pos < this.input.getLength() && this.input[this.pos] == ']' {
         this.pos++;
@@ -232,11 +242,15 @@ f<JsonValue*> JsonParser.parseArray() {
     while true {
         this.skipWhitespace();
         JsonValue* item = this.parseValue();
-        if this.hasError { return nil<JsonValue*>; }
+        if this.hasError {
+            deleteJsonValue(arr);
+            return nil<JsonValue*>;
+        }
         arr.addArrayItem(item);
         this.skipWhitespace();
         if this.pos >= this.input.getLength() {
             this.fail("Unterminated array");
+            deleteJsonValue(arr);
             return nil<JsonValue*>;
         }
         const char c = this.input[this.pos];
@@ -249,6 +263,7 @@ f<JsonValue*> JsonParser.parseArray() {
             return arr;
         }
         this.fail("Expected ',' or ']' in array");
+        deleteJsonValue(arr);
         return nil<JsonValue*>;
     }
     return nil<JsonValue*>;
@@ -256,46 +271,61 @@ f<JsonValue*> JsonParser.parseArray() {
 
 f<JsonValue*> JsonParser.parseObject() {
     this.pos++; // consume '{'
-    heap JsonValue* obj = __new<JsonValue>(JsonValueKind::JSON_OBJECT);
+    JsonValue* obj = __new<JsonValue>(JsonValueKind::JSON_OBJECT);
     this.skipWhitespace();
     if this.pos < this.input.getLength() && this.input[this.pos] == '}' {
         this.pos++;
         return obj;
     }
-    while true {
+    // Leaving a scope early skips the cleanup of the locals it holds, so the loop body
+    // always runs into its own end while `key` is alive
+    bool expectMoreFields = true;
+    while expectMoreFields && !this.hasError {
+        expectMoreFields = false;
         this.skipWhitespace();
         if this.pos >= this.input.getLength() || this.input[this.pos] != '"' {
             this.fail("Expected string key in object");
-            return nil<JsonValue*>;
+        } else {
+            const String key = this.parseStringLiteral();
+            if !this.hasError {
+                this.parseObjectFieldValue(obj, key, expectMoreFields);
+            }
         }
-        const String key = this.parseStringLiteral();
-        if this.hasError { return nil<JsonValue*>; }
-        this.skipWhitespace();
-        if this.pos >= this.input.getLength() || this.input[this.pos] != ':' {
-            this.fail("Expected ':' in object");
-            return nil<JsonValue*>;
-        }
-        this.pos++; // consume ':'
-        this.skipWhitespace();
-        JsonValue* value = this.parseValue();
-        if this.hasError { return nil<JsonValue*>; }
-        obj.addObjectField(key, value);
-        this.skipWhitespace();
-        if this.pos >= this.input.getLength() {
-            this.fail("Unterminated object");
-            return nil<JsonValue*>;
-        }
-        const char c = this.input[this.pos];
-        if c == ',' {
-            this.pos++;
-            continue;
-        }
-        if c == '}' {
-            this.pos++;
-            return obj;
-        }
-        this.fail("Expected ',' or '}' in object");
+    }
+    if this.hasError {
+        deleteJsonValue(obj);
         return nil<JsonValue*>;
     }
-    return nil<JsonValue*>;
+    return obj;
+}
+
+// Parse the ':' separator, the field value and the separator that follows it.
+// `moreFields` is set when another field is expected after this one.
+p JsonParser.parseObjectFieldValue(JsonValue* obj, const String& key, bool& moreFields) {
+    this.skipWhitespace();
+    if this.pos >= this.input.getLength() || this.input[this.pos] != ':' {
+        this.fail("Expected ':' in object");
+        return;
+    }
+    this.pos++; // consume ':'
+    this.skipWhitespace();
+    JsonValue* value = this.parseValue();
+    if this.hasError { return; }
+    obj.addObjectField(key, value);
+    this.skipWhitespace();
+    if this.pos >= this.input.getLength() {
+        this.fail("Unterminated object");
+        return;
+    }
+    const char c = this.input[this.pos];
+    if c == ',' {
+        this.pos++;
+        moreFields = true;
+        return;
+    }
+    if c == '}' {
+        this.pos++;
+        return;
+    }
+    this.fail("Expected ',' or '}' in object");
 }

--- a/std/text/json-value.spice
+++ b/std/text/json-value.spice
@@ -20,6 +20,16 @@ public type JsonValueKind enum {
  * parsed. Numbers are stored as `double`; integers are representable up to
  * 2^53. Object fields preserve insertion order.
  *
+ * Destroying a value recursively destroys everything below it, so a whole tree
+ * is released with a single `deleteJsonValue` call on its root. Accessors like
+ * `getField` hand out borrowed pointers that stay owned by their parent, while
+ * `addArrayItem` and `addObjectField` take ownership of what they are given.
+ *
+ * Note that the root cannot simply be held in a `heap JsonValue*` and left to
+ * the compiler: the `heap` qualifier only emits a raw deallocation when the
+ * variable goes out of scope and never runs the destructor of the pointee, so
+ * the children below the root would be lost.
+ *
  * Parsing lives in "std/text/json-parser" and serialization in
  * "std/text/json-serializer", so programs only pull in what they use.
  */
@@ -78,6 +88,45 @@ public p JsonValue.ctor(double value) {
 public p JsonValue.ctor(const String& value) {
     this.kind = JsonValueKind::JSON_STRING;
     this.stringValue = value;
+}
+
+/**
+ * Destruct the JSON value, releasing every array item and object field it owns.
+ * Since the children are destroyed the same way, this tears down the whole
+ * subtree below the value.
+ */
+public p JsonValue.dtor() {
+    for unsigned long i = 0l; i < this.arrayItems.getSize(); i++ {
+        deleteJsonValue(this.arrayItems.get(i));
+    }
+    for unsigned long i = 0l; i < this.objectValues.getSize(); i++ {
+        deleteJsonValue(this.objectValues.get(i));
+    }
+    // Vector does not destruct its items, so the keys have to be released by hand
+    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
+        String& key = this.objectKeys.get(i);
+        key.dtor();
+    }
+}
+
+/**
+ * Destroys a heap-allocated JSON value together with everything it owns and sets
+ * the given handle to nil, so releasing a whole tree only takes one call on its root.
+ *
+ * Note that this is what `sDelete` would normally be used for. It cannot be used
+ * here, because a value tree is destroyed recursively and the compiler does not
+ * emit an explicit dtor that is only reached through `sDestruct`.
+ *
+ * @param value Handle of the value to destroy
+ */
+public p deleteJsonValue(JsonValue*& value) {
+    if value == nil<JsonValue*> { return; }
+    value.dtor();
+    unsafe {
+        heap byte* raw = cast<heap byte*>(value);
+        sDealloc(raw);
+    }
+    value = nil<JsonValue*>;
 }
 
 // --- Kind inspection -------------------------------------------------------
@@ -245,9 +294,9 @@ public f<JsonValue*> JsonValue.getObjectValue(unsigned long idx) {
  */
 public f<bool> JsonValue.hasField(string key) {
     if this.kind != JsonValueKind::JSON_OBJECT { return false; }
-    const String keyStr = String(key);
+    // Comparing against the raw key avoids building a String that would have to be cleaned up
     for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
-        if this.objectKeys.get(i) == keyStr { return true; }
+        if this.objectKeys.get(i) == key { return true; }
     }
     return false;
 }
@@ -261,9 +310,9 @@ public f<bool> JsonValue.hasField(string key) {
  */
 public f<JsonValue*> JsonValue.getField(string key) {
     assert this.kind == JsonValueKind::JSON_OBJECT;
-    const String keyStr = String(key);
+    // Comparing against the raw key avoids building a String that would have to be cleaned up
     for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
-        if this.objectKeys.get(i) == keyStr {
+        if this.objectKeys.get(i) == key {
             return this.objectValues.get(i);
         }
     }

--- a/std/text/xml-node.spice
+++ b/std/text/xml-node.spice
@@ -14,7 +14,17 @@ public type XmlNodeKind enum {
  * Element nodes carry a tag name, ordered attributes and ordered child nodes
  * (which may themselves be elements or text). Text nodes carry only the
  * decoded character data. Children are owned as heap pointers so the parsed
- * tree is reached via `XmlNode*` (`heap` on the root).
+ * tree is reached via `XmlNode*`.
+ *
+ * Destroying a node recursively destroys everything below it, so a whole tree
+ * is released with a single `deleteXmlNode` call on its root. Accessors like
+ * `getChild` and `findChild` hand out borrowed pointers that stay owned by
+ * their parent, while `addChild` takes ownership of what it is given.
+ *
+ * Note that the root cannot simply be held in a `heap XmlNode*` and left to the
+ * compiler: the `heap` qualifier only emits a raw deallocation when the variable
+ * goes out of scope and never runs the destructor of the pointee, so the
+ * children below the root would be lost.
  *
  * Parsing lives in "std/text/xml-parser" and serialization in
  * "std/text/xml-serializer", so programs only pull in what they use.
@@ -42,6 +52,46 @@ public p XmlNode.ctor() {
  */
 public p XmlNode.ctor(XmlNodeKind kind) {
     this.kind = kind;
+}
+
+/**
+ * Destruct the XML node, releasing every child node and attribute it owns.
+ * Since the children are destroyed the same way, this tears down the whole
+ * subtree below the node.
+ */
+public p XmlNode.dtor() {
+    for unsigned long i = 0l; i < this.children.getSize(); i++ {
+        deleteXmlNode(this.children.get(i));
+    }
+    // Vector does not destruct its items, so the attributes have to be released by hand
+    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
+        String& key = this.attributeKeys.get(i);
+        key.dtor();
+    }
+    for unsigned long i = 0l; i < this.attributeValues.getSize(); i++ {
+        String& value = this.attributeValues.get(i);
+        value.dtor();
+    }
+}
+
+/**
+ * Destroys a heap-allocated XML node together with everything it owns and sets
+ * the given handle to nil, so releasing a whole tree only takes one call on its root.
+ *
+ * Note that this is what `sDelete` would normally be used for. It cannot be used
+ * here, because a node tree is destroyed recursively and the compiler does not
+ * emit an explicit dtor that is only reached through `sDestruct`.
+ *
+ * @param node Handle of the node to destroy
+ */
+public p deleteXmlNode(XmlNode*& node) {
+    if node == nil<XmlNode*> { return; }
+    node.dtor();
+    unsafe {
+        heap byte* raw = cast<heap byte*>(node);
+        sDealloc(raw);
+    }
+    node = nil<XmlNode*>;
 }
 
 // --- Kind inspection -------------------------------------------------------
@@ -149,9 +199,9 @@ public f<const String&> XmlNode.getAttributeValue(unsigned long idx) {
  */
 public f<bool> XmlNode.hasAttribute(string name) {
     if this.kind != XmlNodeKind::XML_ELEMENT { return false; }
-    const String nameStr = String(name);
+    // Comparing against the raw name avoids building a String that would have to be cleaned up
     for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
-        if this.attributeKeys.get(i) == nameStr { return true; }
+        if this.attributeKeys.get(i) == name { return true; }
     }
     return false;
 }
@@ -165,9 +215,9 @@ public f<bool> XmlNode.hasAttribute(string name) {
  */
 public f<const String&> XmlNode.getAttribute(string name) {
     assert this.kind == XmlNodeKind::XML_ELEMENT;
-    const String nameStr = String(name);
+    // Comparing against the raw name avoids building a String that would have to be cleaned up
     for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
-        if this.attributeKeys.get(i) == nameStr {
+        if this.attributeKeys.get(i) == name {
             return this.attributeValues.get(i);
         }
     }
@@ -237,10 +287,10 @@ public p XmlNode.addChild(XmlNode* child) {
  */
 public f<XmlNode*> XmlNode.findChild(string name) {
     assert this.kind == XmlNodeKind::XML_ELEMENT;
-    const String nameStr = String(name);
+    // Comparing against the raw name avoids building a String that would have to be cleaned up
     for unsigned long i = 0l; i < this.children.getSize(); i++ {
         XmlNode* child = this.children.get(i);
-        if child.kind == XmlNodeKind::XML_ELEMENT && child.name == nameStr {
+        if child.kind == XmlNodeKind::XML_ELEMENT && child.name == name {
             return child;
         }
     }

--- a/std/text/xml-parser.spice
+++ b/std/text/xml-parser.spice
@@ -17,7 +17,7 @@ import "std/text/analysis";
 public type XmlParser struct {
     String input
     unsigned long pos
-    String errorMessage
+    string errorMessage  // always points to a string literal, so it outlives the parser
     bool hasError
 }
 
@@ -29,6 +29,7 @@ public type XmlParser struct {
 public p XmlParser.ctor(const String& input) {
     this.input = input;
     this.pos = 0l;
+    this.errorMessage = "";
     this.hasError = false;
 }
 
@@ -40,21 +41,25 @@ public p XmlParser.ctor(const String& input) {
 public f<Result<XmlNode*>> XmlParser.parse() {
     this.skipProlog();
     if this.hasError {
-        return err<XmlNode*>(Error(this.errorMessage.getRaw()));
+        return err<XmlNode*>(Error(this.errorMessage));
     }
     this.skipWhitespace();
     if this.pos >= this.input.getLength() || this.input[this.pos] != '<' {
         return err<XmlNode*>(Error("Expected root element"));
     }
+    // Nothing is handed out on failure, so the partially built tree is ours to release
     XmlNode* root = this.parseElement();
     if this.hasError {
-        return err<XmlNode*>(Error(this.errorMessage.getRaw()));
+        deleteXmlNode(root);
+        return err<XmlNode*>(Error(this.errorMessage));
     }
     this.skipMisc();
     if this.hasError {
-        return err<XmlNode*>(Error(this.errorMessage.getRaw()));
+        deleteXmlNode(root);
+        return err<XmlNode*>(Error(this.errorMessage));
     }
     if this.pos < this.input.getLength() {
+        deleteXmlNode(root);
         return err<XmlNode*>(Error("Trailing data after root element"));
     }
     return ok(root);
@@ -63,8 +68,10 @@ public f<Result<XmlNode*>> XmlParser.parse() {
 /**
  * Parse an XML document and return the root element.
  *
- * On success returns the root XmlNode (heap-allocated; the caller owns it).
- * On failure returns an error describing the first problem encountered.
+ * On success returns the root XmlNode, which the caller owns and releases again
+ * with `deleteXmlNode` from "std/text/xml-node". On failure the partially built
+ * tree is released by the parser and an error describing the first problem
+ * encountered is returned.
  */
 public f<Result<XmlNode*>> parseXml(const String& input) {
     XmlParser parser = XmlParser(input);
@@ -81,7 +88,7 @@ p XmlParser.skipWhitespace() {
 
 p XmlParser.fail(string msg) {
     if !this.hasError {
-        this.errorMessage = String(msg);
+        this.errorMessage = msg;
         this.hasError = true;
     }
 }
@@ -125,16 +132,8 @@ p XmlParser.skipMisc() {
     while true {
         this.skipWhitespace();
         if this.startsWith("<!--") {
-            this.pos += 4l;
-            while this.pos + 2l < this.input.getLength() &&
-                  !(this.input[this.pos] == '-' && this.input[this.pos + 1l] == '-' && this.input[this.pos + 2l] == '>') {
-                this.pos++;
-            }
-            if this.pos + 2l >= this.input.getLength() {
-                this.fail("Unterminated comment");
-                return;
-            }
-            this.pos += 3l; // consume '-->'
+            this.skipComment();
+            if this.hasError { return; }
             continue;
         }
         if this.startsWith("<?") {
@@ -142,15 +141,8 @@ p XmlParser.skipMisc() {
                 this.fail("XML declaration is only allowed at the document start");
                 return;
             }
-            this.pos += 2l;
-            while this.pos + 1l < this.input.getLength() && !(this.input[this.pos] == '?' && this.input[this.pos + 1l] == '>') {
-                this.pos++;
-            }
-            if this.pos + 1l >= this.input.getLength() {
-                this.fail("Unterminated processing instruction");
-                return;
-            }
-            this.pos += 2l; // consume '?>'
+            this.skipProcessingInstruction();
+            if this.hasError { return; }
             continue;
         }
         break;
@@ -204,21 +196,20 @@ f<String> XmlParser.readAttributeValue() {
         return out;
     }
     this.pos++; // consume opening quote
-    while this.pos < this.input.getLength() && this.input[this.pos] != quote {
+    // The loop always runs into its own end condition while `decoded` is alive
+    while !this.hasError && this.pos < this.input.getLength() && this.input[this.pos] != quote {
         const char c = this.input[this.pos];
         if c == '<' {
             this.fail("Unescaped '<' in attribute value");
-            return out;
-        }
-        if c == '&' {
+        } else if c == '&' {
             const String decoded = this.readEntity();
-            if this.hasError { return out; }
-            out += decoded;
-            continue;
+            if !this.hasError { out += decoded; }
+        } else {
+            out += c;
+            this.pos++;
         }
-        out += c;
-        this.pos++;
     }
+    if this.hasError { return out; }
     if this.pos >= this.input.getLength() {
         this.fail("Unterminated attribute value");
         return out;
@@ -241,162 +232,211 @@ f<String> XmlParser.readEntity() {
         this.fail("Unterminated entity reference");
         return out;
     }
+    // `name` has to stay alive until the end of the scope, so that it gets cleaned up
     const String name = this.input.getSubstring(start, this.pos - start);
     this.pos++; // consume ';'
-    if name == String("lt")   { out += '<';  return out; }
-    if name == String("gt")   { out += '>';  return out; }
-    if name == String("amp")  { out += '&';  return out; }
-    if name == String("quot") { out += '"';  return out; }
-    if name == String("apos") { out += '\''; return out; }
-    if name.getLength() >= 2l && name[0] == '#' {
-        int codepoint = 0;
-        unsigned long digitStart = 1l;
-        int base = 10;
-        if name.getLength() >= 3l && (name[1] == 'x' || name[1] == 'X') {
-            digitStart = 2l;
-            base = 16;
-        }
-        if digitStart >= name.getLength() {
-            this.fail("Invalid numeric character reference");
-            return out;
-        }
-        for unsigned long i = digitStart; i < name.getLength(); i++ {
-            const char d = name[i];
-            int digit = -1;
-            if isDigit(d) {
-                digit = cast<int>(d) - cast<int>('0');
-            } else if base == 16 && d >= 'a' && d <= 'f' {
-                digit = cast<int>(d) - cast<int>('a') + 10;
-            } else if base == 16 && d >= 'A' && d <= 'F' {
-                digit = cast<int>(d) - cast<int>('A') + 10;
-            }
-            if digit < 0 || digit >= base {
-                this.fail("Invalid numeric character reference");
-                return out;
-            }
-            codepoint = codepoint * base + digit;
-        }
-        if codepoint < 0 || codepoint > 0x7F {
-            this.fail("Numeric character reference out of supported range");
-            return out;
-        }
-        out += cast<char>(codepoint);
-        return out;
+    if name == "lt" {
+        out += '<';
+    } else if name == "gt" {
+        out += '>';
+    } else if name == "amp" {
+        out += '&';
+    } else if name == "quot" {
+        out += '"';
+    } else if name == "apos" {
+        out += '\'';
+    } else if name.getLength() >= 2l && name[0] == '#' {
+        this.appendCharacterReference(name, out);
+    } else {
+        this.fail("Unknown entity reference");
     }
-    this.fail("Unknown entity reference");
     return out;
 }
 
-p XmlParser.parseAttributes(XmlNode* element) {
-    while true {
-        this.skipWhitespace();
-        if this.pos >= this.input.getLength() { return; }
-        const char c = this.input[this.pos];
-        if c == '>' || c == '/' { return; }
-        const String attrName = this.readName();
-        if this.hasError { return; }
-        this.skipWhitespace();
-        if this.pos >= this.input.getLength() || this.input[this.pos] != '=' {
-            this.fail("Expected '=' in attribute");
+// Decode a numeric character reference (`#NN` or `#xNN`) and append it to `out`
+p XmlParser.appendCharacterReference(const String& name, String& out) {
+    int codepoint = 0;
+    unsigned long digitStart = 1l;
+    int base = 10;
+    if name.getLength() >= 3l && (name[1] == 'x' || name[1] == 'X') {
+        digitStart = 2l;
+        base = 16;
+    }
+    if digitStart >= name.getLength() {
+        this.fail("Invalid numeric character reference");
+        return;
+    }
+    for unsigned long i = digitStart; i < name.getLength(); i++ {
+        const char d = name[i];
+        int digit = -1;
+        if isDigit(d) {
+            digit = cast<int>(d) - cast<int>('0');
+        } else if base == 16 && d >= 'a' && d <= 'f' {
+            digit = cast<int>(d) - cast<int>('a') + 10;
+        } else if base == 16 && d >= 'A' && d <= 'F' {
+            digit = cast<int>(d) - cast<int>('A') + 10;
+        }
+        if digit < 0 || digit >= base {
+            this.fail("Invalid numeric character reference");
             return;
         }
-        this.pos++; // consume '='
+        codepoint = codepoint * base + digit;
+    }
+    if codepoint < 0 || codepoint > 0x7F {
+        this.fail("Numeric character reference out of supported range");
+        return;
+    }
+    out += cast<char>(codepoint);
+}
+
+p XmlParser.parseAttributes(XmlNode* element) {
+    bool moreAttributes = true;
+    while moreAttributes && !this.hasError {
         this.skipWhitespace();
-        const String attrValue = this.readAttributeValue();
-        if this.hasError { return; }
-        for unsigned long i = 0l; i < element.getAttributeCount(); i++ {
-            if element.getAttributeKey(i) == attrName {
-                this.fail("Duplicate attribute name");
-                return;
+        if this.pos >= this.input.getLength() {
+            moreAttributes = false;
+        } else {
+            const char c = this.input[this.pos];
+            if c == '>' || c == '/' {
+                moreAttributes = false;
+            } else {
+                this.parseAttribute(element);
             }
         }
+    }
+}
+
+p XmlParser.parseAttribute(XmlNode* element) {
+    // `attrName` and `attrValue` have to stay alive until the end of the scope,
+    // so that they get cleaned up
+    const String attrName = this.readName();
+    this.skipWhitespace();
+    if !this.hasError && (this.pos >= this.input.getLength() || this.input[this.pos] != '=') {
+        this.fail("Expected '=' in attribute");
+    }
+    if !this.hasError {
+        this.pos++; // consume '='
+        this.skipWhitespace();
+    }
+    const String attrValue = this.readAttributeValue();
+    if !this.hasError && this.hasAttributeNamed(element, attrName) {
+        this.fail("Duplicate attribute name");
+    }
+    if !this.hasError {
         element.addAttribute(attrName, attrValue);
     }
 }
 
+f<bool> XmlParser.hasAttributeNamed(XmlNode* element, const String& name) {
+    bool found = false;
+    const unsigned long attributeCount = element.getAttributeCount();
+    for unsigned long i = 0l; !found && i < attributeCount; i++ {
+        found = element.getAttributeKey(i) == name;
+    }
+    return found;
+}
+
 p XmlParser.parseChildren(XmlNode* element) {
-    while true {
+    bool insideElement = true;
+    while insideElement && !this.hasError {
         if this.pos >= this.input.getLength() {
             this.fail("Unterminated element");
-            return;
-        }
-        if this.startsWith("</") {
-            this.pos += 2l;
-            const String closeName = this.readName();
-            if this.hasError { return; }
-            if closeName != element.getName() {
-                this.fail("Mismatched closing tag");
-                return;
-            }
-            this.skipWhitespace();
-            if this.pos >= this.input.getLength() || this.input[this.pos] != '>' {
-                this.fail("Expected '>' in closing tag");
-                return;
-            }
-            this.pos++; // consume '>'
-            return;
-        }
-        if this.startsWith("<!--") {
-            this.pos += 4l;
-            while this.pos + 2l < this.input.getLength() &&
-                  !(this.input[this.pos] == '-' && this.input[this.pos + 1l] == '-' && this.input[this.pos + 2l] == '>') {
-                this.pos++;
-            }
-            if this.pos + 2l >= this.input.getLength() {
-                this.fail("Unterminated comment");
-                return;
-            }
-            this.pos += 3l;
-            continue;
-        }
-        if this.startsWith("<![CDATA[") {
-            this.pos += 9l;
-            const unsigned long start = this.pos;
-            while this.pos + 2l < this.input.getLength() &&
-                  !(this.input[this.pos] == ']' && this.input[this.pos + 1l] == ']' && this.input[this.pos + 2l] == '>') {
-                this.pos++;
-            }
-            if this.pos + 2l >= this.input.getLength() {
-                this.fail("Unterminated CDATA section");
-                return;
-            }
-            const String content = this.input.getSubstring(start, this.pos - start);
-            this.pos += 3l; // consume ']]>'
-            XmlNode* cdataNode = __new<XmlNode>(XmlNodeKind::XML_TEXT);
-            cdataNode.setText(content);
-            element.addChild(cdataNode);
-            continue;
-        }
-        if this.startsWith("<?") {
-            this.pos += 2l;
-            while this.pos + 1l < this.input.getLength() && !(this.input[this.pos] == '?' && this.input[this.pos + 1l] == '>') {
-                this.pos++;
-            }
-            if this.pos + 1l >= this.input.getLength() {
-                this.fail("Unterminated processing instruction");
-                return;
-            }
-            this.pos += 2l;
-            continue;
-        }
-        if this.input[this.pos] == '<' {
+        } else if this.startsWith("</") {
+            this.parseClosingTag(element);
+            insideElement = false;
+        } else if this.startsWith("<!--") {
+            this.skipComment();
+        } else if this.startsWith("<![CDATA[") {
+            this.parseCdataSection(element);
+        } else if this.startsWith("<?") {
+            this.skipProcessingInstruction();
+        } else if this.input[this.pos] == '<' {
             XmlNode* child = this.parseElement();
-            if this.hasError { return; }
-            element.addChild(child);
-            continue;
+            if !this.hasError { element.addChild(child); }
+        } else {
+            this.parseCharacterData(element);
         }
-        String text;
-        while this.pos < this.input.getLength() && this.input[this.pos] != '<' {
-            const char c = this.input[this.pos];
-            if c == '&' {
-                const String decoded = this.readEntity();
-                if this.hasError { return; }
-                text += decoded;
-                continue;
-            }
+    }
+}
+
+p XmlParser.parseClosingTag(XmlNode* element) {
+    this.pos += 2l; // consume '</'
+    // `closeName` has to stay alive until the end of the scope, so that it gets cleaned up
+    const String closeName = this.readName();
+    if !this.hasError && closeName != element.getName() {
+        this.fail("Mismatched closing tag");
+    }
+    if !this.hasError {
+        this.skipWhitespace();
+        if this.pos >= this.input.getLength() || this.input[this.pos] != '>' {
+            this.fail("Expected '>' in closing tag");
+        } else {
+            this.pos++; // consume '>'
+        }
+    }
+}
+
+// Skip a '<!-- ... -->' comment, including its delimiters
+p XmlParser.skipComment() {
+    this.pos += 4l; // consume '<!--'
+    while this.pos + 2l < this.input.getLength() &&
+          !(this.input[this.pos] == '-' && this.input[this.pos + 1l] == '-' && this.input[this.pos + 2l] == '>') {
+        this.pos++;
+    }
+    if this.pos + 2l >= this.input.getLength() {
+        this.fail("Unterminated comment");
+        return;
+    }
+    this.pos += 3l; // consume '-->'
+}
+
+// Skip a '<? ... ?>' processing instruction, including its delimiters
+p XmlParser.skipProcessingInstruction() {
+    this.pos += 2l; // consume '<?'
+    while this.pos + 1l < this.input.getLength() && !(this.input[this.pos] == '?' && this.input[this.pos + 1l] == '>') {
+        this.pos++;
+    }
+    if this.pos + 1l >= this.input.getLength() {
+        this.fail("Unterminated processing instruction");
+        return;
+    }
+    this.pos += 2l; // consume '?>'
+}
+
+p XmlParser.parseCdataSection(XmlNode* element) {
+    this.pos += 9l; // consume '<![CDATA['
+    const unsigned long start = this.pos;
+    while this.pos + 2l < this.input.getLength() &&
+          !(this.input[this.pos] == ']' && this.input[this.pos + 1l] == ']' && this.input[this.pos + 2l] == '>') {
+        this.pos++;
+    }
+    if this.pos + 2l >= this.input.getLength() {
+        this.fail("Unterminated CDATA section");
+        return;
+    }
+    // `content` has to stay alive until the end of the scope, so that it gets cleaned up
+    const String content = this.input.getSubstring(start, this.pos - start);
+    this.pos += 3l; // consume ']]>'
+    XmlNode* cdataNode = __new<XmlNode>(XmlNodeKind::XML_TEXT);
+    cdataNode.setText(content);
+    element.addChild(cdataNode);
+}
+
+p XmlParser.parseCharacterData(XmlNode* element) {
+    // `text` and `decoded` have to stay alive until the end of their scope,
+    // so that they get cleaned up
+    String text;
+    while !this.hasError && this.pos < this.input.getLength() && this.input[this.pos] != '<' {
+        const char c = this.input[this.pos];
+        if c == '&' {
+            const String decoded = this.readEntity();
+            if !this.hasError { text += decoded; }
+        } else {
             text += c;
             this.pos++;
         }
+    }
+    if !this.hasError {
         XmlNode* textNode = __new<XmlNode>(XmlNodeKind::XML_TEXT);
         textNode.setText(text);
         element.addChild(textNode);
@@ -409,32 +449,40 @@ f<XmlNode*> XmlParser.parseElement() {
         return nil<XmlNode*>;
     }
     this.pos++; // consume '<'
+    // `name` has to stay alive until the end of the scope, so that it gets cleaned up
     const String name = this.readName();
-    if this.hasError { return nil<XmlNode*>; }
-    XmlNode* element = __new<XmlNode>(XmlNodeKind::XML_ELEMENT);
-    element.setName(name);
+    XmlNode* element = nil<XmlNode*>;
+    if !this.hasError {
+        element = __new<XmlNode>(XmlNodeKind::XML_ELEMENT);
+        element.setName(name);
+        this.parseElementBody(element);
+        if this.hasError { deleteXmlNode(element); }
+    }
+    return element;
+}
+
+// Parse the attributes and - unless the tag is self-closing - the children of an element
+p XmlParser.parseElementBody(XmlNode* element) {
     this.parseAttributes(element);
-    if this.hasError { return nil<XmlNode*>; }
+    if this.hasError { return; }
     if this.pos >= this.input.getLength() {
         this.fail("Unterminated start tag");
-        return nil<XmlNode*>;
+        return;
     }
     if this.input[this.pos] == '/' {
         // Self-closing tag '<name ... />'
         this.pos++;
         if this.pos >= this.input.getLength() || this.input[this.pos] != '>' {
             this.fail("Expected '>' after '/' in self-closing tag");
-            return nil<XmlNode*>;
+            return;
         }
         this.pos++; // consume '>'
-        return element;
+        return;
     }
     if this.input[this.pos] != '>' {
         this.fail("Expected '>' in start tag");
-        return nil<XmlNode*>;
+        return;
     }
     this.pos++; // consume '>'
     this.parseChildren(element);
-    if this.hasError { return nil<XmlNode*>; }
-    return element;
 }

--- a/test/test-files/std/text/json-parser/source.spice
+++ b/test/test-files/std/text/json-parser/source.spice
@@ -118,6 +118,12 @@ f<int> main() {
     Result<JsonValue*> trailRes = parseJson(String("42 garbage"));
     assert !trailRes.isOk();
 
+    // The error message stays valid after the parser is gone
+    const Error trailErr = trailRes.getErr();
+    assert isRawEqual(trailErr.message, "Trailing data after JSON value");
+    const Error badErr = badRes.getErr();
+    assert isRawEqual(badErr.message, "Unexpected character in JSON input");
+
     // Incomplete number literals must be rejected
     Result<JsonValue*> bareMinusRes = parseJson(String("-"));
     assert !bareMinusRes.isOk();
@@ -133,6 +139,20 @@ f<int> main() {
     assert !rawNewlineRes.isOk();
     Result<JsonValue*> rawTabRes = parseJson(String("\"a\tb\""));
     assert !rawTabRes.isOk();
+
+    // Every parsed tree is owned by the caller, so release them all again
+    deleteJsonValue(n);
+    deleteJsonValue(t);
+    deleteJsonValue(falseVal);
+    deleteJsonValue(i);
+    deleteJsonValue(neg);
+    deleteJsonValue(e);
+    deleteJsonValue(s);
+    deleteJsonValue(q);
+    deleteJsonValue(arr);
+    deleteJsonValue(emptyArr);
+    deleteJsonValue(emptyObj);
+    deleteJsonValue(obj);
 
     printf("All assertions passed!");
 }

--- a/test/test-files/std/text/json-serializer/source.spice
+++ b/test/test-files/std/text/json-serializer/source.spice
@@ -70,5 +70,14 @@ f<int> main() {
     JsonValue* precReparsed = precReparsedRes.unwrap();
     assert precReparsed.getNumber() == 1.23456789;
 
+    // Every parsed tree is owned by the caller, so release them all again
+    deleteJsonValue(compact);
+    deleteJsonValue(emptyArrSer);
+    deleteJsonValue(emptyObjSer);
+    deleteJsonValue(reParsed);
+    deleteJsonValue(pretty);
+    deleteJsonValue(prec);
+    deleteJsonValue(precReparsed);
+
     printf("All assertions passed!");
 }

--- a/test/test-files/std/text/xml-parser/source.spice
+++ b/test/test-files/std/text/xml-parser/source.spice
@@ -77,6 +77,10 @@ f<int> main() {
     Result<XmlNode*> mismatchRes = parseXml(String("<a></b>"));
     assert !mismatchRes.isOk();
 
+    // The error message stays valid after the parser is gone
+    const Error mismatchErr = mismatchRes.getErr();
+    assert isRawEqual(mismatchErr.message, "Mismatched closing tag");
+
     Result<XmlNode*> dupAttrRes = parseXml(String("<a x='1' x='2'/>"));
     assert !dupAttrRes.isOk();
 
@@ -99,6 +103,13 @@ f<int> main() {
     assert prologRes.isOk();
     XmlNode* prologRoot = prologRes.unwrap();
     assert prologRoot.getName() == String("root");
+
+    // Every parsed tree is owned by the caller, so release them all again
+    deleteXmlNode(empty);
+    deleteXmlNode(a);
+    deleteXmlNode(msg);
+    deleteXmlNode(book);
+    deleteXmlNode(prologRoot);
 
     printf("All assertions passed!");
 }

--- a/test/test-files/std/text/xml-serializer/source.spice
+++ b/test/test-files/std/text/xml-serializer/source.spice
@@ -43,5 +43,12 @@ f<int> main() {
     expectedPrettyXml += "</root>";
     assert prettySerializer.serialize(prettyXml) == expectedPrettyXml;
 
+    // Every parsed tree is owned by the caller, so release them all again
+    deleteXmlNode(serSelf);
+    deleteXmlNode(serText);
+    deleteXmlNode(serRound);
+    deleteXmlNode(reparsedRoot);
+    deleteXmlNode(prettyXml);
+
     printf("All assertions passed!");
 }


### PR DESCRIPTION
## What changed

- `JsonValue` and `XmlNode` get a recursive destructor plus a `deleteJsonValue` / `deleteXmlNode` helper, so a whole parsed tree is released with one call on its root. `parseJson` / `parseXml` release partially built trees on their error paths.
- Fixed two further leak sources in the same modules: `Vector` does not destruct the items it holds, so object keys and attributes are released by hand; and leaving a scope via `return`/`break`/`continue` skips cleanup of the locals alive in it, which abandoned one `String` per object field and per closing tag **on the happy path**.
- Fixed two bugs found while doing the above: both parsers handed out a raw pointer into a `String` field for their error message (callers read freed memory once the parser was gone), and appending a decoded entity that failed to parse dereferenced a nil buffer, crashing the XML parser on any malformed entity reference.

## Why

`JsonValue` and `XmlNode` own their children as heap pointers but had no destructor, so every parsed tree leaked in full. Measured with `spice run --sanitizer=address` on the existing reference tests:

| test | before | after |
|---|---|---|
| `text_jsonParser` | 4355 B / 66 allocs | **0** |
| `text_jsonSerializer` | 5390 B / 83 allocs | **0** |
| `text_xmlParser` | 5947 B / 122 allocs | **0** |
| `text_xmlSerializer` | 5376 B / 94 allocs | **0** |

Two compiler limitations shaped the implementation and are worth knowing about:

- **`sDelete` cannot be used here.** It reaches the destructor through `sDestruct<T>`, which fails to link for a struct with an explicit `dtor()`: `undefined symbol: JsonValue::dtor() >>> referenced by memory_rt.spice`. Hence the module-local delete helper, which calls the destructor directly.
- **The `heap` qualifier cannot be used either.** It only emits a raw deallocation when the variable goes out of scope and never runs the destructor of the pointee — the compiler even reports the explicit `dtor()` as unused. A `heap JsonValue*` root would free the root node and silently lose everything below it.

The abandoned-locals problem is a **general compiler bug**, not specific to these modules: cleanup is only emitted on the fall-through edge out of a scope, so any live non-trivial local is leaked when the scope is left via `return`, `break` or `continue`. Confirmed for loop-body locals with `break`/`continue`/`return`, function-scope locals with a `return` nested in an `if` or a loop, and `if`-body locals with a `break`. Returning the local itself is fine, and a `return` that *is* the last statement of the scope is fine. The affected loops here are written to always run into their own end condition; a proper fix belongs in `IRGenerator::generateScopeCleanup`. Happy to file that separately if useful — it leaks across the whole standard library, not just here.

## How it was validated

- `spice run --sanitizer=address` on all four reference tests — **zero leaks**, where they previously leaked 4–6 kB each.
- Same, clean, for every JSON/XML error path (20 malformed inputs), which also verifies the error messages now survive the parser instead of being garbage.
- **Differential testing**, since the XML parser was restructured substantially: 27 XML documents and 24 JSON documents parsed and re-serialized against the pre-change parsers — **byte-identical output** in both, covering entities, numeric character references, CDATA, processing instructions, prologs, mixed content, namespaced names, self-closing tags and every error case.
- `cmake-build-debug/test/spicetest --gtest_filter='StdTests.text_*'` — 11/11 pass.
- `cmake-build-debug/test/spicetest --gtest_filter='StdTests.*'` — 105 pass, 1 skipped (`net_socketsBasic`), 1 failure: `bindings_llvm`, which fails on unmodified `main` too (the linker command contains an unexpanded `$LLVM_LIB_DIR`, i.e. environmental).

## Follow-up / known limitations

- **This is an API change**: callers of `parseJson` / `parseXml` now own the returned root and must release it with `deleteJsonValue` / `deleteXmlNode`. The reference tests were updated accordingly.
- `csv-parser` / `csv-serializer` still leak (536 B / 1653 B). Their leak lives in the `Vector<Vector<String>>` that is handed back to the caller, so it needs `Vector` to destruct its elements rather than this pattern — related to #1256.
- `String.append(const String&)` forwards to `getRaw()`, which returns `nil` for a String that was never allocated, so appending an empty-but-unallocated String segfaults. Worked around at both call sites here; the underlying sharp edge in `string_rt` remains.

Refs #1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
