### PR TITLE
Extract hardcoded linker/archiver names to named constants

### DIFF
--- a/src/linker/ExternalLinkerInterface.cpp
+++ b/src/linker/ExternalLinkerInterface.cpp
@@ -100,8 +100,8 @@ void ExternalLinkerInterface::link() const {
   const auto [linkerInvokerName, linkerInvokerPath] = SystemUtil::findLinkerInvoker();
   commandBuilder << linkerInvokerPath;
   const auto [linkerName, linkerPath] = SystemUtil::findLinker(cliOptions);
-  const bool isGccInvoker = std::string_view(linkerInvokerName) == "gcc";
-  const bool isClangInvoker = std::string_view(linkerInvokerName) == "clang";
+  const bool isGccInvoker = std::string_view(linkerInvokerName) == LINKER_INVOKER_NAME_GCC;
+  const bool isClangInvoker = std::string_view(linkerInvokerName) == LINKER_INVOKER_NAME_CLANG;
   // GCC does not implement MemorySanitizer or TypeSanitizer
   const Sanitizer sanitizer = cliOptions.instrumentation.sanitizer;
   if (!isClangInvoker && (sanitizer == Sanitizer::MEMORY || sanitizer == Sanitizer::TYPE)) {
@@ -109,7 +109,7 @@ void ExternalLinkerInterface::link() const {
     throw LinkerError(SANITIZER_NOT_SUPPORTED_BY_LINKER_INVOKER, msg);
   }
   // GCC 16 dropped '-fuse-ld=ld'; skip when using GCC with the default BFD linker
-  if (!isGccInvoker || std::string_view(linkerName) != "ld")
+  if (!isGccInvoker || std::string_view(linkerName) != LINKER_NAME_LD)
     commandBuilder << " -fuse-ld=" << linkerPath;
   // '--target=' is clang-only; GCC uses target-specific toolchain prefixes instead
   if (!isGccInvoker)

--- a/src/util/SystemUtil.cpp
+++ b/src/util/SystemUtil.cpp
@@ -58,7 +58,7 @@ ExecResult SystemUtil::exec(const std::string &command, bool redirectStdErrToStd
     result << buffer.data();
 
   const int status = pclose(pipe);
-  return {result.str(), transformStatusToExitCode(status)};
+  return {.output = result.str(), .exitCode = transformStatusToExitCode(status)};
 }
 
 /**
@@ -124,19 +124,19 @@ bool SystemUtil::isGraphvizInstalled() { return isCommandAvailable("dot"); }
  */
 ExternalBinaryFinderResult SystemUtil::findLinkerInvoker() {
 #if OS_UNIX
-  for (const char *linkerInvokerName : {"clang", "gcc"})
-    for (const std::string path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
+  for (const char *linkerInvokerName : LINKER_INVOKER_NAMES)
+    for (const std::string path : BINARY_SEARCH_DIRS)
       if (std::filesystem::exists(path + linkerInvokerName))
-        return ExternalBinaryFinderResult{linkerInvokerName, path + linkerInvokerName};
+        return ExternalBinaryFinderResult{.name = linkerInvokerName, .path = path + linkerInvokerName};
 #elif OS_WINDOWS
-  for (const char *linkerInvokerName : {"clang", "gcc"})
+  for (const char *linkerInvokerName : LINKER_INVOKER_NAMES)
     if (isCommandAvailable(std::string(linkerInvokerName) + " -v"))
       return ExternalBinaryFinderResult{linkerInvokerName, linkerInvokerName};
 #else
 #error "Unsupported platform"
 #endif
-  const auto msg = "No supported linker invoker was found on the system. Supported are: clang and gcc"; // LCOV_EXCL_LINE
-  throw LinkerError(LINKER_INVOKER_NOT_FOUND, msg);                                                     // LCOV_EXCL_LINE
+  constexpr auto msg = "No supported linker invoker was found on the system. Supported are: clang and gcc"; // LCOV_EXCL_LINE
+  throw LinkerError(LINKER_INVOKER_NOT_FOUND, msg);                                                         // LCOV_EXCL_LINE
 }
 
 /**
@@ -149,28 +149,25 @@ ExternalBinaryFinderResult SystemUtil::findLinkerInvoker() {
 ExternalBinaryFinderResult SystemUtil::findLinker([[maybe_unused]] const CliOptions &cliOptions) {
 #if OS_UNIX
   std::vector<const char *> linkerList;
-  linkerList.reserve(5);
+  linkerList.reserve(1 + LINKER_NAMES_UNIX.size());
   // mold does only support linking for unix and darwin
   if (!cliOptions.targetTriple.isOSWindows())
-    linkerList.push_back("mold");
-  linkerList.push_back("ld.lld");
-  linkerList.push_back("ld64.ddl");
-  linkerList.push_back("gold");
-  linkerList.push_back("ld");
+    linkerList.push_back(LINKER_NAME_MOLD);
+  linkerList.insert(linkerList.end(), LINKER_NAMES_UNIX.begin(), LINKER_NAMES_UNIX.end());
 
   for (const char *linkerName : linkerList)
-    for (const std::string path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
+    for (const std::string path : BINARY_SEARCH_DIRS)
       if (std::filesystem::exists(path + linkerName))
-        return ExternalBinaryFinderResult{linkerName, path + linkerName};
+        return ExternalBinaryFinderResult{.name = linkerName, .path = path + linkerName};
 #elif OS_WINDOWS
-  for (const char *linkerName : {"lld", "ld"})
+  for (const char *linkerName : LINKER_NAMES_WINDOWS)
     if (isCommandAvailable(std::string(linkerName) + " -v"))
       return ExternalBinaryFinderResult{linkerName, linkerName};
 #else
 #error "Unsupported platform"
 #endif
-  const auto msg = "No supported linker was found on the system. Supported are: mold, lld, gold and ld"; // LCOV_EXCL_LINE
-  throw LinkerError(LINKER_NOT_FOUND, msg);                                                              // LCOV_EXCL_LINE
+  constexpr auto msg = "No supported linker was found on the system. Supported are: mold, lld, gold and ld"; // LCOV_EXCL_LINE
+  throw LinkerError(LINKER_NOT_FOUND, msg);                                                                  // LCOV_EXCL_LINE
 }
 
 /**
@@ -181,19 +178,19 @@ ExternalBinaryFinderResult SystemUtil::findLinker([[maybe_unused]] const CliOpti
  */
 ExternalBinaryFinderResult SystemUtil::findArchiver() {
 #if OS_UNIX
-  for (const char *archiverName : {"llvm-ar", "gcc-ar", "ar"})
-    for (const std::string path : {"/usr/bin/", "/usr/local/bin/", "/bin/"})
+  for (const char *archiverName : ARCHIVER_NAMES_UNIX)
+    for (const std::string path : BINARY_SEARCH_DIRS)
       if (std::filesystem::exists(path + archiverName))
-        return ExternalBinaryFinderResult{archiverName, path + archiverName};
+        return ExternalBinaryFinderResult{.name = archiverName, .path = path + archiverName};
 #elif OS_WINDOWS
-  for (const char *archiverName : {"llvm-lib", "lib"})
+  for (const char *archiverName : ARCHIVER_NAMES_WINDOWS)
     if (isCommandAvailable(std::string(archiverName) + " -v"))
       return ExternalBinaryFinderResult{archiverName, archiverName};
 #else
 #error "Unsupported platform"
 #endif
-  const auto msg = "No supported archiver was found on the system. Supported are: llvm-ar and ar"; // LCOV_EXCL_LINE
-  throw LinkerError(ARCHIVER_NOT_FOUND, msg);                                                      // LCOV_EXCL_LINE
+  constexpr auto msg = "No supported archiver was found on the system. Supported are: llvm-ar and ar"; // LCOV_EXCL_LINE
+  throw LinkerError(ARCHIVER_NOT_FOUND, msg);                                                          // LCOV_EXCL_LINE
 }
 
 /**
@@ -234,8 +231,8 @@ std::filesystem::path SystemUtil::getStdDir() {
   if (std::getenv("SPICE_STD_DIR"))
     if (const std::filesystem::path stdPath(std::getenv("SPICE_STD_DIR")); exists(stdPath))
       return stdPath;
-  const auto errMsg = "Standard library could not be found. Check if the env var SPICE_STD_DIR exists"; // GCOV_EXCL_LINE
-  throw CompilerError(STD_NOT_FOUND, errMsg);                                                           // GCOV_EXCL_LINE
+  constexpr auto msg = "Standard library could not be found. Check if the env var SPICE_STD_DIR exists"; // GCOV_EXCL_LINE
+  throw CompilerError(STD_NOT_FOUND, msg);                                                               // GCOV_EXCL_LINE
 }
 
 /**
@@ -249,8 +246,8 @@ std::filesystem::path SystemUtil::getBootstrapDir() {
     if (const std::filesystem::path stdPath(std::getenv("SPICE_BOOTSTRAP_DIR")); exists(stdPath))
       return stdPath;
   }
-  const auto errMsg = "Bootstrap compiler could not be found. Check if the env var SPICE_BOOTSTRAP_DIR exists"; // GCOV_EXCL_LINE
-  throw CompilerError(BOOTSTRAP_NOT_FOUND, errMsg);                                                             // GCOV_EXCL_LINE
+  constexpr auto msg = "Bootstrap compiler could not be found. Check if the env var SPICE_BOOTSTRAP_DIR exists"; // GCOV_EXCL_LINE
+  throw CompilerError(BOOTSTRAP_NOT_FOUND, msg);                                                                 // GCOV_EXCL_LINE
 }
 
 /**

--- a/src/util/SystemUtil.h
+++ b/src/util/SystemUtil.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include <array>
 #include <filesystem>
 #include <string>
 
@@ -20,6 +21,33 @@ struct ExternalBinaryFinderResult {
   const char *name;
   std::string path;
 };
+
+// Directories that are searched for a linker invoker, linker or archiver executable
+static constexpr std::array<const char *, 3> BINARY_SEARCH_DIRS = {"/usr/bin/", "/usr/local/bin/", "/bin/"};
+
+// Supported linker invoker names, in order of preference
+static constexpr auto LINKER_INVOKER_NAME_CLANG = "clang";
+static constexpr auto LINKER_INVOKER_NAME_GCC = "gcc";
+static constexpr std::array LINKER_INVOKER_NAMES = {LINKER_INVOKER_NAME_CLANG, LINKER_INVOKER_NAME_GCC};
+
+// Supported linker names, in order of preference
+static constexpr auto LINKER_NAME_MOLD = "mold";
+static constexpr auto LINKER_NAME_LD_LLD = "ld.lld";
+static constexpr auto LINKER_NAME_LD64_LLD = "ld64.ddl";
+static constexpr auto LINKER_NAME_GOLD = "gold";
+static constexpr auto LINKER_NAME_LD = "ld";
+static constexpr auto LINKER_NAME_LLD = "lld";
+static constexpr std::array LINKER_NAMES_UNIX = {LINKER_NAME_LD_LLD, LINKER_NAME_LD64_LLD, LINKER_NAME_GOLD, LINKER_NAME_LD};
+static constexpr std::array LINKER_NAMES_WINDOWS = {LINKER_NAME_LLD, LINKER_NAME_LD};
+
+// Supported archiver names, in order of preference
+static constexpr auto ARCHIVER_NAME_LLVM_AR = "llvm-ar";
+static constexpr auto ARCHIVER_NAME_GCC_AR = "gcc-ar";
+static constexpr auto ARCHIVER_NAME_AR = "ar";
+static constexpr auto ARCHIVER_NAME_LLVM_LIB = "llvm-lib";
+static constexpr auto ARCHIVER_NAME_LIB = "lib";
+static constexpr std::array ARCHIVER_NAMES_UNIX = {ARCHIVER_NAME_LLVM_AR, ARCHIVER_NAME_GCC_AR, ARCHIVER_NAME_AR};
+static constexpr std::array ARCHIVER_NAMES_WINDOWS = {ARCHIVER_NAME_LLVM_LIB, ARCHIVER_NAME_LIB};
 
 class SystemUtil {
 public:


### PR DESCRIPTION
## What changed
- Extracted the hardcoded linker invoker (`clang`, `gcc`), linker (`mold`, `ld.lld`, `ld64.ddl`, `gold`, `ld`, `lld`), and archiver (`llvm-ar`, `gcc-ar`, `ar`, `llvm-lib`, `lib`) name literals, plus the repeated binary search paths, into named `static constexpr` constants and arrays in `src/util/SystemUtil.h`.
- Updated `SystemUtil.cpp`'s discovery loops and `ExternalLinkerInterface.cpp`'s fixed-value comparisons (`isGccInvoker`, `isClangInvoker`, the `-fuse-ld` check) to reference these shared constants instead of duplicating string literals.

## Why
The same binary names were hardcoded as string literals in both `SystemUtil.cpp` (where they're searched for) and `ExternalLinkerInterface.cpp` (where they're compared against), with no single source of truth. Centralizing them in the header removes the duplication and makes it impossible for the two files to drift out of sync.

No behavior change — this is a pure refactor.

## How it was validated
- `cmake --build cmake-build-debug --target spice` — succeeds
- `cmake-build-debug/test/spicetest --gtest_filter='DriverTest*'` (run from `cmake-build-debug/test/`) — 18 passed, 1 skipped (pre-existing, backend-dependent skip)
- Manually ran `spice run` on a hello-world program — compiled and linked successfully, confirming linker/archiver discovery still works end-to-end
- `clang-format --dry-run --Werror` on all changed files — clean

## Follow-up / known limitations
None.