### PR TITLE
Replace functionBodyScopes stack with Scope::getFunctionScope()

### DIFF
--- a/src/irgenerator/GenControlStructures.cpp
+++ b/src/irgenerator/GenControlStructures.cpp
@@ -29,8 +29,8 @@ std::any IRGenerator::visitForLoop(const ForLoopNode *node) {
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::FOR_BODY, node);
 
   // Save the break/continue targets, paired with the scope to clean up to when jumping there
-  breakTargets.emplace_back(node->body, bExit);
-  continueTargets.emplace_back(node->body, bTail);
+  breakTargets.emplace_back(currentScope, bExit);
+  continueTargets.emplace_back(currentScope, bTail);
 
   // Init statement
   visit(node->initDecl);
@@ -82,8 +82,8 @@ std::any IRGenerator::visitForeachLoop(const ForeachLoopNode *node) {
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::FOREACH_BODY, node);
 
   // Save the break/continue targets, paired with the scope to clean up to when jumping there
-  breakTargets.emplace_back(node->body, bExit);
-  continueTargets.emplace_back(node->body, bTail);
+  breakTargets.emplace_back(currentScope, bExit);
+  continueTargets.emplace_back(currentScope, bTail);
 
   // Resolve iterator
   ExprNode *iteratorAssignNode = node->iteratorAssign;
@@ -229,8 +229,8 @@ std::any IRGenerator::visitWhileLoop(const WhileLoopNode *node) {
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::WHILE_BODY, node);
 
   // Save the break/continue targets, paired with the scope to clean up to when jumping there
-  breakTargets.emplace_back(node->body, bExit);
-  continueTargets.emplace_back(node->body, bHead);
+  breakTargets.emplace_back(currentScope, bExit);
+  continueTargets.emplace_back(currentScope, bHead);
 
   // Jump to head block
   insertJump(bHead);
@@ -272,8 +272,8 @@ std::any IRGenerator::visitDoWhileLoop(const DoWhileLoopNode *node) {
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::WHILE_BODY, node);
 
   // Save the break/continue targets, paired with the scope to clean up to when jumping there
-  breakTargets.emplace_back(node->body, bExit);
-  continueTargets.emplace_back(node->body, bFoot);
+  breakTargets.emplace_back(currentScope, bExit);
+  continueTargets.emplace_back(currentScope, bFoot);
 
   // Jump to body block
   insertJump(bBody);
@@ -449,7 +449,7 @@ std::any IRGenerator::visitCaseBranch(const CaseBranchNode *node) {
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::CASE_BODY);
 
   // A 'break' within this branch targets the enclosing switch; point it at this branch's own scope
-  breakTargets.back().scope = node->body;
+  breakTargets.back().scope = currentScope;
 
   // Visit case body
   visit(node->body);
@@ -462,7 +462,7 @@ std::any IRGenerator::visitDefaultBranch(const DefaultBranchNode *node) {
   ScopeHandle scopeHandle(this, node->getScopeId(), ScopeType::DEFAULT_BODY);
 
   // A 'break' within this branch targets the enclosing switch; point it at this branch's own scope
-  breakTargets.back().scope = node->body;
+  breakTargets.back().scope = currentScope;
 
   // Visit case body
   visit(node->body);

--- a/src/irgenerator/GenImplicit.cpp
+++ b/src/irgenerator/GenImplicit.cpp
@@ -139,21 +139,23 @@ void IRGenerator::generateScopeCleanup(const StmtLstNode *node) {
 
 /**
  * Generate cleanup code (dtor calls, deallocations) for every scope between the given node (exclusive) and the given
- * target scope (inclusive). This is required for jumps that leave more than one scope at once (e.g. break/continue),
+ * target scope (inclusive). This is required for jumps that leave more than one scope at once (e.g. break/continue/return),
  * since those skip the normal fall-through cleanup that visitStmtLst() generates for each of the enclosing scopes.
  *
  * @param node Node the jump originates from
  * @param targetScope Outermost scope that is left by the jump; cleanup is generated for this scope as well
  */
-void IRGenerator::generateScopeCleanupUpTo(const ASTNode *node, const StmtLstNode *targetScope) {
+void IRGenerator::generateScopeCleanupUpTo(const ASTNode *node, const Scope *targetScope) {
   assert(targetScope != nullptr);
   const StmtLstNode *scope = node->getNextOuterStmtLst();
+  const Scope *scopeLevel = currentScope;
   while (true) {
     generateScopeCleanup(scope);
-    if (scope == targetScope)
+    if (scopeLevel == targetScope)
       break;
-    assert(scope->parent != nullptr);
+    assert(scope->parent != nullptr && scopeLevel->parent != nullptr);
     scope = scope->parent->getNextOuterStmtLst();
+    scopeLevel = scopeLevel->parent;
   }
 }
 

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -134,7 +134,7 @@ std::any IRGenerator::visitReturnStmt(const ReturnStmtNode *node) {
   }
 
   // Clean up all scopes between here and the enclosing function/procedure/lambda body, then terminate the block
-  generateScopeCleanupUpTo(node, functionBodyScopes.back());
+  generateScopeCleanupUpTo(node, currentScope->getFunctionScope());
   blockAlreadyTerminated = true;
 
   // Create return instruction

--- a/src/irgenerator/GenTopLevelDefinitions.cpp
+++ b/src/irgenerator/GenTopLevelDefinitions.cpp
@@ -112,9 +112,7 @@ std::any IRGenerator::visitMainFctDef(const MainFctDefNode *node) {
   }
 
   // Visit function body
-  functionBodyScopes.push_back(node->body);
   visit(node->body);
-  functionBodyScopes.pop_back();
 
   // Create return statement if the block is not terminated yet
   if (!blockAlreadyTerminated) {
@@ -264,9 +262,7 @@ std::any IRGenerator::visitFctDef(const FctDefNode *node) {
     }
 
     // Visit function body
-    functionBodyScopes.push_back(node->body);
     visit(node->body);
-    functionBodyScopes.pop_back();
 
     // Create return statement if the block is not terminated yet
     if (!blockAlreadyTerminated) {
@@ -417,9 +413,7 @@ std::any IRGenerator::visitProcDef(const ProcDefNode *node) {
     }
 
     // Visit procedure body
-    functionBodyScopes.push_back(node->body);
     visit(node->body);
-    functionBodyScopes.pop_back();
 
     if (node->isCtor)
       isInCtorBody = false;

--- a/src/irgenerator/GenValues.cpp
+++ b/src/irgenerator/GenValues.cpp
@@ -634,9 +634,7 @@ std::any IRGenerator::visitLambdaFunc(const LambdaFuncNode *node) {
   }
 
   // Visit body
-  functionBodyScopes.push_back(node->body);
   visit(node->body);
-  functionBodyScopes.pop_back();
 
   // Create return statement if the block is not terminated yet
   if (!blockAlreadyTerminated) {
@@ -784,9 +782,7 @@ std::any IRGenerator::visitLambdaProc(const LambdaProcNode *node) {
   }
 
   // Visit body
-  functionBodyScopes.push_back(node->body);
   visit(node->body);
-  functionBodyScopes.pop_back();
 
   // Create return statement if the block is not terminated yet
   if (!blockAlreadyTerminated)

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -40,7 +40,7 @@ struct CommonLLVMTypes {
 // A break/continue target: the scope to run cleanup (dtor calls) up to (inclusive) before jumping, since the
 // jump skips the normal fall-through cleanup of enclosing scopes, paired with the block to jump to.
 struct BreakContinueTarget {
-  const StmtLstNode *scope;
+  Scope *scope;
   llvm::BasicBlock *block;
 };
 
@@ -211,7 +211,7 @@ private:
   llvm::Value *doImplicitCast(llvm::Value *src, QualType dstSTy, QualType srcSTy);
   llvm::Value *getUpcastedStructPtr(llvm::Value *structPtr, const QualType &dstType, const QualType &srcType) const;
   void generateScopeCleanup(const StmtLstNode *node);
-  void generateScopeCleanupUpTo(const ASTNode *node, const StmtLstNode *targetScope);
+  void generateScopeCleanupUpTo(const ASTNode *node, const Scope *targetScope);
   void generateFctDecl(const Function *fct, const std::vector<llvm::Value *> &args) const;
   llvm::CallInst *generateFctCall(const Function *fct, const std::vector<llvm::Value *> &args) const;
   llvm::Value *generateFctDeclAndCall(const Function *fct, const std::vector<llvm::Value *> &args) const;
@@ -256,9 +256,6 @@ private:
   CommonLLVMTypes llvmTypes;
   std::vector<BreakContinueTarget> breakTargets;
   std::vector<BreakContinueTarget> continueTargets;
-  // Stack of the enclosing function/procedure/lambda's own body scope, i.e. the scope a 'return' has to clean
-  // up to (inclusive), since it may be nested arbitrarily deep in blocks within that body.
-  std::vector<const StmtLstNode *> functionBodyScopes;
   std::stack<llvm::BasicBlock *> fallthroughBlocks;
   llvm::BasicBlock *allocaInsertBlock = nullptr;
   llvm::AllocaInst *allocaInsertInst = nullptr;

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -330,6 +330,18 @@ unsigned int Scope::getLoopNestingDepth() const { // NOLINT(misc-no-recursion)
 }
 
 /**
+ * Get the nearest enclosing function/procedure/lambda body scope, including this scope itself
+ *
+ * @return Nearest enclosing function/procedure/lambda body scope
+ */
+Scope *Scope::getFunctionScope() { // NOLINT(misc-no-recursion)
+  if (type == ScopeType::FUNC_PROC_BODY || type == ScopeType::LAMBDA_BODY)
+    return this;
+  assert(!isRootScope());
+  return parent->getFunctionScope();
+}
+
+/**
  * Check if this scope is one of the child scopes of a switch statement
  *
  * @return Child scope of switch statement or not

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -97,6 +97,7 @@ public:
   [[nodiscard]] std::vector<const Function *> getVirtualMethods();
   [[nodiscard]] std::vector<const Struct *> getAllStructManifestationsInDeclarationOrder() const;
   [[nodiscard]] unsigned int getLoopNestingDepth() const;
+  [[nodiscard]] Scope *getFunctionScope();
   [[nodiscard]] bool isInCaseBranch() const;
   [[nodiscard]] bool isInAsyncScope() const;
   [[nodiscard]] bool doesAllowUnsafeOperations() const;


### PR DESCRIPTION
## What changed
- Added `Scope::getFunctionScope()`, which walks up from any scope to the nearest enclosing `FUNC_PROC_BODY`/`LAMBDA_BODY` scope.
- `return` now derives its cleanup target on demand via `currentScope->getFunctionScope()` instead of the manually pushed/popped `functionBodyScopes` stack (removed, along with its push/pop calls around every function/procedure/lambda body visit).
- `generateScopeCleanupUpTo()` and the `break`/`continue` targets (`BreakContinueTarget`) now key off `Scope*` identity instead of `StmtLstNode*` identity, walking a parallel `Scope` chain seeded from the live `currentScope`.

## Why
`functionBodyScopes` (added in #1302) required careful manual bookkeeping at every function/procedure/lambda entry/exit point just to answer "what's the nearest enclosing function scope" for a `return`. Since `Scope` already models this nesting, that question can be answered directly from the scope tree instead of a side-tracked stack — removing a class of bugs where the stack and the actual visitor recursion could drift out of sync.

The break/continue targets were switched to `Scope*` for the same reason (to share one target representation with `return`), keyed off the live `currentScope` at push time rather than the AST node's static `bodyScope` field — the latter goes stale across generic-function manifestations, since their scope subtrees get deep-copied per instantiation.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest` — clean build
- `cmake-build-debug/test/spicetest` — 625 passed, 2 skipped, 11 failed (all pre-existing local-environment `LLVM_LIB_DIR` linker-path failures in `BootstrapCompilerTests`/`StdTests.bindings_llvm`, unrelated to this change and reproducible on `main`)
- `cmake-build-debug/test/spicetest --gtest_filter='IRGeneratorTests.scopeCleanup_returnLeak:IRGeneratorTests.scopeCleanup_breakContinueLeak'` — pass (both run under `--sanitizer=address`)

## Follow-up / known limitations
None.