### PR TITLE
Upgrade to LLVM 23.1.0-rc3

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0-rc2"
+  LLVM_VERSION: "llvmorg-23.1.0-rc3"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -9,7 +9,7 @@ on:
       - '**.md'
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0-rc2"
+  LLVM_VERSION: "llvmorg-23.1.0-rc3"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0-rc2"
+  LLVM_VERSION: "llvmorg-23.1.0-rc3"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - '*'
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0-rc2"
+  LLVM_VERSION: "llvmorg-23.1.0-rc3"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0-rc2"
+  LLVM_VERSION: "llvmorg-23.1.0-rc3"
   GCC_VERSION: "16"
 
 jobs:

--- a/dev-setup.py
+++ b/dev-setup.py
@@ -36,7 +36,7 @@ else:
 
 # Step 2: clone LLVM
 log("[Step 2] Cloning LLVM (could take a while) ...")
-run("git", "clone", "--depth", "1", "--branch", "llvmorg-23.1.0-rc2",
+run("git", "clone", "--depth", "1", "--branch", "llvmorg-23.1.0-rc3",
     "https://github.com/llvm/llvm-project", "llvm")
 log("done.")
 


### PR DESCRIPTION
## What changed

Bump the pinned LLVM tag from `llvmorg-23.1.0-rc2` to `llvmorg-23.1.0-rc3` (6 files):

- `.github/workflows/{ci-cpp,ci-asan,codeql-analysis,publish,valgrind}.yml` — the `LLVM_VERSION` env var. The clone step and every LLVM cache key interpolate that var, so the caches invalidate and rebuild on their own; no separate key bump needed.
- `dev-setup.py` — the `git clone --depth 1 --branch` tag.

Deliberately left alone:

- `test/test-files/bootstrap-compiler/standalone-common-util-test/cout.out` prints `LLVM version:  23.1.0`. `LLVM_VERSION_STRING` carries no rc suffix on the release branch, so it stays correct — it was likewise untouched by the rc1 → rc2 bump.
- `deps/tpde` — bumped during the rc1 upgrade for LLVM 23 support; rc2 needed no follow-up and rc3 is the same release branch.

## Why

Track the latest LLVM 23.1.0 release candidate ahead of the final release.

## How it was validated

Verified by inspection only — this change is **not** locally built or tested, and CI is the real check:

- `grep -rn "23\.1\.0-rc" .github/workflows/ dev-setup.py` → all six sites report `llvmorg-23.1.0-rc3`, no stragglers.
- `git ls-remote --tags https://github.com/llvm/llvm-project 'refs/tags/llvmorg-23.1.0*'` → confirms `llvmorg-23.1.0-rc3` exists upstream (`7196f931f212fc7c406066b2628a0ff4ea0ee344`).
- Reviewed the upstream `llvmorg-23.1.0-rc2...llvmorg-23.1.0-rc3` diff as a risk read: 81 commits, concentrated in RISC-V codegen, AArch64 SVE, LLDB and Hexagon build config, plus an MSVC x86_64 alignment ABI gate. Nothing there touches the LLVM C++ APIs the compiler consumes, and nothing obviously perturbs x86-64 output.

The build/test step could not be run: the environment has only system LLVM 18.1.3, and building LLVM 23 from source is a multi-hour job that did not fit there.

## Follow-ups / known limitations

- Watch CI for reference-output mismatches. The rc1 upgrade churned ~40 `ir-code*.ll` / `assembly-*.asm` reference files; rc2 needed none, and rc3 is expected to need none, but that is the likely failure spot. If it fires, regenerate with `--update-refs` on a machine running rc3.
- Follow-up bump to the final `llvmorg-23.1.0` once it is tagged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gja8MAWHZm6pYvi1nuXM5Q)_