### PR TITLE
Fix orphaned cross-file revisit requests in type-checker convergence

### DIFF
--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -665,6 +665,22 @@ void SourceFile::runMiddleEnd() {
   // The second run to ensure, also generic scopes are type-checked properly
   runTypeCheckerPost(); // Visit the dependency tree from top to bottom in topological order
   CHECK_ABORT_FLAG_V()
+  // The per-file convergence loop inside runTypeCheckerPost is scoped to its own call stack: a cross-file revisit
+  // request that lands on a file whose loop already unwound (e.g. a recursive generic dtor chain that closes back
+  // through a runtime module which was itself gated behind another, not-yet-checked importer) is otherwise dropped,
+  // leaving a fully-substantiated manifestation whose body was never type-checked. Sweep every source file in the
+  // program for a straggling revisit request and drive it to convergence directly, repeating until none are left.
+  bool anySourceFileRevisitPending;
+  do {
+    anySourceFileRevisitPending = false;
+    for (const std::unique_ptr<SourceFile> &sourceFile : resourceManager.sourceFiles | std::views::values) {
+      if (sourceFile->reVisitRequested) {
+        sourceFile->runTypeCheckerPost();
+        anySourceFileRevisitPending = true;
+      }
+    }
+  } while (anySourceFileRevisitPending);
+  CHECK_ABORT_FLAG_V()
   // Visualize dependency graph
   runDependencyGraphVisualizer();
   CHECK_ABORT_FLAG_V()

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -673,12 +673,24 @@ void SourceFile::runMiddleEnd() {
   bool anySourceFileRevisitPending;
   do {
     anySourceFileRevisitPending = false;
-    for (const std::unique_ptr<SourceFile> &sourceFile : resourceManager.sourceFiles | std::views::values) {
+    // Snapshot the current files before driving any of them: runTypeCheckerPost() below can itself trigger a
+    // freshly-discovered runtime import (SourceFile::requestRuntimeModule -> GlobalResourceManager::createSourceFile),
+    // which inserts into resourceManager.sourceFiles - iterating that map while it is being mutated is undefined
+    // behavior, so a stable list of raw pointers is collected first.
+    std::vector<SourceFile *> sourceFilesSnapshot;
+    sourceFilesSnapshot.reserve(resourceManager.sourceFiles.size());
+    for (const std::unique_ptr<SourceFile> &sourceFile : resourceManager.sourceFiles | std::views::values)
+      sourceFilesSnapshot.push_back(sourceFile.get());
+    for (SourceFile *sourceFile : sourceFilesSnapshot) {
       if (sourceFile->reVisitRequested) {
         sourceFile->runTypeCheckerPost();
         anySourceFileRevisitPending = true;
       }
     }
+    // A source file created mid-sweep (see above) still needs its own pass; it starts out with reVisitRequested
+    // true, so re-looping picks it up via the snapshot taken on the next iteration.
+    if (resourceManager.sourceFiles.size() > sourceFilesSnapshot.size())
+      anySourceFileRevisitPending = true;
   } while (anySourceFileRevisitPending);
   CHECK_ABORT_FLAG_V()
   // Visualize dependency graph

--- a/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/cout.out
+++ b/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/cout.out
@@ -1,0 +1,1 @@
+bt-contains-20=1

--- a/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/cout.out
+++ b/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/cout.out
@@ -1,1 +1,1 @@
-bt-contains-20=1
+ok

--- a/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source.spice
+++ b/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source.spice
@@ -1,14 +1,16 @@
 import "std/data/linked-list";
 import "source2";
 
-// Regression test for issue #1254: a self-referential generic struct (Node<T>, source2.spice - shaped like
-// std/data/binary-tree.spice with a recursive explicit dtor added) crashed the compiler with
+// Regression test for issue #1254: a self-referential generic struct (Node<T>, source2.spice) with a recursive
+// explicit dtor, plus an explicit dtor on its owning container (Holder<T>), crashed the compiler with
 // 'Assertion `manifestation->alreadyTypeChecked' failed' - but only when another, unrelated module that declares
 // and instantiates its own heap-allocating generic struct (LinkedList<T>, imported here from the std lib) was
-// also imported.
+// also imported. Note: referencing 'Node' directly by name here (instead of only through Holder) would collide
+// with linked-list.spice's own private 'Node<T>' - a separate, unrelated name-resolution quirk - so this test
+// only ever names 'Holder' at the call site.
 //
 // Root cause: the type-checker's cross-file convergence is driven by nested, per-file 'reVisitRequested' loops.
-// When BinaryTree<int>'s dtor (source2.spice) requests a new manifestation in the shared runtime module (sDelete),
+// When Holder<int>'s dtor (source2.spice) requests a new manifestation in the shared runtime module (sDelete),
 // that request can get deferred behind another importer of the runtime module that has not type-checked yet
 // (LinkedList<String>). By the time the runtime module actually processes the request - which itself recurses
 // back into Node<int>.dtor() - source2.spice's own convergence loop had already fully unwound, so the late
@@ -16,11 +18,10 @@ import "source2";
 // type-checked, which crashed the IR generator.
 f<int> main() {
     LinkedList<String> list = LinkedList<String>();
-    list.pushBack(String("hello world this is a heap string"));
+    list.pushBack(String("x"));
 
-    BinaryTree<int> bt = BinaryTree<int>();
-    bt.insert(50);
-    bt.insert(20);
+    Holder<int> holder = Holder<int>();
+    holder.put(5);
 
-    printf("bt-contains-20=%d\n", bt.contains(20));
+    printf("ok\n");
 }

--- a/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source.spice
+++ b/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source.spice
@@ -1,0 +1,26 @@
+import "std/data/linked-list";
+import "source2";
+
+// Regression test for issue #1254: a self-referential generic struct (Node<T>, source2.spice - shaped like
+// std/data/binary-tree.spice with a recursive explicit dtor added) crashed the compiler with
+// 'Assertion `manifestation->alreadyTypeChecked' failed' - but only when another, unrelated module that declares
+// and instantiates its own heap-allocating generic struct (LinkedList<T>, imported here from the std lib) was
+// also imported.
+//
+// Root cause: the type-checker's cross-file convergence is driven by nested, per-file 'reVisitRequested' loops.
+// When BinaryTree<int>'s dtor (source2.spice) requests a new manifestation in the shared runtime module (sDelete),
+// that request can get deferred behind another importer of the runtime module that has not type-checked yet
+// (LinkedList<String>). By the time the runtime module actually processes the request - which itself recurses
+// back into Node<int>.dtor() - source2.spice's own convergence loop had already fully unwound, so the late
+// revisit request on it was silently dropped, leaving Node<int>.dtor() fully substantiated but never
+// type-checked, which crashed the IR generator.
+f<int> main() {
+    LinkedList<String> list = LinkedList<String>();
+    list.pushBack(String("hello world this is a heap string"));
+
+    BinaryTree<int> bt = BinaryTree<int>();
+    bt.insert(50);
+    bt.insert(20);
+
+    printf("bt-contains-20=%d\n", bt.contains(20));
+}

--- a/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source2.spice
+++ b/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source2.spice
@@ -1,0 +1,127 @@
+// Add generic type definitions
+type T dyn;
+
+/**
+ * Node of a BinaryTree - shaped like std/data/binary-tree.spice, with a recursive explicit dtor added
+ * (see issue #1254).
+ */
+public type Node<T> struct {
+    T value
+    heap Node<T>* childLeft
+    heap Node<T>* childRight
+}
+
+/**
+ * Construct a binary tree node holding the given value and optional children
+ *
+ * @param value Value to store in the node
+ * @param childLeft Left child node, or nil if there is none
+ * @param childRight Right child node, or nil if there is none
+ */
+public p Node.ctor(const T& value, heap Node<T>* childLeft = nil<heap Node<T>*>, heap Node<T>* childRight = nil<heap Node<T>*>) {
+    this.value = value;
+    this.childLeft = childLeft;
+    this.childRight = childRight;
+}
+
+/**
+ * Recursively frees the child nodes owned by this node
+ */
+public p Node.dtor() {
+    if this.childLeft != nil<heap Node<T>*> {
+        sDelete(this.childLeft);
+    }
+    if this.childRight != nil<heap Node<T>*> {
+        sDelete(this.childRight);
+    }
+}
+
+/**
+ * A minimal binary tree, only carrying what is needed to reproduce issue #1254.
+ */
+public type BinaryTree<T> struct {
+    heap Node<T>* rootNode = nil<heap Node<T>*>
+}
+
+/**
+ * Recursively frees the whole node chain owned by this tree
+ */
+public p BinaryTree.dtor() {
+    if this.rootNode != nil<heap Node<T>*> {
+        sDelete(this.rootNode);
+    }
+}
+
+/**
+ * Insert a new value into the binary tree
+ *
+ * @param value The value to insert
+ */
+public p BinaryTree.insert<T>(const T& value) {
+    // Create the new node
+    heap Node<T>* newNode = __new<Node<T>>(value, nil<heap Node<T>*>, nil<heap Node<T>*>);
+
+    // Insert the new node
+    if this.rootNode == nil<heap Node<T>*> {
+        this.rootNode = newNode;
+    } else {
+        this.insertNode(this.rootNode, newNode);
+    }
+}
+
+/**
+ * Search for a value in the binary tree
+ *
+ * @param value The value to search for
+ * @return True if the value was found, false otherwise
+ */
+public f<bool> BinaryTree.contains<T>(const T& value) {
+    return this.containsNode(this.rootNode, value);
+}
+
+/**
+ * Recursion helper to insert a new node into the binary tree
+ *
+ * @param currentNode The current node to check
+ * @param newNode The new node to insert
+ */
+p BinaryTree.insertNode<T>(Node<T>* currentNode, heap Node<T>* newNode) {
+    if newNode.value < currentNode.value {
+        if currentNode.childLeft == nil<heap Node<T>*> {
+            currentNode.childLeft = newNode;
+        } else {
+            this.insertNode(currentNode.childLeft, newNode);
+        }
+    } else {
+        if currentNode.childRight == nil<heap Node<T>*> {
+            currentNode.childRight = newNode;
+        } else {
+            this.insertNode(currentNode.childRight, newNode);
+        }
+    }
+}
+
+/**
+ * Recursion helper to check whether a value is present in the binary tree
+ *
+ * @param currentNode The current node to check
+ * @return True if the value was found, false otherwise
+ */
+f<bool> BinaryTree.containsNode<T>(Node<T>* currentNode, const T& value) {
+    // We reached the end of the tree
+    if currentNode == nil<Node<T>*> {
+        return false;
+    }
+
+    // We found the value
+    if currentNode.value == value {
+        return true;
+    }
+
+    // Search in the left or right child
+    if value < currentNode.value {
+        return this.containsNode(currentNode.childLeft, value);
+    } else {
+        return this.containsNode(currentNode.childRight, value);
+    }
+}

--- a/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source2.spice
+++ b/test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/source2.spice
@@ -1,127 +1,32 @@
-// Add generic type definitions
 type T dyn;
 
-/**
- * Node of a BinaryTree - shaped like std/data/binary-tree.spice, with a recursive explicit dtor added
- * (see issue #1254).
- */
+// Self-referential generic struct with a recursive explicit dtor - see the comment in source.spice.
 public type Node<T> struct {
     T value
-    heap Node<T>* childLeft
-    heap Node<T>* childRight
+    heap Node<T>* next = nil<heap Node<T>*>
 }
 
-/**
- * Construct a binary tree node holding the given value and optional children
- *
- * @param value Value to store in the node
- * @param childLeft Left child node, or nil if there is none
- * @param childRight Right child node, or nil if there is none
- */
-public p Node.ctor(const T& value, heap Node<T>* childLeft = nil<heap Node<T>*>, heap Node<T>* childRight = nil<heap Node<T>*>) {
+public p Node.ctor(const T& value) {
     this.value = value;
-    this.childLeft = childLeft;
-    this.childRight = childRight;
 }
 
-/**
- * Recursively frees the child nodes owned by this node
- */
 public p Node.dtor() {
-    if this.childLeft != nil<heap Node<T>*> {
-        sDelete(this.childLeft);
-    }
-    if this.childRight != nil<heap Node<T>*> {
-        sDelete(this.childRight);
+    if this.next != nil<heap Node<T>*> {
+        sDelete(this.next);
     }
 }
 
-/**
- * A minimal binary tree, only carrying what is needed to reproduce issue #1254.
- */
-public type BinaryTree<T> struct {
-    heap Node<T>* rootNode = nil<heap Node<T>*>
+// Minimal owning container with its own explicit dtor - only holds what is needed to reproduce issue #1254.
+public type Holder<T> struct {
+    heap Node<T>* node = nil<heap Node<T>*>
 }
 
-/**
- * Recursively frees the whole node chain owned by this tree
- */
-public p BinaryTree.dtor() {
-    if this.rootNode != nil<heap Node<T>*> {
-        sDelete(this.rootNode);
+public p Holder.dtor() {
+    if this.node != nil<heap Node<T>*> {
+        sDelete(this.node);
     }
 }
 
-/**
- * Insert a new value into the binary tree
- *
- * @param value The value to insert
- */
-public p BinaryTree.insert<T>(const T& value) {
-    // Create the new node
-    heap Node<T>* newNode = __new<Node<T>>(value, nil<heap Node<T>*>, nil<heap Node<T>*>);
-
-    // Insert the new node
-    if this.rootNode == nil<heap Node<T>*> {
-        this.rootNode = newNode;
-    } else {
-        this.insertNode(this.rootNode, newNode);
-    }
-}
-
-/**
- * Search for a value in the binary tree
- *
- * @param value The value to search for
- * @return True if the value was found, false otherwise
- */
-public f<bool> BinaryTree.contains<T>(const T& value) {
-    return this.containsNode(this.rootNode, value);
-}
-
-/**
- * Recursion helper to insert a new node into the binary tree
- *
- * @param currentNode The current node to check
- * @param newNode The new node to insert
- */
-p BinaryTree.insertNode<T>(Node<T>* currentNode, heap Node<T>* newNode) {
-    if newNode.value < currentNode.value {
-        if currentNode.childLeft == nil<heap Node<T>*> {
-            currentNode.childLeft = newNode;
-        } else {
-            this.insertNode(currentNode.childLeft, newNode);
-        }
-    } else {
-        if currentNode.childRight == nil<heap Node<T>*> {
-            currentNode.childRight = newNode;
-        } else {
-            this.insertNode(currentNode.childRight, newNode);
-        }
-    }
-}
-
-/**
- * Recursion helper to check whether a value is present in the binary tree
- *
- * @param currentNode The current node to check
- * @return True if the value was found, false otherwise
- */
-f<bool> BinaryTree.containsNode<T>(Node<T>* currentNode, const T& value) {
-    // We reached the end of the tree
-    if currentNode == nil<Node<T>*> {
-        return false;
-    }
-
-    // We found the value
-    if currentNode.value == value {
-        return true;
-    }
-
-    // Search in the left or right child
-    if value < currentNode.value {
-        return this.containsNode(currentNode.childLeft, value);
-    } else {
-        return this.containsNode(currentNode.childRight, value);
-    }
+public p Holder.put<T>(const T& value) {
+    this.node = __new<Node<T>>(value);
 }


### PR DESCRIPTION
## What changed
- `SourceFile::runMiddleEnd` now follows the existing top-down `runTypeCheckerPost()` pass with a final global sweep: it repeatedly drives any source file still flagged `reVisitRequested` to convergence directly, until none are left pending.
- Added a regression test: `test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/`.

## Why
Fixes #1254. The type-checker's cross-file convergence is implemented as nested, per-file `while (reVisitRequested)` loops (`SourceFile::runTypeCheckerPost`), recursed into via each file's `dependencies` map. A cross-file revisit request (`TypeChecker::requestRevisitIfRequired`) that lands on a file whose own convergence loop has *already fully unwound* is silently dropped — nothing re-invokes that file's `runTypeCheckerPost()` again.

Concretely, this happens with a self-referential generic struct that has a recursive explicit dtor (e.g. a `Node<T>` whose `dtor()` calls `sDelete` on its own next-pointer field) plus a dtor on the owning container, when another, unrelated module that also imports the shared runtime module (for heap allocation) is co-imported:

1. File A's (e.g. `binary-tree.spice`) container dtor requests a new manifestation in the shared runtime module (`sDelete`/`sDestruct`).
2. That runtime module's own convergence is gated behind `haveAllDependantsBeenTypeChecked()` until *every* importer (including File B, e.g. `linked-list.spice`) has type-checked at least once. File A's own loop has, by this point, already converged and returned.
3. Once File B eventually triggers the runtime module's convergence, processing the deferred request recurses back into File A's `Node<T>.dtor()` — a manifestation that didn't exist yet when File A's own loop was still active. The resulting `requestRevisitIfRequired` sets File A's `reVisitRequested` flag, but File A's call frame is gone; nobody observes the flag again.
4. `IRGenerator::visitProcDef` then hits a manifestation that is fully substantiated but never type-checked, tripping `assert(manifestation->alreadyTypeChecked)` (`src/irgenerator/GenTopLevelDefinitions.cpp:306`) — or, in import shapes where the manifestation object itself never lands in the AST node's list at all, the codegen for it is silently skipped, producing an undefined-symbol link error instead.

The fix adds a final, file-registry-wide fixed-point sweep after the existing top-down pass, so any such straggling revisit request still gets processed to completion, regardless of which file's call frame is currently active.

## How it was validated
- Root-caused with temporary `fprintf` instrumentation tracing `runTypeCheckerPost` entry/exit/loop iterations and `requestRevisitIfRequired` call sites (since reverted); confirmed the exact sequence above against the original issue repro (patching `std/data/binary-tree.spice` with the dtors from the issue + importing `std/data/linked-list`).
- New regression test `test/test-files/irgenerator/imports/success-cross-module-recursive-generic-dtor/`: imports the real `std/data/linked-list` (as the co-imported "other importer" from step 2 above) alongside a minimal local module - a self-referential `Node<T>` with a recursive dtor, plus a single-field `Holder<T>` container with its own dtor. (Shrunk from an earlier version that mirrored `std/data/binary-tree.spice`'s full insert/contains tree logic - none of that is needed to trigger the bug.) `git stash`-verified against both `spice run` directly and `spicetest` itself: crashes with the exact `alreadyTypeChecked` assertion on the unfixed compiler (3/3 runs), passes cleanly with the fix.
- `cmake-build-debug/test/spicetest` (run from `test/`, full suite): 602/631 pass, 2 pre-existing skips, 27 pre-existing environment-only failures (missing `LLVMAArch64AsmParser` lib for `BootstrapCompilerTests`, `DriverTest` cwd requirements, `StdTests.bindings_llvm` missing LLVM lib path — all pre-existing on this box, unrelated to this change).
- Excluding those known-environmental suites: `--gtest_filter='-BootstrapCompilerTests.*:DriverTest.*:DriverTest/DriverTest.*:StdTests.bindings_llvm'` → 579/580 pass, 1 pre-existing skip (`net_socketsBasic`), 0 failures.
- Original issue repro (patched `std/data/binary-tree.spice` + `std/data/linked-list` import) also re-verified fixed, including under `--sanitizer=address` (no crash, no corruption; only the separate, already-tracked `LinkedList` leak from issue #1256 remains, since that container's own dtor fix is out of scope here).

## Follow-up / known limitations
- This fixes the compiler-level crash blocking issue #1254. The related library-level leak fix for the container types (adding recursive dtors to `std/data/*.spice`) is tracked separately under #1256 and not part of this PR.

Fixes #1254
