### PR TITLE
Fix isRawEqual() conflating nil<string> with an empty string

### DIFF
--- a/std/math/hash.spice
+++ b/std/math/hash.spice
@@ -109,7 +109,7 @@ public f<Hash> hash(string input) {
     result = 1469598103934665603ul;
     const char* c = cast<const char*>(input);
     unsafe {
-        while c != nil<string> {
+        while *c != '\0' {
             result ^= cast<unsigned long>(cast<unsigned int>(*c++));
             result *= 1099511628211ul; // FNV prime
         }

--- a/std/runtime/string_rt.spice
+++ b/std/runtime/string_rt.spice
@@ -889,6 +889,13 @@ public f<unsigned long> getRawLength(string input) {
  * @return Equality of lhs and rhs
  */
 public f<bool> isRawEqual(string lhs, string rhs) {
+    // A nil string represents the absence of a string and must never be considered equal to a non-nil
+    // string, even an empty one (e.g. nil<string> != ""). getRawLength() cannot tell these apart, since
+    // it reports both as length 0, so the nil-ness has to be checked explicitly beforehand.
+    const bool lhsIsNil = cast<const char*>(lhs) == nil<const char*>;
+    const bool rhsIsNil = cast<const char*>(rhs) == nil<const char*>;
+    if lhsIsNil || rhsIsNil { return lhsIsNil && rhsIsNil; }
+
     unsigned long lhsLength = getRawLength(lhs);
     unsigned long rhsLength = getRawLength(rhs);
     // Return false immediately if length does not match

--- a/test/test-files/std/runtime/string-nil-vs-empty/cout.out
+++ b/test/test-files/std/runtime/string-nil-vs-empty/cout.out
@@ -1,0 +1,12 @@
+empty == nil: 0
+empty != nil: 1
+nil == empty: 0
+nil != empty: 1
+nil == nil: 1
+empty == empty: 1
+empty != empty: 0
+char* empty == nil: 0
+char* empty != nil: 1
+hash(nil) == 0: 1
+hash(empty) != 0: 1
+hash(empty) == hash(""): 1

--- a/test/test-files/std/runtime/string-nil-vs-empty/source.spice
+++ b/test/test-files/std/runtime/string-nil-vs-empty/source.spice
@@ -1,0 +1,33 @@
+import "std/math/hash";
+
+// A nil string represents the absence of a string and must never be treated as
+// equal to a non-nil string, even an empty one. This is a regression test for a
+// bug where isRawEqual() (used to lower `string == nil<string>` / `!=`) reported
+// a valid pointer to an empty string as equal to nil, because it compared string
+// *content* (both being zero-length) instead of pointer nil-ness.
+f<int> main() {
+    string empty = "";
+    string n = nil<string>;
+
+    printf("empty == nil: %d\n", empty == n);
+    printf("empty != nil: %d\n", empty != n);
+    printf("nil == empty: %d\n", n == empty);
+    printf("nil != empty: %d\n", n != empty);
+    printf("nil == nil: %d\n", n == nil<string>);
+    printf("empty == empty: %d\n", empty == "");
+    printf("empty != empty: %d\n", empty != "");
+
+    // Mixed string/char* comparisons take a separate code path in the compiler
+    // and must be equally immune to the nil/empty conflation.
+    const char* c = cast<const char*>(empty);
+    printf("char* empty == nil: %d\n", c == n);
+    printf("char* empty != nil: %d\n", c != n);
+
+    // hash(string) must distinguish a nil string (special-cased to hash 0) from a
+    // non-nil, empty string (which hashes to the FNV-1a offset basis).
+    printf("hash(nil) == 0: %d\n", hash(n) == 0ul);
+    printf("hash(empty) != 0: %d\n", hash(empty) != 0ul);
+    printf("hash(empty) == hash(\"\"): %d\n", hash(empty) == hash(""));
+
+    return 0;
+}


### PR DESCRIPTION
## What changed
- `isRawEqual()` (`std/runtime/string_rt.spice`) now explicitly checks null-ness of both operands before falling back to length+content comparison, instead of relying on `getRawLength()`'s "null → length 0" behavior.
- `hash(string)` (`std/math/hash.spice`) no longer uses `c != nil<string>` as its char-walking loop terminator (it only worked by relying on the bug above); it now dereferences and compares against `'\0'`, matching `getRawLength()`'s own idiom.
- Added a regression test at `test/test-files/std/runtime/string-nil-vs-empty/`.

## Why
Every `string == nil<string>` / `!= nil<string>` comparison lowers to a call to `isRawEqual()`. That function computed both operands' lengths via `getRawLength()`, which treats a null pointer as length 0. So a valid, non-null pointer to an **empty** string was indistinguishable from an actual null pointer: both reported length 0, the zero-iteration content-compare loop trivially "matched", and `isRawEqual()` returned `true`.

This silently broke every "is this owned/initialized" nil-guard in the codebase whenever the wrapped string happened to be non-null-but-empty. Concretely: `llvm.spice`'s `Message.dtor()` guards its `LLVMDisposeMessage()` call with `if this.message != nil<string>`. `LLVMVerifyModule()` always writes a `strdup()`'d `OutMessage`, even on a clean, error-free verification (an empty string). That made the dtor's nil-check wrongly evaluate to `false`, skipping the dispose call and leaking the buffer on every successful verification.

Root-caused via a minimal LLVM-free repro of the same struct/dtor pattern, confirmed with `valgrind` + `gdb`: the dtor was reached with the correct non-null pointer, but the guard branch was never taken.

Fixing `isRawEqual()` alone would have introduced an infinite loop / OOB read in `hash(string)`, since its loop condition `c != nil<string>` was (accidentally) relying on the exact bug being fixed to detect the string's null terminator. Fixed alongside.

## How it was validated
- Minimal LLVM-free repro of the `Message`/dtor leak pattern: leak reproduced under `valgrind --leak-check=full` with the old `isRawEqual()`, gone after the fix.
- `cmake-build-debug/test/spicetest --gtest_filter='StdTests.runtime_stringNilVsEmpty'` — new regression test passes with the fix, and was confirmed to fail against the old `isRawEqual()` (verified by temporarily reverting just that change).
- Full suite: `cmake-build-debug/test/spicetest --gtest_filter='-BootstrapCompilerTests*:StdTests.bindings_llvm'` — 599 passed, 2 pre-existing skips, 0 failures. (`BootstrapCompilerTests` and `StdTests.bindings_llvm` excluded/fail in this sandbox due to a pre-existing, unrelated LLVM linker library-path issue, confirmed to exist before this change too.)

## Follow-up / known limitations
- Could not run `StdTests.bindings_llvm` end-to-end in this environment due to the pre-existing linker issue noted above; the underlying leak pattern was instead verified via an isolated repro exercising the identical struct/dtor/nil-check mechanism.