### PR TITLE
Parallelize the back end over a thread pool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@ include(Conditionals.cmake)
 # Parse CMake args
 include(Options.cmake)
 
+# Find the system threading library (used by the parallel back end)
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package(Threads REQUIRED)
+
 # Find LLVM
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Spice: Found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/media/specs/parallel-backend.md
+++ b/media/specs/parallel-backend.md
@@ -44,7 +44,7 @@ resulting worklist is the unit of scheduling; the order it defines is what the s
 
 ### Utilities
 
-- `src/util/ThreadPool.h` — a fixed-size worker pool. Tasks are `void()` and the submitter blocks in `waitForAll()`.
+- `src/util/ThreadPool.{h,cpp}` — a fixed-size worker pool. Tasks are `void()` and the submitter blocks in `waitForAll()`.
   Two properties matter for the compiler:
   - Passes report failures by **throwing** (`LexerError`, `SemanticError`, `CompilerError`, ...). An exception escaping
     a worker thread would terminate the process, so tasks are wrapped and the exception is re-thrown on the waiting

--- a/media/specs/parallel-backend.md
+++ b/media/specs/parallel-backend.md
@@ -1,0 +1,144 @@
+# Parallel back end design document
+
+The `--jobs`/`-j` cli option has existed for a long time, but was never wired up to anything: `CliOptions::compileJobCount`
+was parsed and then ignored, so every build compiled strictly serially. This document describes how the back end is
+parallelized across source files with a thread pool, and which shared state had to be made safe for it.
+
+## Why the back end
+
+The compiler pipeline (see [compile-stages.md](compile-stages.md)) has three phases per source file:
+
+- **Front end** — lexer, parser, AST builder, import collector, symbol table builder
+- **Middle end** — type checker (pre + post)
+- **Back end** — IR generator, IR optimizer, object emitter
+
+Only the back end is embarrassingly parallel across source files:
+
+- Every `SourceFile` already owns its own `llvm::LLVMContext`, `llvm::IRBuilder`, `llvm::TargetMachine`, `llvm::Module`
+  and `typeToLLVMTypeMapping`. Two source files therefore never touch the same LLVM data structure.
+- References to symbols of other source files are emitted as *declarations* into the local module
+  (`module->getOrInsertFunction` / `module->getOrInsertGlobal`). No source file reads the IR of another one.
+- The AST, the symbol tables and the type registry are inputs to the back end, and are fully populated once the middle
+  end is done.
+
+The front end cannot be parallelized as easily, because the import collector discovers dependencies while it runs and
+files feed symbols into each other. The middle end is a fixpoint iteration over a dependency graph that may contain
+cycles. Both are worth a separate look; this change deliberately stops at the back end.
+
+The old back end recursed over the dependency graph (`runBackEnd` calling itself for every dependency first). That
+recursion looked like a data dependency but is not one — it only exists so that the graph is walked cycle-safely. It is
+replaced by an explicit, deterministic worklist.
+
+## Design
+
+```
+runBackEnd()                                          [main thread]
+ ├─ collectBackEndSourceFiles()                       flatten the dependency graph, dependencies first
+ ├─ for each source file: runBackEndForThisFile()     [worker threads, via ThreadPool]
+ │    ├─ runIRGenerator()
+ │    ├─ runDefaultIROptimizer()
+ │    └─ runObjectEmitter()
+ └─ for each source file: concludeCompilation()       [main thread, deterministic order]
+      ├─ linker.addFileToLinkage(objectFilePath)
+      └─ cacheManager.cacheSourceFile()
+```
+
+### New utilities
+
+- `src/util/ThreadPool.h` — a fixed-size worker pool. Tasks are `void()` and the submitter blocks in `waitForAll()`.
+  Two properties matter for the compiler:
+  - Passes report failures by **throwing** (`LexerError`, `SemanticError`, `CompilerError`, ...). An exception escaping
+    a worker thread would terminate the process, so tasks are wrapped and the exception is re-thrown on the waiting
+    thread.
+  - If several tasks fail, the exception of the **task that was submitted first** wins, so the reported error does not
+    depend on the scheduling. Queued tasks that have not started yet are dropped after the first failure.
+- `src/util/Concurrency.h` — `ParallelSection`, `ConditionalLock` and the shared `symbolRegistryMutex`.
+  `ConditionalLock` only takes its mutex while a `ParallelSection` is active. The process-wide caches it protects sit on
+  the hottest paths of the (single-threaded) front end and middle end, where an unconditional lock would be pure
+  overhead; outside of a parallel section the lock degenerates to a relaxed atomic load plus a well-predicted branch.
+
+The pool is owned by the `GlobalResourceManager` and created lazily, so a `-j 1` build never spawns a thread.
+
+### Job count
+
+`GlobalResourceManager::getCompileJobCount()` resolves the cli option:
+
+| `-j` value | Result |
+| --- | --- |
+| `0` (default) | `std::thread::hardware_concurrency()`, or 1 if it cannot be determined |
+| `1` | serial back end, no threads are spawned |
+| `n > 1` | `n` workers |
+
+The job count is additionally capped at the number of source files.
+
+### When the back end stays serial
+
+- **LTO** (`--lto`). All source files share `GlobalResourceManager::ltoContext` and `ltoModule`, and `BitcodeLinker`
+  merges the modules of all files. This has to stay serial until every file gets its own context and the modules are
+  moved into the LTO context explicitly.
+- **Dump modes** (`-ir`, `-s`, `--dump-obj`). Their output goes to the console/output dir and its ordering is part of
+  what the user reads. `--abort-after-dump` also expects to stop the pipeline at a well-defined point.
+- **Single source file**, since there is nothing to overlap.
+
+## Shared state
+
+Everything the back end touches outside its own `SourceFile` was audited. The result:
+
+### Safe as-is (read-only during the back end)
+
+| State | Written by |
+| --- | --- |
+| `astNodeAlloc`, `nodeToNodeId` | AST builder |
+| `compileTimeStringValues` | AST builder, type checker |
+| `nextCustomTypeId` | AST builder (and already an atomic) |
+| `sourceFiles`, ASTs, symbol tables, scopes | front end, middle end |
+| `sourceLinkerFlags`, `sourceAdditionalSourcePaths` | symbol table builder |
+
+### Made safe by this change
+
+| State | Problem | Fix |
+| --- | --- | --- |
+| `TypeRegistry::types` | Deriving a type (`QualType::toPtr`, ...) can insert into the registry and invalidate concurrent lookups | `ConditionalLock` on a dedicated mutex |
+| `FunctionManager::lookupCache` (+ counters) | `FunctionManager::lookup` is called by the IR generator (copy ctor lookup) | `ConditionalLock` on `symbolRegistryMutex` |
+| `StructManager` / `InterfaceManager` matchers | `Type::toLLVMType` lowers struct/interface types through `QualType::getStruct`/`getInterface`, which mutate lookup caches, manifestation lists and `used` flags | `ConditionalLock` on `symbolRegistryMutex` (recursive, because struct matching recurses into struct and interface matching) |
+| `TypeNameDisambiguator::claimedTypeIds` | Reached from `NameMangling::mangleType` | `ConditionalLock` on a dedicated mutex |
+| `ExternalLinkerInterface::linkLibMath` | `OpRuleConversionManager` requests libm linkage while emitting operators | `std::atomic<bool>` |
+| `GlobalResourceManager::abortCompilation` | Written by the dump logic, which runs inside the back end | `std::atomic<bool>` |
+| `ExternalLinkerInterface::linkedFiles` | `runObjectEmitter` used to append to it, which would make the link order depend on the scheduling | Registration moved to `concludeCompilation`, which runs serially in dependency order |
+
+Lock ordering is always `symbolRegistryMutex` → `TypeRegistry::typesMutex` /
+`TypeNameDisambiguator::claimedTypeIdsMutex`; the inner locks never acquire the outer one, so there is no cycle.
+
+## Determinism
+
+A parallel build has to produce byte-identical output to a serial one:
+
+- The **linker input order** is unchanged, because object files are registered in `concludeCompilation`, which the main
+  thread drives over the same dependency-first list the old recursion produced.
+- The **compilation cache** is written from the same serial pass.
+- **Per-file compiler output** (`compilerOutput.irString`, `asmString`, timings, warnings) lives on the `SourceFile`, so
+  it is unaffected.
+- **Error reporting** is stable, see the `ThreadPool` note about the first failing task above.
+
+### Known limitation
+
+`TypeNameDisambiguator` hands out a suffix based on the order in which type names are *claimed*. In practice every
+struct/interface name is claimed while the type checker builds signatures and diagnostics, so the back end only reads
+back existing claims. A name claimed for the very first time during back-end name mangling would get a
+scheduling-dependent index — consistent within one compilation, but possibly different between runs. Ranking claimants
+by type id over the complete, front-end-known set of types would remove this residual nondeterminism; that is a
+follow-up.
+
+Independently of this change, two source files with the same file name in different directories map to the same object
+file path (`outputDir / filePath.filename()`). That was already a last-one-wins bug serially; with a parallel back end
+it becomes a concurrent write. It should be fixed by deriving the object file name from the cache key or the full path.
+
+## Testing
+
+- `test/unittest/UnitThreadPool.cpp` covers the pool (task execution, deterministic exception selection, reuse after a
+  failure) and `ConditionalLock`/`ParallelSection`.
+- The integration test runner compiles with `-j 1`. The test cases are already spread over processes by
+  `gtest-parallel` (`spicetest_parallel` target), so an additional intra-process parallel back end would only
+  oversubscribe the machine, and the reference outputs stay strictly deterministic this way.
+- The races are best flushed out with the existing thread sanitizer build option
+  (`-DSPICE_TSAN=ON`, see `Options.cmake`) on a project with many imports.

--- a/media/specs/parallel-backend.md
+++ b/media/specs/parallel-backend.md
@@ -1,8 +1,7 @@
 # Parallel back end design document
 
-The `--jobs`/`-j` cli option has existed for a long time, but was never wired up to anything: `CliOptions::compileJobCount`
-was parsed and then ignored, so every build compiled strictly serially. This document describes how the back end is
-parallelized across source files with a thread pool, and which shared state had to be made safe for it.
+The back end runs one pipeline per source file, spread over a thread pool sized by the `--jobs`/`-j` cli option. This
+document describes that design and the synchronization it relies on.
 
 ## Why the back end
 
@@ -14,20 +13,16 @@ The compiler pipeline (see [compile-stages.md](compile-stages.md)) has three pha
 
 Only the back end is embarrassingly parallel across source files:
 
-- Every `SourceFile` already owns its own `llvm::LLVMContext`, `llvm::IRBuilder`, `llvm::TargetMachine`, `llvm::Module`
-  and `typeToLLVMTypeMapping`. Two source files therefore never touch the same LLVM data structure.
+- Every `SourceFile` owns its own `llvm::LLVMContext`, `llvm::IRBuilder`, `llvm::TargetMachine`, `llvm::Module` and
+  `typeToLLVMTypeMapping`. Two source files therefore never touch the same LLVM data structure.
 - References to symbols of other source files are emitted as *declarations* into the local module
   (`module->getOrInsertFunction` / `module->getOrInsertGlobal`). No source file reads the IR of another one.
 - The AST, the symbol tables and the type registry are inputs to the back end, and are fully populated once the middle
   end is done.
 
-The front end cannot be parallelized as easily, because the import collector discovers dependencies while it runs and
-files feed symbols into each other. The middle end is a fixpoint iteration over a dependency graph that may contain
-cycles. Both are worth a separate look; this change deliberately stops at the back end.
-
-The old back end recursed over the dependency graph (`runBackEnd` calling itself for every dependency first). That
-recursion looked like a data dependency but is not one — it only exists so that the graph is walked cycle-safely. It is
-replaced by an explicit, deterministic worklist.
+The front end is not parallelized as easily, because the import collector discovers dependencies while it runs and files
+feed symbols into each other. The middle end is a fixpoint iteration over a dependency graph that may contain cycles.
+Both are worth a separate look; the parallelization stops at the back end.
 
 ## Design
 
@@ -43,7 +38,11 @@ runBackEnd()                                          [main thread]
       └─ cacheManager.cacheSourceFile()
 ```
 
-### New utilities
+`collectBackEndSourceFiles` walks the dependency graph depth-first, dependencies before dependants, and marks every file
+it visits so that a cyclic import (which resolves to the same `SourceFile` instance) is only collected once. The
+resulting worklist is the unit of scheduling; the order it defines is what the serial phases replay.
+
+### Utilities
 
 - `src/util/ThreadPool.h` — a fixed-size worker pool. Tasks are `void()` and the submitter blocks in `waitForAll()`.
   Two properties matter for the compiler:
@@ -74,7 +73,7 @@ The job count is additionally capped at the number of source files.
 ### When the back end stays serial
 
 - **LTO** (`--lto`). All source files share `GlobalResourceManager::ltoContext` and `ltoModule`, and `BitcodeLinker`
-  merges the modules of all files. This has to stay serial until every file gets its own context and the modules are
+  merges the modules of all files. Parallelizing this requires every file to get its own context, with the modules
   moved into the LTO context explicitly.
 - **Dump modes** (`-ir`, `-s`, `--dump-obj`). Their output goes to the console/output dir and its ordering is part of
   what the user reads. `--abort-after-dump` also expects to stop the pipeline at a well-defined point.
@@ -82,21 +81,21 @@ The job count is additionally capped at the number of source files.
 
 ## Shared state
 
-Everything the back end touches outside its own `SourceFile` was audited. The result:
+Everything the back end touches outside its own `SourceFile`:
 
-### Safe as-is (read-only during the back end)
+### Read-only during the back end
 
 | State | Written by |
 | --- | --- |
 | `astNodeAlloc`, `nodeToNodeId` | AST builder |
 | `compileTimeStringValues` | AST builder, type checker |
-| `nextCustomTypeId` | AST builder (and already an atomic) |
+| `nextCustomTypeId` | AST builder (an atomic) |
 | `sourceFiles`, ASTs, symbol tables, scopes | front end, middle end |
 | `sourceLinkerFlags`, `sourceAdditionalSourcePaths` | symbol table builder |
 
-### Made safe by this change
+### Synchronized
 
-| State | Problem | Fix |
+| State | Why it is reachable concurrently | Synchronization |
 | --- | --- | --- |
 | `TypeRegistry::types` | Deriving a type (`QualType::toPtr`, ...) can insert into the registry and invalidate concurrent lookups | `ConditionalLock` on a dedicated mutex |
 | `FunctionManager::lookupCache` (+ counters) | `FunctionManager::lookup` is called by the IR generator (copy ctor lookup) | `ConditionalLock` on `symbolRegistryMutex` |
@@ -104,34 +103,39 @@ Everything the back end touches outside its own `SourceFile` was audited. The re
 | `TypeNameDisambiguator::claimedTypeIds` | Reached from `NameMangling::mangleType` | `ConditionalLock` on a dedicated mutex |
 | `ExternalLinkerInterface::linkLibMath` | `OpRuleConversionManager` requests libm linkage while emitting operators | `std::atomic<bool>` |
 | `GlobalResourceManager::abortCompilation` | Written by the dump logic, which runs inside the back end | `std::atomic<bool>` |
-| `ExternalLinkerInterface::linkedFiles` | `runObjectEmitter` used to append to it, which would make the link order depend on the scheduling | Registration moved to `concludeCompilation`, which runs serially in dependency order |
 
 Lock ordering is always `symbolRegistryMutex` → `TypeRegistry::typesMutex` /
 `TypeNameDisambiguator::claimedTypeIdsMutex`; the inner locks never acquire the outer one, so there is no cycle.
 
+### Kept off the worker threads
+
+`ExternalLinkerInterface::linkedFiles` defines the order in which object files are passed to the linker, so appending to
+it from a worker would make the link command depend on the scheduling. The object emitter therefore only records the
+path on the `SourceFile` (`SourceFile::objectFilePath`), and `concludeCompilation` registers it. The same serial pass
+writes the compilation cache.
+
 ## Determinism
 
-A parallel build has to produce byte-identical output to a serial one:
+A parallel build produces byte-identical output to a serial one:
 
-- The **linker input order** is unchanged, because object files are registered in `concludeCompilation`, which the main
-  thread drives over the same dependency-first list the old recursion produced.
+- The **linker input order** follows the worklist, because object files are registered in `concludeCompilation`, which
+  the main thread drives over that list.
 - The **compilation cache** is written from the same serial pass.
 - **Per-file compiler output** (`compilerOutput.irString`, `asmString`, timings, warnings) lives on the `SourceFile`, so
-  it is unaffected.
+  the scheduling cannot affect it.
 - **Error reporting** is stable, see the `ThreadPool` note about the first failing task above.
 
-### Known limitation
+### Known limitations
 
 `TypeNameDisambiguator` hands out a suffix based on the order in which type names are *claimed*. In practice every
 struct/interface name is claimed while the type checker builds signatures and diagnostics, so the back end only reads
-back existing claims. A name claimed for the very first time during back-end name mangling would get a
-scheduling-dependent index — consistent within one compilation, but possibly different between runs. Ranking claimants
-by type id over the complete, front-end-known set of types would remove this residual nondeterminism; that is a
-follow-up.
+back existing claims. A name claimed for the very first time during back-end name mangling gets a scheduling-dependent
+index — consistent within one compilation, but possibly different between runs. Ranking claimants by type id over the
+complete, front-end-known set of types would remove this residual nondeterminism.
 
-Independently of this change, two source files with the same file name in different directories map to the same object
-file path (`outputDir / filePath.filename()`). That was already a last-one-wins bug serially; with a parallel back end
-it becomes a concurrent write. It should be fixed by deriving the object file name from the cache key or the full path.
+Two source files with the same file name in different directories map to the same object file path
+(`outputDir / filePath.filename()`), which makes the emitters race for that file. Deriving the object file name from the
+cache key or the full path would fix it.
 
 ## Testing
 
@@ -140,5 +144,5 @@ it becomes a concurrent write. It should be fixed by deriving the object file na
 - The integration test runner compiles with `-j 1`. The test cases are already spread over processes by
   `gtest-parallel` (`spicetest_parallel` target), so an additional intra-process parallel back end would only
   oversubscribe the machine, and the reference outputs stay strictly deterministic this way.
-- The races are best flushed out with the existing thread sanitizer build option
-  (`-DSPICE_TSAN=ON`, see `Options.cmake`) on a project with many imports.
+- The races are best flushed out with the thread sanitizer build option (`-DSPICE_TSAN=ON`, see `Options.cmake`) on a
+  project with many imports.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -119,6 +119,7 @@ set(SOURCES
         util/CodeLoc.cpp
         util/CompilerWarning.cpp
         util/RawStringOStream.cpp
+        util/ThreadPool.cpp
 )
 
 # Initialize ANTLR

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -129,7 +129,7 @@ add_library(spicecore STATIC ${SOURCES} ${ANTLR_Spice_CXX_OUTPUTS})
 # Add the current directory as include dir
 target_include_directories(spicecore SYSTEM PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 # Link ANTLR runtime and header-only dependencies
-target_link_libraries(spicecore PUBLIC antlr4_static nlohmann_json::nlohmann_json CLI11::CLI11)
+target_link_libraries(spicecore PUBLIC antlr4_static nlohmann_json::nlohmann_json CLI11::CLI11 Threads::Threads)
 
 # Optional TPDE backend — compiled into its own static library so TPDE's -fno-rtti requirement
 # (propagated by tpde::tpde_llvm as a usage requirement) does not leak into spicecore, which

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -2,6 +2,7 @@
 
 #include "SourceFile.h"
 
+#include <algorithm>
 #include <queue>
 #include <unordered_set>
 
@@ -28,8 +29,10 @@
 #include <typechecker/StructManager.h>
 #include <typechecker/TypeChecker.h>
 #include <util/CompilerWarning.h>
+#include <util/Concurrency.h>
 #include <util/FileUtil.h>
 #include <util/SystemUtil.h>
+#include <util/ThreadPool.h>
 #include <util/Timer.h>
 #include <visualizer/ASTVisualizer.h>
 #include <visualizer/CSTVisualizer.h>
@@ -547,7 +550,7 @@ void SourceFile::runObjectEmitter() {
   timer.start();
 
   // Deduce an object file path
-  std::filesystem::path objectFilePath = cliOptions.outputDir / filePath.filename();
+  objectFilePath = cliOptions.outputDir / filePath.filename();
   objectFilePath.replace_extension("o");
 
   // Pick a concrete emitter based on the selected backend. The TPDE emitter is compiled into a
@@ -576,8 +579,8 @@ void SourceFile::runObjectEmitter() {
   if (cliOptions.dump.dumpAssembly)
     dumpOutput(compilerOutput.asmString, "Assembly code", "assembly-code.s");
 
-  // Add the object file to the linker objects
-  resourceManager.linker.addFileToLinkage(objectFilePath);
+  // The object file is registered with the linker in concludeCompilation and not here, because this stage may run on a
+  // worker thread of the parallel back end and the linker input order has to stay deterministic.
 
   previousStage = OBJECT_EMITTER;
   timer.stop();
@@ -587,8 +590,8 @@ void SourceFile::runObjectEmitter() {
 void SourceFile::concludeCompilation() {
   // Handle cache-restored files: register all cached objects with linker
   if (restoredFromCache) {
-    for (const auto &objectFilePath : cachedObjectFilePaths)
-      resourceManager.linker.addFileToLinkage(objectFilePath);
+    for (const auto &cachedObjectFilePath : cachedObjectFilePaths)
+      resourceManager.linker.addFileToLinkage(cachedObjectFilePath);
     for (const auto &flag : sourceLinkerFlags)
       resourceManager.linker.addLinkerFlag(flag);
     for (const auto &path : sourceAdditionalSourcePaths)
@@ -598,6 +601,12 @@ void SourceFile::concludeCompilation() {
 
   if (previousStage >= FINISHED)
     return;
+
+  // Add the emitted object file to the linker objects. This happens here and not in runObjectEmitter, because
+  // concludeCompilation is always driven serially and in dependency order, while the object emitter may run on a worker
+  // thread of the parallel back end.
+  if (!objectFilePath.empty())
+    resourceManager.linker.addFileToLinkage(objectFilePath);
 
   // Cache the source file
   if (!cliOptions.ignoreCache)
@@ -661,17 +670,21 @@ void SourceFile::runMiddleEnd() {
   CHECK_ABORT_FLAG_V()
 }
 
-void SourceFile::runBackEnd() { // NOLINT(misc-no-recursion)
-  // Guard against re-entering a file that is already running its back end. Circular imports form a cycle in the
+void SourceFile::collectBackEndSourceFiles(std::vector<SourceFile *> &backEndSourceFiles) { // NOLINT(misc-no-recursion)
+  // Guard against collecting a file that already went through the back end. Circular imports form a cycle in the
   // dependency graph, so the deps-first recursion below would otherwise loop forever.
   if (backEndStarted)
     return;
   backEndStarted = true;
 
-  // Run backend for all dependencies first
+  // Collect all dependencies first, so that they end up in front of this file in the resulting list
   for (SourceFile *sourceFile : dependencies | std::views::values)
-    sourceFile->runBackEnd();
+    sourceFile->collectBackEndSourceFiles(backEndSourceFiles);
 
+  backEndSourceFiles.push_back(this);
+}
+
+void SourceFile::runBackEndForThisFile() {
   runIRGenerator();
   CHECK_ABORT_FLAG_V()
   if (cliOptions.useLTO) {
@@ -686,8 +699,46 @@ void SourceFile::runBackEnd() { // NOLINT(misc-no-recursion)
     CHECK_ABORT_FLAG_V()
   }
   runObjectEmitter();
+}
+
+void SourceFile::runBackEnd() {
+  // Flatten the dependency graph into the order the back end used to recurse in: every file comes after all of its
+  // dependencies, and files that already ran their back end are skipped.
+  std::vector<SourceFile *> backEndSourceFiles;
+  collectBackEndSourceFiles(backEndSourceFiles);
+
+  // Nothing to do if this file and all of its dependencies already went through the back end
+  if (backEndSourceFiles.empty())
+    return;
+
+  // Unlike the front end and the middle end, the back end has no cross-file data dependencies: every source file owns
+  // its own LLVMContext, IRBuilder, TargetMachine and llvm::Module, and references to symbols of other files are emitted
+  // as declarations into the local module. So the per-file pipelines can simply be spread over a worker pool.
+  // Exceptions, in which the back end stays serial:
+  // - LTO, because all source files share the LTO context and module of the GlobalResourceManager
+  // - dump modes, because they write to the console/output dir and their ordering is part of the user-visible output
+  const bool dumpRequested = cliOptions.dump.dumpIR || cliOptions.dump.dumpAssembly || cliOptions.dump.dumpObjectFile;
+  const size_t jobCount = std::min(resourceManager.getCompileJobCount(), backEndSourceFiles.size());
+  const bool runParallel = jobCount > 1 && !cliOptions.useLTO && !dumpRequested;
+
+  if (runParallel) {
+    ThreadPool &threadPool = resourceManager.getThreadPool(jobCount);
+    const ParallelSection parallelSection;
+    for (SourceFile *sourceFile : backEndSourceFiles)
+      threadPool.submit([sourceFile] { sourceFile->runBackEndForThisFile(); });
+    threadPool.waitForAll(); // Re-throws the exception of the first failing source file, if there was one
+  } else {
+    for (SourceFile *sourceFile : backEndSourceFiles) {
+      sourceFile->runBackEndForThisFile();
+      CHECK_ABORT_FLAG_V()
+    }
+  }
   CHECK_ABORT_FLAG_V()
-  concludeCompilation();
+
+  // Conclude the compilation of all source files. This registers the emitted object files with the linker and writes the
+  // compilation cache, both of which have to happen serially and in a fixed order to stay deterministic.
+  for (SourceFile *sourceFile : backEndSourceFiles)
+    sourceFile->concludeCompilation();
 
   if (isMainFile) {
     resourceManager.totalTimer.stop();

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -717,7 +717,7 @@ void SourceFile::runBackEnd() {
   // Exceptions, in which the back end stays serial:
   // - LTO, because all source files share the LTO context and module of the GlobalResourceManager
   // - dump modes, because they write to the console/output dir and their ordering is part of the user-visible output
-  const bool dumpRequested = cliOptions.dump.dumpIR || cliOptions.dump.dumpAssembly || cliOptions.dump.dumpObjectFile;
+  const bool dumpRequested = cliOptions.dump.dumpIR || cliOptions.dump.dumpAssembly || cliOptions.dump.dumpObjectFiles;
   const size_t jobCount = std::min(resourceManager.getCompileJobCount(), backEndSourceFiles.size());
   const bool runParallel = jobCount > 1 && !cliOptions.useLTO && !dumpRequested;
 

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -151,6 +151,11 @@ public:
   void runMiddleEnd();
   void runBackEnd();
 
+private:
+  void collectBackEndSourceFiles(std::vector<SourceFile *> &backEndSourceFiles);
+  void runBackEndForThisFile();
+
+public:
   // Public methods
   void addDependency(SourceFile *sourceFile, const std::string &dependencyName);
   [[nodiscard]] bool imports(const SourceFile *sourceFile) const;
@@ -184,6 +189,7 @@ public:
   CompilerOutput compilerOutput;
   SourceFile *parent;
   std::string cacheKey;
+  std::filesystem::path objectFilePath; // Set by the object emitter, handed to the linker in concludeCompilation
   std::vector<std::filesystem::path> cachedObjectFilePaths;
   std::vector<std::string> sourceLinkerFlags;
   std::vector<std::filesystem::path> sourceAdditionalSourcePaths;

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -393,7 +393,8 @@ void Driver::addCompileSubcommandOptions(CLI::App *subCmd) const {
   // --llvm-args
   subCmd->add_option<std::string>("--llvm-args,-llvm", cliOptions.llvmArgs, "Additional arguments for LLVM")->join(' ');
   // --jobs
-  subCmd->add_option<unsigned short>("--jobs,-j", cliOptions.compileJobCount, "Compile jobs (threads), used for compilation");
+  subCmd->add_option<unsigned short>("--jobs,-j", cliOptions.compileJobCount,
+                                     "Number of source files to compile in parallel in the back end (0 = auto)");
   // --build-var
   CLI::Option *buildVarOption = subCmd->add_option_function<std::vector<std::string>>(
       "--build-var,-b", buildVarCallback, "Add build variable to parametrize the compiled program (e.g. -v key=value)");

--- a/src/global/GlobalResourceManager.cpp
+++ b/src/global/GlobalResourceManager.cpp
@@ -2,6 +2,9 @@
 
 #include "GlobalResourceManager.h"
 
+#include <cassert>
+#include <thread>
+
 #include <SourceFile.h>
 #include <driver/Driver.h>
 #include <global/TypeNameDisambiguator.h>
@@ -77,6 +80,35 @@ SourceFile *GlobalResourceManager::createSourceFile(SourceFile *parent, const st
 }
 
 uint64_t GlobalResourceManager::getNextCustomTypeId() { return nextCustomTypeId++; }
+
+/**
+ * Determine how many source files may be compiled at the same time, based on the --jobs/-j cli option
+ *
+ * @return Number of compile jobs (always >= 1)
+ */
+size_t GlobalResourceManager::getCompileJobCount() const {
+  // An explicit job count always wins
+  if (cliOptions.compileJobCount > 0)
+    return cliOptions.compileJobCount;
+
+  // Otherwise derive the job count from the machine. hardware_concurrency may return 0 if it cannot be determined, in
+  // which case we fall back to a serial back end.
+  const unsigned int hardwareConcurrency = std::thread::hardware_concurrency();
+  return hardwareConcurrency > 0 ? hardwareConcurrency : 1;
+}
+
+/**
+ * Get the worker pool for parallel compiler passes. The pool is created on first use and re-used afterwards.
+ *
+ * @param threadCount Number of worker threads to create the pool with
+ * @return Thread pool
+ */
+ThreadPool &GlobalResourceManager::getThreadPool(size_t threadCount) {
+  assert(threadCount > 0);
+  if (!threadPool)
+    threadPool = std::make_unique<ThreadPool>(threadCount);
+  return *threadPool;
+}
 
 size_t GlobalResourceManager::getTotalLineCount() const {
   const auto acc = [](size_t sum, const auto &sourceFile) { return sum + FileUtil::getLineCount(sourceFile.second->filePath); };

--- a/src/global/GlobalResourceManager.h
+++ b/src/global/GlobalResourceManager.h
@@ -7,6 +7,7 @@
 #include <global/RuntimeModuleManager.h>
 #include <linker/ExternalLinkerInterface.h>
 #include <util/BlockAllocator.h>
+#include <util/ThreadPool.h>
 #include <util/Timer.h>
 
 #include <llvm/IR/LLVMContext.h>
@@ -40,6 +41,8 @@ public:
   SourceFile *createSourceFile(SourceFile *parent, const std::string &depName, const std::filesystem::path &path, bool isStdFile);
   uint64_t getNextCustomTypeId();
   size_t getTotalLineCount() const;
+  [[nodiscard]] size_t getCompileJobCount() const;
+  ThreadPool &getThreadPool(size_t threadCount);
 
   // Public members
   std::string cpuName;
@@ -57,11 +60,14 @@ public:
   RuntimeModuleManager runtimeModuleManager;
   Timer totalTimer;
   ErrorManager errorManager;
-  bool abortCompilation = false;
+  // Set by the dump logic to stop the pipeline after a requested dump. The back end may write it from a worker thread.
+  std::atomic<bool> abortCompilation = false;
 
 private:
   // Private members
   std::atomic<uint64_t> nextCustomTypeId = UINT8_MAX + 1; // Start at 256 because all primitive types come first
+  // Worker pool for the parallel back end. Created lazily, so single-job builds never spawn a thread.
+  std::unique_ptr<ThreadPool> threadPool;
 };
 
 } // namespace spice::compiler

--- a/src/global/TypeNameDisambiguator.cpp
+++ b/src/global/TypeNameDisambiguator.cpp
@@ -2,10 +2,13 @@
 
 #include "TypeNameDisambiguator.h"
 
+#include <util/Concurrency.h>
+
 namespace spice::compiler {
 
 // Static member initialization
 std::unordered_map<std::string, std::vector<uint64_t>> TypeNameDisambiguator::claimedTypeIds = {};
+std::mutex TypeNameDisambiguator::claimedTypeIdsMutex;
 
 /**
  * Get the disambiguation suffix for a struct/interface type with the given name and type id.
@@ -18,6 +21,8 @@ std::unordered_map<std::string, std::vector<uint64_t>> TypeNameDisambiguator::cl
  * @return Disambiguation suffix (empty for the first claimer of the name)
  */
 std::string TypeNameDisambiguator::getDisambiguationSuffix(const std::string &name, uint64_t typeId) {
+  ConditionalLock lock(claimedTypeIdsMutex);
+
   std::vector<uint64_t> &ids = claimedTypeIds[name];
 
   // Find the index of the type id among the ones already claiming this name

--- a/src/global/TypeNameDisambiguator.h
+++ b/src/global/TypeNameDisambiguator.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstdint>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -19,6 +20,13 @@ namespace spice::compiler {
  *
  * The state is process-global (like TypeRegistry) and therefore must be cleared between compilations, since custom type
  * ids restart at the same value for every compilation.
+ *
+ * Note on the parallel back end: the suffix a type receives depends on the order in which the names are claimed. In
+ * practice every struct/interface name is already claimed while the type checker builds signatures and diagnostics, so
+ * the back end only ever reads back an existing claim. A name that is claimed for the very first time during back-end
+ * name mangling would however get a scheduling-dependent index, which stays consistent within one compilation but may
+ * differ between runs. Making the claim order independent of the scheduling (e.g. by ranking claimants by type id over
+ * the complete, front-end-known set of types) is a follow-up.
  */
 class TypeNameDisambiguator {
 public:
@@ -34,6 +42,9 @@ private:
   // Private members
   // Maps a simple type name to the list of distinct type ids claiming it, in first-seen order
   static std::unordered_map<std::string, std::vector<uint64_t>> claimedTypeIds;
+  // The name mangler queries this registry, so it is reached from the IR generator and therefore from the worker threads
+  // of the parallel back end.
+  static std::mutex claimedTypeIdsMutex;
 };
 
 } // namespace spice::compiler

--- a/src/global/TypeRegistry.cpp
+++ b/src/global/TypeRegistry.cpp
@@ -8,12 +8,14 @@
 #include <sstream>
 
 #include <symboltablebuilder/Type.h>
+#include <util/Concurrency.h>
 #include <util/CustomHashFunctions.h>
 
 namespace spice::compiler {
 
 // Static member initialization
 std::unordered_map<uint64_t, std::unique_ptr<Type>> TypeRegistry::types = {};
+std::mutex TypeRegistry::typesMutex;
 
 /**
  * Compute the hash for a type (aka type id)
@@ -31,6 +33,8 @@ uint64_t TypeRegistry::getTypeHash(const Type &type) { return std::hash<Type>{}(
  */
 const Type *TypeRegistry::getOrInsert(const Type &&type) {
   const uint64_t hash = getTypeHash(type);
+
+  ConditionalLock lock(typesMutex);
 
   // Check if type already exists
   const auto it = types.find(hash);

--- a/src/global/TypeRegistry.h
+++ b/src/global/TypeRegistry.h
@@ -5,6 +5,7 @@
 #include <symboltablebuilder/TypeChain.h>
 
 #include <memory>
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -30,6 +31,10 @@ public:
 private:
   // Private members
   static std::unordered_map<uint64_t, std::unique_ptr<Type>> types;
+  // Guards the type map while back-end passes run concurrently. Deriving a type (e.g. QualType::toPtr) can insert into
+  // the registry, which invalidates concurrent lookups, so every access goes through this mutex. See util/Concurrency.h
+  // for why it is a ConditionalLock and not a plain lock_guard.
+  static std::mutex typesMutex;
 
   // Private methods
   static const Type *getOrInsert(const Type &&type);

--- a/src/linker/ExternalLinkerInterface.h
+++ b/src/linker/ExternalLinkerInterface.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -43,7 +44,9 @@ private:
   const CliOptions &cliOptions;
   std::vector<std::filesystem::path> linkedFiles;
   std::vector<std::string> linkerFlags;
-  bool linkLibMath = false;
+  // The IR generator requests libm linkage while emitting certain operators, so this flag is written from the back-end
+  // worker threads. Everything else on this class is only touched from the single-threaded phases of the pipeline.
+  std::atomic<bool> linkLibMath = false;
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -13,6 +13,7 @@
 #include <typechecker/TypeChecker.h>
 #include <typechecker/TypeMatcher.h>
 #include <util/CodeLoc.h>
+#include <util/Concurrency.h>
 #include <util/CustomHashFunctions.h>
 
 namespace spice::compiler {
@@ -146,6 +147,10 @@ Function *FunctionManager::insertSubstantiation(Scope *insertScope, const Functi
 const Function *FunctionManager::lookup(Scope *matchScope, const std::string &reqName, const QualType &reqThisType,
                                         const ArgList &reqArgs, bool strictQualifierMatching) {
   assert(reqThisType.isOneOf({TY_DYN, TY_STRUCT}));
+
+  // Unlike match(), lookup() is also called from the IR generator (e.g. to find a copy ctor), so it can run on multiple
+  // threads at once and has to guard the process-wide lookup machinery.
+  const ConditionalLock lock(symbolRegistryMutex);
 
   // Do cache lookup
   const uint64_t cacheKey = getCacheKey(matchScope, reqName, reqThisType, reqArgs, {});

--- a/src/typechecker/InterfaceManager.cpp
+++ b/src/typechecker/InterfaceManager.cpp
@@ -9,6 +9,7 @@
 #include <symboltablebuilder/Scope.h>
 #include <typechecker/FunctionManager.h>
 #include <typechecker/TypeMatcher.h>
+#include <util/Concurrency.h>
 #include <util/CustomHashFunctions.h>
 
 namespace spice::compiler {
@@ -58,6 +59,9 @@ Interface *InterfaceManager::insertSubstantiation(Scope *insertScope, Interface 
  */
 Interface *InterfaceManager::match(Scope *matchScope, const std::string &reqName, const QualTypeList &reqTemplateTypes,
                                    const ASTNode *node) {
+  // The IR generator lowers interface types through QualType::getInterface, so this may run on multiple threads at once
+  const ConditionalLock lock(symbolRegistryMutex);
+
   // Do cache lookup
   const uint64_t cacheKey = getCacheKey(matchScope, reqName, reqTemplateTypes);
   if (const auto it = lookupCache.find(cacheKey); it != lookupCache.end()) {

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -9,6 +9,7 @@
 #include <symboltablebuilder/Scope.h>
 #include <typechecker/TypeMatcher.h>
 #include <util/CodeLoc.h>
+#include <util/Concurrency.h>
 #include <util/CustomHashFunctions.h>
 
 namespace spice::compiler {
@@ -62,6 +63,10 @@ Struct *StructManager::insertSubstantiation(Scope *insertScope, Struct &newManif
  */
 Struct *StructManager::match(Scope *matchScope, const std::string &qt, const QualTypeList &reqTemplateTypes,
                              const ASTNode *node) {
+  // The IR generator lowers struct types through QualType::getStruct, so this may run on multiple threads at once. The
+  // lock is recursive, because matching a struct recurses into matching its field and interface types.
+  const ConditionalLock lock(symbolRegistryMutex);
+
   // Do cache lookup
   const uint64_t cacheKey = getCacheKey(matchScope, qt, reqTemplateTypes);
   if (const auto it = lookupCache.find(cacheKey); it != lookupCache.end()) {

--- a/src/util/Concurrency.h
+++ b/src/util/Concurrency.h
@@ -1,0 +1,82 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <atomic>
+#include <mutex>
+
+namespace spice::compiler {
+
+/**
+ * Global switch that tells the process-wide caches of the compiler (type registry, function lookup cache, ...) whether
+ * compiler passes are currently executed on more than one thread.
+ *
+ * Those caches sit on the hottest paths of the single-threaded front end and middle end, where taking a lock for every
+ * access would be pure overhead. The back end on the other hand runs one pipeline per source file in parallel (see
+ * SourceFile::runBackEnd), and there the caches do need protection. ParallelSection flips this switch for exactly the
+ * time span in which worker threads are alive.
+ */
+inline std::atomic<bool> concurrentPassesRunning = false;
+
+/**
+ * RAII marker for a section of the compiler in which passes are executed on multiple threads.
+ *
+ * It has to be entered before the worker threads are handed any work and left only after all of them are joined again,
+ * so that every ConditionalLock taken on a worker thread actually locks.
+ */
+class ParallelSection final {
+public:
+  // Constructors
+  ParallelSection() { concurrentPassesRunning.store(true, std::memory_order_relaxed); }
+
+  // Prevent copy
+  ParallelSection(const ParallelSection &) = delete;
+  ParallelSection &operator=(const ParallelSection &) = delete;
+
+  // Destructor
+  ~ParallelSection() { concurrentPassesRunning.store(false, std::memory_order_relaxed); }
+};
+
+/**
+ * RAII lock that is only actually acquired while compiler passes run concurrently.
+ *
+ * Outside of a ParallelSection this degrades to a relaxed atomic load plus a well-predicted branch, which keeps the
+ * single-threaded stages at their current speed.
+ */
+template <typename MutexT> class ConditionalLock final {
+public:
+  // Constructors
+  explicit ConditionalLock(MutexT &mutex) : mutex(concurrentPassesRunning.load(std::memory_order_relaxed) ? &mutex : nullptr) {
+    if (this->mutex != nullptr)
+      this->mutex->lock();
+  }
+
+  // Prevent copy
+  ConditionalLock(const ConditionalLock &) = delete;
+  ConditionalLock &operator=(const ConditionalLock &) = delete;
+
+  // Destructor
+  ~ConditionalLock() {
+    if (mutex != nullptr)
+      mutex->unlock();
+  }
+
+private:
+  // Members
+  MutexT *mutex;
+};
+
+/**
+ * Guards the process-wide symbol lookup machinery: the lookup caches of FunctionManager, StructManager and
+ * InterfaceManager, plus the manifestation lists and symbol table entries those matchers touch.
+ *
+ * The IR generator lowers struct and interface types through QualType::getStruct/getInterface and looks up implicit
+ * functions (e.g. copy ctors), so all three matchers are reachable from the back-end worker threads. By the time the
+ * back end runs, the type checker has already created every manifestation, so these calls degenerate to cache hits and
+ * the lock is barely contended.
+ *
+ * It is recursive because struct matching recurses into struct and interface matching for field and interface types.
+ */
+inline std::recursive_mutex symbolRegistryMutex;
+
+} // namespace spice::compiler

--- a/src/util/ThreadPool.cpp
+++ b/src/util/ThreadPool.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#include "ThreadPool.h"
+
+#include <cassert>
+#include <utility>
+
+namespace spice::compiler {
+
+ThreadPool::ThreadPool(size_t threadCount) {
+  assert(threadCount > 0);
+  workers.reserve(threadCount);
+  for (size_t i = 0; i < threadCount; i++)
+    workers.emplace_back([this] { workerLoop(); });
+}
+
+ThreadPool::~ThreadPool() {
+  {
+    std::lock_guard lock(mutex);
+    shuttingDown = true;
+  }
+  taskAvailable.notify_all();
+  for (std::thread &worker : workers)
+    worker.join();
+}
+
+/**
+ * Enqueue a task for execution on one of the worker threads
+ *
+ * @param task Task to execute
+ */
+void ThreadPool::submit(std::function<void()> task) {
+  {
+    std::lock_guard lock(mutex);
+    assert(!shuttingDown);
+    tasks.emplace(nextTaskIndex++, std::move(task));
+    pendingCount++;
+  }
+  taskAvailable.notify_one();
+}
+
+/**
+ * Block until all submitted tasks are done and re-throw the exception of the first failing task, if there was one.
+ * Afterwards the pool is reset and can be used for the next batch of tasks.
+ */
+void ThreadPool::waitForAll() {
+  std::exception_ptr failure;
+  {
+    std::unique_lock lock(mutex);
+    allTasksDone.wait(lock, [this] { return pendingCount == 0; });
+    // Reset for the next batch
+    failure = std::exchange(firstException, nullptr);
+    canceled = false;
+    nextTaskIndex = 0;
+  }
+  if (failure)
+    std::rethrow_exception(failure);
+}
+
+/**
+ * Body of a worker thread: take tasks off the queue until the pool shuts down
+ */
+void ThreadPool::workerLoop() {
+  while (true) {
+    Task task;
+    bool skip;
+    {
+      std::unique_lock lock(mutex);
+      taskAvailable.wait(lock, [this] { return shuttingDown || !tasks.empty(); });
+      if (tasks.empty()) {
+        assert(shuttingDown);
+        return;
+      }
+      task = std::move(tasks.front());
+      tasks.pop();
+      // Do not start new work after another task has already failed
+      skip = canceled;
+    }
+
+    if (!skip) {
+      try {
+        task.job();
+      } catch (...) {
+        std::lock_guard lock(mutex);
+        // Keep the exception of the earliest submitted task, to make error reporting independent of the scheduling
+        if (!firstException || task.index < firstExceptionTaskIndex) {
+          firstException = std::current_exception();
+          firstExceptionTaskIndex = task.index;
+        }
+        canceled = true;
+      }
+    }
+
+    {
+      std::lock_guard lock(mutex);
+      pendingCount--;
+      if (pendingCount == 0)
+        allTasksDone.notify_all();
+    }
+  }
+}
+
+} // namespace spice::compiler

--- a/src/util/ThreadPool.h
+++ b/src/util/ThreadPool.h
@@ -2,7 +2,6 @@
 
 #pragma once
 
-#include <cassert>
 #include <condition_variable>
 #include <cstddef>
 #include <exception>
@@ -10,7 +9,6 @@
 #include <mutex>
 #include <queue>
 #include <thread>
-#include <utility>
 #include <vector>
 
 namespace spice::compiler {
@@ -32,63 +30,18 @@ namespace spice::compiler {
 class ThreadPool final {
 public:
   // Constructors
-  explicit ThreadPool(size_t threadCount) {
-    assert(threadCount > 0);
-    workers.reserve(threadCount);
-    for (size_t i = 0; i < threadCount; i++)
-      workers.emplace_back([this] { workerLoop(); });
-  }
+  explicit ThreadPool(size_t threadCount);
 
   // Prevent copy
   ThreadPool(const ThreadPool &) = delete;
   ThreadPool &operator=(const ThreadPool &) = delete;
 
   // Destructor
-  ~ThreadPool() {
-    {
-      std::lock_guard lock(mutex);
-      shuttingDown = true;
-    }
-    taskAvailable.notify_all();
-    for (std::thread &worker : workers)
-      worker.join();
-  }
+  ~ThreadPool();
 
   // Public methods
-
-  /**
-   * Enqueue a task for execution on one of the worker threads
-   *
-   * @param task Task to execute
-   */
-  void submit(std::function<void()> task) {
-    {
-      std::lock_guard lock(mutex);
-      assert(!shuttingDown);
-      tasks.emplace(nextTaskIndex++, std::move(task));
-      pendingCount++;
-    }
-    taskAvailable.notify_one();
-  }
-
-  /**
-   * Block until all submitted tasks are done and re-throw the exception of the first failing task, if there was one.
-   * Afterwards the pool is reset and can be used for the next batch of tasks.
-   */
-  void waitForAll() {
-    std::exception_ptr failure;
-    {
-      std::unique_lock lock(mutex);
-      allTasksDone.wait(lock, [this] { return pendingCount == 0; });
-      // Reset for the next batch
-      failure = std::exchange(firstException, nullptr);
-      canceled = false;
-      nextTaskIndex = 0;
-    }
-    if (failure)
-      std::rethrow_exception(failure);
-  }
-
+  void submit(std::function<void()> task);
+  void waitForAll();
   [[nodiscard]] size_t getThreadCount() const { return workers.size(); }
 
 private:
@@ -99,45 +52,7 @@ private:
   };
 
   // Private methods
-  void workerLoop() {
-    while (true) {
-      Task task;
-      bool skip;
-      {
-        std::unique_lock lock(mutex);
-        taskAvailable.wait(lock, [this] { return shuttingDown || !tasks.empty(); });
-        if (tasks.empty()) {
-          assert(shuttingDown);
-          return;
-        }
-        task = std::move(tasks.front());
-        tasks.pop();
-        // Do not start new work after another task has already failed
-        skip = canceled;
-      }
-
-      if (!skip) {
-        try {
-          task.job();
-        } catch (...) { // NOLINT(bugprone-empty-catch) - the exception is stored and re-thrown in waitForAll
-          std::lock_guard lock(mutex);
-          // Keep the exception of the earliest submitted task, to make error reporting independent of the scheduling
-          if (!firstException || task.index < firstExceptionTaskIndex) {
-            firstException = std::current_exception();
-            firstExceptionTaskIndex = task.index;
-          }
-          canceled = true;
-        }
-      }
-
-      {
-        std::lock_guard lock(mutex);
-        pendingCount--;
-        if (pendingCount == 0)
-          allTasksDone.notify_all();
-      }
-    }
-  }
+  void workerLoop();
 
   // Members
   std::vector<std::thread> workers;

--- a/src/util/ThreadPool.h
+++ b/src/util/ThreadPool.h
@@ -1,0 +1,156 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <cassert>
+#include <condition_variable>
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace spice::compiler {
+
+/**
+ * Fixed-size pool of worker threads, used to run independent compiler passes concurrently.
+ *
+ * The pool is intentionally minimal: work is submitted as void() tasks and the submitter blocks in waitForAll() until
+ * the whole batch is done. Two properties matter for the compiler:
+ *
+ * - Compiler passes report failures by throwing (LexerError, SemanticError, CompilerError, ...). An exception escaping
+ *   a task would terminate the process, so tasks are wrapped and the exception is re-thrown on the waiting thread.
+ * - Diagnostics must not depend on thread scheduling. Every task carries the index it was submitted with and, if
+ *   multiple tasks fail, the one with the lowest index wins. The user therefore always sees the same error, no matter
+ *   which worker happened to get there first.
+ *
+ * As soon as one task has failed, queued tasks that have not started yet are dropped, so a broken build fails fast.
+ */
+class ThreadPool final {
+public:
+  // Constructors
+  explicit ThreadPool(size_t threadCount) {
+    assert(threadCount > 0);
+    workers.reserve(threadCount);
+    for (size_t i = 0; i < threadCount; i++)
+      workers.emplace_back([this] { workerLoop(); });
+  }
+
+  // Prevent copy
+  ThreadPool(const ThreadPool &) = delete;
+  ThreadPool &operator=(const ThreadPool &) = delete;
+
+  // Destructor
+  ~ThreadPool() {
+    {
+      std::lock_guard lock(mutex);
+      shuttingDown = true;
+    }
+    taskAvailable.notify_all();
+    for (std::thread &worker : workers)
+      worker.join();
+  }
+
+  // Public methods
+
+  /**
+   * Enqueue a task for execution on one of the worker threads
+   *
+   * @param task Task to execute
+   */
+  void submit(std::function<void()> task) {
+    {
+      std::lock_guard lock(mutex);
+      assert(!shuttingDown);
+      tasks.emplace(nextTaskIndex++, std::move(task));
+      pendingCount++;
+    }
+    taskAvailable.notify_one();
+  }
+
+  /**
+   * Block until all submitted tasks are done and re-throw the exception of the first failing task, if there was one.
+   * Afterwards the pool is reset and can be used for the next batch of tasks.
+   */
+  void waitForAll() {
+    std::exception_ptr failure;
+    {
+      std::unique_lock lock(mutex);
+      allTasksDone.wait(lock, [this] { return pendingCount == 0; });
+      // Reset for the next batch
+      failure = std::exchange(firstException, nullptr);
+      cancelled = false;
+      nextTaskIndex = 0;
+    }
+    if (failure)
+      std::rethrow_exception(failure);
+  }
+
+  [[nodiscard]] size_t getThreadCount() const { return workers.size(); }
+
+private:
+  // Structs
+  struct Task {
+    size_t index = 0;
+    std::function<void()> job;
+  };
+
+  // Private methods
+  void workerLoop() {
+    while (true) {
+      Task task;
+      bool skip;
+      {
+        std::unique_lock lock(mutex);
+        taskAvailable.wait(lock, [this] { return shuttingDown || !tasks.empty(); });
+        if (tasks.empty()) {
+          assert(shuttingDown);
+          return;
+        }
+        task = std::move(tasks.front());
+        tasks.pop();
+        // Do not start new work after another task has already failed
+        skip = cancelled;
+      }
+
+      if (!skip) {
+        try {
+          task.job();
+        } catch (...) { // NOLINT(bugprone-empty-catch) - the exception is stored and re-thrown in waitForAll
+          std::lock_guard lock(mutex);
+          // Keep the exception of the earliest submitted task, to make error reporting independent of the scheduling
+          if (!firstException || task.index < firstExceptionTaskIndex) {
+            firstException = std::current_exception();
+            firstExceptionTaskIndex = task.index;
+          }
+          cancelled = true;
+        }
+      }
+
+      {
+        std::lock_guard lock(mutex);
+        pendingCount--;
+        if (pendingCount == 0)
+          allTasksDone.notify_all();
+      }
+    }
+  }
+
+  // Members
+  std::vector<std::thread> workers;
+  std::queue<Task> tasks;
+  std::mutex mutex;
+  std::condition_variable taskAvailable;
+  std::condition_variable allTasksDone;
+  std::exception_ptr firstException;
+  size_t firstExceptionTaskIndex = 0;
+  size_t nextTaskIndex = 0;
+  size_t pendingCount = 0;
+  bool cancelled = false;
+  bool shuttingDown = false;
+};
+
+} // namespace spice::compiler

--- a/src/util/ThreadPool.h
+++ b/src/util/ThreadPool.h
@@ -82,7 +82,7 @@ public:
       allTasksDone.wait(lock, [this] { return pendingCount == 0; });
       // Reset for the next batch
       failure = std::exchange(firstException, nullptr);
-      cancelled = false;
+      canceled = false;
       nextTaskIndex = 0;
     }
     if (failure)
@@ -113,7 +113,7 @@ private:
         task = std::move(tasks.front());
         tasks.pop();
         // Do not start new work after another task has already failed
-        skip = cancelled;
+        skip = canceled;
       }
 
       if (!skip) {
@@ -126,7 +126,7 @@ private:
             firstException = std::current_exception();
             firstExceptionTaskIndex = task.index;
           }
-          cancelled = true;
+          canceled = true;
         }
       }
 
@@ -149,7 +149,7 @@ private:
   size_t firstExceptionTaskIndex = 0;
   size_t nextTaskIndex = 0;
   size_t pendingCount = 0;
-  bool cancelled = false;
+  bool canceled = false;
   bool shuttingDown = false;
 };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
         unittest/UnitFileUtil.cpp
         unittest/UnitSystemUtil.cpp
         unittest/UnitDriver.cpp
+        unittest/UnitThreadPool.cpp
 )
 
 add_executable(spicetest ${SOURCES})

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -98,7 +98,9 @@ static void execTestCase(const TestCase &testCase) {
       /* outputPath= */ "",
       /* buildMode= */ BuildMode::DEBUG,
       /* outputContainer= */ OutputContainer::EXECUTABLE,
-      /* compileJobCount= */ 0,
+      // Compile serially: the test cases are already spread over processes by gtest-parallel, so a parallel back end
+      // would only oversubscribe the machine, and the reference outputs stay strictly deterministic this way.
+      /* compileJobCount= */ 1,
       /* ignoreCache */ true,
       /* llvmArgs= */ "",
       /* printDebugOutput= */ false,

--- a/test/unittest/UnitThreadPool.cpp
+++ b/test/unittest/UnitThreadPool.cpp
@@ -1,0 +1,116 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <mutex>
+#include <ranges>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include <util/Concurrency.h>
+#include <util/ThreadPool.h>
+
+namespace spice::testing {
+
+using namespace spice::compiler;
+
+TEST(ThreadPoolTest, RunsAllSubmittedTasks) {
+  ThreadPool pool(4);
+  std::atomic<size_t> executedTasks = 0;
+  for (size_t i = 0; i < 1000; i++)
+    pool.submit([&executedTasks] { executedTasks++; });
+  pool.waitForAll();
+
+  EXPECT_EQ(1000u, executedTasks);
+  EXPECT_EQ(4u, pool.getThreadCount());
+}
+
+TEST(ThreadPoolTest, RethrowsExceptionOfEarliestFailingTask) {
+  ThreadPool pool(4);
+  // Two tasks fail. Independent of which worker gets there first, the failure of the task that was submitted first has
+  // to win, so that the reported compiler error does not depend on the scheduling.
+  for (size_t i = 0; i < 200; i++)
+    pool.submit([i] {
+      if (i == 7 || i == 90)
+        throw std::runtime_error("task " + std::to_string(i));
+    });
+
+  try {
+    pool.waitForAll();
+    FAIL() << "Expected the failure of the earliest task to be re-thrown"; // GCOV_EXCL_LINE
+  } catch (const std::runtime_error &e) {
+    EXPECT_EQ("task 7", std::string(e.what()));
+  }
+}
+
+TEST(ThreadPoolTest, IsReusableAfterFailure) {
+  ThreadPool pool(2);
+  pool.submit([] { throw std::runtime_error("boom"); });
+  EXPECT_THROW(pool.waitForAll(), std::runtime_error);
+
+  std::atomic<size_t> executedTasks = 0;
+  for (size_t i = 0; i < 100; i++)
+    pool.submit([&executedTasks] { executedTasks++; });
+  pool.waitForAll();
+
+  EXPECT_EQ(100u, executedTasks);
+}
+
+TEST(ConcurrencyTest, ConditionalLockOnlyLocksInParallelSection) {
+  std::mutex mutex;
+  // try_lock on a mutex that is already held by the calling thread is undefined behavior, so the probe has to run on
+  // another thread
+  const auto isLockedByUs = [&mutex] {
+    bool couldLock = false;
+    std::thread probe([&] {
+      couldLock = mutex.try_lock();
+      if (couldLock)
+        mutex.unlock();
+    });
+    probe.join();
+    return !couldLock;
+  };
+
+  ASSERT_FALSE(concurrentPassesRunning);
+
+  { // Outside of a parallel section the lock is a no-op
+    ConditionalLock lock(mutex);
+    EXPECT_FALSE(isLockedByUs());
+  }
+
+  { // Inside a parallel section the mutex is held for the lifetime of the lock
+    const ParallelSection parallelSection;
+    ASSERT_TRUE(concurrentPassesRunning);
+    ConditionalLock lock(mutex);
+    EXPECT_TRUE(isLockedByUs());
+  }
+
+  EXPECT_FALSE(concurrentPassesRunning);
+}
+
+TEST(ConcurrencyTest, ConditionalLockGuardsSharedMapUnderContention) {
+  ThreadPool pool(4);
+  std::mutex mutex;
+  std::unordered_map<size_t, size_t> sharedMap; // Stands in for the type registry / lookup caches
+
+  {
+    const ParallelSection parallelSection;
+    for (size_t i = 0; i < 4; i++)
+      pool.submit([&] {
+        for (size_t key = 0; key < 10000; key++) {
+          ConditionalLock lock(mutex);
+          sharedMap[key % 500]++;
+        }
+      });
+    pool.waitForAll();
+  }
+
+  ASSERT_EQ(500u, sharedMap.size());
+  for (const auto &count : sharedMap | std::views::values)
+    EXPECT_EQ(4u * 20u, count);
+}
+
+} // namespace spice::testing

--- a/test/unittest/UnitThreadPool.cpp
+++ b/test/unittest/UnitThreadPool.cpp
@@ -24,7 +24,7 @@ TEST(ThreadPoolTest, RunsAllSubmittedTasks) {
     pool.submit([&executedTasks] { executedTasks++; });
   pool.waitForAll();
 
-  EXPECT_EQ(1000u, executedTasks);
+  EXPECT_EQ(1000u, executedTasks.load());
   EXPECT_EQ(4u, pool.getThreadCount());
 }
 
@@ -56,7 +56,7 @@ TEST(ThreadPoolTest, IsReusableAfterFailure) {
     pool.submit([&executedTasks] { executedTasks++; });
   pool.waitForAll();
 
-  EXPECT_EQ(100u, executedTasks);
+  EXPECT_EQ(100u, executedTasks.load());
 }
 
 TEST(ConcurrencyTest, ConditionalLockOnlyLocksInParallelSection) {
@@ -74,7 +74,7 @@ TEST(ConcurrencyTest, ConditionalLockOnlyLocksInParallelSection) {
     return !couldLock;
   };
 
-  ASSERT_FALSE(concurrentPassesRunning);
+  ASSERT_FALSE(concurrentPassesRunning.load());
 
   { // Outside of a parallel section the lock is a no-op
     ConditionalLock lock(mutex);
@@ -83,12 +83,12 @@ TEST(ConcurrencyTest, ConditionalLockOnlyLocksInParallelSection) {
 
   { // Inside a parallel section the mutex is held for the lifetime of the lock
     const ParallelSection parallelSection;
-    ASSERT_TRUE(concurrentPassesRunning);
+    ASSERT_TRUE(concurrentPassesRunning.load());
     ConditionalLock lock(mutex);
     EXPECT_TRUE(isLockedByUs());
   }
 
-  EXPECT_FALSE(concurrentPassesRunning);
+  EXPECT_FALSE(concurrentPassesRunning.load());
 }
 
 TEST(ConcurrencyTest, ConditionalLockGuardsSharedMapUnderContention) {


### PR DESCRIPTION
The --jobs/-j cli option was parsed into CliOptions::compileJobCount and
then never used, so every build compiled strictly serially. Wire it up to
a worker pool that runs the per-source-file back end (IR generator, IR
optimizer, object emitter) concurrently.

The back end is the one phase that is embarrassingly parallel across source
files: every SourceFile already owns its own LLVMContext, IRBuilder,
TargetMachine and llvm::Module, and cross-file symbol references are emitted
as declarations into the local module. The old deps-first recursion in
runBackEnd was only a cycle-safe graph walk, not a data dependency, so it is
replaced by an explicit worklist that is either spread over the pool or run
serially.

Shared state that the back end reaches is now guarded:

- TypeRegistry, TypeNameDisambiguator and the FunctionManager/StructManager/
  InterfaceManager lookup machinery take a ConditionalLock, which only locks
  while worker threads are alive, so the hot single-threaded front end and
  middle end keep their current speed.
- ExternalLinkerInterface::linkLibMath and
  GlobalResourceManager::abortCompilation became atomics.
- Object files are registered with the linker in concludeCompilation instead
  of runObjectEmitter, so the linker input order stays identical to a serial
  build.

The back end stays serial for LTO (all files share the LTO context and
module) and for the dump modes (their output ordering is user visible).

Adds src/util/ThreadPool.h, which re-throws the exception of the earliest
submitted failing task so diagnostics do not depend on the scheduling, and
src/util/Concurrency.h with ParallelSection/ConditionalLock. Design notes in
media/specs/parallel-backend.md.

The integration test runner compiles with -j 1, because gtest-parallel
already spreads the test cases over processes.