### PR TITLE
Fix leaked/skipped dtor for ternary temporary vs. reference operand

### DIFF
--- a/src/typechecker/TypeCheckerExpressions.cpp
+++ b/src/typechecker/TypeCheckerExpressions.cpp
@@ -126,9 +126,21 @@ std::any TypeChecker::visitTernaryExpr(TernaryExprNode *node) {
                   "True and false operands in ternary must be of same data type. Got " + trueType.getName(true) + " and " +
                       falseType.getName(true))
 
+  // An anonymous entry marks a temporary (e.g. a fresh struct instantiation or a non-trivial function-call
+  // result), whose storage does not outlive this expression.
+  const bool trueIsTemporary = trueEntry != nullptr && trueEntry->anonymous;
+  const bool falseIsTemporary = falseEntry != nullptr && falseEntry->anonymous;
+
   // The result type must be a reference if one of true/false branch is of reference type. Otherwise,
-  // the copy ctor is not called correctly
-  QualType resultType = trueType.isRef() ? trueType : falseType;
+  // the copy ctor is not called correctly. This can only be done if neither branch is a temporary though:
+  // a temporary's storage ends with this expression, so the result must take a copy of it instead of
+  // referencing it, or the copy ctor call for the temporary would end up being skipped further down,
+  // leaking it.
+  QualType resultType;
+  if (!trueIsTemporary && !falseIsTemporary && (trueType.isRef() || falseType.isRef()))
+    resultType = trueType.isRef() ? trueType : falseType;
+  else
+    resultType = trueTypeModified;
   // Infer the const-ness from the more restrictive operand
   resultType.makeConst(trueType.isConst() || falseType.isConst());
 
@@ -139,7 +151,7 @@ std::any TypeChecker::visitTernaryExpr(TernaryExprNode *node) {
     if (trueEntry->anonymous) {
       currentScope->symbolTable.deleteAnonymous(trueEntry->name);
       removedAnonymousSymbols = true;
-    } else if (!trueType.isRef() && !trueType.isTriviallyCopyable(node)) {
+    } else if (!resultType.isRef() && !trueTypeModified.isTriviallyCopyable(node)) {
       node->trueSideCallsCopyCtor = true;
     }
   }
@@ -147,7 +159,7 @@ std::any TypeChecker::visitTernaryExpr(TernaryExprNode *node) {
     if (falseEntry->anonymous) {
       currentScope->symbolTable.deleteAnonymous(falseEntry->name);
       removedAnonymousSymbols = true;
-    } else if (!falseType.isRef() && !falseType.isTriviallyCopyable(node)) {
+    } else if (!resultType.isRef() && !falseTypeModified.isTriviallyCopyable(node)) {
       node->falseSideCallsCopyCtor = true;
     }
   }

--- a/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/cout.out
+++ b/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/cout.out
@@ -1,0 +1,6 @@
+Ctor!
+Ctor!
+Dtor!
+Copy ctor!
+Dtor!
+Dtor!

--- a/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/ir-code.ll
@@ -1,0 +1,96 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+
+%struct.Test = type {}
+
+@printf.str.0 = private unnamed_addr constant [7 x i8] c"Ctor!\0A\00", align 4
+@printf.str.1 = private unnamed_addr constant [12 x i8] c"Copy ctor!\0A\00", align 4
+@printf.str.2 = private unnamed_addr constant [7 x i8] c"Dtor!\0A\00", align 4
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal void @_ZN4Test4ctorEv(ptr noundef nonnull align 1 %0) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
+  ret void
+}
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 1 %0, ptr noundef %1) #0 {
+  %this = alloca ptr, align 8
+  %_ = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  store ptr %1, ptr %_, align 8
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1)
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal void @_ZN4Test4dtorEv(ptr noundef nonnull align 1 %0) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2)
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal noundef %struct.Test @_Z6choosebRK4Test(i1 noundef zeroext %0, ptr noundef %1) #0 {
+  %result = alloca %struct.Test, align 8
+  %cond = alloca i1, align 1
+  %ref = alloca ptr, align 8
+  %3 = alloca %struct.Test, align 8
+  %4 = alloca ptr, align 8
+  store i1 %0, ptr %cond, align 1
+  store ptr %1, ptr %ref, align 8
+  %5 = load i1, ptr %cond, align 1
+  br i1 %5, label %cond.true.L11C12, label %cond.false.L11C12
+
+cond.true.L11C12:                                 ; preds = %2
+  call void @_ZN4Test4ctorEv(ptr noundef nonnull align 1 %3)
+  br label %cond.exit.L11C12
+
+cond.false.L11C12:                                ; preds = %2
+  %6 = load ptr, ptr %ref, align 8
+  call void @_ZN4Test4ctorERK4Test(ptr noundef nonnull align 1 %4, ptr %6)
+  br label %cond.exit.L11C12
+
+cond.exit.L11C12:                                 ; preds = %cond.false.L11C12, %cond.true.L11C12
+  %cond.result = phi ptr [ %3, %cond.true.L11C12 ], [ %4, %cond.false.L11C12 ]
+  %7 = load %struct.Test, ptr %cond.result, align 1
+  ret %struct.Test %7
+}
+
+; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
+define dso_local noundef i32 @main() #2 {
+  %result = alloca i32, align 4
+  %t = alloca %struct.Test, align 8
+  %viaTemp = alloca %struct.Test, align 8
+  %viaRef = alloca %struct.Test, align 8
+  store i32 0, ptr %result, align 4
+  call void @_ZN4Test4ctorEv(ptr noundef nonnull align 1 %t)
+  %1 = call noundef %struct.Test @_Z6choosebRK4Test(i1 noundef zeroext true, ptr noundef %t)
+  store %struct.Test %1, ptr %viaTemp, align 1
+  call void @_ZN4Test4dtorEv(ptr noundef nonnull align 1 %viaTemp)
+  %2 = call noundef %struct.Test @_Z6choosebRK4Test(i1 noundef zeroext false, ptr noundef %t)
+  store %struct.Test %2, ptr %viaRef, align 1
+  call void @_ZN4Test4dtorEv(ptr noundef nonnull align 1 %viaRef)
+  call void @_ZN4Test4dtorEv(ptr noundef nonnull align 1 %t)
+  %3 = load i32, ptr %result, align 4
+  ret i32 %3
+}
+
+attributes #0 = { noinline nounwind optnone uwtable }
+attributes #1 = { nofree nounwind }
+attributes #2 = { mustprogress noinline norecurse nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/source.spice
+++ b/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/source.spice
@@ -1,0 +1,26 @@
+type Test struct {}
+
+p Test.ctor() { printf("Ctor!\n"); }
+p Test.ctor(const Test& _) { printf("Copy ctor!\n"); }
+p Test.dtor() { printf("Dtor!\n"); }
+
+// The true branch is a fresh temporary (anonymous), the false branch is a reference. The ternary's own
+// result type must not become a reference here, or the temporary would either leak (its dtor call would be
+// skipped) or the false branch would be aliased without a copy (leading to a double dtor call on 'ref').
+f<Test> choose(bool cond, const Test& ref) {
+    return cond ? Test() : ref;
+}
+
+f<int> main() {
+    Test t; // Ctor call
+
+    {
+        Test viaTemp = choose(true, t); // Ctor call for the temporary, moved into viaTemp
+    } // Dtor call for viaTemp
+
+    {
+        Test viaRef = choose(false, t); // Copy ctor call for the ref side
+    } // Dtor call for viaRef
+
+    // Dtor call for t
+}


### PR DESCRIPTION
## What changed
- `TypeChecker::visitTernaryExpr` no longer forces the ternary's result type to a reference when the *other* branch is an anonymous temporary (a fresh struct instantiation or non-trivial function-call result). The result is now an owned value in that case, matching how two named operands are already handled.
- The "does this side need an explicit copy-ctor call" check now uses the ref-stripped type, since checking triviality on the raw reference type always short-circuited to `true`.
- Added `test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/`, an `IRGeneratorTests` case covering both branches of `cond ? Temp() : ref` (checks `cout.out` ctor/dtor call balance and `ir-code.ll`).

## Why
A ternary like `cond ? Temp() : ref` (one branch a fresh temporary, the other a reference) computed its result type as a reference, since that's what the reference-typed branch used. A reference owns nothing, so the temporary's destructor tracking was dropped under the (correct-for-by-value-results, wrong-for-ref-results) assumption that "the result takes over ownership." Whenever the temporary branch was actually taken at runtime, its destructor call was silently skipped, leaking it.

This was found while investigating a real memory leak in `src-bootstrap/util/common-util.spice`'s `getLastFragment()`, reported via valgrind:
```
==758311== 9 bytes in 1 blocks are definitely lost in loss record 1 of 8
==758311==    at 0x64F0B80: realloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==758311==    by 0x5B6B8AA: String::resize(unsigned long) (string_rt.spice:853)
==758311==    by 0x5B6CD5C: void String::reserve<long>(unsigned long) (string_rt.spice:839)
==758311==    by 0x5B6CC9A: String String::getSubstring<long>(unsigned long) (string_rt.spice:791)
==758311==    by 0x5B720C6: getLastFragment(String const&, char const*) (common-util.spice:18)
==758311==    by 0x5B7254D: main (test.spice:32)
```
Fixes #1304, which has a minimal `LifetimeObject`-based reproducer isolating the defect from `String`'s heap allocation.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest -j` — builds clean.
- `cmake-build-debug/test/spicetest` (run from `cmake-build-debug/test`) — 625/636 relevant tests pass. The 11 failures are a pre-existing environment issue unrelated to this change (`mold: fatal: library not found: LLVMIREmbUtils` when linking anything that pulls in `std/bindings/llvm`; reproduces identically on an unmodified checkout).
- `cmake-build-debug/test/spicetest --gtest_filter='*Ternary*:*LifetimeObject*:*ternary*:*lifetime*'` — all 10 pass, including the new case and the existing `StdTests.test_lifetimeObject`, whose output is byte-identical to its reference (no regression in already-covered ternary combinations).
- Confirmed the new test case fails on the pre-fix code (extra/missing ctor-dtor pair in `cout.out`, extra copy-ctor call in `ir-code.ll`) and passes with the fix.
- Verified via `--dump-ir` that the original `String`-based leak in `getLastFragment()` is gone: the reference branch now performs a real deep copy instead of aliasing the caller's `haystack`, and the temporary branch's object is moved out directly with no orphaned allocation.
- Checked the double-free hazard of a naive alternative fix (just keeping the temporary's destructor tracked without also fixing the copy-ctor condition) — it would have caused a double-destruct on the reference branch; the actual fix avoids this.

## Follow-up / known limitations
None known. The `LLVMIREmbUtils` linker failure noted above is a local environment/LLVM-build issue, not something this PR should fix.

Fixes #1304
