### PR TITLE
Add TOML support to the standard library

### DIFF
--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -2,8 +2,6 @@
 
 #include "TypeChecker.h"
 
-#include <unordered_set>
-
 #include <SourceFile.h>
 #include <ast/Attributes.h>
 #include <global/GlobalResourceManager.h>

--- a/std/README.md
+++ b/std/README.md
@@ -131,16 +131,16 @@ Basic mechanisms for testing in Spice.
 ### `std/text`
 Text processing, parsing, and formatted output.
 
-| Module                                                  | Description                                        |
-|---------------------------------------------------------|----------------------------------------------------|
-| `print`                                                 | Formatted printing helpers.                        |
-| `format`                                                | String formatting.                                 |
-| `stringstream`                                          | Stream-style string building.                      |
-| `string-ext`                                            | Extra string utility functions.                    |
-| `analysis`                                              | Text analysis helpers.                             |
-| `csv-parser` / `json-parser` / `xml-parser`             | Parsers for CSV, JSON, and XML.                    |
-| `csv-serializer` / `json-serializer` / `xml-serializer` | Serializers for CSV, JSON, and XML.                |
-| `json-value` / `xml-node`                               | Data models shared by the parsers and serializers. |
+| Module                                                                      | Description                                        |
+|-----------------------------------------------------------------------------|----------------------------------------------------|
+| `print`                                                                     | Formatted printing helpers.                        |
+| `format`                                                                    | String formatting.                                 |
+| `stringstream`                                                              | Stream-style string building.                      |
+| `string-ext`                                                                | Extra string utility functions.                    |
+| `analysis`                                                                  | Text analysis helpers.                             |
+| `csv-parser` / `json-parser` / `toml-parser` / `xml-parser`                 | Parsers for CSV, JSON, TOML, and XML.              |
+| `csv-serializer` / `json-serializer` / `toml-serializer` / `xml-serializer` | Serializers for CSV, JSON, TOML, and XML.          |
+| `json-value` / `toml-value` / `xml-node`                                    | Data models shared by the parsers and serializers. |
 
 ### `std/time`
 Accessing system time in different formats and measuring durations.

--- a/std/text/toml-parser.spice
+++ b/std/text/toml-parser.spice
@@ -1,0 +1,1011 @@
+import "std/text/toml-value";
+import "std/text/analysis";
+import "std/type/type-conversion";
+import "std/data/vector";
+
+// Separator used to build the flat path keys with which already defined tables are tracked.
+// It is a control character, so it can never be part of a TOML key itself.
+const long PATH_SEPARATOR_CODE = 1l;
+
+/**
+ * Recursive-descent parser for TOML v1.0.0.
+ *
+ * Use `parseToml` for one-shot parsing; the struct is exposed mainly so the
+ * parser state (position, error message) can be inspected when needed.
+ *
+ * Supported are comments, bare/quoted/dotted keys, basic and literal strings
+ * (single- and multi-line), decimal/hexadecimal/octal/binary integers, floats
+ * including `inf` and `nan`, booleans, date-times, arrays, inline tables,
+ * `[table]` headers and `[[array of table]]` headers.
+ *
+ * The TomlValue data model lives in "std/text/toml-value" and serialization
+ * in "std/text/toml-serializer".
+ */
+public type TomlParser struct {
+    String input
+    unsigned long pos
+    string errorMessage  // always points to a string literal, so it outlives the parser
+    bool hasError
+    TomlValue* root
+    TomlValue* currentTable
+    Vector<String> definedTablePaths  // paths that were opened by a [table] header
+    Vector<String> arrayTablePaths    // paths that were opened by a [[array of table]] header
+}
+
+/**
+ * Construct a TOML parser over the given input string
+ *
+ * @param input TOML text to parse
+ */
+public p TomlParser.ctor(const String& input) {
+    this.input = input;
+    this.pos = 0l;
+    this.errorMessage = "";
+    this.hasError = false;
+    this.root = nil<TomlValue*>;
+    this.currentTable = nil<TomlValue*>;
+}
+
+/**
+ * Destruct the TOML parser, releasing the bookkeeping it built up while parsing
+ */
+public p TomlParser.dtor() {
+    releaseStrings(this.definedTablePaths);
+    releaseStrings(this.arrayTablePaths);
+}
+
+/**
+ * Parse the input string into a TOML value tree
+ *
+ * @return Result holding the root table, or an error if the input is malformed
+ */
+public f<Result<TomlValue*>> TomlParser.parse() {
+    this.root = __new<TomlValue>(TomlValueKind::TOML_TABLE);
+    this.currentTable = this.root;
+    this.skipByteOrderMark();
+    this.parseDocument();
+    if this.hasError {
+        // Nothing is handed out, so the partially built tree is ours to release
+        deleteTomlValue(this.root);
+        this.currentTable = nil<TomlValue*>;
+        return err<TomlValue*>(Error(this.errorMessage));
+    }
+    return ok(this.root);
+}
+
+/**
+ * Parse a TOML document.
+ *
+ * On success returns the root table, which the caller owns and releases again
+ * with `deleteTomlValue` from "std/text/toml-value". On failure the partially
+ * built tree is released by the parser and an error describing the first
+ * problem encountered is returned.
+ */
+public f<Result<TomlValue*>> parseToml(const String& input) {
+    TomlParser parser = TomlParser(input);
+    return parser.parse();
+}
+
+// --- Character level helpers ----------------------------------------------
+
+f<bool> TomlParser.atEnd() {
+    return this.pos >= this.input.getLength();
+}
+
+// Return the character `offset` positions ahead, or '\0' when out of bounds.
+f<char> TomlParser.peekAt(unsigned long offset) {
+    const unsigned long idx = this.pos + offset;
+    if idx >= this.input.getLength() { return '\0'; }
+    return this.input[idx];
+}
+
+f<char> TomlParser.peek() {
+    return this.peekAt(0l);
+}
+
+p TomlParser.fail(string msg) {
+    if !this.hasError {
+        this.errorMessage = msg;
+        this.hasError = true;
+    }
+}
+
+f<bool> TomlParser.matchLiteral(string literal) {
+    const unsigned long ll = getRawLength(literal);
+    if this.pos + ll > this.input.getLength() { return false; }
+    for unsigned long i = 0l; i < ll; i++ {
+        if this.input[this.pos + i] != literal[i] { return false; }
+    }
+    this.pos += ll;
+    return true;
+}
+
+// A leading UTF-8 byte order mark is not part of the document
+p TomlParser.skipByteOrderMark() {
+    const char b0 = this.peekAt(0l);
+    const char b1 = this.peekAt(1l);
+    const char b2 = this.peekAt(2l);
+    if b0 == toChar(0xEF) && b1 == toChar(0xBB) && b2 == toChar(0xBF) {
+        this.pos += 3l;
+    }
+}
+
+// Skip spaces and tabs, but no line breaks
+p TomlParser.skipSpaces() {
+    while true {
+        const char c = this.peek();
+        if c != ' ' && c != '\t' { break; }
+        this.pos++;
+    }
+}
+
+// Skip a comment up to (but excluding) the terminating line break
+p TomlParser.skipComment() {
+    if this.peek() != '#' { return; }
+    this.pos++;
+    while !this.atEnd() {
+        const char c = this.peek();
+        if c == '\n' || c == '\r' { return; }
+        if isTomlDisallowedChar(c) {
+            this.fail("Control character in comment");
+            return;
+        }
+        this.pos++;
+    }
+}
+
+// Skip any combination of whitespace, line breaks and comments
+p TomlParser.skipBlanks() {
+    while !this.atEnd() {
+        const char c = this.peek();
+        if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+            this.pos++;
+        } else if c == '#' {
+            this.skipComment();
+            if this.hasError { return; }
+        } else {
+            break;
+        }
+    }
+}
+
+// Consume the line break that has to follow a table header or a key/value pair
+p TomlParser.expectLineEnd() {
+    this.skipSpaces();
+    if this.peek() == '#' {
+        this.skipComment();
+        if this.hasError { return; }
+    }
+    if this.atEnd() { return; }
+    const char c = this.peek();
+    if c == '\n' {
+        this.pos++;
+        return;
+    }
+    if c == '\r' && this.peekAt(1l) == '\n' {
+        this.pos += 2l;
+        return;
+    }
+    this.fail("Expected line break after entry");
+}
+
+// --- Document structure ----------------------------------------------------
+
+p TomlParser.parseDocument() {
+    while true {
+        this.skipBlanks();
+        if this.hasError || this.atEnd() { return; }
+        if this.peek() == '[' {
+            this.parseTableHeader();
+        } else {
+            this.parseKeyValuePair(this.currentTable);
+        }
+        if this.hasError { return; }
+        this.expectLineEnd();
+        if this.hasError { return; }
+    }
+}
+
+p TomlParser.parseTableHeader() {
+    Vector<String> path;
+    this.parseTableHeaderInto(path);
+    releaseStrings(path);
+}
+
+p TomlParser.parseTableHeaderInto(Vector<String>& path) {
+    this.pos++; // consume '['
+    bool isArrayTable = false;
+    if this.peek() == '[' {
+        isArrayTable = true;
+        this.pos++;
+    }
+    this.parseKeyPathInto(path);
+    if this.hasError { return; }
+    this.skipSpaces();
+    if this.peek() != ']' {
+        this.fail("Expected ']' to close the table header");
+        return;
+    }
+    this.pos++;
+    if isArrayTable {
+        if this.peek() != ']' {
+            this.fail("Expected ']]' to close the array of tables header");
+            return;
+        }
+        this.pos++;
+    }
+
+    // Walk all but the last path segment, creating implicit tables on the way
+    TomlValue* target = this.root;
+    for unsigned long i = 0l; i + 1l < path.getSize(); i++ {
+        const String& segment = path.get(i);
+        target = this.descendInto(target, segment);
+        if this.hasError { return; }
+    }
+
+    const String& lastSegment = path.back();
+    const String pathKey = joinKeyPath(path);
+    TomlValue* existing = target.getFieldOrNil(lastSegment);
+    // All branches fall through to the end of the scope, so that `pathKey` is cleaned up
+    if isArrayTable {
+        if existing == nil<TomlValue*> {
+            existing = __new<TomlValue>(TomlValueKind::TOML_ARRAY);
+            target.addTableField(lastSegment, existing);
+            this.arrayTablePaths.pushBack(pathKey);
+        } else if !existing.isArray() || !containsPath(this.arrayTablePaths, pathKey) {
+            this.fail("Cannot redefine an existing value as an array of tables");
+        }
+        if !this.hasError {
+            TomlValue* newTable = __new<TomlValue>(TomlValueKind::TOML_TABLE);
+            existing.addArrayItem(newTable);
+            this.currentTable = newTable;
+        }
+    } else if existing == nil<TomlValue*> {
+        existing = __new<TomlValue>(TomlValueKind::TOML_TABLE);
+        target.addTableField(lastSegment, existing);
+        this.definedTablePaths.pushBack(pathKey);
+        this.currentTable = existing;
+    } else if !existing.isTable() || containsPath(this.definedTablePaths, pathKey) {
+        this.fail("Cannot define the same table twice");
+    } else {
+        this.definedTablePaths.pushBack(pathKey);
+        this.currentTable = existing;
+    }
+}
+
+// Resolve one intermediate path segment, creating an implicit table if needed.
+// For arrays of tables the most recently opened table is used.
+f<TomlValue*> TomlParser.descendInto(TomlValue* table, const String& segment) {
+    TomlValue* child = table.getFieldOrNil(segment);
+    if child == nil<TomlValue*> {
+        TomlValue* implicitTable = __new<TomlValue>(TomlValueKind::TOML_TABLE);
+        table.addTableField(segment, implicitTable);
+        return implicitTable;
+    }
+    if child.isTable() { return child; }
+    if child.isArray() {
+        const unsigned long itemCount = child.getArraySize();
+        if itemCount > 0l {
+            TomlValue* lastItem = child.getArrayItem(itemCount - 1l);
+            if lastItem.isTable() { return lastItem; }
+        }
+    }
+    this.fail("Cannot use a non-table value as an intermediate table");
+    return nil<TomlValue*>;
+}
+
+p TomlParser.parseKeyValuePair(TomlValue* table) {
+    Vector<String> path;
+    this.parseKeyValuePairInto(table, path);
+    releaseStrings(path);
+}
+
+p TomlParser.parseKeyValuePairInto(TomlValue* table, Vector<String>& path) {
+    this.parseKeyPathInto(path);
+    if this.hasError { return; }
+    this.skipSpaces();
+    if this.peek() != '=' {
+        this.fail("Expected '=' after key");
+        return;
+    }
+    this.pos++;
+    this.skipSpaces();
+    TomlValue* value = this.parseValue();
+    if this.hasError { return; }
+
+    // Walk all but the last path segment, creating implicit tables on the way
+    TomlValue* target = table;
+    for unsigned long i = 0l; i + 1l < path.getSize(); i++ {
+        const String& segment = path.get(i);
+        TomlValue* child = target.getFieldOrNil(segment);
+        if child == nil<TomlValue*> {
+            TomlValue* implicitTable = __new<TomlValue>(TomlValueKind::TOML_TABLE);
+            target.addTableField(segment, implicitTable);
+            target = implicitTable;
+            continue;
+        }
+        if !child.isTable() {
+            this.fail("Cannot use a non-table value as an intermediate table");
+            deleteTomlValue(value);
+            return;
+        }
+        target = child;
+    }
+
+    const String& lastSegment = path.back();
+    if target.hasField(lastSegment) {
+        this.fail("Cannot define the same key twice");
+        deleteTomlValue(value);
+        return;
+    }
+    target.addTableField(lastSegment, value);
+}
+
+// --- Keys ------------------------------------------------------------------
+
+p TomlParser.parseKeyPathInto(Vector<String>& path) {
+    // Leaving a scope early skips the cleanup of the locals it holds, so the loop is
+    // written to always run into its own end condition while `segment` is alive
+    bool expectMoreSegments = true;
+    while expectMoreSegments && !this.hasError {
+        this.skipSpaces();
+        const String segment = this.parseKeySegment();
+        if !this.hasError {
+            path.pushBack(segment);
+            this.skipSpaces();
+            expectMoreSegments = this.peek() == '.';
+            if expectMoreSegments { this.pos++; }
+        }
+    }
+}
+
+f<String> TomlParser.parseKeySegment() {
+    String segment;
+    const char c = this.peek();
+    if c == '"' || c == '\'' {
+        if this.peekAt(1l) == c && this.peekAt(2l) == c {
+            this.fail("Multi-line strings cannot be used as keys");
+            return segment;
+        }
+        return this.parseStringValue();
+    }
+    if !isBareKeyChar(c) {
+        this.fail("Expected key");
+        return segment;
+    }
+    while isBareKeyChar(this.peek()) {
+        segment += this.peek();
+        this.pos++;
+    }
+    return segment;
+}
+
+// --- Values ----------------------------------------------------------------
+
+f<TomlValue*> TomlParser.parseValue() {
+    const char c = this.peek();
+    if c == '"' || c == '\'' {
+        // `text` has to stay alive until the end of the scope, so that it gets cleaned up
+        TomlValue* stringValue = nil<TomlValue*>;
+        const String text = this.parseStringValue();
+        if !this.hasError {
+            stringValue = __new<TomlValue>(TomlValueKind::TOML_STRING, text);
+        }
+        return stringValue;
+    }
+    if c == '[' { return this.parseArray(); }
+    if c == '{' { return this.parseInlineTable(); }
+    if c == 't' || c == 'f' { return this.parseBool(); }
+    if c == '+' || c == '-' || c == 'i' || c == 'n' || isDigit(c) { return this.parseNumberOrDateTime(); }
+    this.fail("Expected value");
+    return nil<TomlValue*>;
+}
+
+f<TomlValue*> TomlParser.parseBool() {
+    if this.matchLiteral("true") { return __new<TomlValue>(true); }
+    if this.matchLiteral("false") { return __new<TomlValue>(false); }
+    this.fail("Expected 'true' or 'false'");
+    return nil<TomlValue*>;
+}
+
+f<TomlValue*> TomlParser.parseArray() {
+    this.pos++; // consume '['
+    TomlValue* arr = __new<TomlValue>(TomlValueKind::TOML_ARRAY);
+    while true {
+        // Line breaks and comments are allowed anywhere inside an array
+        this.skipBlanks();
+        if this.hasError {
+            deleteTomlValue(arr);
+            return nil<TomlValue*>;
+        }
+        if this.atEnd() {
+            this.fail("Unterminated array");
+            deleteTomlValue(arr);
+            return nil<TomlValue*>;
+        }
+        if this.peek() == ']' {
+            this.pos++;
+            return arr;
+        }
+        TomlValue* item = this.parseValue();
+        if this.hasError {
+            deleteTomlValue(arr);
+            return nil<TomlValue*>;
+        }
+        arr.addArrayItem(item);
+        this.skipBlanks();
+        if this.hasError {
+            deleteTomlValue(arr);
+            return nil<TomlValue*>;
+        }
+        if this.atEnd() {
+            this.fail("Unterminated array");
+            deleteTomlValue(arr);
+            return nil<TomlValue*>;
+        }
+        const char c = this.peek();
+        if c == ',' {
+            this.pos++;
+            continue;
+        }
+        if c == ']' {
+            this.pos++;
+            return arr;
+        }
+        this.fail("Expected ',' or ']' in array");
+        deleteTomlValue(arr);
+        return nil<TomlValue*>;
+    }
+    return nil<TomlValue*>;
+}
+
+f<TomlValue*> TomlParser.parseInlineTable() {
+    this.pos++; // consume '{'
+    TomlValue* table = __new<TomlValue>(TomlValueKind::TOML_TABLE);
+    this.skipSpaces();
+    if this.peek() == '}' {
+        this.pos++;
+        return table;
+    }
+    while true {
+        this.skipSpaces();
+        // Inline tables have to stay on a single line and must not have a trailing comma,
+        // so parsing the entry rejects both a line break and a closing brace here
+        this.parseKeyValuePair(table);
+        if this.hasError {
+            deleteTomlValue(table);
+            return nil<TomlValue*>;
+        }
+        this.skipSpaces();
+        if this.atEnd() {
+            this.fail("Unterminated inline table");
+            deleteTomlValue(table);
+            return nil<TomlValue*>;
+        }
+        const char c = this.peek();
+        if c == ',' {
+            this.pos++;
+            continue;
+        }
+        if c == '}' {
+            this.pos++;
+            return table;
+        }
+        this.fail("Expected ',' or '}' in inline table");
+        deleteTomlValue(table);
+        return nil<TomlValue*>;
+    }
+    return nil<TomlValue*>;
+}
+
+// --- Strings ---------------------------------------------------------------
+
+f<String> TomlParser.parseStringValue() {
+    const char quote = this.peek();
+    const bool isMultiLine = this.peekAt(1l) == quote && this.peekAt(2l) == quote;
+    if quote == '"' {
+        if isMultiLine { return this.parseMultiLineBasicString(); }
+        return this.parseBasicString();
+    }
+    if isMultiLine { return this.parseMultiLineLiteralString(); }
+    return this.parseLiteralString();
+}
+
+f<String> TomlParser.parseBasicString() {
+    String literal;
+    this.pos++; // consume opening '"'
+    while !this.atEnd() {
+        const char c = this.peek();
+        if c == '"' {
+            this.pos++; // consume closing '"'
+            return literal;
+        }
+        if c == '\n' || c == '\r' {
+            this.fail("Unterminated basic string");
+            return literal;
+        }
+        if c == '\\' {
+            this.pos++;
+            this.appendEscapeSequence(literal);
+            if this.hasError { return literal; }
+            continue;
+        }
+        if isTomlDisallowedChar(c) {
+            this.fail("Unescaped control character in string");
+            return literal;
+        }
+        literal += c;
+        this.pos++;
+    }
+    this.fail("Unterminated basic string");
+    return literal;
+}
+
+f<String> TomlParser.parseMultiLineBasicString() {
+    String literal;
+    this.pos += 3l; // consume opening '"""'
+    this.skipLeadingLineBreak();
+    while !this.atEnd() {
+        const char c = this.peek();
+        if c == '"' {
+            // The delimiter is formed by the last three quotes of a run, so up to two
+            // additional quotes still belong to the content
+            unsigned long runLength = 0l;
+            while this.peekAt(runLength) == '"' { runLength++; }
+            if runLength >= 3l {
+                if runLength > 5l {
+                    this.fail("Too many quotes at the end of a multi-line basic string");
+                    return literal;
+                }
+                for unsigned long i = 3l; i < runLength; i++ { literal += '"'; }
+                this.pos += runLength;
+                return literal;
+            }
+            for unsigned long i = 0l; i < runLength; i++ { literal += '"'; }
+            this.pos += runLength;
+            continue;
+        }
+        if c == '\\' {
+            // A backslash at the end of a line trims the line break and all following whitespace
+            unsigned long lookahead = 1l;
+            while this.peekAt(lookahead) == ' ' || this.peekAt(lookahead) == '\t' { lookahead++; }
+            const char lineEnd = this.peekAt(lookahead);
+            if lineEnd == '\n' || (lineEnd == '\r' && this.peekAt(lookahead + 1l) == '\n') {
+                this.pos += lookahead;
+                while isWhitespace(this.peek()) { this.pos++; }
+                continue;
+            }
+            this.pos++;
+            this.appendEscapeSequence(literal);
+            if this.hasError { return literal; }
+            continue;
+        }
+        if c != '\n' && c != '\r' && isTomlDisallowedChar(c) {
+            this.fail("Unescaped control character in string");
+            return literal;
+        }
+        literal += c;
+        this.pos++;
+    }
+    this.fail("Unterminated multi-line basic string");
+    return literal;
+}
+
+f<String> TomlParser.parseLiteralString() {
+    String literal;
+    this.pos++; // consume opening '\''
+    while !this.atEnd() {
+        const char c = this.peek();
+        if c == '\'' {
+            this.pos++; // consume closing '\''
+            return literal;
+        }
+        if c == '\n' || c == '\r' {
+            this.fail("Unterminated literal string");
+            return literal;
+        }
+        if isTomlDisallowedChar(c) {
+            this.fail("Unescaped control character in string");
+            return literal;
+        }
+        literal += c;
+        this.pos++;
+    }
+    this.fail("Unterminated literal string");
+    return literal;
+}
+
+f<String> TomlParser.parseMultiLineLiteralString() {
+    String literal;
+    this.pos += 3l; // consume opening '\'\'\''
+    this.skipLeadingLineBreak();
+    while !this.atEnd() {
+        const char c = this.peek();
+        if c == '\'' {
+            unsigned long runLength = 0l;
+            while this.peekAt(runLength) == '\'' { runLength++; }
+            if runLength >= 3l {
+                if runLength > 5l {
+                    this.fail("Too many quotes at the end of a multi-line literal string");
+                    return literal;
+                }
+                for unsigned long i = 3l; i < runLength; i++ { literal += '\''; }
+                this.pos += runLength;
+                return literal;
+            }
+            for unsigned long i = 0l; i < runLength; i++ { literal += '\''; }
+            this.pos += runLength;
+            continue;
+        }
+        if c != '\n' && c != '\r' && isTomlDisallowedChar(c) {
+            this.fail("Unescaped control character in string");
+            return literal;
+        }
+        literal += c;
+        this.pos++;
+    }
+    this.fail("Unterminated multi-line literal string");
+    return literal;
+}
+
+// A line break directly after the opening delimiter of a multi-line string is not content
+p TomlParser.skipLeadingLineBreak() {
+    const char c = this.peek();
+    if c == '\n' {
+        this.pos++;
+    } else if c == '\r' && this.peekAt(1l) == '\n' {
+        this.pos += 2l;
+    }
+}
+
+p TomlParser.appendEscapeSequence(String& out) {
+    if this.atEnd() {
+        this.fail("Unterminated escape sequence");
+        return;
+    }
+    const char esc = this.peek();
+    this.pos++;
+    if esc == '"' {
+        out += '"';
+    } else if esc == '\\' {
+        out += '\\';
+    } else if esc == 'b' {
+        out += '\b';
+    } else if esc == 't' {
+        out += '\t';
+    } else if esc == 'n' {
+        out += '\n';
+    } else if esc == 'f' {
+        out += '\f';
+    } else if esc == 'r' {
+        out += '\r';
+    } else if esc == 'u' {
+        this.appendUnicodeEscape(out, 4l);
+    } else if esc == 'U' {
+        this.appendUnicodeEscape(out, 8l);
+    } else {
+        this.fail("Unsupported escape sequence");
+    }
+}
+
+p TomlParser.appendUnicodeEscape(String& out, unsigned long digitCount) {
+    long codePoint = 0l;
+    for unsigned long i = 0l; i < digitCount; i++ {
+        const char c = this.peek();
+        if !isHexDigit(c) {
+            this.fail("Invalid unicode escape sequence");
+            return;
+        }
+        codePoint = codePoint * 16l + hexDigitValue(c);
+        this.pos++;
+    }
+    if !appendCodePointUtf8(out, codePoint) {
+        this.fail("Invalid unicode scalar value in escape sequence");
+    }
+}
+
+// --- Numbers and date-times ------------------------------------------------
+
+f<TomlValue*> TomlParser.parseNumberOrDateTime() {
+    if this.looksLikeDate() || this.looksLikeTime() { return this.parseDateTime(); }
+    return this.parseNumber();
+}
+
+f<bool> TomlParser.looksLikeDate() {
+    return isDigit(this.peekAt(0l)) && isDigit(this.peekAt(1l)) && isDigit(this.peekAt(2l))
+        && isDigit(this.peekAt(3l)) && this.peekAt(4l) == '-';
+}
+
+f<bool> TomlParser.looksLikeTime() {
+    return isDigit(this.peekAt(0l)) && isDigit(this.peekAt(1l)) && this.peekAt(2l) == ':';
+}
+
+f<TomlValue*> TomlParser.parseDateTime() {
+    const unsigned long start = this.pos;
+    if this.looksLikeTime() {
+        // Local time
+        if !this.consumeTime() { return nil<TomlValue*>; }
+    } else {
+        if !this.consumeDate() { return nil<TomlValue*>; }
+        // The time part may be separated by 'T', 't' or a single space
+        const char separator = this.peek();
+        const bool spaceSeparated = separator == ' ' && isDigit(this.peekAt(1l)) && isDigit(this.peekAt(2l))
+                                    && this.peekAt(3l) == ':';
+        if separator == 'T' || separator == 't' || spaceSeparated {
+            this.pos++;
+            if !this.consumeTime() { return nil<TomlValue*>; }
+            if !this.consumeTimeOffset() { return nil<TomlValue*>; }
+        }
+    }
+    const String raw = this.input.getSubstring(start, this.pos - start);
+    return __new<TomlValue>(TomlValueKind::TOML_DATETIME, raw);
+}
+
+f<bool> TomlParser.consumeDate() {
+    if !this.consumeDigits(4l) { return false; }
+    if !this.consumeChar('-') { return false; }
+    if !this.consumeDigits(2l) { return false; }
+    if !this.consumeChar('-') { return false; }
+    return this.consumeDigits(2l);
+}
+
+f<bool> TomlParser.consumeTime() {
+    if !this.consumeDigits(2l) { return false; }
+    if !this.consumeChar(':') { return false; }
+    if !this.consumeDigits(2l) { return false; }
+    if !this.consumeChar(':') { return false; }
+    if !this.consumeDigits(2l) { return false; }
+    // Optional fractional seconds
+    if this.peek() == '.' {
+        this.pos++;
+        if !isDigit(this.peek()) {
+            this.fail("Invalid date-time literal");
+            return false;
+        }
+        while isDigit(this.peek()) { this.pos++; }
+    }
+    return true;
+}
+
+f<bool> TomlParser.consumeTimeOffset() {
+    const char c = this.peek();
+    if c == 'Z' || c == 'z' {
+        this.pos++;
+        return true;
+    }
+    if c != '+' && c != '-' { return true; } // a local date-time carries no offset
+    this.pos++;
+    if !this.consumeDigits(2l) { return false; }
+    if !this.consumeChar(':') { return false; }
+    return this.consumeDigits(2l);
+}
+
+f<bool> TomlParser.consumeDigits(unsigned long count) {
+    for unsigned long i = 0l; i < count; i++ {
+        if !isDigit(this.peek()) {
+            this.fail("Invalid date-time literal");
+            return false;
+        }
+        this.pos++;
+    }
+    return true;
+}
+
+f<bool> TomlParser.consumeChar(char expected) {
+    if this.peek() != expected {
+        this.fail("Invalid date-time literal");
+        return false;
+    }
+    this.pos++;
+    return true;
+}
+
+f<TomlValue*> TomlParser.parseNumber() {
+    bool hasSign = false;
+    bool isNegative = false;
+    const char sign = this.peek();
+    if sign == '+' || sign == '-' {
+        hasSign = true;
+        isNegative = sign == '-';
+        this.pos++;
+    }
+
+    // Special float values
+    if this.matchLiteral("inf") {
+        const double infinity = tomlInfinity();
+        return __new<TomlValue>(isNegative ? -infinity : infinity);
+    }
+    if this.matchLiteral("nan") {
+        return __new<TomlValue>(tomlNaN());
+    }
+
+    // Integers with a radix prefix never carry a sign
+    if !hasSign && this.peek() == '0' {
+        const char prefix = this.peekAt(1l);
+        if prefix == 'x' {
+            this.pos += 2l;
+            return this.parseRadixInteger(16);
+        }
+        if prefix == 'o' {
+            this.pos += 2l;
+            return this.parseRadixInteger(8);
+        }
+        if prefix == 'b' {
+            this.pos += 2l;
+            return this.parseRadixInteger(2);
+        }
+    }
+
+    // `digits` has to stay alive until the end of the scope, so that it gets cleaned up
+    String digits;
+    if isNegative { digits += '-'; }
+    bool isFloat = false;
+    bool isValid = this.consumeDecDigits(digits, true);
+    if isValid && this.peek() == '.' {
+        isFloat = true;
+        digits += '.';
+        this.pos++;
+        isValid = this.consumeDecDigits(digits, false);
+    }
+    if isValid {
+        const char exponent = this.peek();
+        if exponent == 'e' || exponent == 'E' {
+            isFloat = true;
+            digits += 'e';
+            this.pos++;
+            const char expSign = this.peek();
+            if expSign == '+' || expSign == '-' {
+                digits += expSign;
+                this.pos++;
+            }
+            isValid = this.consumeDecDigits(digits, false);
+        }
+    }
+    TomlValue* number = nil<TomlValue*>;
+    if isValid {
+        const string raw = digits.getRaw();
+        number = isFloat ? __new<TomlValue>(toDouble(raw)) : __new<TomlValue>(toLong(raw, 10));
+    }
+    return number;
+}
+
+f<TomlValue*> TomlParser.parseRadixInteger(int base) {
+    // `digits` has to stay alive until the end of the scope, so that it gets cleaned up
+    String digits;
+    bool afterUnderscore = true; // an underscore has to be surrounded by digits
+    bool scanning = true;
+    while scanning && !this.atEnd() {
+        const char c = this.peek();
+        if c == '_' {
+            if afterUnderscore {
+                this.fail("Misplaced underscore in number literal");
+                scanning = false;
+            } else {
+                afterUnderscore = true;
+                this.pos++;
+            }
+        } else if !isDigitForBase(c, base) {
+            scanning = false;
+        } else {
+            digits += c;
+            afterUnderscore = false;
+            this.pos++;
+        }
+    }
+    TomlValue* number = nil<TomlValue*>;
+    if digits.isEmpty() || afterUnderscore {
+        this.fail("Invalid integer literal"); // no-op if a more precise error was already reported
+    } else {
+        number = __new<TomlValue>(toLong(digits.getRaw(), base));
+    }
+    return number;
+}
+
+// Consume a run of decimal digits with optional underscore separators, appending them to `out`
+f<bool> TomlParser.consumeDecDigits(String& out, bool rejectLeadingZeros) {
+    const unsigned long startLength = out.getLength();
+    bool afterUnderscore = true; // an underscore has to be surrounded by digits
+    while !this.atEnd() {
+        const char c = this.peek();
+        if c == '_' {
+            if afterUnderscore {
+                this.fail("Misplaced underscore in number literal");
+                return false;
+            }
+            afterUnderscore = true;
+            this.pos++;
+            continue;
+        }
+        if !isDigit(c) { break; }
+        out += c;
+        afterUnderscore = false;
+        this.pos++;
+    }
+    if out.getLength() == startLength || afterUnderscore {
+        this.fail("Invalid number literal");
+        return false;
+    }
+    if rejectLeadingZeros && out.getLength() > startLength + 1l && out[startLength] == '0' {
+        this.fail("Leading zeros are not allowed in number literals");
+        return false;
+    }
+    return true;
+}
+
+// --- Free helpers ----------------------------------------------------------
+
+// Checks if the given character may appear in a bare TOML key
+inline f<bool> isBareKeyChar(char c) {
+    return isAlphaNum(c) || c == '_' || c == '-';
+}
+
+// Checks if the given character is a control character that TOML never allows unescaped.
+// Tab is excluded, since it is legal in strings and comments alike. Bytes of multi-byte
+// UTF-8 sequences are excluded as well, no matter whether char is signed or not.
+inline f<bool> isTomlDisallowedChar(char c) {
+    return (c >= '\0' && c < ' ' && c != '\t') || cast<int>(c) == 0x7F;
+}
+
+inline f<bool> isDigitForBase(char c, int base) {
+    if base == 16 { return isHexDigit(c); }
+    if base == 8 { return isOctDigit(c); }
+    return isBinDigit(c);
+}
+
+inline f<long> hexDigitValue(char c) {
+    if isDigit(c) { return toLong(c) - toLong('0'); }
+    if isLower(c) { return toLong(c) - toLong('a') + 10l; }
+    return toLong(c) - toLong('A') + 10l;
+}
+
+// Encode a unicode scalar value as UTF-8. Returns false for values outside the
+// unicode range as well as for surrogates, which are not scalar values.
+f<bool> appendCodePointUtf8(String& out, long codePoint) {
+    if codePoint < 0l || codePoint > 0x10FFFFl { return false; }
+    if codePoint >= 0xD800l && codePoint <= 0xDFFFl { return false; }
+    if codePoint < 0x80l {
+        out += toChar(codePoint);
+    } else if codePoint < 0x800l {
+        out += toChar(0xC0l | (codePoint >> 6));
+        out += toChar(0x80l | (codePoint & 0x3Fl));
+    } else if codePoint < 0x10000l {
+        out += toChar(0xE0l | (codePoint >> 12));
+        out += toChar(0x80l | ((codePoint >> 6) & 0x3Fl));
+        out += toChar(0x80l | (codePoint & 0x3Fl));
+    } else {
+        out += toChar(0xF0l | (codePoint >> 18));
+        out += toChar(0x80l | ((codePoint >> 12) & 0x3Fl));
+        out += toChar(0x80l | ((codePoint >> 6) & 0x3Fl));
+        out += toChar(0x80l | (codePoint & 0x3Fl));
+    }
+    return true;
+}
+
+// Flatten a dotted key path so already defined tables can be tracked by identity
+f<String> joinKeyPath(const Vector<String>& path) {
+    String flatPath;
+    const char separator = toChar(PATH_SEPARATOR_CODE);
+    for unsigned long i = 0l; i < path.getSize(); i++ {
+        if i > 0l { flatPath += separator; }
+        const String& segment = path.get(i);
+        flatPath += segment;
+    }
+    return flatPath;
+}
+
+// Vector does not destruct the items it holds, so strings stored in one have to be released by hand
+p releaseStrings(Vector<String>& strings) {
+    for unsigned long i = 0l; i < strings.getSize(); i++ {
+        String& item = strings.get(i);
+        item.dtor();
+    }
+    strings.clear();
+}
+
+f<bool> containsPath(const Vector<String>& paths, const String& path) {
+    for unsigned long i = 0l; i < paths.getSize(); i++ {
+        const String& candidate = paths.get(i);
+        if candidate == path { return true; }
+    }
+    return false;
+}

--- a/std/text/toml-serializer.spice
+++ b/std/text/toml-serializer.spice
@@ -1,0 +1,247 @@
+import "std/text/toml-value";
+import "std/text/analysis";
+import "std/type/type-conversion";
+
+ext f<int> snprintf(char*, unsigned long, string, ...);
+
+/**
+ * Serializer for TOML output.
+ *
+ * By default sub-tables are emitted as `[table]` sections and arrays that only
+ * contain tables as `[[array of table]]` sections, which is how TOML documents
+ * are usually written. With `inlineTables` enabled everything is emitted as
+ * `key = value` lines instead, using inline tables for nested structures.
+ *
+ * Either way the result round-trips through `parseToml` from
+ * "std/text/toml-parser".
+ */
+public type TomlSerializer struct {
+    bool inlineTables
+}
+
+/**
+ * Construct a TOML serializer
+ *
+ * @param inlineTables Emit nested tables inline instead of as separate sections
+ */
+public p TomlSerializer.ctor(bool inlineTables = false) {
+    this.inlineTables = inlineTables;
+}
+
+/**
+ * Serializes a TOML table into a TOML document
+ *
+ * @param root Root table to serialize
+ * @return TOML representation
+ */
+public f<String> TomlSerializer.serialize(TomlValue& root) {
+    return this.serialize(&root);
+}
+
+/**
+ * Serializes a TOML table into a TOML document
+ *
+ * @param root Root table to serialize
+ * @return TOML representation
+ */
+public f<String> TomlSerializer.serialize(TomlValue* root) {
+    assert root.isTable();
+    String out;
+    const String rootPath;
+    this.serializeTableBody(root, rootPath, out);
+    return out;
+}
+
+/**
+ * Serializes a single TOML value in its inline form, as it would appear on the
+ * right hand side of a `key = value` pair
+ *
+ * @param value Value to serialize
+ * @return TOML representation
+ */
+public f<String> TomlSerializer.serializeValue(TomlValue* value) {
+    String out;
+    this.serializeInlineValue(value, out);
+    return out;
+}
+
+// --- Internal serializer helpers --------------------------------------------
+
+// Emit the contents of one table: first all entries that fit on a single line,
+// then all entries that get a section of their own.
+p TomlSerializer.serializeTableBody(TomlValue* table, const String& path, String& out) {
+    const unsigned long size = table.getTableSize();
+
+    for unsigned long i = 0l; i < size; i++ {
+        TomlValue* value = table.getTableValue(i);
+        if !this.inlineTables && needsOwnSection(value) { continue; }
+        const String& key = table.getTableKey(i);
+        serializeTomlKey(out, key);
+        out += " = ";
+        this.serializeInlineValue(value, out);
+        out += '\n';
+    }
+
+    if this.inlineTables { return; }
+
+    for unsigned long i = 0l; i < size; i++ {
+        TomlValue* value = table.getTableValue(i);
+        if !needsOwnSection(value) { continue; }
+        const String& key = table.getTableKey(i);
+        String childPath = path;
+        if !childPath.isEmpty() { childPath += '.'; }
+        serializeTomlKey(childPath, key);
+
+        // Both branches fall through to the end of the scope, so that `childPath` is cleaned up
+        if value.isTable() {
+            if !out.isEmpty() { out += '\n'; }
+            out += '[';
+            out += childPath;
+            out += "]\n";
+            this.serializeTableBody(value, childPath, out);
+        } else {
+            const unsigned long itemCount = value.getArraySize();
+            for unsigned long itemIdx = 0l; itemIdx < itemCount; itemIdx++ {
+                TomlValue* item = value.getArrayItem(itemIdx);
+                if !out.isEmpty() { out += '\n'; }
+                out += "[[";
+                out += childPath;
+                out += "]]\n";
+                this.serializeTableBody(item, childPath, out);
+            }
+        }
+    }
+}
+
+p TomlSerializer.serializeInlineValue(TomlValue* value, String& out) {
+    const TomlValueKind kind = value.getKind();
+    if kind == TomlValueKind::TOML_STRING {
+        serializeTomlString(out, value.getString());
+    } else if kind == TomlValueKind::TOML_INTEGER {
+        out += toString(value.getInteger());
+    } else if kind == TomlValueKind::TOML_FLOAT {
+        out += serializeTomlFloat(value.getFloat());
+    } else if kind == TomlValueKind::TOML_BOOL {
+        out += value.getBool() ? "true" : "false";
+    } else if kind == TomlValueKind::TOML_DATETIME {
+        out += value.getDateTime();
+    } else if kind == TomlValueKind::TOML_ARRAY {
+        const unsigned long size = value.getArraySize();
+        out += '[';
+        for unsigned long i = 0l; i < size; i++ {
+            if i > 0l { out += ", "; }
+            TomlValue* item = value.getArrayItem(i);
+            this.serializeInlineValue(item, out);
+        }
+        out += ']';
+    } else {
+        const unsigned long size = value.getTableSize();
+        out += '{';
+        for unsigned long i = 0l; i < size; i++ {
+            if i > 0l { out += ", "; }
+            const String& key = value.getTableKey(i);
+            serializeTomlKey(out, key);
+            out += " = ";
+            TomlValue* entry = value.getTableValue(i);
+            this.serializeInlineValue(entry, out);
+        }
+        out += '}';
+    }
+}
+
+// A value gets a section of its own if it is a table or a non-empty array that
+// exclusively holds tables. Everything else stays on a single line.
+f<bool> needsOwnSection(TomlValue* value) {
+    if value.isTable() { return true; }
+    if !value.isArray() { return false; }
+    const unsigned long size = value.getArraySize();
+    if size == 0l { return false; }
+    for unsigned long i = 0l; i < size; i++ {
+        TomlValue* item = value.getArrayItem(i);
+        if !item.isTable() { return false; }
+    }
+    return true;
+}
+
+// Emit a key as a bare key if possible and as a quoted key otherwise.
+p serializeTomlKey(String& out, const String& key) {
+    if isBareKey(key) {
+        out += key;
+        return;
+    }
+    serializeTomlString(out, key);
+}
+
+f<bool> isBareKey(const String& key) {
+    if key.isEmpty() { return false; }
+    const unsigned long length = key.getLength();
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = key[i];
+        if !isAlphaNum(c) && c != '_' && c != '-' { return false; }
+    }
+    return true;
+}
+
+// Serialize a string value as a basic string, i.e. with surrounding quotes and escaping.
+p serializeTomlString(String& out, const String& value) {
+    out += '"';
+    const unsigned long length = value.getLength();
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = value[i];
+        if c == '"' {
+            out += "\\\"";
+        } else if c == '\\' {
+            out += "\\\\";
+        } else if c == '\n' {
+            out += "\\n";
+        } else if c == '\r' {
+            out += "\\r";
+        } else if c == '\t' {
+            out += "\\t";
+        } else if c == '\b' {
+            out += "\\b";
+        } else if c == '\f' {
+            out += "\\f";
+        } else if (c >= '\0' && c < ' ') || cast<int>(c) == 0x7F {
+            // All other control characters are emitted as \u00XX escapes.
+            // Bytes of multi-byte UTF-8 sequences are passed through unchanged.
+            string hexDigits = "0123456789ABCDEF";
+            const int code = cast<int>(c);
+            out += "\\u00";
+            out += hexDigits[(code >> 4) & 0xF];
+            out += hexDigits[code & 0xF];
+        } else {
+            out += c;
+        }
+    }
+    out += '"';
+}
+
+// Serialize a float, making sure the output is always recognizable as a TOML float.
+// Integral values therefore get a ".0" suffix, and non-integral values use 17 significant
+// digits ("%.17g"), which is enough to round-trip any double exactly.
+f<String> serializeTomlFloat(double value) {
+    if tomlIsNaN(value) { return String("nan"); }
+    const double infinity = tomlInfinity();
+    if value == infinity { return String("inf"); }
+    if value == -infinity { return String("-inf"); }
+
+    // Only take the integral shortcut while the value is safely inside the long range
+    if value >= -9.0e18 && value <= 9.0e18 {
+        const long asLong = cast<long>(value);
+        if cast<double>(asLong) == value {
+            String integral = toString(asLong);
+            integral += ".0";
+            return integral;
+        }
+    }
+
+    const int length = snprintf(nil<char*>, 0l, "%.17g", value);
+    String out = String(length);
+    snprintf(cast<char*>(out.getRaw()), cast<unsigned long>(length + 1), "%.17g", value);
+    // Very large magnitudes may print without a fractional or exponent part
+    if out.find('.') < 0l && out.find('e') < 0l && out.find('E') < 0l {
+        out += ".0";
+    }
+    return out;
+}

--- a/std/text/toml-value.spice
+++ b/std/text/toml-value.spice
@@ -1,0 +1,467 @@
+import "std/data/vector";
+import "std/type/type-conversion";
+
+/**
+ * Tag for the variant stored inside a TomlValue.
+ */
+public type TomlValueKind enum {
+    TOML_STRING,
+    TOML_INTEGER,
+    TOML_FLOAT,
+    TOML_BOOL,
+    TOML_DATETIME,
+    TOML_ARRAY,
+    TOML_TABLE
+}
+
+/**
+ * Represents a single TOML value.
+ *
+ * Composite values (arrays and tables) own their children as heap pointers,
+ * so a TomlValue is always reached via `TomlValue*` once it has been parsed.
+ * Destroying a value recursively destroys everything below it, so a whole tree
+ * is released with a single `deleteTomlValue` call on its root. Accessors like
+ * `getField` hand out borrowed pointers that stay owned by their parent, while
+ * `addArrayItem` and `addTableField` take ownership of what they are given.
+ *
+ * Note that the root cannot simply be held in a `heap TomlValue*` and left to
+ * the compiler: the `heap` qualifier only emits a raw deallocation when the
+ * variable goes out of scope and never runs the destructor of the pointee, so
+ * the children below the root would be lost.
+ * Unlike JSON, TOML distinguishes integers from floats, so both are stored
+ * separately. Date-times are kept in their lexical form (e.g.
+ * `1979-05-27T07:32:00Z`), which the parser validates and the serializer
+ * emits verbatim. Table entries preserve insertion order and TOML has no
+ * null value.
+ *
+ * Parsing lives in "std/text/toml-parser" and serialization in
+ * "std/text/toml-serializer", so programs only pull in what they use.
+ */
+public type TomlValue struct {
+    TomlValueKind kind
+    bool boolValue
+    long intValue
+    double floatValue
+    String stringValue    // payload of strings as well as date-times
+    Vector<TomlValue*> arrayItems
+    Vector<String> tableKeys
+    Vector<TomlValue*> tableValues
+}
+
+/**
+ * Construct an empty TOML table, which is what a TOML document is rooted at
+ */
+public p TomlValue.ctor() {
+    this.kind = TomlValueKind::TOML_TABLE;
+}
+
+/**
+ * Construct an empty TOML value of the given kind. Useful for building
+ * arrays and tables from scratch.
+ *
+ * @param kind Kind of the value
+ */
+public p TomlValue.ctor(TomlValueKind kind) {
+    this.kind = kind;
+}
+
+/**
+ * Construct a TOML value that carries text, which is either a string or a
+ * date-time in its lexical form.
+ *
+ * @param kind Kind of the value - TOML_STRING or TOML_DATETIME
+ * @param value Text payload
+ */
+public p TomlValue.ctor(TomlValueKind kind, const String& value) {
+    assert kind == TomlValueKind::TOML_STRING || kind == TomlValueKind::TOML_DATETIME;
+    this.kind = kind;
+    this.stringValue = value;
+}
+
+/**
+ * Construct a TOML boolean value
+ *
+ * @param value Boolean value
+ */
+public p TomlValue.ctor(bool value) {
+    this.kind = TomlValueKind::TOML_BOOL;
+    this.boolValue = value;
+}
+
+/**
+ * Construct a TOML integer value
+ *
+ * @param value Integer value
+ */
+public p TomlValue.ctor(long value) {
+    this.kind = TomlValueKind::TOML_INTEGER;
+    this.intValue = value;
+}
+
+/**
+ * Construct a TOML float value
+ *
+ * @param value Float value
+ */
+public p TomlValue.ctor(double value) {
+    this.kind = TomlValueKind::TOML_FLOAT;
+    this.floatValue = value;
+}
+
+/**
+ * Construct a TOML string value
+ *
+ * @param value String value
+ */
+public p TomlValue.ctor(const String& value) {
+    this.kind = TomlValueKind::TOML_STRING;
+    this.stringValue = value;
+}
+
+/**
+ * Destruct the TOML value, releasing every array item and table entry it owns.
+ * Since the children are destroyed the same way, this tears down the whole
+ * subtree below the value.
+ */
+public p TomlValue.dtor() {
+    for unsigned long i = 0l; i < this.arrayItems.getSize(); i++ {
+        deleteTomlValue(this.arrayItems.get(i));
+    }
+    for unsigned long i = 0l; i < this.tableValues.getSize(); i++ {
+        deleteTomlValue(this.tableValues.get(i));
+    }
+    // Vector does not destruct its items, so the keys have to be released by hand
+    for unsigned long i = 0l; i < this.tableKeys.getSize(); i++ {
+        String& key = this.tableKeys.get(i);
+        key.dtor();
+    }
+}
+
+/**
+ * Destroys a heap-allocated TOML value together with everything it owns and sets
+ * the given handle to nil, so releasing a whole tree only takes one call on its root.
+ *
+ * Note that this is what `sDelete` would normally be used for. It cannot be used
+ * here, because a value tree is destroyed recursively and the compiler does not
+ * emit an explicit dtor that is only reached through `sDestruct`.
+ *
+ * @param value Handle of the value to destroy
+ */
+public p deleteTomlValue(TomlValue*& value) {
+    if value == nil<TomlValue*> { return; }
+    value.dtor();
+    unsafe {
+        heap byte* raw = cast<heap byte*>(value);
+        sDealloc(raw);
+    }
+    value = nil<TomlValue*>;
+}
+
+// --- Kind inspection -------------------------------------------------------
+
+/**
+ * Retrieve the kind of the TOML value
+ *
+ * @return Kind of the value
+ */
+public f<TomlValueKind> TomlValue.getKind() { return this.kind; }
+/**
+ * Check whether the TOML value is a string
+ *
+ * @return true if the value is a string, false otherwise
+ */
+public f<bool> TomlValue.isString()   { return this.kind == TomlValueKind::TOML_STRING; }
+/**
+ * Check whether the TOML value is an integer
+ *
+ * @return true if the value is an integer, false otherwise
+ */
+public f<bool> TomlValue.isInteger()  { return this.kind == TomlValueKind::TOML_INTEGER; }
+/**
+ * Check whether the TOML value is a float
+ *
+ * @return true if the value is a float, false otherwise
+ */
+public f<bool> TomlValue.isFloat()    { return this.kind == TomlValueKind::TOML_FLOAT; }
+/**
+ * Check whether the TOML value is a boolean
+ *
+ * @return true if the value is a boolean, false otherwise
+ */
+public f<bool> TomlValue.isBool()     { return this.kind == TomlValueKind::TOML_BOOL; }
+/**
+ * Check whether the TOML value is a date-time
+ *
+ * @return true if the value is a date-time, false otherwise
+ */
+public f<bool> TomlValue.isDateTime() { return this.kind == TomlValueKind::TOML_DATETIME; }
+/**
+ * Check whether the TOML value is an array
+ *
+ * @return true if the value is an array, false otherwise
+ */
+public f<bool> TomlValue.isArray()    { return this.kind == TomlValueKind::TOML_ARRAY; }
+/**
+ * Check whether the TOML value is a table
+ *
+ * @return true if the value is a table, false otherwise
+ */
+public f<bool> TomlValue.isTable()    { return this.kind == TomlValueKind::TOML_TABLE; }
+
+// --- Scalar accessors (panic on wrong kind) --------------------------------
+
+/**
+ * Retrieve the string payload. Panics if the value is not a string.
+ *
+ * @return String value
+ */
+public f<const String&> TomlValue.getString() {
+    assert this.kind == TomlValueKind::TOML_STRING;
+    return this.stringValue;
+}
+
+/**
+ * Retrieve the integer payload. Panics if the value is not an integer.
+ *
+ * @return Integer value
+ */
+public f<long> TomlValue.getInteger() {
+    assert this.kind == TomlValueKind::TOML_INTEGER;
+    return this.intValue;
+}
+
+/**
+ * Retrieve the float payload. Panics if the value is not a float.
+ *
+ * @return Float value
+ */
+public f<double> TomlValue.getFloat() {
+    assert this.kind == TomlValueKind::TOML_FLOAT;
+    return this.floatValue;
+}
+
+/**
+ * Retrieve the boolean payload. Panics if the value is not a boolean.
+ *
+ * @return Boolean value
+ */
+public f<bool> TomlValue.getBool() {
+    assert this.kind == TomlValueKind::TOML_BOOL;
+    return this.boolValue;
+}
+
+/**
+ * Retrieve the date-time payload in its lexical form. Panics if the value is
+ * not a date-time.
+ *
+ * @return Date-time value
+ */
+public f<const String&> TomlValue.getDateTime() {
+    assert this.kind == TomlValueKind::TOML_DATETIME;
+    return this.stringValue;
+}
+
+// --- Array operations ------------------------------------------------------
+
+/**
+ * Retrieve the number of items in the array. Panics if the value is not an array.
+ *
+ * @return Number of array items
+ */
+public f<unsigned long> TomlValue.getArraySize() {
+    assert this.kind == TomlValueKind::TOML_ARRAY;
+    return this.arrayItems.getSize();
+}
+
+/**
+ * Retrieve the array item at the given index. Panics if the value is not an array.
+ *
+ * @param idx Index of the item
+ * @return Pointer to the array item
+ */
+public f<TomlValue*> TomlValue.getArrayItem(unsigned long idx) {
+    assert this.kind == TomlValueKind::TOML_ARRAY;
+    return this.arrayItems.get(idx);
+}
+
+/**
+ * Retrieve the array item at the given index. Panics if the value is not an array.
+ *
+ * @param idx Index of the item
+ * @return Pointer to the array item
+ */
+public f<TomlValue*> TomlValue.getArrayItem(unsigned int idx) {
+    return this.getArrayItem(cast<unsigned long>(idx));
+}
+
+/**
+ * Append an item to the array. Panics if the value is not an array.
+ * The array takes ownership of the heap-allocated item.
+ *
+ * @param item Item to append
+ */
+public p TomlValue.addArrayItem(TomlValue* item) {
+    assert this.kind == TomlValueKind::TOML_ARRAY;
+    this.arrayItems.pushBack(item);
+}
+
+// --- Table operations ------------------------------------------------------
+
+/**
+ * Retrieve the number of entries in the table. Panics if the value is not a table.
+ *
+ * @return Number of table entries
+ */
+public f<unsigned long> TomlValue.getTableSize() {
+    assert this.kind == TomlValueKind::TOML_TABLE;
+    return this.tableKeys.getSize();
+}
+
+/**
+ * Retrieve the key of the table entry at the given index, in insertion order.
+ * Panics if the value is not a table.
+ *
+ * @param idx Index of the entry
+ * @return Entry key
+ */
+public f<const String&> TomlValue.getTableKey(unsigned long idx) {
+    assert this.kind == TomlValueKind::TOML_TABLE;
+    return this.tableKeys.get(idx);
+}
+
+/**
+ * Retrieve the value of the table entry at the given index, in insertion order.
+ * Panics if the value is not a table.
+ *
+ * @param idx Index of the entry
+ * @return Pointer to the entry value
+ */
+public f<TomlValue*> TomlValue.getTableValue(unsigned long idx) {
+    assert this.kind == TomlValueKind::TOML_TABLE;
+    return this.tableValues.get(idx);
+}
+
+/**
+ * Check whether the table contains an entry with the given key
+ *
+ * @param key Entry key to look for
+ * @return true if the entry exists, false otherwise
+ */
+public f<bool> TomlValue.hasField(const String& key) {
+    if this.kind != TomlValueKind::TOML_TABLE { return false; }
+    for unsigned long i = 0l; i < this.tableKeys.getSize(); i++ {
+        if this.tableKeys.get(i) == key { return true; }
+    }
+    return false;
+}
+
+/**
+ * Check whether the table contains an entry with the given key
+ *
+ * @param key Entry key to look for
+ * @return true if the entry exists, false otherwise
+ */
+public f<bool> TomlValue.hasField(string key) {
+    return this.hasField(String(key));
+}
+
+/**
+ * Retrieve the value of the table entry with the given key, or nil if the value
+ * is not a table or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value, or nil
+ */
+public f<TomlValue*> TomlValue.getFieldOrNil(const String& key) {
+    if this.kind != TomlValueKind::TOML_TABLE { return nil<TomlValue*>; }
+    for unsigned long i = 0l; i < this.tableKeys.getSize(); i++ {
+        if this.tableKeys.get(i) == key {
+            return this.tableValues.get(i);
+        }
+    }
+    return nil<TomlValue*>;
+}
+
+/**
+ * Retrieve the value of the table entry with the given key, or nil if the value
+ * is not a table or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value, or nil
+ */
+public f<TomlValue*> TomlValue.getFieldOrNil(string key) {
+    return this.getFieldOrNil(String(key));
+}
+
+/**
+ * Retrieve the value of the table entry with the given key. Panics if the value
+ * is not a table or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value
+ */
+public f<TomlValue*> TomlValue.getField(const String& key) {
+    assert this.kind == TomlValueKind::TOML_TABLE;
+    TomlValue* value = this.getFieldOrNil(key);
+    if value == nil<TomlValue*> {
+        panic(Error("TOML table has no such entry"));
+    }
+    return value;
+}
+
+/**
+ * Retrieve the value of the table entry with the given key. Panics if the value
+ * is not a table or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value
+ */
+public f<TomlValue*> TomlValue.getField(string key) {
+    return this.getField(String(key));
+}
+
+/**
+ * Append an entry to the table. Panics if the value is not a table.
+ * The table takes ownership of the heap-allocated entry value.
+ *
+ * @param key Entry key
+ * @param value Entry value
+ */
+public p TomlValue.addTableField(const String& key, TomlValue* value) {
+    assert this.kind == TomlValueKind::TOML_TABLE;
+    this.tableKeys.pushBack(key);
+    this.tableValues.pushBack(value);
+}
+
+// --- Special float values --------------------------------------------------
+
+/**
+ * Retrieve positive infinity, which TOML spells `inf`. Spice has no literal
+ * for it, so it is provided here for building and inspecting float values.
+ *
+ * @return Positive infinity
+ */
+public f<double> tomlInfinity() {
+    return toDouble("inf");
+}
+
+/**
+ * Retrieve a quiet NaN, which TOML spells `nan`. Spice has no literal for it,
+ * so it is provided here for building float values.
+ *
+ * @return Not a number
+ */
+public f<double> tomlNaN() {
+    return toDouble("nan");
+}
+
+/**
+ * Checks whether the given float is a NaN. The usual `value != value` trick does
+ * not work in Spice, since its float comparisons are ordered ones.
+ *
+ * @param value Float value to check
+ * @return true if the value is a NaN, false otherwise
+ */
+public f<bool> tomlIsNaN(double value) {
+    return !(value == value);
+}

--- a/std/type/type-conversion.spice
+++ b/std/type/type-conversion.spice
@@ -1,6 +1,6 @@
 // External functions
 ext f<int> snprintf(char*, unsigned long, string, ...);
-ext f<long> strtol(string, char**, int);
+ext f<long> strtoll(string, char**, int);
 ext f<int> atoi(string, char**, int);
 ext f<double> strtod(string, char**);
 
@@ -279,7 +279,7 @@ public f<long> toLong(char input) {
  * @return Long value
  */
 public f<long> toLong(string input, int base = 10) {
-    return strtol(input, nil<char**>, base);
+    return strtoll(input, nil<char**>, base);
 }
 
 /**

--- a/test/test-files/std/text/toml-parser/cout.out
+++ b/test/test-files/std/text/toml-parser/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/toml-parser/source.spice
+++ b/test/test-files/std/text/toml-parser/source.spice
@@ -1,0 +1,389 @@
+import "std/text/toml-value";
+import "std/text/toml-parser";
+
+f<int> main() {
+    // Strings
+    Result<TomlValue*> basicRes = parseToml(String("s = \"hello\\nworld\"\n"));
+    assert basicRes.isOk();
+    TomlValue* basicRoot = basicRes.unwrap();
+    assert basicRoot.isTable();
+    assert basicRoot.getTableSize() == 1;
+    TomlValue* basic = basicRoot.getField("s");
+    assert basic.isString();
+    assert basic.getString() == String("hello\nworld");
+
+    Result<TomlValue*> literalRes = parseToml(String("s = 'C:\\Users\\nodejs'\n"));
+    TomlValue* literalRoot = literalRes.unwrap();
+    TomlValue* literal = literalRoot.getField("s");
+    assert literal.getString() == String("C:\\Users\\nodejs");
+
+    // Multi-line basic string: the line break right after the delimiter is trimmed
+    String mlDoc = String("s = \"\"\"\n");
+    mlDoc += "Roses are red\n";
+    mlDoc += "Violets are blue\"\"\"\n";
+    Result<TomlValue*> mlRes = parseToml(mlDoc);
+    TomlValue* mlRoot = mlRes.unwrap();
+    TomlValue* ml = mlRoot.getField("s");
+    assert ml.getString() == String("Roses are red\nViolets are blue");
+
+    // A backslash at the end of a line trims the line break and the following whitespace
+    String contDoc = String("s = \"\"\"\\\n");
+    contDoc += "    The quick brown \\\n";
+    contDoc += "    fox jumps\"\"\"\n";
+    Result<TomlValue*> contRes = parseToml(contDoc);
+    TomlValue* contRoot = contRes.unwrap();
+    TomlValue* cont = contRoot.getField("s");
+    assert cont.getString() == String("The quick brown fox jumps");
+
+    // Multi-line literal string
+    String mlLitDoc = String("s = '''\n");
+    mlLitDoc += "no \\escapes\n";
+    mlLitDoc += "here'''\n";
+    Result<TomlValue*> mlLitRes = parseToml(mlLitDoc);
+    TomlValue* mlLitRoot = mlLitRes.unwrap();
+    TomlValue* mlLit = mlLitRoot.getField("s");
+    assert mlLit.getString() == String("no \\escapes\nhere");
+
+    // Up to two quotes directly before the closing delimiter still belong to the content
+    Result<TomlValue*> quoteRes = parseToml(String("s = \"\"\"a\"\"\"\"\n"));
+    TomlValue* quoteRoot = quoteRes.unwrap();
+    TomlValue* quoted = quoteRoot.getField("s");
+    assert quoted.getString() == String("a\"");
+
+    // Unicode escapes are encoded as UTF-8
+    Result<TomlValue*> uniRes = parseToml(String("s = \"\\u00E9\\U0001F600\"\n"));
+    TomlValue* uniRoot = uniRes.unwrap();
+    TomlValue* uni = uniRoot.getField("s");
+    assert uni.getString() == String("\303\251\360\237\230\200");
+
+    // Raw multi-byte UTF-8 passes through unchanged
+    Result<TomlValue*> rawRes = parseToml(String("s = \"\303\251\"\n"));
+    TomlValue* rawRoot = rawRes.unwrap();
+    TomlValue* raw = rawRoot.getField("s");
+    assert raw.getString() == String("\303\251");
+
+    // Integers
+    Result<TomlValue*> intRes = parseToml(String("a = 42\nb = -17\nc = +99\nd = 1_000_000\ne = 0\n"));
+    TomlValue* intRoot = intRes.unwrap();
+    TomlValue* intA = intRoot.getField("a");
+    assert intA.isInteger();
+    assert intA.getInteger() == 42l;
+    TomlValue* intB = intRoot.getField("b");
+    assert intB.getInteger() == -17l;
+    TomlValue* intC = intRoot.getField("c");
+    assert intC.getInteger() == 99l;
+    TomlValue* intD = intRoot.getField("d");
+    assert intD.getInteger() == 1000000l;
+    TomlValue* intE = intRoot.getField("e");
+    assert intE.getInteger() == 0l;
+
+    Result<TomlValue*> radixRes = parseToml(String("h = 0xdead_BEEF\no = 0o755\nb = 0b1101\n"));
+    TomlValue* radixRoot = radixRes.unwrap();
+    TomlValue* hexVal = radixRoot.getField("h");
+    assert hexVal.getInteger() == 3735928559l;
+    TomlValue* octVal = radixRoot.getField("o");
+    assert octVal.getInteger() == 493l;
+    TomlValue* binVal = radixRoot.getField("b");
+    assert binVal.getInteger() == 13l;
+
+    // Floats
+    Result<TomlValue*> floatRes = parseToml(String("a = 3.14\nb = -0.01\nc = 5e+22\nd = 6.626e-34\ne = 224_617.445_991\n"));
+    TomlValue* floatRoot = floatRes.unwrap();
+    TomlValue* floatA = floatRoot.getField("a");
+    assert floatA.isFloat();
+    assert floatA.getFloat() == 3.14;
+    TomlValue* floatB = floatRoot.getField("b");
+    assert floatB.getFloat() == -0.01;
+    TomlValue* floatC = floatRoot.getField("c");
+    assert floatC.getFloat() == 5.0e+22;
+    TomlValue* floatD = floatRoot.getField("d");
+    assert floatD.getFloat() == 6.626e-34;
+    TomlValue* floatE = floatRoot.getField("e");
+    assert floatE.getFloat() == 224617.445991;
+
+    Result<TomlValue*> specialRes = parseToml(String("a = inf\nb = -inf\nc = nan\n"));
+    TomlValue* specialRoot = specialRes.unwrap();
+    TomlValue* posInf = specialRoot.getField("a");
+    assert posInf.getFloat() == tomlInfinity();
+    TomlValue* negInf = specialRoot.getField("b");
+    assert negInf.getFloat() == -tomlInfinity();
+    TomlValue* notANumber = specialRoot.getField("c");
+    assert tomlIsNaN(notANumber.getFloat());
+    assert !tomlIsNaN(3.0);
+
+    // Booleans
+    Result<TomlValue*> boolRes = parseToml(String("t = true\nf = false\n"));
+    TomlValue* boolRoot = boolRes.unwrap();
+    TomlValue* boolT = boolRoot.getField("t");
+    assert boolT.isBool();
+    assert boolT.getBool() == true;
+    TomlValue* boolF = boolRoot.getField("f");
+    assert boolF.getBool() == false;
+
+    // Date-times are kept in their lexical form
+    String dtDoc = String("odt = 1979-05-27T07:32:00Z\n");
+    dtDoc += "odt2 = 1979-05-27T00:32:00.999999-07:00\n";
+    dtDoc += "ldt = 1979-05-27T07:32:00\n";
+    dtDoc += "spaced = 1979-05-27 07:32:00\n";
+    dtDoc += "ld = 1979-05-27\n";
+    dtDoc += "lt = 07:32:00.5\n";
+    Result<TomlValue*> dtRes = parseToml(dtDoc);
+    assert dtRes.isOk();
+    TomlValue* dtRoot = dtRes.unwrap();
+    TomlValue* odt = dtRoot.getField("odt");
+    assert odt.isDateTime();
+    assert odt.getDateTime() == String("1979-05-27T07:32:00Z");
+    TomlValue* odt2 = dtRoot.getField("odt2");
+    assert odt2.getDateTime() == String("1979-05-27T00:32:00.999999-07:00");
+    TomlValue* ldt = dtRoot.getField("ldt");
+    assert ldt.getDateTime() == String("1979-05-27T07:32:00");
+    TomlValue* spaced = dtRoot.getField("spaced");
+    assert spaced.getDateTime() == String("1979-05-27 07:32:00");
+    TomlValue* ld = dtRoot.getField("ld");
+    assert ld.getDateTime() == String("1979-05-27");
+    TomlValue* lt = dtRoot.getField("lt");
+    assert lt.getDateTime() == String("07:32:00.5");
+
+    // A trailing comment must not become part of the value
+    Result<TomlValue*> dateCommentRes = parseToml(String("d = 1979-05-27 # birthday\n"));
+    TomlValue* dateCommentRoot = dateCommentRes.unwrap();
+    TomlValue* dateComment = dateCommentRoot.getField("d");
+    assert dateComment.getDateTime() == String("1979-05-27");
+
+    // Arrays, including nested, heterogeneous and multi-line ones with a trailing comma
+    String arrDoc = String("nums = [1, 2, 3]\n");
+    arrDoc += "empty = []\n";
+    arrDoc += "nested = [[1, 2], [\"a\"]]\n";
+    arrDoc += "mixed = [1, \"two\", 3.0, true]\n";
+    arrDoc += "multi = [\n  1, # first\n  2,\n]\n";
+    Result<TomlValue*> arrRes = parseToml(arrDoc);
+    assert arrRes.isOk();
+    TomlValue* arrRoot = arrRes.unwrap();
+    TomlValue* nums = arrRoot.getField("nums");
+    assert nums.isArray();
+    assert nums.getArraySize() == 3;
+    TomlValue* num0 = nums.getArrayItem(0);
+    assert num0.getInteger() == 1l;
+    TomlValue* empty = arrRoot.getField("empty");
+    assert empty.getArraySize() == 0;
+    TomlValue* nested = arrRoot.getField("nested");
+    TomlValue* nested0 = nested.getArrayItem(0);
+    assert nested0.getArraySize() == 2;
+    TomlValue* mixed = arrRoot.getField("mixed");
+    assert mixed.getArraySize() == 4;
+    TomlValue* mixed1 = mixed.getArrayItem(1);
+    assert mixed1.getString() == String("two");
+    TomlValue* multi = arrRoot.getField("multi");
+    assert multi.getArraySize() == 2;
+
+    // Inline tables
+    Result<TomlValue*> inlineRes = parseToml(String("point = { x = 1, y = 2 }\nblank = {}\n"));
+    assert inlineRes.isOk();
+    TomlValue* inlineRoot = inlineRes.unwrap();
+    TomlValue* point = inlineRoot.getField("point");
+    assert point.isTable();
+    assert point.getTableSize() == 2;
+    TomlValue* pointX = point.getField("x");
+    assert pointX.getInteger() == 1l;
+    TomlValue* blank = inlineRoot.getField("blank");
+    assert blank.getTableSize() == 0;
+
+    // Bare, quoted and dotted keys
+    String keyDoc = String("bare-key_1 = 1\n");
+    keyDoc += "\"quoted key\" = 2\n";
+    keyDoc += "'literal key' = 3\n";
+    keyDoc += "physical.color = \"orange\"\n";
+    keyDoc += "physical.shape = \"round\"\n";
+    Result<TomlValue*> keyRes = parseToml(keyDoc);
+    assert keyRes.isOk();
+    TomlValue* keyRoot = keyRes.unwrap();
+    assert keyRoot.hasField("bare-key_1");
+    assert keyRoot.hasField("quoted key");
+    assert keyRoot.hasField("literal key");
+    TomlValue* physical = keyRoot.getField("physical");
+    assert physical.isTable();
+    assert physical.getTableSize() == 2;
+    TomlValue* color = physical.getField("color");
+    assert color.getString() == String("orange");
+
+    // Tables, nested tables and comments
+    String tableDoc = String("# a comment\n");
+    tableDoc += "title = \"TOML Example\"\n";
+    tableDoc += "\n";
+    tableDoc += "[owner] # trailing comment\n";
+    tableDoc += "name = \"Tom\"\n";
+    tableDoc += "\n";
+    tableDoc += "[owner.address]\n";
+    tableDoc += "city = \"NYC\"\n";
+    tableDoc += "\n";
+    tableDoc += "[servers.alpha]\n";
+    tableDoc += "ip = \"10.0.0.1\"\n";
+    Result<TomlValue*> tableRes = parseToml(tableDoc);
+    assert tableRes.isOk();
+    TomlValue* tableRoot = tableRes.unwrap();
+    assert tableRoot.getTableSize() == 3;
+    TomlValue* owner = tableRoot.getField("owner");
+    assert owner.isTable();
+    TomlValue* ownerName = owner.getField("name");
+    assert ownerName.getString() == String("Tom");
+    TomlValue* address = owner.getField("address");
+    TomlValue* city = address.getField("city");
+    assert city.getString() == String("NYC");
+    // Super-tables are created implicitly
+    TomlValue* servers = tableRoot.getField("servers");
+    assert servers.isTable();
+    TomlValue* alpha = servers.getField("alpha");
+    TomlValue* alphaIp = alpha.getField("ip");
+    assert alphaIp.getString() == String("10.0.0.1");
+    // Table entries keep their insertion order
+    assert tableRoot.getTableKey(0l) == String("title");
+    assert tableRoot.getTableKey(1l) == String("owner");
+    assert tableRoot.getTableKey(2l) == String("servers");
+
+    // Arrays of tables, including sub-tables of the most recent element
+    String aotDoc = String("[[fruit]]\n");
+    aotDoc += "name = \"apple\"\n";
+    aotDoc += "\n";
+    aotDoc += "[fruit.physical]\n";
+    aotDoc += "color = \"red\"\n";
+    aotDoc += "\n";
+    aotDoc += "[[fruit.variety]]\n";
+    aotDoc += "name = \"red delicious\"\n";
+    aotDoc += "\n";
+    aotDoc += "[[fruit]]\n";
+    aotDoc += "name = \"banana\"\n";
+    Result<TomlValue*> aotRes = parseToml(aotDoc);
+    assert aotRes.isOk();
+    TomlValue* aotRoot = aotRes.unwrap();
+    TomlValue* fruits = aotRoot.getField("fruit");
+    assert fruits.isArray();
+    assert fruits.getArraySize() == 2;
+    TomlValue* apple = fruits.getArrayItem(0);
+    assert apple.isTable();
+    TomlValue* appleName = apple.getField("name");
+    assert appleName.getString() == String("apple");
+    TomlValue* applePhysical = apple.getField("physical");
+    TomlValue* appleColor = applePhysical.getField("color");
+    assert appleColor.getString() == String("red");
+    TomlValue* appleVarieties = apple.getField("variety");
+    assert appleVarieties.getArraySize() == 1;
+    TomlValue* banana = fruits.getArrayItem(1);
+    TomlValue* bananaName = banana.getField("name");
+    assert bananaName.getString() == String("banana");
+    assert !banana.hasField("physical");
+
+    // Defining a super-table after one of its sub-tables is allowed
+    Result<TomlValue*> superRes = parseToml(String("[a.b]\nx = 1\n[a]\ny = 2\n"));
+    assert superRes.isOk();
+    TomlValue* superTree = superRes.unwrap();
+    deleteTomlValue(superTree);
+
+    // An empty document yields an empty root table
+    Result<TomlValue*> emptyRes = parseToml(String("\n# nothing here\n\n"));
+    assert emptyRes.isOk();
+    TomlValue* emptyRoot = emptyRes.unwrap();
+    assert emptyRoot.getTableSize() == 0;
+
+    // CRLF line endings are accepted
+    Result<TomlValue*> crlfRes = parseToml(String("a = 1\r\n[t]\r\nb = 2\r\n"));
+    assert crlfRes.isOk();
+    TomlValue* crlfTree = crlfRes.unwrap();
+    deleteTomlValue(crlfTree);
+
+    // --- Malformed input surfaces an error ---------------------------------
+
+    Result<TomlValue*> noValueRes = parseToml(String("a = \n"));
+    assert !noValueRes.isOk();
+    Result<TomlValue*> noEqualsRes = parseToml(String("a 1\n"));
+    assert !noEqualsRes.isOk();
+    Result<TomlValue*> dupKeyRes = parseToml(String("a = 1\na = 2\n"));
+    assert !dupKeyRes.isOk();
+    Result<TomlValue*> dupTableRes = parseToml(String("[a]\n[a]\n"));
+    assert !dupTableRes.isOk();
+    Result<TomlValue*> clashRes = parseToml(String("[a]\nb = 1\n[a.b.c]\n"));
+    assert !clashRes.isOk();
+    Result<TomlValue*> aotClashRes = parseToml(String("a = [1]\n[[a]]\n"));
+    assert !aotClashRes.isOk();
+    Result<TomlValue*> trailingRes = parseToml(String("a = 1 b = 2\n"));
+    assert !trailingRes.isOk();
+    Result<TomlValue*> unclosedTableRes = parseToml(String("[a\n"));
+    assert !unclosedTableRes.isOk();
+    Result<TomlValue*> emptyHeaderRes = parseToml(String("[]\n"));
+    assert !emptyHeaderRes.isOk();
+
+    // Numbers
+    Result<TomlValue*> leadingZeroRes = parseToml(String("a = 01\n"));
+    assert !leadingZeroRes.isOk();
+    Result<TomlValue*> doubleUnderscoreRes = parseToml(String("a = 1__0\n"));
+    assert !doubleUnderscoreRes.isOk();
+    Result<TomlValue*> trailingUnderscoreRes = parseToml(String("a = 1_\n"));
+    assert !trailingUnderscoreRes.isOk();
+    Result<TomlValue*> trailingDotRes = parseToml(String("a = 1.\n"));
+    assert !trailingDotRes.isOk();
+    Result<TomlValue*> bareExpRes = parseToml(String("a = 1e\n"));
+    assert !bareExpRes.isOk();
+    Result<TomlValue*> emptyHexRes = parseToml(String("a = 0x\n"));
+    assert !emptyHexRes.isOk();
+    Result<TomlValue*> signedHexRes = parseToml(String("a = -0x1\n"));
+    assert !signedHexRes.isOk();
+
+    // Strings
+    Result<TomlValue*> unterminatedRes = parseToml(String("a = \"oops\n"));
+    assert !unterminatedRes.isOk();
+    Result<TomlValue*> badEscapeRes = parseToml(String("a = \"\\q\"\n"));
+    assert !badEscapeRes.isOk();
+    Result<TomlValue*> badUnicodeRes = parseToml(String("a = \"\\u00Z1\"\n"));
+    assert !badUnicodeRes.isOk();
+    Result<TomlValue*> surrogateRes = parseToml(String("a = \"\\uD800\"\n"));
+    assert !surrogateRes.isOk();
+    Result<TomlValue*> rawNewlineRes = parseToml(String("a = \"x\ny\"\n"));
+    assert !rawNewlineRes.isOk();
+    // Tabs on the other hand are legal inside strings
+    Result<TomlValue*> tabRes = parseToml(String("a = \"x\ty\"\n"));
+    assert tabRes.isOk();
+    TomlValue* tabTree = tabRes.unwrap();
+    deleteTomlValue(tabTree);
+
+    // Arrays and inline tables
+    Result<TomlValue*> unterminatedArrRes = parseToml(String("a = [1, 2\n"));
+    assert !unterminatedArrRes.isOk();
+    Result<TomlValue*> inlineCommaRes = parseToml(String("a = {b = 1,}\n"));
+    assert !inlineCommaRes.isOk();
+    Result<TomlValue*> inlineBreakRes = parseToml(String("a = {\nb = 1}\n"));
+    assert !inlineBreakRes.isOk();
+    Result<TomlValue*> dupInlineRes = parseToml(String("a = {b = 1, b = 2}\n"));
+    assert !dupInlineRes.isOk();
+
+    // Bad booleans and dates
+    Result<TomlValue*> badBoolRes = parseToml(String("a = tru\n"));
+    assert !badBoolRes.isOk();
+    Result<TomlValue*> badDateRes = parseToml(String("a = 2024-13\n"));
+    assert !badDateRes.isOk();
+    Result<TomlValue*> badTimeRes = parseToml(String("a = 07:32\n"));
+    assert !badTimeRes.isOk();
+
+    // Every parsed tree is owned by the caller, so release them all again
+    deleteTomlValue(basicRoot);
+    deleteTomlValue(literalRoot);
+    deleteTomlValue(mlRoot);
+    deleteTomlValue(contRoot);
+    deleteTomlValue(mlLitRoot);
+    deleteTomlValue(quoteRoot);
+    deleteTomlValue(uniRoot);
+    deleteTomlValue(rawRoot);
+    deleteTomlValue(intRoot);
+    deleteTomlValue(radixRoot);
+    deleteTomlValue(floatRoot);
+    deleteTomlValue(specialRoot);
+    deleteTomlValue(boolRoot);
+    deleteTomlValue(dtRoot);
+    deleteTomlValue(dateCommentRoot);
+    deleteTomlValue(arrRoot);
+    deleteTomlValue(inlineRoot);
+    deleteTomlValue(keyRoot);
+    deleteTomlValue(tableRoot);
+    deleteTomlValue(aotRoot);
+    deleteTomlValue(emptyRoot);
+
+    printf("All assertions passed!");
+}

--- a/test/test-files/std/text/toml-serializer/cout.out
+++ b/test/test-files/std/text/toml-serializer/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/toml-serializer/source.spice
+++ b/test/test-files/std/text/toml-serializer/source.spice
@@ -1,0 +1,169 @@
+import "std/text/toml-value";
+import "std/text/toml-serializer";
+import "std/text/toml-parser";
+
+f<int> main() {
+    TomlSerializer serializer;
+
+    // Serialization of single values
+    TomlValue strVal = TomlValue(String("a\"b\nc"));
+    assert serializer.serializeValue(&strVal) == String("\"a\\\"b\\nc\"");
+    TomlValue intVal = TomlValue(42l);
+    assert serializer.serializeValue(&intVal) == String("42");
+    TomlValue negVal = TomlValue(-17l);
+    assert serializer.serializeValue(&negVal) == String("-17");
+    TomlValue boolVal = TomlValue(true);
+    assert serializer.serializeValue(&boolVal) == String("true");
+    TomlValue dtVal = TomlValue(TomlValueKind::TOML_DATETIME, String("1979-05-27T07:32:00Z"));
+    assert serializer.serializeValue(&dtVal) == String("1979-05-27T07:32:00Z");
+
+    // Floats always stay recognizable as floats
+    TomlValue fracVal = TomlValue(-3.5);
+    assert serializer.serializeValue(&fracVal) == String("-3.5");
+    TomlValue integralVal = TomlValue(42.0);
+    assert serializer.serializeValue(&integralVal) == String("42.0");
+    TomlValue zeroVal = TomlValue(0.0);
+    assert serializer.serializeValue(&zeroVal) == String("0.0");
+    TomlValue infVal = TomlValue(tomlInfinity());
+    assert serializer.serializeValue(&infVal) == String("inf");
+    TomlValue negInfVal = TomlValue(-tomlInfinity());
+    assert serializer.serializeValue(&negInfVal) == String("-inf");
+    TomlValue nanVal = TomlValue(tomlNaN());
+    assert serializer.serializeValue(&nanVal) == String("nan");
+
+    // Values built programmatically serialize as expected
+    TomlValue arrVal = TomlValue(TomlValueKind::TOML_ARRAY);
+    arrVal.addArrayItem(__new<TomlValue>(1l));
+    arrVal.addArrayItem(__new<TomlValue>(String("two")));
+    assert serializer.serializeValue(&arrVal) == String("[1, \"two\"]");
+
+    TomlValue emptyArrVal = TomlValue(TomlValueKind::TOML_ARRAY);
+    assert serializer.serializeValue(&emptyArrVal) == String("[]");
+
+    TomlValue inlineVal = TomlValue(TomlValueKind::TOML_TABLE);
+    inlineVal.addTableField(String("a"), __new<TomlValue>(true));
+    inlineVal.addTableField(String("b"), __new<TomlValue>(String("x")));
+    assert serializer.serializeValue(&inlineVal) == String("{a = true, b = \"x\"}");
+
+    // Keys that are not bare keys get quoted
+    TomlValue keyVal = TomlValue(TomlValueKind::TOML_TABLE);
+    keyVal.addTableField(String("bare-key_1"), __new<TomlValue>(1l));
+    keyVal.addTableField(String("needs quoting"), __new<TomlValue>(2l));
+    keyVal.addTableField(String(""), __new<TomlValue>(3l));
+    assert serializer.serializeValue(&keyVal) == String("{bare-key_1 = 1, \"needs quoting\" = 2, \"\" = 3}");
+
+    // A document lays sub-tables out as sections
+    TomlValue root = TomlValue();
+    root.addTableField(String("title"), __new<TomlValue>(String("Example")));
+    TomlValue* owner = __new<TomlValue>(TomlValueKind::TOML_TABLE);
+    owner.addTableField(String("name"), __new<TomlValue>(String("Tom")));
+    root.addTableField(String("owner"), owner);
+    String expectedDoc = String("title = \"Example\"\n");
+    expectedDoc += "\n";
+    expectedDoc += "[owner]\n";
+    expectedDoc += "name = \"Tom\"\n";
+    assert serializer.serialize(root) == expectedDoc;
+
+    // An empty root table produces an empty document
+    TomlValue emptyRoot = TomlValue();
+    assert serializer.serialize(emptyRoot) == String("");
+
+    // A full document round-trips through the parser
+    String doc = String("title = \"TOML Example\"\n");
+    doc += "ports = [8001, 8002]\n";
+    doc += "\n";
+    doc += "[owner]\n";
+    doc += "name = \"Tom\"\n";
+    doc += "dob = 1979-05-27T07:32:00Z\n";
+    doc += "\n";
+    doc += "[owner.address]\n";
+    doc += "city = \"NYC\"\n";
+    doc += "\n";
+    doc += "[[fruit]]\n";
+    doc += "name = \"apple\"\n";
+    doc += "\n";
+    doc += "[fruit.physical]\n";
+    doc += "color = \"red\"\n";
+    doc += "\n";
+    doc += "[[fruit]]\n";
+    doc += "name = \"banana\"\n";
+    Result<TomlValue*> parsedRes = parseToml(doc);
+    assert parsedRes.isOk();
+    TomlValue* parsed = parsedRes.unwrap();
+    assert serializer.serialize(parsed) == doc;
+
+    // Serialize -> parse -> serialize is stable
+    String onceSerialized = serializer.serialize(parsed);
+    Result<TomlValue*> reParsedRes = parseToml(onceSerialized);
+    assert reParsedRes.isOk();
+    TomlValue* reParsed = reParsedRes.unwrap();
+    assert serializer.serialize(reParsed) == doc;
+
+    // Empty sub-tables keep their section header
+    Result<TomlValue*> emptySectionRes = parseToml(String("[a]\n\n[a.b]\n"));
+    assert emptySectionRes.isOk();
+    TomlValue* emptySection = emptySectionRes.unwrap();
+    assert serializer.serialize(emptySection) == String("[a]\n\n[a.b]\n");
+
+    // Arrays that hold something other than tables stay on a single line
+    Result<TomlValue*> mixedRes = parseToml(String("a = [{x = 1}, 2]\nb = []\n"));
+    assert mixedRes.isOk();
+    TomlValue* mixed = mixedRes.unwrap();
+    assert serializer.serialize(mixed) == String("a = [{x = 1}, 2]\nb = []\n");
+
+    // The inline mode emits everything as key/value pairs
+    TomlSerializer inlineSerializer = TomlSerializer(true);
+    String expectedInline = String("title = \"TOML Example\"\n");
+    expectedInline += "ports = [8001, 8002]\n";
+    expectedInline += "owner = {name = \"Tom\", dob = 1979-05-27T07:32:00Z, address = {city = \"NYC\"}}\n";
+    expectedInline += "fruit = [{name = \"apple\", physical = {color = \"red\"}}, {name = \"banana\"}]\n";
+    String inlineOut = inlineSerializer.serialize(parsed);
+    assert inlineOut == expectedInline;
+
+    // Inline output round-trips to the very same value tree
+    Result<TomlValue*> inlineReparsedRes = parseToml(inlineOut);
+    assert inlineReparsedRes.isOk();
+    TomlValue* inlineReparsed = inlineReparsedRes.unwrap();
+    assert serializer.serialize(inlineReparsed) == doc;
+
+    // Non-integral floats keep full precision across a serialize/parse round-trip
+    Result<TomlValue*> precRes = parseToml(String("a = 1.23456789\n"));
+    TomlValue* precRoot = precRes.unwrap();
+    String precSerialized = serializer.serialize(precRoot);
+    Result<TomlValue*> precReparsedRes = parseToml(precSerialized);
+    TomlValue* precReparsedRoot = precReparsedRes.unwrap();
+    TomlValue* precReparsed = precReparsedRoot.getField("a");
+    assert precReparsed.getFloat() == 1.23456789;
+
+    // Keys that need quoting also work in section headers
+    Result<TomlValue*> quotedRes = parseToml(String("[\"weird.key\".sub]\nx = 1\n"));
+    assert quotedRes.isOk();
+    TomlValue* quoted = quotedRes.unwrap();
+    assert serializer.serialize(quoted) == String("[\"weird.key\"]\n\n[\"weird.key\".sub]\nx = 1\n");
+
+    // Control characters are escaped
+    TomlValue ctrlVal = TomlValue(String("a\001b\177c"));
+    assert serializer.serializeValue(&ctrlVal) == String("\"a\\u0001b\\u007Fc\"");
+    Result<TomlValue*> ctrlRes = parseToml(String("a = \"\\u0001\\u007F\"\n"));
+    assert ctrlRes.isOk();
+    TomlValue* ctrlRoot = ctrlRes.unwrap();
+    TomlValue* ctrl = ctrlRoot.getField("a");
+    assert ctrl.getString() == String("\001\177");
+
+    // Multi-byte UTF-8 is passed through instead of being escaped
+    TomlValue utf8Val = TomlValue(String("\303\251"));
+    assert serializer.serializeValue(&utf8Val) == String("\"\303\251\"");
+
+    // Every parsed tree is owned by the caller, so release them all again
+    deleteTomlValue(parsed);
+    deleteTomlValue(reParsed);
+    deleteTomlValue(emptySection);
+    deleteTomlValue(mixed);
+    deleteTomlValue(inlineReparsed);
+    deleteTomlValue(precRoot);
+    deleteTomlValue(precReparsedRoot);
+    deleteTomlValue(quoted);
+    deleteTomlValue(ctrlRoot);
+
+    printf("All assertions passed!");
+}

--- a/test/test-files/std/type/string-type-functions/source.spice
+++ b/test/test-files/std/type/string-type-functions/source.spice
@@ -12,6 +12,10 @@ f<int> main() {
     // toLong()
     long asLong = toLong("56");
     assert asLong == 56l;
+    long asNegativeLong = toLong("-17");
+    assert asNegativeLong == -17l;
+    long asWideLong = toLong("deadBEEF", 16);
+    assert asWideLong == 3735928559l;
 
     // toShort()
     short asShort = toShort("-12");


### PR DESCRIPTION
Add a parser, a serializer and the value model they share, laid out like the existing JSON modules so programs only pull in what they use.

The parser covers TOML v1.0.0: comments, bare/quoted/dotted keys, basic and literal strings (single- and multi-line, including line-ending backslash trimming and unicode escapes encoded as UTF-8), decimal/hexadecimal/octal/ binary integers with underscore separators, floats including inf and nan, booleans, all four date-time shapes, arrays, inline tables, [table] headers and [[array of table]] headers. Duplicate keys and tables, leading zeros, misplaced underscores, unescaped control characters and trailing commas in inline tables are rejected.

The serializer emits idiomatic section-based documents by default and can emit everything inline instead. Both directions round-trip through the parser.

Unlike JSON, TOML separates integers from floats, so both are stored on their own; date-times keep their lexical form. Since Spice has no literal for them and its float comparisons are ordered ones, tomlInfinity, tomlNaN and tomlIsNaN are provided alongside the value model.

Value trees are owned by the caller and released with deleteTomlValue, the same ownership model the JSON and XML modules use.