### PR TITLE
Work-around memory leak in HashEntry

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,13 +1,3 @@
-import "std/test/lifetime-object";
-
-p foo(const LifetimeObject& _t) {
-
-}
-
-p bar() {
-    foo(LifetimeObject());
-}
-
 f<int> main() {
-    bar();
+
 }

--- a/std/data/hash-table.spice
+++ b/std/data/hash-table.spice
@@ -30,6 +30,11 @@ public p HashEntry.ctor(const HashEntry<K, V>& original) {
     this.value = original.value;
 }
 
+public p HashEntry.dtor() {
+    sDestruct(this.key);
+    sDestruct(this.value);
+}
+
 /**
  * A hash table in Spice is a commonly used data structure, which stores key-value pairs and allows
  * fast access to a value by its key. Collisions are resolved via separate chaining, where each

--- a/test/test-files/bootstrap-compiler/standalone-scope-test/cout.out
+++ b/test/test-files/bootstrap-compiler/standalone-scope-test/cout.out
@@ -1,2 +1,1 @@
-Created and retrieved 3 child scopes; nesting works.
 All assertions passed!

--- a/test/test-files/bootstrap-compiler/standalone-scope-test/source.spice
+++ b/test/test-files/bootstrap-compiler/standalone-scope-test/source.spice
@@ -36,7 +36,6 @@ f<int> main() {
     assert nested.getParent() == fnScope;
     assert fnScope.getChildScope(String("foreach:0")) == nested;
 
-    printf("Created and retrieved %d child scopes; nesting works.\n", 3);
     printf("All assertions passed!\n");
     return 0;
 }

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -143,3 +143,44 @@
    fun:_ZN4llvm20createSanitizerCtorERNS_6ModuleENS_9StringRefE
    ...
 }
+
+# ---------------------------------------------------------------------------
+# gtest RawBytesPrinter reading struct padding — when a parameterized-test
+# assertion prints a spice::testing::TestCase (or similar aggregate with
+# padding bytes), gtest falls back to dumping the object's raw memory via
+# snprintf("%02X", byte). The padding bytes are never initialized by the
+# struct's constructor, so glibc's snprintf/_itoa_word internals trip
+# Memcheck's uninitialised-value checks. The value is only used for a debug
+# string, never for control flow, so this is a harmless false positive.
+# ---------------------------------------------------------------------------
+{
+   gtest_RawBytesPrinter_itoa_word_value8
+   Memcheck:Value8
+   fun:_itoa_word
+   fun:__printf_buffer
+   fun:__vsnprintf_internal
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_1L26PrintByteSegmentInObjectToEPKhmmPSo
+   ...
+}
+
+{
+   gtest_RawBytesPrinter_itoa_word_cond
+   Memcheck:Cond
+   fun:_itoa_word
+   fun:__printf_buffer
+   fun:__vsnprintf_internal
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_1L26PrintByteSegmentInObjectToEPKhmmPSo
+   ...
+}
+
+{
+   gtest_RawBytesPrinter_printf_buffer_cond
+   Memcheck:Cond
+   fun:__printf_buffer
+   fun:__vsnprintf_internal
+   fun:snprintf
+   fun:_ZN7testing12_GLOBAL__N_1L26PrintByteSegmentInObjectToEPKhmmPSo
+   ...
+}


### PR DESCRIPTION
This is related to issue #1297. It is just a work-around to fix memory leaks, that originate from this bug, before there is a proper compiler fix.