### PR TITLE
Fix duplicate LLVM libs

### DIFF
--- a/Conditionals.cmake
+++ b/Conditionals.cmake
@@ -48,3 +48,18 @@ set(SPICE_EXTRA_COMPILE_OPTIONS "")
 if (APPLE)
     list(APPEND SPICE_EXTRA_COMPILE_OPTIONS -Wno-error=deprecated-declarations)
 endif()
+
+# On macOS, Spice's own LLVM component list (LLVMOptions.cmake) and TPDE's independently-computed
+# LLVM component list (deps/tpde/tpde-llvm/CMakeLists.txt) are both linked statically into the same
+# executables (see TPDE_LINK_LLVM_STATIC in the top-level CMakeLists.txt) and legitimately share some
+# transitive LLVM archives (e.g. Desc/Info/Utils/Target/Passes). Newer Xcode ld64 warns about the same
+# static archive appearing more than once on the link line; the duplication is harmless (the archive is
+# just scanned twice), so silence the cosmetic warning instead of forcing the two component lists apart.
+if (APPLE)
+    set(CMAKE_REQUIRED_FLAGS "-Wl,-no_warn_duplicate_libraries")
+    check_cxx_compiler_flag("" LINKER_SUPPORTS_NO_WARN_DUPLICATE_LIBRARIES)
+    unset(CMAKE_REQUIRED_FLAGS)
+    if (LINKER_SUPPORTS_NO_WARN_DUPLICATE_LIBRARIES)
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-no_warn_duplicate_libraries")
+    endif ()
+endif()

--- a/LLVMOptions.cmake
+++ b/LLVMOptions.cmake
@@ -54,6 +54,11 @@ foreach (LLVM_TARGET ${LLVM_TARGETS_TO_BUILD})
     endforeach ()
 endforeach ()
 
+# De-duplicate, since llvm_map_components_to_libnames() and the per-target loop above can both
+# add the same library (e.g. a target's AsmParser/CodeGen component transitively depends on its
+# Desc/Info/Utils libs, which the loop above also adds explicitly)
+list(REMOVE_DUPLICATES LLVM_LIBS)
+
 # Print status messages
 string(JOIN "," LLVM_TARGET_ARCHITECTURES_JOINED ${LLVM_TARGET_ARCHITECTURES})
 message(STATUS "Spice: Enabled targets: ${LLVM_TARGET_ARCHITECTURES_JOINED}")


### PR DESCRIPTION
Fix duplicate LLVM libs due to Spice and TPDE both link against the same static libs of LLVM