### PR TITLE
Use internal instead of private linkage for non-public functions

### DIFF
--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_INCLUDE_DIRS" value="-I/home/marc/Documents/Dev/llvm-project-latest/llvm/include -I/home/marc/Documents/Dev/llvm-project-latest/build/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,7 +1,13 @@
-import "bootstrap/model/interface";
+import "std/test/lifetime-object";
 
-// Wrapper for 'spice test' unit test
+p foo(const LifetimeObject& t) {
+
+}
+
+p bar() {
+    foo(LifetimeObject());
+}
+
 f<int> main() {
-    testInterfaceSmoke();
-    printf("All assertions passed!");
+    bar();
 }

--- a/src-bootstrap/lexer/token.spice
+++ b/src-bootstrap/lexer/token.spice
@@ -133,7 +133,7 @@ public p Token.ctor(TokenType tokenType) {
     this.tokenType = tokenType;
 }
 
-public p Token.ctor(TokenType tokenType, String text, const CodeLoc& codeLoc) {
+public p Token.ctor(TokenType tokenType, const String& text, const CodeLoc& codeLoc) {
     this.tokenType = tokenType;
     this.text = text;
     this.codeLoc = codeLoc;

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -140,7 +140,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
     assert(manifestation->entry != nullptr);
 
     // Check if the manifestation is substantiated or not public and not used by anybody
-    const bool isPublic = manifestation->entry->getQualType().isPublic();
+    bool isPublic = manifestation->entry->getQualType().isPublic();
     if (!manifestation->isFullySubstantiated() || (!isPublic && !manifestation->used)) {
       manIdx++; // Increment symbolTypeIndex
       continue;
@@ -192,10 +192,8 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
     llvm::Type *returnType = manifestation->returnType.toLLVMType(sourceFile);
 
     // Get function linkage
-    bool externalLinkage = isPublic;
     if (node->attrs && node->attrs->attrLst->hasAttr(ATTR_TEST))
-      externalLinkage |= node->attrs->attrLst->getAttrValueByName(ATTR_TEST)->boolValue;
-    const auto linkage = externalLinkage ? llvm::Function::ExternalLinkage : llvm::Function::PrivateLinkage;
+      isPublic |= node->attrs->attrLst->getAttrValueByName(ATTR_TEST)->boolValue;
 
     // Create function or implement declared function
     const std::string mangledName = manifestation->getMangledName();
@@ -208,7 +206,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
 
     // Set attributes to function
     func->setDSOLocal(isSymbolDSOLocal(isPublic));
-    func->setLinkage(linkage);
+    func->setLinkage(getSymbolLinkageType(isPublic));
     addCommonFctAttrs(func, manifestation->entry->getQualType().isInline());
     enableFunctionInstrumentation(func);
     // Set attributes to function parameters and return value

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -543,7 +543,7 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
   llvm::Function *lambda = module->getFunction(mangledName);
 
   // Set attributes to function
-  lambda->setLinkage(llvm::Function::PrivateLinkage);
+  lambda->setLinkage(llvm::Function::InternalLinkage);
   lambda->setDSOLocal(true);
   addCommonFctAttrs(lambda);
   enableFunctionInstrumentation(lambda);
@@ -699,7 +699,7 @@ std::any IRGenerator::visitLambdaProc(const LambdaProcNode *node) {
   llvm::Function *lambda = module->getFunction(mangledName);
 
   // Set attributes to function
-  lambda->setLinkage(llvm::Function::PrivateLinkage);
+  lambda->setLinkage(llvm::Function::InternalLinkage);
   lambda->setDSOLocal(true);
   addCommonFctAttrs(lambda);
   enableFunctionInstrumentation(lambda);
@@ -849,7 +849,7 @@ std::any IRGenerator::visitLambdaExpr(const LambdaExprNode *node) {
   llvm::Function *lambda = module->getFunction(mangledName);
 
   // Set attributes to function
-  lambda->setLinkage(llvm::Function::PrivateLinkage);
+  lambda->setLinkage(llvm::Function::InternalLinkage);
   lambda->setDSOLocal(true);
   addCommonFctAttrs(lambda);
   enableFunctionInstrumentation(lambda);

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -671,7 +671,7 @@ bool IRGenerator::isSymbolDSOLocal(bool isPublic) const {
 }
 
 llvm::GlobalValue::LinkageTypes IRGenerator::getSymbolLinkageType(bool isPublic) const {
-  return isPublic ? llvm::GlobalValue::ExternalLinkage : llvm::GlobalValue::PrivateLinkage;
+  return isPublic ? llvm::GlobalValue::ExternalLinkage : llvm::GlobalValue::InternalLinkage;
 }
 
 llvm::GlobalValue::LinkageTypes IRGenerator::getVTableLinkageType(bool isPublic) const {

--- a/test/test-files/benchmark/success-ackermann/assembly-linux-amd64.asm
+++ b/test/test-files/benchmark/success-ackermann/assembly-linux-amd64.asm
@@ -2,8 +2,8 @@
 	.file	"source.spice"
 	.text
 	.prefalign	4, .Lfunc_end0, nop     # -- Begin function _Z3ackii
-	.type	.L_Z3ackii,@function
-.L_Z3ackii:                             # @_Z3ackii
+	.type	_Z3ackii,@function
+_Z3ackii:                               # @_Z3ackii
 	.cfi_startproc
 # %bb.0:
 	movl	%esi, %eax
@@ -29,7 +29,7 @@
 	decl	%eax
 	movl	%ebx, %edi
 	movl	%eax, %esi
-	callq	.L_Z3ackii
+	callq	_Z3ackii
 	decl	%ebx
 	jne	.LBB0_2
 .LBB0_5:
@@ -40,7 +40,7 @@
 	incl	%eax
 	retq
 .Lfunc_end0:
-	.size	.L_Z3ackii, .Lfunc_end0-.L_Z3ackii
+	.size	_Z3ackii, .Lfunc_end0-_Z3ackii
 	.cfi_endproc
                                         # -- End function
 	.globl	main                            # -- Begin function main
@@ -53,7 +53,7 @@ main:                                   # @main
 	.cfi_def_cfa_offset 16
 	movl	$3, %edi
 	movl	$10, %esi
-	callq	.L_Z3ackii
+	callq	_Z3ackii
 	leaq	.Lprintf.str.0(%rip), %rdi
 	movl	$3, %esi
 	movl	$10, %edx

--- a/test/test-files/benchmark/success-ackermann/ir-code-O3-linux-aarch64.ll
+++ b/test/test-files/benchmark/success-ackermann/ir-code-O3-linux-aarch64.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [36 x i8] c"Ackermann of base m=%d and n=%d: %d\00", align 4
 
 ; Function Attrs: nofree nosync nounwind memory(none) uwtable
-define private fastcc noundef range(i32 -2147483647, -2147483648) i32 @_Z3ackii(i32 noundef range(i32 0, 4) %0, i32 noundef %1) unnamed_addr #0 {
+define internal fastcc noundef range(i32 -2147483647, -2147483648) i32 @_Z3ackii(i32 noundef range(i32 0, 4) %0, i32 noundef %1) unnamed_addr #0 {
   %3 = icmp eq i32 %0, 0
   br i1 %3, label %if.then.L2, label %if.exit.L2
 

--- a/test/test-files/benchmark/success-ackermann/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-ackermann/ir-code-O3.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [36 x i8] c"Ackermann of base m=%d and n=%d: %d\00", align 4
 
 ; Function Attrs: nofree nosync nounwind memory(none) uwtable
-define private fastcc noundef range(i32 -2147483647, -2147483648) i32 @_Z3ackii(i32 noundef range(i32 0, 4) %0, i32 noundef %1) unnamed_addr #0 {
+define internal fastcc noundef range(i32 -2147483647, -2147483648) i32 @_Z3ackii(i32 noundef range(i32 0, 4) %0, i32 noundef %1) unnamed_addr #0 {
   %3 = icmp eq i32 %0, 0
   br i1 %3, label %if.then.L2, label %if.exit.L2
 

--- a/test/test-files/benchmark/success-ackermann/ir-code.ll
+++ b/test/test-files/benchmark/success-ackermann/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [36 x i8] c"Ackermann of base m=%d and n=%d: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3ackii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3ackii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %m = alloca i32, align 4
   %n = alloca i32, align 4

--- a/test/test-files/benchmark/success-faculty/ir-code.ll
+++ b/test/test-files/benchmark/success-faculty/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [21 x i8] c"Faculty of %d is: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z7facultyi(i32 noundef %0) #0 {
+define internal noundef i32 @_Z7facultyi(i32 noundef %0) #0 {
   %result = alloca i32, align 4
   %input = alloca i32, align 4
   store i32 %0, ptr %input, align 4

--- a/test/test-files/benchmark/success-fibonacci-threaded/assembly-linux-amd64.asm
+++ b/test/test-files/benchmark/success-fibonacci-threaded/assembly-linux-amd64.asm
@@ -2,8 +2,8 @@
 	.file	"source.spice"
 	.text
 	.prefalign	4, .Lfunc_end0, nop     # -- Begin function _Z3fibi
-	.type	.L_Z3fibi,@function
-.L_Z3fibi:                              # @_Z3fibi
+	.type	_Z3fibi,@function
+_Z3fibi:                                # @_Z3fibi
 	.cfi_startproc
 # %bb.0:
 	pushq	%r14
@@ -25,7 +25,7 @@
 .LBB0_2:                                # %if.exit.L4
                                         # =>This Inner Loop Header: Depth=1
 	movl	%r14d, %edi
-	callq	.L_Z3fibi
+	callq	_Z3fibi
 	addl	%eax, %ebx
 	leal	-2(%r14), %eax
 	incl	%r14d
@@ -44,7 +44,7 @@
 	.cfi_def_cfa_offset 8
 	retq
 .Lfunc_end0:
-	.size	.L_Z3fibi, .Lfunc_end0-.L_Z3fibi
+	.size	_Z3fibi, .Lfunc_end0-_Z3fibi
 	.cfi_endproc
                                         # -- End function
 	.globl	main                            # -- Begin function main
@@ -77,7 +77,7 @@ main:                                   # @main
 	leaq	144(%rsp), %rbx
 	leaq	192(%rsp), %r12
 	leaq	240(%rsp), %r13
-	leaq	.L_Z15lambda.L12C29.0v(%rip), %r14
+	leaq	_Z15lambda.L12C29.0v(%rip), %r14
 	movq	%rsp, %r15
 	movq	%r15, %rdi
 	movq	%r14, %rsi
@@ -230,14 +230,14 @@ main:                                   # @main
 	.cfi_endproc
                                         # -- End function
 	.prefalign	4, .Lfunc_end2, nop     # -- Begin function _Z15lambda.L12C29.0v
-	.type	.L_Z15lambda.L12C29.0v,@function
-.L_Z15lambda.L12C29.0v:                 # @_Z15lambda.L12C29.0v
+	.type	_Z15lambda.L12C29.0v,@function
+_Z15lambda.L12C29.0v:                   # @_Z15lambda.L12C29.0v
 	.cfi_startproc
 # %bb.0:
 	pushq	%rax
 	.cfi_def_cfa_offset 16
 	movl	$30, %edi
-	callq	.L_Z3fibi
+	callq	_Z3fibi
 	leaq	.Lprintf.str.0(%rip), %rdi
 	movl	%eax, %esi
 	xorl	%eax, %eax
@@ -245,7 +245,7 @@ main:                                   # @main
 	.cfi_def_cfa_offset 8
 	jmp	printf@PLT                      # TAILCALL
 .Lfunc_end2:
-	.size	.L_Z15lambda.L12C29.0v, .Lfunc_end2-.L_Z15lambda.L12C29.0v
+	.size	_Z15lambda.L12C29.0v, .Lfunc_end2-_Z15lambda.L12C29.0v
 	.cfi_endproc
                                         # -- End function
 	.type	.Lprintf.str.0,@object          # @printf.str.0

--- a/test/test-files/benchmark/success-fibonacci-threaded/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-fibonacci-threaded/ir-code-O3.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 @str = private unnamed_addr constant [45 x i8] c"Started all threads. Waiting for results ...\00", align 1
 
 ; Function Attrs: nofree nosync nounwind memory(none) uwtable
-define private fastcc noundef i32 @_Z3fibi(i32 noundef %0) unnamed_addr #0 {
+define internal fastcc noundef i32 @_Z3fibi(i32 noundef %0) unnamed_addr #0 {
   %2 = icmp slt i32 %0, 3
   br i1 %2, label %common.ret, label %if.exit.L4
 
@@ -84,7 +84,7 @@ for.body.L11:
 }
 
 ; Function Attrs: nofree nounwind uwtable
-define private void @_Z15lambda.L12C29.0v(ptr nofree readnone captures(none) %0) #2 {
+define internal void @_Z15lambda.L12C29.0v(ptr nofree readnone captures(none) %0) #2 {
   %2 = tail call fastcc noundef i32 @_Z3fibi(i32 noundef 30)
   %3 = tail call noundef i32 (ptr, ...) @printf(ptr noundef nonnull dereferenceable(1) @printf.str.0, i32 noundef %2)
   ret void

--- a/test/test-files/benchmark/success-fibonacci/assembly-linux-amd64.asm
+++ b/test/test-files/benchmark/success-fibonacci/assembly-linux-amd64.asm
@@ -2,8 +2,8 @@
 	.file	"source.spice"
 	.text
 	.prefalign	4, .Lfunc_end0, nop     # -- Begin function _Z4fiboi
-	.type	.L_Z4fiboi,@function
-.L_Z4fiboi:                             # @_Z4fiboi
+	.type	_Z4fiboi,@function
+_Z4fiboi:                               # @_Z4fiboi
 	.cfi_startproc
 # %bb.0:
 	pushq	%r14
@@ -27,7 +27,7 @@
 .LBB0_4:                                # %if.exit.L2
                                         # =>This Inner Loop Header: Depth=1
 	leal	-1(%r14), %edi
-	callq	.L_Z4fiboi
+	callq	_Z4fiboi
 	leal	-2(%r14), %ecx
 	addl	%eax, %ebx
 	cmpl	$4, %r14d
@@ -44,7 +44,7 @@
 	.cfi_def_cfa_offset 8
 	retq
 .Lfunc_end0:
-	.size	.L_Z4fiboi, .Lfunc_end0-.L_Z4fiboi
+	.size	_Z4fiboi, .Lfunc_end0-_Z4fiboi
 	.cfi_endproc
                                         # -- End function
 	.globl	main                            # -- Begin function main
@@ -56,7 +56,7 @@ main:                                   # @main
 	pushq	%rax
 	.cfi_def_cfa_offset 16
 	movl	$30, %edi
-	callq	.L_Z4fiboi
+	callq	_Z4fiboi
 	leaq	.Lprintf.str.0(%rip), %rdi
 	movl	%eax, %esi
 	xorl	%eax, %eax

--- a/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code-O3.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 4
 
 ; Function Attrs: nofree nosync nounwind memory(none) uwtable
-define private fastcc noundef i32 @_Z4fiboi(i32 noundef %0) unnamed_addr #0 {
+define internal fastcc noundef i32 @_Z4fiboi(i32 noundef %0) unnamed_addr #0 {
   %2 = icmp slt i32 %0, 2
   br i1 %2, label %common.ret, label %if.exit.L2
 

--- a/test/test-files/benchmark/success-fibonacci/ir-code.ll
+++ b/test/test-files/benchmark/success-fibonacci/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z4fiboi(i32 noundef %0) #0 {
+define internal noundef i32 @_Z4fiboi(i32 noundef %0) #0 {
   %result = alloca i32, align 4
   %n = alloca i32, align 4
   store i32 %0, ptr %n, align 4

--- a/test/test-files/irgenerator/anonymous-blocks/success-nested-anonymous-blocks/ir-code.ll
+++ b/test/test-files/irgenerator/anonymous-blocks/success-nested-anonymous-blocks/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Param: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4testi(i32 noundef %0) #0 {
+define internal void @_Z4testi(i32 noundef %0) #0 {
   %param = alloca i32, align 4
   store i32 %0, ptr %param, align 4
   %2 = load i32, ptr %param, align 4

--- a/test/test-files/irgenerator/arrays/success-array-params-decay/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/arrays/success-array-params-decay/ir-code-macos-amd64.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @anon.array.2 = private unnamed_addr constant [2 x i32] [i32 7, i32 8]
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3sumA4_i(ptr noundef %values) #0 {
+define internal noundef i32 @_Z3sumA4_i(ptr noundef %values) #0 {
   %result = alloca i32, align 4
   %total = alloca i32, align 4
   %i = alloca i32, align 4
@@ -48,7 +48,7 @@ for.exit.L6:                                      ; preds = %for.head.L6
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z8setFirstA4_ii(ptr noundef %values, i32 noundef %0) #0 {
+define internal void @_Z8setFirstA4_ii(ptr noundef %values, i32 noundef %0) #0 {
   %newValue = alloca i32, align 4
   store i32 %0, ptr %newValue, align 4
   %2 = getelementptr inbounds [4 x i32], ptr %values, i64 0, i32 0
@@ -58,7 +58,7 @@ define private void @_Z8setFirstA4_ii(ptr noundef %values, i32 noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z7op.plus6OffsetA2_i(%struct.Offset noundef %0, ptr noundef %values) #0 {
+define internal noundef i32 @_Z7op.plus6OffsetA2_i(%struct.Offset noundef %0, ptr noundef %values) #0 {
   %result = alloca i32, align 4
   %offset = alloca %struct.Offset, align 8
   store %struct.Offset %0, ptr %offset, align 4
@@ -77,7 +77,7 @@ define private noundef i32 @_Z7op.plus6OffsetA2_i(%struct.Offset noundef %0, ptr
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z9sumMatrixA3_A2_b(ptr noundef %matrix) #0 {
+define internal noundef i32 @_Z9sumMatrixA3_A2_b(ptr noundef %matrix) #0 {
   %result = alloca i32, align 4
   %total = alloca i32, align 4
   %i = alloca i32, align 4
@@ -189,7 +189,7 @@ define dso_local noundef i32 @main() #1 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #2
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i32 @_Z15lambda.L52C29.0A4_i(ptr %0, ptr %values) #0 {
+define internal i32 @_Z15lambda.L52C29.0A4_i(ptr %0, ptr %values) #0 {
   %result = alloca i32, align 4
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8

--- a/test/test-files/irgenerator/arrays/success-array-params-decay/ir-code.ll
+++ b/test/test-files/irgenerator/arrays/success-array-params-decay/ir-code.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @anon.array.2 = private unnamed_addr constant [2 x i32] [i32 7, i32 8]
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3sumA4_i(ptr noundef %values) #0 {
+define internal noundef i32 @_Z3sumA4_i(ptr noundef %values) #0 {
   %result = alloca i32, align 4
   %total = alloca i32, align 4
   %i = alloca i32, align 4
@@ -48,7 +48,7 @@ for.exit.L6:                                      ; preds = %for.head.L6
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z8setFirstA4_ii(ptr noundef %values, i32 noundef %0) #0 {
+define internal void @_Z8setFirstA4_ii(ptr noundef %values, i32 noundef %0) #0 {
   %newValue = alloca i32, align 4
   store i32 %0, ptr %newValue, align 4
   %2 = getelementptr inbounds [4 x i32], ptr %values, i64 0, i32 0
@@ -58,7 +58,7 @@ define private void @_Z8setFirstA4_ii(ptr noundef %values, i32 noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z7op.plus6OffsetA2_i(%struct.Offset noundef %0, ptr noundef %values) #0 {
+define internal noundef i32 @_Z7op.plus6OffsetA2_i(%struct.Offset noundef %0, ptr noundef %values) #0 {
   %result = alloca i32, align 4
   %offset = alloca %struct.Offset, align 8
   store %struct.Offset %0, ptr %offset, align 4
@@ -77,7 +77,7 @@ define private noundef i32 @_Z7op.plus6OffsetA2_i(%struct.Offset noundef %0, ptr
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z9sumMatrixA3_A2_b(ptr noundef %matrix) #0 {
+define internal noundef i32 @_Z9sumMatrixA3_A2_b(ptr noundef %matrix) #0 {
   %result = alloca i32, align 4
   %total = alloca i32, align 4
   %i = alloca i32, align 4
@@ -189,7 +189,7 @@ define dso_local noundef i32 @main() #1 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #2
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i32 @_Z15lambda.L52C29.0A4_i(ptr %0, ptr %values) #0 {
+define internal i32 @_Z15lambda.L52C29.0A4_i(ptr %0, ptr %values) #0 {
   %result = alloca i32, align 4
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8

--- a/test/test-files/irgenerator/builtins/success-implements-interface/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-implements-interface/ir-code.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @printf.str.3 = private unnamed_addr constant [40 x i8] c"Implements interface (ITest, bool): %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Test17methodAEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal void @_ZN5Test17methodAEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)

--- a/test/test-files/irgenerator/builtins/success-new/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-new/ir-code.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [7 x i8] c"%d %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Point4ctorEii(ptr noundef nonnull align 4 dereferenceable(8) %0, i32 noundef %1, i32 noundef %2) #0 {
+define internal void @_ZN5Point4ctorEii(ptr noundef nonnull align 4 dereferenceable(8) %0, i32 noundef %1, i32 noundef %2) #0 {
   %this = alloca ptr, align 8
   %x = alloca i32, align 4
   %y = alloca i32, align 4

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code-O2-macos.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code-O2-macos.ll
@@ -7,8 +7,8 @@ source_filename = "source.spice"
 @anon.string.0 = private unnamed_addr constant [117 x i8] c"Program panicked at ./source.spice:2:5: %s\0A2  panic(Error(\22This is an error\22));\0A   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\0A\00", align 4
 @anon.string.1 = private unnamed_addr constant [17 x i8] c"This is an error\00", align 4
 
-; Function Attrs: cold noreturn nounwind uwtable
-define private fastcc void @_Z3foov() unnamed_addr #0 {
+; Function Attrs: cold norecurse noreturn nounwind uwtable
+define internal fastcc void @_Z3foov() unnamed_addr #0 {
   %1 = alloca %struct.Error, align 8
   %2 = load ptr, ptr @__stderrp, align 8
   call void @_ZN5Error4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr noundef nonnull @anon.string.1) #4
@@ -33,7 +33,7 @@ define dso_local noundef i32 @main() local_unnamed_addr #3 {
   unreachable
 }
 
-attributes #0 = { cold noreturn nounwind uwtable }
+attributes #0 = { cold norecurse noreturn nounwind uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold nofree noreturn nounwind }
 attributes #3 = { cold mustprogress noinline norecurse noreturn nounwind uwtable }

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code-O2-windows.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code-O2-windows.ll
@@ -6,8 +6,8 @@ source_filename = "source.spice"
 @anon.string.0 = private unnamed_addr constant [117 x i8] c"Program panicked at ./source.spice:2:5: %s\0A2  panic(Error(\22This is an error\22));\0A   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\0A\00", align 4
 @anon.string.1 = private unnamed_addr constant [17 x i8] c"This is an error\00", align 4
 
-; Function Attrs: cold noreturn nounwind uwtable
-define private fastcc void @_Z3foov() unnamed_addr #0 {
+; Function Attrs: cold norecurse noreturn nounwind uwtable
+define internal fastcc void @_Z3foov() unnamed_addr #0 {
   %1 = alloca %struct.Error, align 8
   %2 = tail call ptr @__acrt_iob_func(i32 2) #4
   call void @_ZN5Error4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr noundef nonnull @anon.string.1) #4
@@ -34,7 +34,7 @@ define dso_local noundef i32 @main() local_unnamed_addr #3 {
   unreachable
 }
 
-attributes #0 = { cold noreturn nounwind uwtable }
+attributes #0 = { cold norecurse noreturn nounwind uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold nofree noreturn nounwind }
 attributes #3 = { cold mustprogress noinline norecurse noreturn nounwind uwtable }

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code-O2.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code-O2.ll
@@ -7,8 +7,8 @@ source_filename = "source.spice"
 @anon.string.0 = private unnamed_addr constant [117 x i8] c"Program panicked at ./source.spice:2:5: %s\0A2  panic(Error(\22This is an error\22));\0A   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\0A\00", align 4
 @anon.string.1 = private unnamed_addr constant [17 x i8] c"This is an error\00", align 4
 
-; Function Attrs: cold noreturn nounwind uwtable
-define private fastcc void @_Z3foov() unnamed_addr #0 {
+; Function Attrs: cold norecurse noreturn nounwind uwtable
+define internal fastcc void @_Z3foov() unnamed_addr #0 {
   %1 = alloca %struct.Error, align 8
   %2 = load ptr, ptr @stderr, align 8
   call void @_ZN5Error4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr noundef nonnull @anon.string.1) #4
@@ -33,7 +33,7 @@ define dso_local noundef i32 @main() local_unnamed_addr #3 {
   unreachable
 }
 
-attributes #0 = { cold noreturn nounwind uwtable }
+attributes #0 = { cold norecurse noreturn nounwind uwtable }
 attributes #1 = { nofree nounwind }
 attributes #2 = { cold nofree noreturn nounwind }
 attributes #3 = { cold mustprogress noinline norecurse noreturn nounwind uwtable }

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code-macos.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code-macos.ll
@@ -8,7 +8,7 @@ source_filename = "source.spice"
 @anon.string.1 = private unnamed_addr constant [17 x i8] c"This is an error\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z3foov() #0 {
+define internal void @_Z3foov() #0 {
   %1 = alloca %struct.Error, align 8
   %2 = load ptr, ptr @__stderrp, align 8
   call void @_ZN5Error4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr noundef @anon.string.1)

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code-windows.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code-windows.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @anon.string.1 = private unnamed_addr constant [17 x i8] c"This is an error\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z3foov() #0 {
+define internal void @_Z3foov() #0 {
   %1 = alloca %struct.Error, align 8
   %2 = call ptr @__acrt_iob_func(i32 2)
   call void @_ZN5Error4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr noundef @anon.string.1)

--- a/test/test-files/irgenerator/builtins/success-panic/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-panic/ir-code.ll
@@ -8,7 +8,7 @@ source_filename = "source.spice"
 @anon.string.1 = private unnamed_addr constant [17 x i8] c"This is an error\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z3foov() #0 {
+define internal void @_Z3foov() #0 {
   %1 = alloca %struct.Error, align 8
   %2 = load ptr, ptr @stderr, align 8
   call void @_ZN5Error4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %1, ptr noundef @anon.string.1)

--- a/test/test-files/irgenerator/builtins/success-placement-new/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-placement-new/ir-code.ll
@@ -6,7 +6,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [7 x i8] c"%d %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Point4ctorEii(ptr noundef nonnull align 4 dereferenceable(8) %0, i32 noundef %1, i32 noundef %2) #0 {
+define internal void @_ZN5Point4ctorEii(ptr noundef nonnull align 4 dereferenceable(8) %0, i32 noundef %1, i32 noundef %2) #0 {
   %this = alloca ptr, align 8
   %x = alloca i32, align 4
   %y = alloca i32, align 4

--- a/test/test-files/irgenerator/ext-decl/success-ext-decl-force-substantiate/ir-code.ll
+++ b/test/test-files/irgenerator/ext-decl/success-ext-decl-force-substantiate/ir-code.ll
@@ -52,7 +52,7 @@ define dso_local noundef i32 @main() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z15lambda.L11C39.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
+define internal void @_Z15lambda.L11C39.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = load volatile ptr, ptr %captures, align 8
@@ -67,7 +67,7 @@ define private void @_Z15lambda.L11C39.0v(ptr noundef nonnull dereferenceable(8)
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #2
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z15lambda.L15C39.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
+define internal void @_Z15lambda.L15C39.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = load ptr, ptr %captures, align 8

--- a/test/test-files/irgenerator/foreach-loops/success-foreach-item-copy-ctor/ir-code.ll
+++ b/test/test-files/irgenerator/foreach-loops/success-foreach-item-copy-ctor/ir-code.ll
@@ -22,7 +22,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN20ExampleContainedType4ctorEv(ptr noundef nonnull align 1 dereferenceable(1) %0) #0 {
+define internal void @_ZN20ExampleContainedType4ctorEv(ptr noundef nonnull align 1 dereferenceable(1) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -31,7 +31,7 @@ define private void @_ZN20ExampleContainedType4ctorEv(ptr noundef nonnull align 
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN20ExampleContainedType4ctorERK20ExampleContainedType(ptr noundef nonnull align 1 dereferenceable(1) %0, ptr noundef %1) #0 {
+define internal void @_ZN20ExampleContainedType4ctorERK20ExampleContainedType(ptr noundef nonnull align 1 dereferenceable(1) %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %_ = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -67,7 +67,7 @@ define void @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE4ctorEv(ptr noundef
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE3getEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE3getEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca ptr, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -77,7 +77,7 @@ define private noundef ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE3get
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Pair @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef %struct.Pair @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca %struct.Pair, align 8
   %this = alloca ptr, align 8
   %2 = alloca %struct.Pair, align 8
@@ -92,7 +92,7 @@ define private noundef %struct.Pair @_ZN19ExampleTypeIteratorI20ExampleContained
 declare void @_ZN4PairImR20ExampleContainedTypeE4ctorEmR20ExampleContainedType(ptr, i64, ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE7isValidEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef zeroext i1 @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE7isValidEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca i1, align 1
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -108,14 +108,14 @@ define private noundef zeroext i1 @_ZN19ExampleTypeIteratorI20ExampleContainedTy
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE4nextEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE4nextEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.ExampleTypeIterator @_ZN19ExampleIterableType11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal noundef %struct.ExampleTypeIterator @_ZN19ExampleIterableType11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %result = alloca %struct.ExampleTypeIterator, align 8
   %this = alloca ptr, align 8
   %2 = alloca %struct.ExampleTypeIterator, align 8

--- a/test/test-files/irgenerator/function-pointers/success-basic/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-basic/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z4testv() #0 {
+define internal noundef i32 @_Z4testv() #0 {
   %result = alloca i32, align 4
   ret i32 12
 }

--- a/test/test-files/irgenerator/function-pointers/success-indirect/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-indirect/ir-code.ll
@@ -5,7 +5,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z4testPKc(ptr noundef %0) #0 {
+define internal noundef i32 @_Z4testPKc(ptr noundef %0) #0 {
   %result = alloca i32, align 4
   %_input = alloca ptr, align 8
   store ptr %0, ptr %_input, align 8
@@ -13,7 +13,7 @@ define private noundef i32 @_Z4testPKc(ptr noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z6invokePFiPKcE({ ptr, ptr, i64 } noundef %0) #0 {
+define internal noundef i32 @_Z6invokePFiPKcE({ ptr, ptr, i64 } noundef %0) #0 {
   %result = alloca i32, align 4
   %fctPtr = alloca { ptr, ptr, i64 }, align 8
   store { ptr, ptr, i64 } %0, ptr %fctPtr, align 8

--- a/test/test-files/irgenerator/function-pointers/success-pass-by-non-value/ir-code.ll
+++ b/test/test-files/irgenerator/function-pointers/success-pass-by-non-value/ir-code.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z4testPKc(ptr noundef %0) #0 {
+define internal noundef i32 @_Z4testPKc(ptr noundef %0) #0 {
   %result = alloca i32, align 4
   %_input = alloca ptr, align 8
   store ptr %0, ptr %_input, align 8
@@ -15,7 +15,7 @@ define private noundef i32 @_Z4testPKc(ptr noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z6invokePPPFiPKcE(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal noundef i32 @_Z6invokePPPFiPKcE(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %result = alloca i32, align 4
   %fctPtr = alloca ptr, align 8
   store ptr %0, ptr %fctPtr, align 8
@@ -29,7 +29,7 @@ define private noundef i32 @_Z6invokePPPFiPKcE(ptr noundef nonnull align 8 deref
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z6invokeRPFiPKcE(ptr noundef %0) #0 {
+define internal noundef i32 @_Z6invokeRPFiPKcE(ptr noundef %0) #0 {
   %result = alloca i32, align 4
   %fctPtr = alloca ptr, align 8
   store ptr %0, ptr %fctPtr, align 8

--- a/test/test-files/irgenerator/functions/success-default-arg-value-expressions/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-default-arg-value-expressions/ir-code.ll
@@ -4,13 +4,13 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [10 x i8] c"Test: %f\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef double @_Z6getArgv() #0 {
+define internal noundef double @_Z6getArgv() #0 {
   %result = alloca double, align 8
   ret double 4.300000e+00
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef double @_Z4testv() #0 {
+define internal noundef double @_Z4testv() #0 {
   %result = alloca double, align 8
   %arg = alloca double, align 8
   %1 = call noundef double @_Z6getArgv()

--- a/test/test-files/irgenerator/functions/success-default-arg-values/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-default-arg-values/ir-code.ll
@@ -5,7 +5,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [12 x i8] c"Result: %s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z13getTestStringidb(i32 noundef %0, double noundef %1, i1 noundef zeroext %2) #0 {
+define internal noundef ptr @_Z13getTestStringidb(i32 noundef %0, double noundef %1, i1 noundef zeroext %2) #0 {
   %result = alloca ptr, align 8
   %_arg0 = alloca i32, align 4
   %_arg1 = alloca double, align 8

--- a/test/test-files/irgenerator/functions/success-down-call/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-down-call/ir-code.ll
@@ -17,7 +17,7 @@ define dso_local noundef i32 @main() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z4testv() #1 {
+define internal noundef i32 @_Z4testv() #1 {
   %result = alloca i32, align 4
   ret i32 1
 }

--- a/test/test-files/irgenerator/functions/success-overloading/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-overloading/ir-code.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @anon.string.0 = private unnamed_addr constant [12 x i8] c"param value\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z8testFuncv() #0 {
+define internal noundef i32 @_Z8testFuncv() #0 {
   %result = alloca i32, align 4
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
   ret i32 1
@@ -17,7 +17,7 @@ define private noundef i32 @_Z8testFuncv() #0 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z8testFuncPKc(ptr noundef %0) #0 {
+define internal noundef i32 @_Z8testFuncPKc(ptr noundef %0) #0 {
   %result = alloca i32, align 4
   %param = alloca ptr, align 8
   store ptr %0, ptr %param, align 8

--- a/test/test-files/irgenerator/functions/success-result-variable-ref/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-result-variable-ref/ir-code.ll
@@ -6,7 +6,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [16 x i8] c"Field value: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_ZN4Test8getFieldEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal noundef ptr @_ZN4Test8getFieldEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %result = alloca ptr, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/functions/success-result-variable/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-result-variable/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"The age is: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z6getAgev() #0 {
+define internal noundef i32 @_Z6getAgev() #0 {
   %result = alloca i32, align 4
   %i = alloca i1, align 1
   %b = alloca i1, align 1

--- a/test/test-files/irgenerator/functions/success-return-value-optimization/ir-code.ll
+++ b/test/test-files/irgenerator/functions/success-return-value-optimization/ir-code.ll
@@ -10,7 +10,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal void @_ZN4Test4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -19,7 +19,7 @@ define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 4 dereferenceable
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferenceable(4) %0, ptr noundef %1) #0 {
+define internal void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferenceable(4) %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %old = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -35,14 +35,14 @@ define private void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferen
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4dtorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal void @_ZN4Test4dtorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Test @_Z8testRVO14Test(%struct.Test noundef %0) #0 {
+define internal noundef %struct.Test @_Z8testRVO14Test(%struct.Test noundef %0) #0 {
   %result = alloca %struct.Test, align 8
   %old = alloca %struct.Test, align 8
   store %struct.Test %0, ptr %old, align 4
@@ -51,7 +51,7 @@ define private noundef %struct.Test @_Z8testRVO14Test(%struct.Test noundef %0) #
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Test @_Z8testRVO2RK4Test(ptr noundef %0) #0 {
+define internal noundef %struct.Test @_Z8testRVO2RK4Test(ptr noundef %0) #0 {
   %result = alloca %struct.Test, align 8
   %old = alloca ptr, align 8
   %2 = alloca %struct.Test, align 8
@@ -63,7 +63,7 @@ define private noundef %struct.Test @_Z8testRVO2RK4Test(ptr noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Test @_Z8testRVO34Test(%struct.Test noundef %0) #0 {
+define internal noundef %struct.Test @_Z8testRVO34Test(%struct.Test noundef %0) #0 {
   %result = alloca %struct.Test, align 8
   %old = alloca %struct.Test, align 8
   %old1 = alloca %struct.Test, align 8
@@ -74,7 +74,7 @@ define private noundef %struct.Test @_Z8testRVO34Test(%struct.Test noundef %0) #
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Test @_Z8testRVO4RK4Test(ptr noundef %0) #0 {
+define internal noundef %struct.Test @_Z8testRVO4RK4Test(ptr noundef %0) #0 {
   %result = alloca %struct.Test, align 8
   %old = alloca ptr, align 8
   %old1 = alloca ptr, align 8

--- a/test/test-files/irgenerator/generics/success-generic-functions1/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions1/ir-code.ll
@@ -6,7 +6,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef double @_Z15genericFunctionIidEdid(i32 noundef %0, double noundef %1) #0 {
+define internal noundef double @_Z15genericFunctionIidEdid(i32 noundef %0, double noundef %1) #0 {
   %result = alloca double, align 8
   %arg1 = alloca i32, align 4
   %arg2 = alloca double, align 8
@@ -25,7 +25,7 @@ define private noundef double @_Z15genericFunctionIidEdid(i32 noundef %0, double
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef double @_Z15genericFunctionIldEdld(i64 noundef %0, double noundef %1) #0 {
+define internal noundef double @_Z15genericFunctionIldEdld(i64 noundef %0, double noundef %1) #0 {
   %result = alloca double, align 8
   %arg1 = alloca i64, align 8
   %arg2 = alloca double, align 8
@@ -44,7 +44,7 @@ define private noundef double @_Z15genericFunctionIldEdld(i64 noundef %0, double
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i64 @_Z15genericFunctionIlsEllsl(i64 noundef %0, i16 noundef signext %1, i64 noundef %2) #0 {
+define internal noundef i64 @_Z15genericFunctionIlsEllsl(i64 noundef %0, i16 noundef signext %1, i64 noundef %2) #0 {
   %result = alloca i64, align 8
   %arg1 = alloca i64, align 8
   %arg2 = alloca i16, align 2

--- a/test/test-files/irgenerator/generics/success-generic-functions2/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions2/ir-code-macos-amd64.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Results: %d, %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z10sumNumbersIsEiPsl(ptr noundef %0, i64 noundef %1) #0 {
+define internal noundef i32 @_Z10sumNumbersIsEiPsl(ptr noundef %0, i64 noundef %1) #0 {
   %result = alloca i32, align 4
   %numberArray = alloca ptr, align 8
   %arrayLength = alloca i64, align 8
@@ -47,7 +47,7 @@ for.exit.L6:                                      ; preds = %for.head.L6
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z10sumNumbersIlEiPll(ptr noundef %0, i64 noundef %1) #0 {
+define internal noundef i32 @_Z10sumNumbersIlEiPll(ptr noundef %0, i64 noundef %1) #0 {
   %result = alloca i32, align 4
   %numberArray = alloca ptr, align 8
   %arrayLength = alloca i64, align 8
@@ -87,7 +87,7 @@ for.exit.L6:                                      ; preds = %for.head.L6
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z9printDataIPiEvlPi(i64 noundef %0, ptr noundef %1) #0 {
+define internal void @_Z9printDataIPiEvlPi(i64 noundef %0, ptr noundef %1) #0 {
   %arrayLength = alloca i64, align 8
   %list = alloca ptr, align 8
   %i = alloca i64, align 8

--- a/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions2/ir-code.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Results: %d, %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z10sumNumbersIsEiPsl(ptr noundef %0, i64 noundef %1) #0 {
+define internal noundef i32 @_Z10sumNumbersIsEiPsl(ptr noundef %0, i64 noundef %1) #0 {
   %result = alloca i32, align 4
   %numberArray = alloca ptr, align 8
   %arrayLength = alloca i64, align 8
@@ -47,7 +47,7 @@ for.exit.L6:                                      ; preds = %for.head.L6
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z10sumNumbersIlEiPll(ptr noundef %0, i64 noundef %1) #0 {
+define internal noundef i32 @_Z10sumNumbersIlEiPll(ptr noundef %0, i64 noundef %1) #0 {
   %result = alloca i32, align 4
   %numberArray = alloca ptr, align 8
   %arrayLength = alloca i64, align 8
@@ -87,7 +87,7 @@ for.exit.L6:                                      ; preds = %for.head.L6
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z9printDataIPiEvlPi(i64 noundef %0, ptr noundef %1) #0 {
+define internal void @_Z9printDataIPiEvlPi(i64 noundef %0, ptr noundef %1) #0 {
   %arrayLength = alloca i64, align 8
   %list = alloca ptr, align 8
   %i = alloca i64, align 8

--- a/test/test-files/irgenerator/generics/success-generic-functions3/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-functions3/ir-code.ll
@@ -6,7 +6,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [24 x i8] c"All assertions passed!\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z3fooIRiEvRi(ptr noundef %0) #0 {
+define internal void @_Z3fooIRiEvRi(ptr noundef %0) #0 {
   %t = alloca ptr, align 8
   store ptr %0, ptr %t, align 8
   %2 = load ptr, ptr %t, align 8
@@ -17,7 +17,7 @@ define private void @_Z3fooIRiEvRi(ptr noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z3barRi(ptr noundef %0) #0 {
+define internal void @_Z3barRi(ptr noundef %0) #0 {
   %t = alloca ptr, align 8
   store ptr %0, ptr %t, align 8
   %2 = load ptr, ptr %t, align 8

--- a/test/test-files/irgenerator/generics/success-generic-type-ctor-call1/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-type-ctor-call1/ir-code.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Nested4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal void @_ZN6Nested4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -16,7 +16,7 @@ define private void @_ZN6Nested4ctorEv(ptr noundef nonnull align 4 dereferenceab
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4TestI6NestedE8testFuncEv(ptr noundef nonnull align 1 %0) #0 {
+define internal void @_ZN4TestI6NestedE8testFuncEv(ptr noundef nonnull align 1 %0) #0 {
   %this = alloca ptr, align 8
   %t = alloca %struct.Nested, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/generics/success-generic-type-ctor-call2/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-generic-type-ctor-call2/ir-code.ll
@@ -20,7 +20,7 @@ source_filename = "source.spice"
 @_ZTV19ExampleTypeIteratorI20ExampleContainedTypeE = private unnamed_addr constant { [6 x ptr] } { [6 x ptr] [ptr null, ptr @_ZTI19ExampleTypeIteratorI20ExampleContainedTypeE, ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE3getEv, ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE6getIdxEv, ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE7isValidEv, ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE4nextEv] }, align 8
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN20ExampleContainedType4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal void @_ZN20ExampleContainedType4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -29,7 +29,7 @@ define private void @_ZN20ExampleContainedType4ctorEv(ptr noundef nonnull align 
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN20ExampleContainedType4ctorERK20ExampleContainedType(ptr noundef nonnull align 4 dereferenceable(4) %0, ptr noundef %1) #0 {
+define internal void @_ZN20ExampleContainedType4ctorERK20ExampleContainedType(ptr noundef nonnull align 4 dereferenceable(4) %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %other = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -66,7 +66,7 @@ define void @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE4ctorEv(ptr noundef
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE3getEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE3getEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca ptr, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -76,7 +76,7 @@ define private noundef ptr @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE3get
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Pair @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef %struct.Pair @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE6getIdxEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca %struct.Pair, align 8
   %this = alloca ptr, align 8
   %2 = alloca %struct.Pair, align 8
@@ -91,7 +91,7 @@ define private noundef %struct.Pair @_ZN19ExampleTypeIteratorI20ExampleContained
 declare void @_ZN4PairImR20ExampleContainedTypeE4ctorEmR20ExampleContainedType(ptr, i64, ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE7isValidEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef zeroext i1 @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE7isValidEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca i1, align 1
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -107,14 +107,14 @@ define private noundef zeroext i1 @_ZN19ExampleTypeIteratorI20ExampleContainedTy
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE4nextEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN19ExampleTypeIteratorI20ExampleContainedTypeE4nextEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.ExampleTypeIterator @_ZN19ExampleIterableType11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal noundef %struct.ExampleTypeIterator @_ZN19ExampleIterableType11getIteratorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %result = alloca %struct.ExampleTypeIterator, align 8
   %this = alloca ptr, align 8
   %2 = alloca %struct.ExampleTypeIterator, align 8

--- a/test/test-files/irgenerator/generics/success-heap-qualified-generic-mangling/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-heap-qualified-generic-mangling/ir-code.ll
@@ -4,14 +4,14 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [6 x i8] c"done\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4noopIPhEvRPh(ptr noundef %0) #0 {
+define internal void @_Z4noopIPhEvRPh(ptr noundef %0) #0 {
   %obj = alloca ptr, align 8
   store ptr %0, ptr %obj, align 8
   ret void
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4noopIPVhEvRPVh(ptr noundef %0) #0 {
+define internal void @_Z4noopIPVhEvRPVh(ptr noundef %0) #0 {
   %obj = alloca ptr, align 8
   store ptr %0, ptr %obj, align 8
   ret void

--- a/test/test-files/irgenerator/generics/success-type-hints/ir-code.ll
+++ b/test/test-files/irgenerator/generics/success-type-hints/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [4 x i8] c"%d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z4testIiEiv() #0 {
+define internal noundef i32 @_Z4testIiEiv() #0 {
   %result = alloca i32, align 4
   ret i32 0
 }

--- a/test/test-files/irgenerator/instrumentation/success-dbg-info-simple/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-dbg-info-simple/ir-code.ll
@@ -23,7 +23,7 @@ define void @_ZN10TestStruct4dtorEv(ptr noundef nonnull align 8 dereferenceable(
 declare void @_ZN6String4dtorEv(ptr noundef nonnull align 8 dereferenceable(24))
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.TestStruct @_Z3fctRi(ptr noundef %0) #1 !dbg !46 {
+define internal noundef %struct.TestStruct @_Z3fctRi(ptr noundef %0) #1 !dbg !46 {
   %result = alloca %struct.TestStruct, align 8
   %ref = alloca ptr, align 8
   %2 = alloca %struct.String, align 8

--- a/test/test-files/irgenerator/instrumentation/success-tsan-and-dbg-info/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-tsan-and-dbg-info/ir-code.ll
@@ -4,12 +4,12 @@ source_filename = "source.spice"
 %struct.Thread = type { %struct.Lambda, i64 }
 %struct.Lambda = type { { ptr, ptr, i64 }, ptr, i64 }
 
-@COUNTER = private global i32 0, !dbg !0
+@COUNTER = internal global i32 0, !dbg !0
 @llvm.used = appending global [1 x ptr] [ptr @tsan.module_ctor], section "llvm.metadata"
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @tsan.module_ctor, ptr null }]
 
 ; Function Attrs: noinline nounwind optnone sanitize_thread uwtable
-define private void @_Z6workerv() #0 !dbg !15 {
+define internal void @_Z6workerv() #0 !dbg !15 {
   %1 = call ptr @llvm.returnaddress.p0(i32 0), !dbg !20
   call void @__tsan_func_entry(ptr %1), !dbg !20
   %i = alloca i32, align 4

--- a/test/test-files/irgenerator/instrumentation/success-tsan/ir-code.ll
+++ b/test/test-files/irgenerator/instrumentation/success-tsan/ir-code.ll
@@ -4,12 +4,12 @@ source_filename = "source.spice"
 %struct.Thread = type { %struct.Lambda, i64 }
 %struct.Lambda = type { { ptr, ptr, i64 }, ptr, i64 }
 
-@COUNTER = private global i32 0
+@COUNTER = internal global i32 0
 @llvm.used = appending global [1 x ptr] [ptr @tsan.module_ctor], section "llvm.metadata"
 @llvm.global_ctors = appending global [1 x { i32, ptr, ptr }] [{ i32, ptr, ptr } { i32 0, ptr @tsan.module_ctor, ptr null }]
 
 ; Function Attrs: noinline nounwind optnone sanitize_thread uwtable
-define private void @_Z6workerv() #0 {
+define internal void @_Z6workerv() #0 {
   %1 = call ptr @llvm.returnaddress.p0(i32 0)
   call void @__tsan_func_entry(ptr %1)
   %i = alloca i32, align 4

--- a/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-basic-interface/ir-code.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Is driving: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -28,7 +28,7 @@ define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1) #0 {
+define internal void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1) #0 {
   %this = alloca ptr, align 8
   %_param = alloca i32, align 4
   store ptr %0, ptr %this, align 8
@@ -40,7 +40,7 @@ define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca i1, align 1
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2-macos-amd64.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2-macos-amd64.ll
@@ -9,14 +9,14 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Is driving: %d\00", align 4
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) uwtable
-define private void @_ZN3Car5driveEi(ptr nofree noundef nonnull writeonly align 8 captures(none) dereferenceable(16) initializes((8, 9)) %0, i32 %1) #0 {
+define internal void @_ZN3Car5driveEi(ptr nofree noundef nonnull writeonly align 8 captures(none) dereferenceable(16) initializes((8, 9)) %0, i32 %1) #0 {
   %driving.addr = getelementptr inbounds nuw i8, ptr %0, i64 8
   store i1 true, ptr %driving.addr, align 8
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read) uwtable
-define private noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr nofree noundef nonnull readonly align 8 captures(none) dereferenceable(16) %0) #1 {
+define internal noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr nofree noundef nonnull readonly align 8 captures(none) dereferenceable(16) %0) #1 {
   %driving.addr = getelementptr inbounds nuw i8, ptr %0, i64 8
   %2 = load i1, ptr %driving.addr, align 8
   ret i1 %2

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-O2.ll
@@ -15,14 +15,14 @@ $_ZTV3Car = comdat any
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Is driving: %d\00", align 4
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: write) uwtable
-define private void @_ZN3Car5driveEi(ptr nofree noundef nonnull writeonly align 8 captures(none) dereferenceable(16) initializes((8, 9)) %0, i32 %1) #0 {
+define internal void @_ZN3Car5driveEi(ptr nofree noundef nonnull writeonly align 8 captures(none) dereferenceable(16) initializes((8, 9)) %0, i32 %1) #0 {
   %driving.addr = getelementptr inbounds nuw i8, ptr %0, i64 8
   store i1 true, ptr %driving.addr, align 8
   ret void
 }
 
 ; Function Attrs: mustprogress nofree norecurse nosync nounwind willreturn memory(argmem: read) uwtable
-define private noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr nofree noundef nonnull readonly align 8 captures(none) dereferenceable(16) %0) #1 {
+define internal noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr nofree noundef nonnull readonly align 8 captures(none) dereferenceable(16) %0) #1 {
   %driving.addr = getelementptr inbounds nuw i8, ptr %0, i64 8
   %2 = load i1, ptr %driving.addr, align 8
   ret i1 %2

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code-macos-amd64.ll
@@ -12,7 +12,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Is driving: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -26,7 +26,7 @@ define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1) #0 {
+define internal void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1) #0 {
   %this = alloca ptr, align 8
   %_param = alloca i32, align 4
   store ptr %0, ptr %this, align 8
@@ -38,7 +38,7 @@ define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca i1, align 1
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-cross-sourcefile-interfaces/ir-code.ll
@@ -18,7 +18,7 @@ $_ZTV3Car = comdat any
 @printf.str.0 = private unnamed_addr constant [15 x i8] c"Is driving: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -32,7 +32,7 @@ define private void @_ZN3Car4ctorEv(ptr noundef nonnull align 8 dereferenceable(
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1) #0 {
+define internal void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1) #0 {
   %this = alloca ptr, align 8
   %_param = alloca i32, align 4
   store ptr %0, ptr %this, align 8
@@ -44,7 +44,7 @@ define private void @_ZN3Car5driveEi(ptr noundef nonnull align 8 dereferenceable
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef zeroext i1 @_ZN3Car9isDrivingEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca i1, align 1
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code-macos-amd64.ll
@@ -18,7 +18,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2, i32 noundef %3) #0 {
+define internal void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2, i32 noundef %3) #0 {
   %this = alloca ptr, align 8
   %firstName = alloca ptr, align 8
   %lastName = alloca ptr, align 8
@@ -51,7 +51,7 @@ define private void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 derefer
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_ZN6Person7compareERKlRKl(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2) #0 {
+define internal noundef i32 @_ZN6Person7compareERKlRKl(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2) #0 {
   %result = alloca i32, align 4
   %this = alloca ptr, align 8
   %a = alloca ptr, align 8

--- a/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-generic-interfaces/ir-code.ll
@@ -18,7 +18,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [3 x i8] c"%d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2, i32 noundef %3) #0 {
+define internal void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2, i32 noundef %3) #0 {
   %this = alloca ptr, align 8
   %firstName = alloca ptr, align 8
   %lastName = alloca ptr, align 8
@@ -51,7 +51,7 @@ define private void @_ZN6Person4ctorEPKcPKcj(ptr noundef nonnull align 8 derefer
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_ZN6Person7compareERKlRKl(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2) #0 {
+define internal noundef i32 @_ZN6Person7compareERKlRKl(ptr noundef nonnull align 8 dereferenceable(32) %0, ptr noundef %1, ptr noundef %2) #0 {
   %result = alloca i32, align 4
   %this = alloca ptr, align 8
   %a = alloca ptr, align 8

--- a/test/test-files/irgenerator/interfaces/success-interface-param-struct-match1/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-interface-param-struct-match1/ir-code.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [5 x i8] c"Test\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -23,7 +23,7 @@ define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4testEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal void @_ZN4Test4testEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
@@ -34,7 +34,7 @@ define private void @_ZN4Test4testEv(ptr noundef nonnull align 8 dereferenceable
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z7testFctR5ITest(ptr noundef %0) #0 {
+define internal void @_Z7testFctR5ITest(ptr noundef %0) #0 {
   %test = alloca ptr, align 8
   store ptr %0, ptr %test, align 8
   %2 = load ptr, ptr %test, align 8

--- a/test/test-files/irgenerator/interfaces/success-interface-param-struct-match2/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-interface-param-struct-match2/ir-code.ll
@@ -35,7 +35,7 @@ define void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 8 dereferenceable(8
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test3barEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #2 {
+define internal void @_ZN4Test3barEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #2 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
@@ -46,7 +46,7 @@ define private void @_ZN4Test3barEv(ptr noundef nonnull align 8 dereferenceable(
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #3
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z3fooR5ITest(ptr noundef %0) #2 {
+define internal void @_Z3fooR5ITest(ptr noundef %0) #2 {
   %test = alloca ptr, align 8
   store ptr %0, ptr %test, align 8
   %2 = load ptr, ptr %test, align 8

--- a/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
+++ b/test/test-files/irgenerator/interfaces/success-nested-call/ir-code.ll
@@ -15,7 +15,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [18 x i8] c"InnerTest.test()\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN9InnerTest4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN9InnerTest4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -29,7 +29,7 @@ define private void @_ZN9InnerTest4ctorEv(ptr noundef nonnull align 8 dereferenc
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN9InnerTest4testEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN9InnerTest4testEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)

--- a/test/test-files/irgenerator/lambdas/success-captures/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/lambdas/success-captures/ir-code-macos-amd64.ll
@@ -88,7 +88,7 @@ assert.exit.L15:                                  ; preds = %assert.exit.L14
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L4C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
+define internal void @_Z14lambda.L4C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
@@ -106,7 +106,7 @@ define private void @_Z14lambda.L4C20.0Ri(ptr noundef nonnull dereferenceable(8)
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i1 @_Z14lambda.L7C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
+define internal i1 @_Z14lambda.L7C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
   %result = alloca i1, align 1
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8

--- a/test/test-files/irgenerator/lambdas/success-captures/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-captures/ir-code.ll
@@ -88,7 +88,7 @@ assert.exit.L15:                                  ; preds = %assert.exit.L14
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L4C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
+define internal void @_Z14lambda.L4C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
@@ -106,7 +106,7 @@ define private void @_Z14lambda.L4C20.0Ri(ptr noundef nonnull dereferenceable(8)
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i1 @_Z14lambda.L7C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
+define internal i1 @_Z14lambda.L7C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #1 {
   %result = alloca i1, align 1
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8

--- a/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code-macos-amd64.ll
@@ -38,7 +38,7 @@ define dso_local noundef i32 @main() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L4C18.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
+define internal void @_Z14lambda.L4C18.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = load ptr, ptr %captures, align 8

--- a/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-different-capture-modes/ir-code.ll
@@ -38,7 +38,7 @@ define dso_local noundef i32 @main() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L4C18.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
+define internal void @_Z14lambda.L4C18.0v(ptr noundef nonnull dereferenceable(8) %0) #1 {
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = load ptr, ptr %captures, align 8

--- a/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code-macos-amd64.ll
@@ -6,7 +6,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4swapRiRi(ptr noundef %0, ptr noundef %1) #0 {
+define internal void @_Z4swapRiRi(ptr noundef %0, ptr noundef %1) #0 {
   %a = alloca ptr, align 8
   %b = alloca ptr, align 8
   %temp = alloca i32, align 4
@@ -26,7 +26,7 @@ define private void @_Z4swapRiRi(ptr noundef %0, ptr noundef %1) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4sortRA10_iPFbiiE(ptr noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
+define internal void @_Z4sortRA10_iPFbiiE(ptr noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
   %array = alloca ptr, align 8
   %sortFct = alloca { ptr, ptr, i64 }, align 8
   %i = alloca i32, align 4
@@ -125,7 +125,7 @@ define dso_local noundef i32 @main() #1 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i1 @_Z15lambda.L19C17.0ii(ptr %0, i32 %1, i32 %2) #0 {
+define internal i1 @_Z15lambda.L19C17.0ii(ptr %0, i32 %1, i32 %2) #0 {
   %captures = alloca ptr, align 8
   %a = alloca i32, align 4
   %b = alloca i32, align 4
@@ -139,7 +139,7 @@ define private i1 @_Z15lambda.L19C17.0ii(ptr %0, i32 %1, i32 %2) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z10printArrayRA10_i(ptr noundef %0) #0 {
+define internal void @_Z10printArrayRA10_i(ptr noundef %0) #0 {
   %array = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %0, ptr %array, align 8

--- a/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-expression-lambda/ir-code.ll
@@ -6,7 +6,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [2 x i8] c"\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4swapRiRi(ptr noundef %0, ptr noundef %1) #0 {
+define internal void @_Z4swapRiRi(ptr noundef %0, ptr noundef %1) #0 {
   %a = alloca ptr, align 8
   %b = alloca ptr, align 8
   %temp = alloca i32, align 4
@@ -26,7 +26,7 @@ define private void @_Z4swapRiRi(ptr noundef %0, ptr noundef %1) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4sortRA10_iPFbiiE(ptr noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
+define internal void @_Z4sortRA10_iPFbiiE(ptr noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
   %array = alloca ptr, align 8
   %sortFct = alloca { ptr, ptr, i64 }, align 8
   %i = alloca i32, align 4
@@ -125,7 +125,7 @@ define dso_local noundef i32 @main() #1 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i1 @_Z15lambda.L19C17.0ii(ptr %0, i32 %1, i32 %2) #0 {
+define internal i1 @_Z15lambda.L19C17.0ii(ptr %0, i32 %1, i32 %2) #0 {
   %captures = alloca ptr, align 8
   %a = alloca i32, align 4
   %b = alloca i32, align 4
@@ -139,7 +139,7 @@ define private i1 @_Z15lambda.L19C17.0ii(ptr %0, i32 %1, i32 %2) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z10printArrayRA10_i(ptr noundef %0) #0 {
+define internal void @_Z10printArrayRA10_i(ptr noundef %0) #0 {
   %array = alloca ptr, align 8
   %i = alloca i32, align 4
   store ptr %0, ptr %array, align 8

--- a/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code-macos-amd64.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [19 x i8] c"All tests passed!\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4testPFCvRiEPFCbRiE({ ptr, ptr, i64 } noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
+define internal void @_Z4testPFCvRiEPFCbRiE({ ptr, ptr, i64 } noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
   %l1 = alloca { ptr, ptr, i64 }, align 8
   %l2 = alloca { ptr, ptr, i64 }, align 8
   %x = alloca i32, align 4
@@ -106,7 +106,7 @@ define dso_local noundef i32 @main() #3 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z15lambda.L12C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
+define internal void @_Z15lambda.L12C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
@@ -124,7 +124,7 @@ define private void @_Z15lambda.L12C20.0Ri(ptr noundef nonnull dereferenceable(8
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i1 @_Z15lambda.L15C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
+define internal i1 @_Z15lambda.L15C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
   %result = alloca i1, align 1
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8

--- a/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-foreign-captures/ir-code.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [19 x i8] c"All tests passed!\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4testPFCvRiEPFCbRiE({ ptr, ptr, i64 } noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
+define internal void @_Z4testPFCvRiEPFCbRiE({ ptr, ptr, i64 } noundef %0, { ptr, ptr, i64 } noundef %1) #0 {
   %l1 = alloca { ptr, ptr, i64 }, align 8
   %l2 = alloca { ptr, ptr, i64 }, align 8
   %x = alloca i32, align 4
@@ -106,7 +106,7 @@ define dso_local noundef i32 @main() #3 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z15lambda.L12C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
+define internal void @_Z15lambda.L12C20.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
@@ -124,7 +124,7 @@ define private void @_Z15lambda.L12C20.0Ri(ptr noundef nonnull dereferenceable(8
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i1 @_Z15lambda.L15C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
+define internal i1 @_Z15lambda.L15C26.0Ri(ptr noundef nonnull dereferenceable(8) %0, ptr %1) #0 {
   %result = alloca i1, align 1
   %captures = alloca ptr, align 8
   %x = alloca ptr, align 8

--- a/test/test-files/irgenerator/lambdas/success-function-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-function-lambda/ir-code.ll
@@ -79,7 +79,7 @@ define dso_local noundef i32 @main() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private ptr @_Z14lambda.L2C39.0v(ptr %0) #1 {
+define internal ptr @_Z14lambda.L2C39.0v(ptr %0) #1 {
   %result = alloca ptr, align 8
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
@@ -90,7 +90,7 @@ define private ptr @_Z14lambda.L2C39.0v(ptr %0) #1 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #2
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i1 @_Z14lambda.L7C50.0R6Stringd(ptr %0, ptr %1, double %2) #1 {
+define internal i1 @_Z14lambda.L7C50.0R6Stringd(ptr %0, ptr %1, double %2) #1 {
   %result = alloca i1, align 1
   %captures = alloca ptr, align 8
   %str = alloca ptr, align 8
@@ -124,7 +124,7 @@ declare i1 @_Z10isRawEqualPKcPKc(ptr, ptr)
 declare void @_ZN6String4ctorEPKc(ptr, ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private i16 @_Z15lambda.L13C49.06Strings(ptr %0, %struct.String %1, i16 %2) #1 {
+define internal i16 @_Z15lambda.L13C49.06Strings(ptr %0, %struct.String %1, i16 %2) #1 {
   %result = alloca i16, align 2
   %captures = alloca ptr, align 8
   %str = alloca %struct.String, align 8

--- a/test/test-files/irgenerator/lambdas/success-multiple-visits/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-multiple-visits/ir-code.ll
@@ -5,7 +5,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [8 x i8] c"%d, %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4testv() #0 {
+define internal void @_Z4testv() #0 {
   %t = alloca i32, align 4
   %x = alloca i32, align 4
   %captures = alloca { i32, i32 }, align 8
@@ -33,7 +33,7 @@ define private void @_Z4testv() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L3C13.0v(ptr noundef nonnull dereferenceable(8) %0) #0 {
+define internal void @_Z14lambda.L3C13.0v(ptr noundef nonnull dereferenceable(8) %0) #0 {
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = load ptr, ptr %captures, align 8
@@ -48,7 +48,7 @@ define private void @_Z14lambda.L3C13.0v(ptr noundef nonnull dereferenceable(8) 
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4testi(i32 noundef %0) #0 {
+define internal void @_Z4testi(i32 noundef %0) #0 {
   %t = alloca i32, align 4
   %x = alloca i32, align 4
   %captures = alloca { i32, i32 }, align 8
@@ -76,7 +76,7 @@ define private void @_Z4testi(i32 noundef %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L3C13.1v(ptr noundef nonnull dereferenceable(8) %0) #0 {
+define internal void @_Z14lambda.L3C13.1v(ptr noundef nonnull dereferenceable(8) %0) #0 {
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = load ptr, ptr %captures, align 8

--- a/test/test-files/irgenerator/lambdas/success-procedure-lambda/ir-code.ll
+++ b/test/test-files/irgenerator/lambdas/success-procedure-lambda/ir-code.ll
@@ -67,7 +67,7 @@ define dso_local noundef i32 @main() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L2C31.0v(ptr %0) #1 {
+define internal void @_Z14lambda.L2C31.0v(ptr %0) #1 {
   %captures = alloca ptr, align 8
   store ptr %0, ptr %captures, align 8
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
@@ -78,7 +78,7 @@ define private void @_Z14lambda.L2C31.0v(ptr %0) #1 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #2
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z14lambda.L7C44.0R6Stringd(ptr %0, ptr %1, double %2) #1 {
+define internal void @_Z14lambda.L7C44.0R6Stringd(ptr %0, ptr %1, double %2) #1 {
   %captures = alloca ptr, align 8
   %str = alloca ptr, align 8
   %d = alloca double, align 8
@@ -95,7 +95,7 @@ define private void @_Z14lambda.L7C44.0R6Stringd(ptr %0, ptr %1, double %2) #1 {
 declare void @_ZN6String4ctorEPKc(ptr, ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z15lambda.L12C41.06Stringb(ptr %0, %struct.String %1, i1 %2) #1 {
+define internal void @_Z15lambda.L12C41.06Stringb(ptr %0, %struct.String %1, i1 %2) #1 {
   %captures = alloca ptr, align 8
   %str = alloca %struct.String, align 8
   %b = alloca i1, align 1

--- a/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-call-on-return-value/ir-code.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [17 x i8] c"Stamp glued: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Stamp5printEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN5Stamp5printEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -27,7 +27,7 @@ define private void @_ZN5Stamp5printEv(ptr noundef nonnull align 8 dereferenceab
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Stamp @_ZN6Letter8getStampEv(ptr noundef nonnull align 8 dereferenceable(24) %0) #0 {
+define internal noundef %struct.Stamp @_ZN6Letter8getStampEv(ptr noundef nonnull align 8 dereferenceable(24) %0) #0 {
   %result = alloca %struct.Stamp, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-method-down-up-call/ir-code.ll
@@ -17,7 +17,7 @@ define dso_local noundef i32 @main() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN10TestStructIcE9printTestEv(ptr noundef nonnull align 4 dereferenceable(8) %0) #1 {
+define internal void @_ZN10TestStructIcE9printTestEv(ptr noundef nonnull align 4 dereferenceable(8) %0) #1 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -27,7 +27,7 @@ define private void @_ZN10TestStructIcE9printTestEv(ptr noundef nonnull align 4 
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_ZN10TestStructIcE7getTestEv(ptr noundef nonnull align 4 dereferenceable(8) %0) #1 {
+define internal noundef i32 @_ZN10TestStructIcE7getTestEv(ptr noundef nonnull align 4 dereferenceable(8) %0) #1 {
   %result = alloca i32, align 4
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/methods/success-methods/ir-code.ll
+++ b/test/test-files/irgenerator/methods/success-methods/ir-code.ll
@@ -8,7 +8,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [13 x i8] c"Content: %s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_ZN6Letter10getContentEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal noundef ptr @_ZN6Letter10getContentEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %result = alloca ptr, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -19,7 +19,7 @@ define private noundef ptr @_ZN6Letter10getContentEv(ptr noundef nonnull align 8
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Letter10setContentEPKc(ptr noundef nonnull align 8 dereferenceable(8) %0, ptr noundef %1) #0 {
+define internal void @_ZN6Letter10setContentEPKc(ptr noundef nonnull align 8 dereferenceable(8) %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %text = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code-macos-amd64.ll
@@ -19,7 +19,7 @@ source_filename = "source.spice"
 @printf.str.12 = private unnamed_addr constant [20 x i8] c"Counter8 value: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %0, i64 noundef %1) #0 {
+define internal void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %0, i64 noundef %1) #0 {
   %this = alloca ptr, align 8
   %initialValue = alloca i64, align 8
   store ptr %0, ptr %this, align 8
@@ -34,7 +34,7 @@ define private void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferencea
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal noundef i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %result = alloca i64, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -45,7 +45,7 @@ define private noundef i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 d
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -63,7 +63,7 @@ define private noundef %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Count
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -81,7 +81,7 @@ define private noundef %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Coun
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -99,7 +99,7 @@ define private noundef %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -117,7 +117,7 @@ define private noundef %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -135,7 +135,7 @@ define private noundef %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -153,7 +153,7 @@ define private noundef %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z12op.plusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z12op.plusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -169,7 +169,7 @@ define private void @_Z12op.plusequalR7Counter7Counter(ptr noundef %0, %struct.C
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z13op.minusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z13op.minusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -185,7 +185,7 @@ define private void @_Z13op.minusequalR7Counter7Counter(ptr noundef %0, %struct.
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z11op.mulequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z11op.mulequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -201,7 +201,7 @@ define private void @_Z11op.mulequalR7Counter7Counter(ptr noundef %0, %struct.Co
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z11op.divequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z11op.divequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -217,7 +217,7 @@ define private void @_Z11op.divequalR7Counter7Counter(ptr noundef %0, %struct.Co
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z12op.subscriptR7Counterj(ptr noundef %0, i32 noundef %1) #0 {
+define internal noundef ptr @_Z12op.subscriptR7Counterj(ptr noundef %0, i32 noundef %1) #0 {
   %result = alloca ptr, align 8
   %c = alloca ptr, align 8
   %summand = alloca i32, align 4

--- a/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-binary/ir-code.ll
@@ -19,7 +19,7 @@ source_filename = "source.spice"
 @printf.str.12 = private unnamed_addr constant [20 x i8] c"Counter8 value: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %0, i64 noundef %1) #0 {
+define internal void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferenceable(8) %0, i64 noundef %1) #0 {
   %this = alloca ptr, align 8
   %initialValue = alloca i64, align 8
   store ptr %0, ptr %this, align 8
@@ -34,7 +34,7 @@ define private void @_ZN7Counter4ctorEl(ptr noundef nonnull align 8 dereferencea
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal noundef i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %result = alloca i64, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -45,7 +45,7 @@ define private noundef i64 @_ZN7Counter8getValueEv(ptr noundef nonnull align 8 d
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -63,7 +63,7 @@ define private noundef %struct.Counter @_Z7op.plus7Counter7Counter(%struct.Count
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -81,7 +81,7 @@ define private noundef %struct.Counter @_Z8op.minus7Counter7Counter(%struct.Coun
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -99,7 +99,7 @@ define private noundef %struct.Counter @_Z6op.mul7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -117,7 +117,7 @@ define private noundef %struct.Counter @_Z6op.div7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -135,7 +135,7 @@ define private noundef %struct.Counter @_Z6op.shl7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
+define internal noundef %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counter noundef %0, %struct.Counter noundef %1) #0 {
   %result = alloca %struct.Counter, align 8
   %c1 = alloca %struct.Counter, align 8
   %c2 = alloca %struct.Counter, align 8
@@ -153,7 +153,7 @@ define private noundef %struct.Counter @_Z6op.shr7Counter7Counter(%struct.Counte
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z12op.plusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z12op.plusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -169,7 +169,7 @@ define private void @_Z12op.plusequalR7Counter7Counter(ptr noundef %0, %struct.C
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z13op.minusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z13op.minusequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -185,7 +185,7 @@ define private void @_Z13op.minusequalR7Counter7Counter(ptr noundef %0, %struct.
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z11op.mulequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z11op.mulequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -201,7 +201,7 @@ define private void @_Z11op.mulequalR7Counter7Counter(ptr noundef %0, %struct.Co
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z11op.divequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
+define internal void @_Z11op.divequalR7Counter7Counter(ptr noundef %0, %struct.Counter noundef %1) #0 {
   %c1 = alloca ptr, align 8
   %c2 = alloca %struct.Counter, align 8
   store ptr %0, ptr %c1, align 8
@@ -217,7 +217,7 @@ define private void @_Z11op.divequalR7Counter7Counter(ptr noundef %0, %struct.Co
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z12op.subscriptR7Counterj(ptr noundef %0, i32 noundef %1) #0 {
+define internal noundef ptr @_Z12op.subscriptR7Counterj(ptr noundef %0, i32 noundef %1) #0 {
   %result = alloca ptr, align 8
   %c = alloca ptr, align 8
   %summand = alloca i32, align 4

--- a/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-operator-overloading-unary/ir-code.ll
@@ -10,7 +10,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z16op.plusplus.postR10TestStruct(ptr noundef %0) #0 {
+define internal noundef ptr @_Z16op.plusplus.postR10TestStruct(ptr noundef %0) #0 {
   %result = alloca ptr, align 8
   %ts = alloca ptr, align 8
   store ptr %0, ptr %ts, align 8
@@ -24,7 +24,7 @@ define private noundef ptr @_Z16op.plusplus.postR10TestStruct(ptr noundef %0) #0
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z18op.minusminus.postR10TestStruct(ptr noundef %0) #0 {
+define internal noundef ptr @_Z18op.minusminus.postR10TestStruct(ptr noundef %0) #0 {
   %result = alloca ptr, align 8
   %ts = alloca ptr, align 8
   store ptr %0, ptr %ts, align 8

--- a/test/test-files/irgenerator/operators/success-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/operators/success-short-circuiting/ir-code.ll
@@ -7,7 +7,7 @@ source_filename = "source.spice"
 @printf.str.3 = private unnamed_addr constant [29 x i8] c"Logical or evaluated to: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_Z12functionTruev() #0 {
+define internal noundef zeroext i1 @_Z12functionTruev() #0 {
   %result = alloca i1, align 1
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
   ret i1 true
@@ -17,7 +17,7 @@ define private noundef zeroext i1 @_Z12functionTruev() #0 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_Z13functionFalsev() #0 {
+define internal noundef zeroext i1 @_Z13functionFalsev() #0 {
   %result = alloca i1, align 1
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1)
   ret i1 false

--- a/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-nested-pointers/ir-code.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 @printf.str.4 = private unnamed_addr constant [7 x i8] c"1: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z8testProcPPPA4_i(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
+define internal void @_Z8testProcPPPA4_i(ptr noundef nonnull align 8 dereferenceable(8) %0) #0 {
   %nums = alloca ptr, align 8
   %nums1 = alloca ptr, align 8
   %nums2 = alloca [4 x i32], align 4

--- a/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
+++ b/test/test-files/irgenerator/pointers/success-pointer-functions/ir-code.ll
@@ -10,7 +10,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [24 x i8] c"Age after birthday: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z8birthdayP6Person(ptr noundef nonnull align 8 dereferenceable(24) %0) #0 {
+define internal void @_Z8birthdayP6Person(ptr noundef nonnull align 8 dereferenceable(24) %0) #0 {
   %person = alloca ptr, align 8
   store ptr %0, ptr %person, align 8
   %2 = load ptr, ptr %person, align 8

--- a/test/test-files/irgenerator/procedures/success-early-return/ir-code.ll
+++ b/test/test-files/irgenerator/procedures/success-early-return/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [16 x i8] c"Input was false\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z13executeActionb(i1 noundef zeroext %0) #0 {
+define internal void @_Z13executeActionb(i1 noundef zeroext %0) #0 {
   %input = alloca i1, align 1
   store i1 %0, ptr %input, align 1
   %2 = load i1, ptr %input, align 1

--- a/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
+++ b/test/test-files/irgenerator/references/success-ref-params/ir-code.ll
@@ -10,7 +10,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [23 x i8] c"All assertions passed!\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4procRiRK6Struct(ptr noundef %0, ptr noundef %1) #0 {
+define internal void @_Z4procRiRK6Struct(ptr noundef %0, ptr noundef %1) #0 {
   %intRef = alloca ptr, align 8
   %structRef = alloca ptr, align 8
   store ptr %0, ptr %intRef, align 8
@@ -31,7 +31,7 @@ define private void @_Z4procRiRK6Struct(ptr noundef %0, ptr noundef %1) #0 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z4funcRdRK6Struct(ptr noundef %0, ptr noundef %1) #0 {
+define internal noundef i32 @_Z4funcRdRK6Struct(ptr noundef %0, ptr noundef %1) #0 {
   %result = alloca i32, align 4
   %doubleRef = alloca ptr, align 8
   %structRef = alloca ptr, align 8

--- a/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-constructors/ir-code.ll
@@ -13,7 +13,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [13 x i8] c"Message: %s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Vector4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN6Vector4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   %msg = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -33,7 +33,7 @@ define private void @_ZN6Vector4ctorEv(ptr noundef nonnull align 8 dereferenceab
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Vector4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %0, ptr noundef %1) #0 {
+define internal void @_ZN6Vector4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(16) %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %msg = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -53,7 +53,7 @@ define private void @_ZN6Vector4ctorEPKc(ptr noundef nonnull align 8 dereference
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_ZN6Vector4testEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef ptr @_ZN6Vector4testEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca ptr, align 8
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-copy-ctor-nested/ir-code.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [8 x i8] c"x = %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 2 dereferenceable(2) %0) #0 {
+define internal void @_ZN5Inner4ctorEv(ptr noundef nonnull align 2 dereferenceable(2) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -18,7 +18,7 @@ define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 2 dereferenceabl
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 2 dereferenceable(2) %0, ptr noundef %1) #0 {
+define internal void @_ZN5Inner4ctorERK5Inner(ptr noundef nonnull align 2 dereferenceable(2) %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %other = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor-nested/ir-code.ll
@@ -54,7 +54,7 @@ define void @_ZN5Inner4ctorER5Inner(ptr noundef nonnull align 8 dereferenceable(
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #2 {
+define internal void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #2 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -69,7 +69,7 @@ define private void @_ZN5Inner4ctorEv(ptr noundef nonnull align 8 dereferenceabl
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN5Inner4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #2 {
+define internal void @_ZN5Inner4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #2 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
@@ -20,7 +20,7 @@ define void @_ZN20StructWithHeapFields4dtorEv(ptr noundef nonnull align 8 derefe
 declare void @_Z8sDeallocRPVh(ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #1 {
+define internal void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align 8 dereferenceable(8) %0) #1 {
   %this = alloca ptr, align 8
   %res = alloca %struct.Result, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-field-values4/ir-code.ll
@@ -8,7 +8,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [12 x i8] c"String: %s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN4Test4ctorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors1/ir-code.ll
@@ -11,7 +11,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [16 x i8] c"Fields: %d, %s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %this = alloca ptr, align 8
   %2 = alloca i1, align 1
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors2/ir-code.ll
@@ -31,7 +31,7 @@ define dso_local noundef i32 @main() #0 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #2 {
+define internal void @_ZN6Vector4dtorEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #2 {
   %this = alloca ptr, align 8
   %2 = alloca i1, align 1
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-destructors3/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-destructors3/ir-code.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 @anon.string.1 = private unnamed_addr constant [5 x i8] c"test\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4testv() #0 {
+define internal void @_Z4testv() #0 {
   %1 = alloca %struct.String, align 8
   %t = alloca ptr, align 8
   call void @_ZN6String4ctorEPKc(ptr noundef nonnull align 8 dereferenceable(24) %1, ptr noundef @anon.string.0)
@@ -29,7 +29,7 @@ declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unna
 declare void @_ZN6String4dtorEv(ptr noundef nonnull align 8 dereferenceable(24))
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4testRK6String(ptr noundef %0) #0 {
+define internal void @_Z4testRK6String(ptr noundef %0) #0 {
   %t = alloca ptr, align 8
   store ptr %0, ptr %t, align 8
   %2 = load ptr, ptr %t, align 8

--- a/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-explicit-composed-base-cast/ir-code.ll
@@ -21,7 +21,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [20 x i8] c"derived->iface: %d\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Base4initEi(ptr noundef nonnull align 4 dereferenceable(4) %0, i32 noundef %1) #0 {
+define internal void @_ZN4Base4initEi(ptr noundef nonnull align 4 dereferenceable(4) %0, i32 noundef %1) #0 {
   %this = alloca ptr, align 8
   %v = alloca i32, align 4
   store ptr %0, ptr %this, align 8
@@ -34,7 +34,7 @@ define private void @_ZN4Base4initEi(ptr noundef nonnull align 4 dereferenceable
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_ZN4Base3getEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal noundef i32 @_ZN4Base3getEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %result = alloca i32, align 4
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -74,7 +74,7 @@ define void @_ZN7Derived4ctorERK7Derived(ptr noundef nonnull align 8 dereference
 declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #2
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN7Derived4initEii(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1, i32 noundef %2) #0 {
+define internal void @_ZN7Derived4initEii(ptr noundef nonnull align 8 dereferenceable(16) %0, i32 noundef %1, i32 noundef %2) #0 {
   %this = alloca ptr, align 8
   %b = alloca i32, align 4
   %d = alloca i32, align 4
@@ -93,7 +93,7 @@ define private void @_ZN7Derived4initEii(ptr noundef nonnull align 8 dereference
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_ZN7Derived6markerEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
+define internal noundef i32 @_ZN7Derived6markerEv(ptr noundef nonnull align 8 dereferenceable(16) %0) #0 {
   %result = alloca i32, align 4
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -117,7 +117,7 @@ define void @_ZN4Leaf4ctorEv(ptr noundef nonnull align 8 dereferenceable(32) %0)
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Leaf4initEiii(ptr noundef nonnull align 8 dereferenceable(32) %0, i32 noundef %1, i32 noundef %2, i32 noundef %3) #0 {
+define internal void @_ZN4Leaf4initEiii(ptr noundef nonnull align 8 dereferenceable(32) %0, i32 noundef %1, i32 noundef %2, i32 noundef %3) #0 {
   %this = alloca ptr, align 8
   %b = alloca i32, align 4
   %d = alloca i32, align 4
@@ -139,7 +139,7 @@ define private void @_ZN4Leaf4initEiii(ptr noundef nonnull align 8 dereferenceab
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_ZN4Leaf6markerEv(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 {
+define internal noundef i32 @_ZN4Leaf6markerEv(ptr noundef nonnull align 8 dereferenceable(32) %0) #0 {
   %result = alloca i32, align 4
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8

--- a/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-struct-in-place/ir-code.ll
@@ -25,7 +25,7 @@ source_filename = "source.spice"
 @printf.str.1 = private unnamed_addr constant [30 x i8] c"Another cart item 2 unit: %s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.ShoppingCart @_Z15newShoppingCartv() #0 {
+define internal noundef %struct.ShoppingCart @_Z15newShoppingCartv() #0 {
   %result = alloca %struct.ShoppingCart, align 8
   %items = alloca [3 x %struct.ShoppingItem], align 8
   %1 = alloca %struct.ShoppingCart, align 8
@@ -45,7 +45,7 @@ define private noundef %struct.ShoppingCart @_Z15newShoppingCartv() #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.ShoppingCart @_Z19anotherShoppingCartv() #0 {
+define internal noundef %struct.ShoppingCart @_Z19anotherShoppingCartv() #0 {
   %result = alloca %struct.ShoppingCart, align 8
   %items = alloca [3 x %struct.ShoppingItem], align 8
   %1 = alloca %struct.ShoppingCart, align 8

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-enums/ir-code.ll
@@ -9,7 +9,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [4 x i8] c"%s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z7getNamei(i32 noundef %0) #0 {
+define internal noundef ptr @_Z7getNamei(i32 noundef %0) #0 {
   %result = alloca ptr, align 8
   %input = alloca i32, align 4
   store i32 %0, ptr %input, align 4

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt-with-fallthrough/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt-with-fallthrough/ir-code.ll
@@ -8,7 +8,7 @@ source_filename = "source.spice"
 @printf.str.4 = private unnamed_addr constant [22 x i8] c"Input is at least 1.\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z12isBiggerThani(i32 noundef %0) #0 {
+define internal void @_Z12isBiggerThani(i32 noundef %0) #0 {
   %input = alloca i32, align 4
   store i32 %0, ptr %input, align 4
   %2 = load i32, ptr %input, align 4

--- a/test/test-files/irgenerator/switch-stmts/success-switch-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/switch-stmts/success-switch-stmt/ir-code.ll
@@ -25,7 +25,7 @@ source_filename = "source.spice"
 @printf.str.10 = private unnamed_addr constant [10 x i8] c"10 is %s\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z13digitToStringj(i32 noundef %0) #0 {
+define internal noundef ptr @_Z13digitToStringj(i32 noundef %0) #0 {
   %result = alloca ptr, align 8
   %number = alloca i32, align 4
   store i32 %0, ptr %number, align 4

--- a/test/test-files/irgenerator/ternary/success-shortened-ternary/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-shortened-ternary/ir-code.ll
@@ -6,7 +6,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_Z2f1v() #0 {
+define internal noundef zeroext i1 @_Z2f1v() #0 {
   %result = alloca i1, align 1
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
   ret i1 false
@@ -16,7 +16,7 @@ define private noundef zeroext i1 @_Z2f1v() #0 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_Z2f2v() #0 {
+define internal noundef zeroext i1 @_Z2f2v() #0 {
   %result = alloca i1, align 1
   %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1)
   ret i1 true

--- a/test/test-files/irgenerator/ternary/success-ternary-cond-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-cond-short-circuiting/ir-code.ll
@@ -4,13 +4,13 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_Z10condition1v() #0 {
+define internal noundef zeroext i1 @_Z10condition1v() #0 {
   %result = alloca i1, align 1
   ret i1 false
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_Z10condition2v() #0 {
+define internal noundef zeroext i1 @_Z10condition2v() #0 {
   %result = alloca i1, align 1
   ret i1 true
 }

--- a/test/test-files/irgenerator/ternary/success-ternary-ref-non-ref/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-ref-non-ref/ir-code.ll
@@ -8,7 +8,7 @@ source_filename = "source.spice"
 @printf.str.2 = private unnamed_addr constant [7 x i8] c"Dtor!\0A\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 1 %0) #0 {
+define internal void @_ZN4Test4ctorEv(ptr noundef nonnull align 1 %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
@@ -19,7 +19,7 @@ define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 1 %0) #0 {
 declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 1 %0, ptr noundef %1) #0 {
+define internal void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 1 %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %_ = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -29,7 +29,7 @@ define private void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 1 %0, ptr n
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4dtorEv(ptr noundef nonnull align 1 %0) #0 {
+define internal void @_ZN4Test4dtorEv(ptr noundef nonnull align 1 %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2)
@@ -37,7 +37,7 @@ define private void @_ZN4Test4dtorEv(ptr noundef nonnull align 1 %0) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef %struct.Test @_Z3fooRK4Test(ptr noundef %0) #0 {
+define internal noundef %struct.Test @_Z3fooRK4Test(ptr noundef %0) #0 {
   %result = alloca %struct.Test, align 8
   %t = alloca ptr, align 8
   %copy = alloca %struct.Test, align 8

--- a/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
@@ -6,13 +6,13 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %s\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef zeroext i1 @_Z7condFctv() #0 {
+define internal noundef zeroext i1 @_Z7condFctv() #0 {
   %result = alloca i1, align 1
   ret i1 false
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z7trueFctv() #0 {
+define internal noundef ptr @_Z7trueFctv() #0 {
   %result = alloca ptr, align 8
   br i1 false, label %assert.exit.L6, label %assert.then.L6, !prof !5
 
@@ -33,7 +33,7 @@ declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unna
 declare void @exit(i32) #2
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef ptr @_Z8falseFctv() #0 {
+define internal noundef ptr @_Z8falseFctv() #0 {
   %result = alloca ptr, align 8
   ret ptr @anon.string.1
 }

--- a/test/test-files/irgenerator/ternary/success-ternary-stmt/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-stmt/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 @printf.str.0 = private unnamed_addr constant [11 x i8] c"Result: %d\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3getv() #0 {
+define internal noundef i32 @_Z3getv() #0 {
   %result = alloca i32, align 4
   ret i32 12
 }

--- a/test/test-files/irgenerator/testing/error-testing-failing-test2/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/testing/error-testing-failing-test2/ir-code-macos-amd64.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @testName0 = private unnamed_addr constant [8 x i8] c"testAdd\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4

--- a/test/test-files/irgenerator/testing/error-testing-failing-test2/ir-code.ll
+++ b/test/test-files/irgenerator/testing/error-testing-failing-test2/ir-code.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @testName0 = private unnamed_addr constant [8 x i8] c"testAdd\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4

--- a/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code-macos-amd64.ll
@@ -23,7 +23,7 @@ source_filename = "source.spice"
 @testName3 = private unnamed_addr constant [9 x i8] c"testAdd2\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4

--- a/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code.ll
+++ b/test/test-files/irgenerator/testing/success-testing-multi-file/ir-code.ll
@@ -23,7 +23,7 @@ source_filename = "source.spice"
 @testName3 = private unnamed_addr constant [9 x i8] c"testAdd2\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4

--- a/test/test-files/irgenerator/testing/success-testing/ir-code-macos-amd64.ll
+++ b/test/test-files/irgenerator/testing/success-testing/ir-code-macos-amd64.ll
@@ -28,7 +28,7 @@ source_filename = "source.spice"
 @testName3 = private unnamed_addr constant [9 x i8] c"testSub2\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4
@@ -41,7 +41,7 @@ define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3subii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3subii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4

--- a/test/test-files/irgenerator/testing/success-testing/ir-code.ll
+++ b/test/test-files/irgenerator/testing/success-testing/ir-code.ll
@@ -28,7 +28,7 @@ source_filename = "source.spice"
 @testName3 = private unnamed_addr constant [9 x i8] c"testSub2\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4
@@ -41,7 +41,7 @@ define private noundef i32 @_Z3addii(i32 noundef %0, i32 noundef %1) #0 {
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private noundef i32 @_Z3subii(i32 noundef %0, i32 noundef %1) #0 {
+define internal noundef i32 @_Z3subii(i32 noundef %0, i32 noundef %1) #0 {
   %result = alloca i32, align 4
   %a = alloca i32, align 4
   %b = alloca i32, align 4

--- a/test/test-files/irgenerator/variables/success-global-variables/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-global-variables/ir-code.ll
@@ -1,11 +1,11 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
 
-@TEST1 = private global i32 10
-@TEST2 = private global ptr @anon.string.0
+@TEST1 = internal global i32 10
+@TEST2 = internal global ptr @anon.string.0
 @anon.string.0 = private unnamed_addr constant [12 x i8] c"test string\00", align 4
-@TEST3 = private global double 5.830000e+00
-@TEST4 = private global i1 false
+@TEST3 = internal global double 5.830000e+00
+@TEST4 = internal global i1 false
 @anon.string.1 = private unnamed_addr constant [5 x i8] c"test\00", align 4
 @printf.str.0 = private unnamed_addr constant [32 x i8] c"Variable values: %d, %s, %f, %u\00", align 4
 

--- a/test/test-files/irgenerator/variables/success-self-assign/ir-code.ll
+++ b/test/test-files/irgenerator/variables/success-self-assign/ir-code.ll
@@ -4,7 +4,7 @@ source_filename = "source.spice"
 %struct.Test = type { i32 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal void @_ZN4Test4ctorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8
@@ -16,7 +16,7 @@ define private void @_ZN4Test4ctorEv(ptr noundef nonnull align 4 dereferenceable
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferenceable(4) %0, ptr noundef %1) #0 {
+define internal void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferenceable(4) %0, ptr noundef %1) #0 {
   %this = alloca ptr, align 8
   %other = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
@@ -33,7 +33,7 @@ define private void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 4 dereferen
 }
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_ZN4Test4dtorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
+define internal void @_ZN4Test4dtorEv(ptr noundef nonnull align 4 dereferenceable(4) %0) #0 {
   %this = alloca ptr, align 8
   store ptr %0, ptr %this, align 8
   %2 = load ptr, ptr %this, align 8

--- a/test/test-files/std/bindings/gtk4-with-builder/ir-code.ll
+++ b/test/test-files/std/bindings/gtk4-with-builder/ir-code.ll
@@ -21,7 +21,7 @@ source_filename = "source.spice"
 @anon.string.7 = private unnamed_addr constant [22 x i8] c"com.spicelang.Example\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z8btnClick9GtkWidget(%struct.GtkWidget noundef %0) #0 {
+define internal void @_Z8btnClick9GtkWidget(%struct.GtkWidget noundef %0) #0 {
   %widget = alloca %struct.GtkWidget, align 8
   store %struct.GtkWidget %0, ptr %widget, align 8
   call void @_Z6gPrintPKc(ptr noundef @anon.string.0)
@@ -31,7 +31,7 @@ define private void @_Z8btnClick9GtkWidget(%struct.GtkWidget noundef %0) #0 {
 declare void @_Z6gPrintPKc(ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z4quit9GtkWidget9GtkWindow(%struct.GtkWidget noundef %0, %struct.GtkWindow noundef %1) #0 {
+define internal void @_Z4quit9GtkWidget9GtkWindow(%struct.GtkWidget noundef %0, %struct.GtkWindow noundef %1) #0 {
   %widget = alloca %struct.GtkWidget, align 8
   %window = alloca %struct.GtkWindow, align 8
   store %struct.GtkWidget %0, ptr %widget, align 8
@@ -43,7 +43,7 @@ define private void @_Z4quit9GtkWidget9GtkWindow(%struct.GtkWidget noundef %0, %
 declare void @_ZN9GtkWindow7destroyEv(ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z8activate14GtkApplicationPh(%struct.GtkApplication noundef %0, ptr noundef nonnull align 1 dereferenceable(1) %1) #0 {
+define internal void @_Z8activate14GtkApplicationPh(%struct.GtkApplication noundef %0, ptr noundef nonnull align 1 dereferenceable(1) %1) #0 {
   %app = alloca %struct.GtkApplication, align 8
   %data = alloca ptr, align 8
   %spiceStdDir = alloca %struct.Result, align 8

--- a/test/test-files/std/bindings/gtk4-without-builder/ir-code.ll
+++ b/test/test-files/std/bindings/gtk4-without-builder/ir-code.ll
@@ -14,7 +14,7 @@ source_filename = "source.spice"
 @anon.string.4 = private unnamed_addr constant [22 x i8] c"com.spicelang.Example\00", align 4
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z11btnYesClick9GtkWidget(%struct.GtkWidget noundef %0) #0 {
+define internal void @_Z11btnYesClick9GtkWidget(%struct.GtkWidget noundef %0) #0 {
   %widget = alloca %struct.GtkWidget, align 8
   store %struct.GtkWidget %0, ptr %widget, align 8
   call void @_Z6gPrintPKc(ptr noundef @anon.string.0)
@@ -24,7 +24,7 @@ define private void @_Z11btnYesClick9GtkWidget(%struct.GtkWidget noundef %0) #0 
 declare void @_Z6gPrintPKc(ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z13destroyWindow9GtkWidget9GtkWindow(%struct.GtkWidget noundef %0, %struct.GtkWindow noundef %1) #0 {
+define internal void @_Z13destroyWindow9GtkWidget9GtkWindow(%struct.GtkWidget noundef %0, %struct.GtkWindow noundef %1) #0 {
   %widget = alloca %struct.GtkWidget, align 8
   %window = alloca %struct.GtkWindow, align 8
   store %struct.GtkWidget %0, ptr %widget, align 8
@@ -36,7 +36,7 @@ define private void @_Z13destroyWindow9GtkWidget9GtkWindow(%struct.GtkWidget nou
 declare void @_ZN9GtkWindow7destroyEv(ptr)
 
 ; Function Attrs: noinline nounwind optnone uwtable
-define private void @_Z8activate14GtkApplicationPh(%struct.GtkApplication noundef %0, ptr noundef nonnull align 1 dereferenceable(1) %1) #0 {
+define internal void @_Z8activate14GtkApplicationPh(%struct.GtkApplication noundef %0, ptr noundef nonnull align 1 dereferenceable(1) %1) #0 {
   %app = alloca %struct.GtkApplication, align 8
   %data = alloca ptr, align 8
   %window = alloca %struct.GtkWindow, align 8


### PR DESCRIPTION
Use internal instead of private linkage for non-public functions/methods/lambdas.
This way, also profilers and valgrind can find symbol names and show them in their backtraces.
This alignes Spices behaviour with C++, which, if the function lives in anonymous namespace, also uses internal over private  linkage.