### PR TITLE
Bump googletest from v1.17.0 to v1.18.0

### DIFF
--- a/test/unittest/UnitBlockAllocator.cpp
+++ b/test/unittest/UnitBlockAllocator.cpp
@@ -107,7 +107,7 @@ TEST(BlockAllocatorTest, BlockAllocatorOOM) {
   auto mallocCallback = [](size_t size) { return static_cast<byte *>(malloc(size)); };
   EXPECT_CALL(mockMemoryManager, allocate(::testing::_)).Times(4).WillRepeatedly(mallocCallback);
   EXPECT_CALL(mockMemoryManager, allocate(::testing::_)).Times(1).WillOnce(::testing::Return(nullptr));
-  EXPECT_CALL(mockMemoryManager, deallocate(::testing::_)).Times(4).WillRepeatedly(::testing::Invoke(free));
+  EXPECT_CALL(mockMemoryManager, deallocate(::testing::_)).Times(4).WillRepeatedly(free);
 
   {
     // Create allocator, that can hold 2 nodes per block


### PR DESCRIPTION
Update the deps/googletest submodule to the v1.18.0 tag.

GoogleTest 1.18 deprecates the single-callable `testing::Invoke()`
wrapper ("actions can now be implicitly constructed from callables"),
which breaks the `-Werror` build of spicetest. Drop the wrapper in
UnitBlockAllocator, matching the implicit-callable form already used
for the `allocate` expectation right above it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DyTDKFYT4eceSPV7yGYPU3