### PR TITLE
Decide implicit default members per struct manifestation

### DIFF
--- a/.run/spice run.run.xml
+++ b/.run/spice run.run.xml
@@ -1,5 +1,5 @@
 <component name="ProjectRunConfigurationManager">
-  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 -ir ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
+  <configuration default="false" name="spice run" type="CMakeRunConfiguration" factoryName="Application" PROGRAM_PARAMS="run -d -O0 -ir --ignore-cache ../../media/test-project/test.spice" REDIRECT_INPUT="false" ELEVATE="false" USE_EXTERNAL_CONSOLE="false" EMULATE_TERMINAL="false" PASS_PARENT_ENVS_2="true" PROJECT_NAME="Spice" TARGET_NAME="spice" CONFIG_NAME="Debug" RUN_TARGET_PROJECT_NAME="Spice" RUN_TARGET_NAME="spice">
     <envs>
       <env name="LLVM_INCLUDE_DIRS" value="-I/home/marc/Documents/Dev/llvm-project-latest/llvm/include -I/home/marc/Documents/Dev/llvm-project-latest/build/include" />
       <env name="LLVM_LIB_DIR" value="$PROJECT_DIR$/../llvm-project-latest/build/lib" />

--- a/docs/docs/language/builtin-types.md
+++ b/docs/docs/language/builtin-types.md
@@ -121,6 +121,22 @@ The `Result<T>` builtin type offers the following static functions:
 - `Result<T> err(int, string)`: Returns a Result object with an error, constructed with an error code and an error message
 - `Result<T> err(string)`: Returns a Result object with an error, constructed with an error message
 
+### Ownership
+
+A `Result<T>` owns the value it wraps. The compiler-generated destructor destructs a struct payload and frees a heap
+payload, so a `Result<heap byte*>` releases its block when it goes out of scope.
+
+To keep a heap payload alive beyond the result, take it out of the result with `sMove`. This nils the payload inside the
+result, which leaves its destructor with nothing to free and makes the caller the single owner of the block:
+
+```spice
+Result<heap byte*> allocResult = sAlloc(16l);
+heap byte* buffer = sMove(allocResult.unwrap()); // the caller owns the block from here on
+```
+
+Unwrapping a heap payload without `sMove` yields a borrowed pointer that stays owned by the result. Storing such a
+pointer somewhere that outlives the result, or freeing it manually, results in a double free.
+
 ## The `Error` data type
 The `Error` builtin type is used to represent an error. It can be used e.g. in combination with the `Result<T>` type.
 

--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,3 +1,3 @@
 f<int> main() {
-
+    Result<heap byte*> r = sAlloc(4l);
 }

--- a/src-bootstrap/util/memory.spice
+++ b/src-bootstrap/util/memory.spice
@@ -6,8 +6,9 @@ public type IMemoryManager interface {
 public type DefaultMemoryManager struct : IMemoryManager {}
 
 public f<heap byte*> DefaultMemoryManager.allocate(unsigned long size) {
-    const Result<heap byte*> allocation = sAlloc(size);
-    return allocation.unwrap();
+    Result<heap byte*> allocation = sAlloc(size);
+    // Take the block out of the result: the caller becomes its owner, so the result must not free it on the way out
+    return sMove(allocation.unwrap());
 }
 
 public p DefaultMemoryManager.deallocate(heap byte*& ptr) {

--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -658,6 +658,10 @@ void SourceFile::runMiddleEnd() {
   // whose registry is not populated yet). runMiddleEnd is the first stage that is only ever invoked at the top level.
   mergeNameRegistriesRecursive();
   CHECK_ABORT_FLAG_V()
+  // From here on, struct manifestations may be substantiated, and each of them gets its compiler-generated default
+  // members decided right at that point (see TypeChecker::createImplicitDefaultMembers). Once the middle end is done,
+  // every manifestation exists and was decided on, so the back end must not create any more of them.
+  const DefaultMemberCreationSection defaultMemberCreationSection;
   // We need two runs here due to generics.
   // The first run to determine all concrete function/struct/interface substantiations
   runTypeCheckerPre(); // Visit the dependency tree from bottom to top

--- a/src/model/Function.cpp
+++ b/src/model/Function.cpp
@@ -226,7 +226,13 @@ bool Function::hasSubstantiatedParams() const {
  * @return Substantiated generics or not
  */
 bool Function::hasSubstantiatedGenerics() const {
-  const auto predicate = [this](const GenericType &genericType) { return typeMapping.contains(genericType.getSubType()); };
+  const auto predicate = [this](const GenericType &genericType) {
+    // A template slot that is not generic (anymore) is already substantiated. This is the case for the default members
+    // of an already-concrete struct manifestation (e.g. HashEntry<int, String>::dtor()), whose template type list holds
+    // the concrete types instead of generic placeholders. Only generic types carry a sub type usable as a mapping key -
+    // getSubType() would assert on e.g. a primitive or a 'heap byte*'.
+    return !genericType.is(TY_GENERIC) || typeMapping.contains(genericType.getSubType());
+  };
   return std::ranges::all_of(templateTypes, predicate);
 }
 

--- a/src/model/StructBase.h
+++ b/src/model/StructBase.h
@@ -52,6 +52,9 @@ public:
   } vTableData;
   bool used = false;
   bool isNewlyInserted = false;
+  // Whether it was already decided which compiler-generated default members (ctor, copy ctor, move ctor, dtor) this
+  // manifestation needs. The decision is taken exactly once per manifestation, as soon as it comes into existence.
+  bool implicitDefaultMembersDecided = false;
 };
 
 } // namespace spice::compiler

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -300,12 +300,12 @@ std::vector<const Function *> Scope::getVirtualMethods() {
  *
  * @return All struct manifestations in declaration order
  */
-std::vector<const Struct *> Scope::getAllStructManifestationsInDeclarationOrder() const {
+std::vector<Struct *> Scope::getAllStructManifestationsInDeclarationOrder() {
   // Retrieve all struct manifestations in this scope
-  std::vector<const Struct *> manifestations;
+  std::vector<Struct *> manifestations;
   manifestations.reserve(structs.size()); // Reserve at least the size of individual generic structs
-  for (const auto &structManifestations : structs | std::views::values)
-    for (const auto &manifestation : structManifestations | std::views::values)
+  for (auto &structManifestations : structs | std::views::values)
+    for (auto &manifestation : structManifestations | std::views::values)
       manifestations.push_back(&manifestation);
 
   // Sort manifestations by declaration code location

--- a/src/symboltablebuilder/Scope.h
+++ b/src/symboltablebuilder/Scope.h
@@ -95,7 +95,7 @@ public:
   void ensureSuccessfulTypeInference() const;
   [[nodiscard]] size_t getFieldCount() const;
   [[nodiscard]] std::vector<const Function *> getVirtualMethods();
-  [[nodiscard]] std::vector<const Struct *> getAllStructManifestationsInDeclarationOrder() const;
+  [[nodiscard]] std::vector<Struct *> getAllStructManifestationsInDeclarationOrder();
   [[nodiscard]] unsigned int getLoopNestingDepth() const;
   [[nodiscard]] Scope *getFunctionScope();
   [[nodiscard]] bool isInCaseBranch() const;

--- a/src/typechecker/FunctionManager.cpp
+++ b/src/typechecker/FunctionManager.cpp
@@ -111,6 +111,20 @@ Function FunctionManager::createMainFunction(SymbolTableEntry *entry, const Qual
   return {MAIN_FUNCTION_NAME, entry, QualType(TY_DYN), QualType(TY_INT), paramList, {}, declNode};
 }
 
+/**
+ * Search all manifestation lists of the given scope for a function with the given signature
+ *
+ * @param scope Scope to search in
+ * @param signature Signature to search for
+ * @return Found function or nullptr
+ */
+Function *FunctionManager::findManifestationBySignature(Scope *scope, const std::string &signature) {
+  for (auto &manifestations : scope->functions | std::views::values)
+    if (const auto it = manifestations.find(signature); it != manifestations.end())
+      return &it->second;
+  return nullptr;
+}
+
 Function *FunctionManager::insertSubstantiation(Scope *insertScope, const Function &newManifestation, const ASTNode *declNode) {
   assert(newManifestation.hasSubstantiatedParams());
 
@@ -242,7 +256,13 @@ Function *FunctionManager::match(Scope *matchScope, const std::string &reqName, 
       TypeMapping &typeMapping = candidate.typeMapping;
       typeMapping.clear();
       for (size_t i = 0; i < std::min(templateTypeHints.size(), candidate.templateTypes.size()); i++) {
-        const std::string &typeName = candidate.templateTypes.at(i).getSubType();
+        // Skip template slots that are not generic (anymore). The default members of an already-concrete struct
+        // manifestation carry the concrete types in their template type list, and only generic types have a sub type
+        // usable as a mapping key here - getSubType() would assert on e.g. a primitive or a 'heap byte*'.
+        const GenericType &candidateTemplateType = candidate.templateTypes.at(i);
+        if (!candidateTemplateType.is(TY_GENERIC))
+          continue;
+        const std::string &typeName = candidateTemplateType.getSubType();
         const QualType &templateType = templateTypeHints.at(i);
         typeMapping.emplace(typeName, templateType);
       }
@@ -268,11 +288,15 @@ Function *FunctionManager::match(Scope *matchScope, const std::string &reqName, 
         continue; // Match was successful -> match the next function
       }
 
-      // Check if we already have this manifestation and can simply re-use it
+      // Check if we already have this manifestation and can simply re-use it. matchManifestation may have redirected
+      // matchScope from the generic struct scope to the concrete manifestation scope; the substantiation is inserted
+      // there, so that is also where an already existing one has to be looked for. Searching the manifestation list we
+      // are currently iterating instead would miss it and insert a duplicate (which insertSubstantiation then reports
+      // as 'declared twice').
       const std::string newSignature = candidate.getSignature(true, true, false, true);
-      if (const auto it = manifestations.find(newSignature); it != manifestations.end()) {
-        it->second.used = true;
-        matches.push_back(&it->second);
+      if (Function *existingManifestation = findManifestationBySignature(matchScope, newSignature)) {
+        existingManifestation->used = true;
+        matches.push_back(existingManifestation);
         break; // Leave the whole manifestation list to not double-match the manifestation
       }
 
@@ -359,8 +383,11 @@ MatchResult FunctionManager::matchManifestation(Function &candidate, Scope *&mat
   if (!matchArgTypes(candidate, reqArgs, typeMapping, strictQualifierMatching, forceSubstantiation, callNode))
     return MatchResult::SKIP_MANIFESTATION; // Leave this manifestation and try the next one
 
-  // Check if there are unresolved generic types
-  if (typeMapping.size() < candidate.templateTypes.size())
+  // Check if there are unresolved generic types. Only template slots that actually are generic have to be resolved into
+  // the type mapping - a slot that already holds a concrete type (as for the default members of an already-concrete
+  // struct manifestation, e.g. HashEntry<int, String>::dtor()) never ends up there and must not count as unresolved.
+  const auto isGeneric = [](const GenericType &templateType) { return templateType.is(TY_GENERIC); };
+  if (typeMapping.size() < static_cast<size_t>(std::ranges::count_if(candidate.templateTypes, isGeneric)))
     return MatchResult::SKIP_MANIFESTATION; // Leave this manifestation and try the next one
 
   // Substantiate return type
@@ -643,6 +670,14 @@ bool FunctionManager::hasCtor(const Scope *matchScope, CtorKind kind) {
       }
     }
   }
+  return false;
+}
+
+bool FunctionManager::hasAnyCtor(const Scope *matchScope) {
+  for (const auto &manifestations : matchScope->functions | std::views::values)
+    for (const auto &function : manifestations | std::views::values)
+      if (function.name == CTOR_FUNCTION_NAME)
+        return true;
   return false;
 }
 

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -44,6 +44,7 @@ public:
                                               const ArgList &reqArgs, bool strictQualifierMatching);
   static Function *match(Scope *matchScope, const std::string &reqName, const QualType &reqThisType, const ArgList &reqArgs,
                          const QualTypeList &templateTypeHints, bool strictQualifierMatching, const ASTNode *callNode);
+  [[nodiscard]] static bool hasAnyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasAnyNonCopyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasCopyCtor(const Scope *matchScope);
   [[nodiscard]] static bool hasUserCopyCtor(const Scope *matchScope);
@@ -78,6 +79,7 @@ private:
   [[nodiscard]] static uint64_t getCacheKey(const Scope *scope, const std::string &name, const QualType &thisType,
                                             const ArgList &args, const QualTypeList &templateTypes);
   static void breakOverloadTie(std::vector<Function *> &matches, const ArgList &reqArgs);
+  [[nodiscard]] static Function *findManifestationBySignature(Scope *scope, const std::string &signature);
   enum class CtorKind : uint8_t { ANY_NON_COPY_NON_MOVE, COPY, MOVE };
   [[nodiscard]] static bool hasCtor(const Scope *matchScope, CtorKind kind);
 };

--- a/src/typechecker/StructManager.cpp
+++ b/src/typechecker/StructManager.cpp
@@ -2,11 +2,13 @@
 
 #include "StructManager.h"
 
+#include <SourceFile.h>
 #include <ast/ASTNodes.h>
 #include <exception/SemanticError.h>
 #include <model/GenericType.h>
 #include <model/Interface.h>
 #include <symboltablebuilder/Scope.h>
+#include <typechecker/TypeChecker.h>
 #include <typechecker/TypeMatcher.h>
 #include <util/CodeLoc.h>
 #include <util/Concurrency.h>
@@ -127,6 +129,9 @@ Struct *StructManager::match(Scope *matchScope, const std::string &qt, const Qua
       substantiatedStruct->genericPreset = &matchScope->structs.at(structId).at(mangledName);
       substantiatedStruct->declNode->getStructManifestations()->push_back(substantiatedStruct);
       substantiatedStruct->isNewlyInserted = true; // To not iterate over it in the same matching
+      // The generic preset was already decided on, but this manifestation carries concrete field types and therefore
+      // needs its own decision (taken further below, once its fields and interfaces are substantiated)
+      substantiatedStruct->implicitDefaultMembersDecided = false;
 
       // Copy struct entry
       const std::string newSignature = substantiatedStruct->getSignature();
@@ -184,6 +189,18 @@ Struct *StructManager::match(Scope *matchScope, const std::string &qt, const Qua
         assert(spiceInterface != nullptr);
         interfaceType = spiceInterface->entry->getQualType();
       }
+
+      // Decide which compiler-generated default members this brand-new manifestation needs. This has to happen right
+      // here, because the decision depends on the concrete field types and every reactive lookup that asks the struct
+      // for its dtor/ctor from now on has to see the answer (see TypeChecker::createImplicitDefaultMembers). The nested
+      // field manifestations created above are decided on first, by their own recursive match() call, so a field's dtor
+      // is already in place when the outer struct is asked whether it needs one.
+      // A manifestation that is created while its own file is still being prepared is left alone: the generic preset
+      // has not been decided on yet at that point, so this manifestation could neither inherit its default members
+      // through the copied scope nor come to the same conclusion on its own. Those manifestations are covered by the
+      // one-shot sweep at the end of the file's prepare run (TypeChecker::visitEntry), which sees all of them.
+      if (structDefaultMembersDecidable && substantiatedStruct->scope->sourceFile->previousStage >= TYPE_CHECKER_PRE)
+        TypeChecker::createImplicitDefaultMembers(*substantiatedStruct, node, /*withMoveCtor=*/false);
 
       // Add to matched structs
       matches.push_back(substantiatedStruct);

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -17,28 +17,6 @@ TypeChecker::TypeChecker(GlobalResourceManager &resourceManager, SourceFile *sou
     : CompilerPass(resourceManager, sourceFile), typeCheckerMode(typeCheckerMode), warnings(sourceFile->compilerOutput.warnings) {
 }
 
-/**
- * Check whether the given struct and all of its by-value struct fields are manifested, transitively. While a circular
- * import is still being prepared, a by-value struct field may (transitively) reference a struct that is not manifested
- * yet; generating implicit special members for such a struct recurses through isTriviallyConstructible and would
- * dereference a null struct lookup. A genuine infinite-size containment cycle among these structs is reported
- * separately by the infinite-size check during struct preparation, so a containment cycle here is treated as manifested.
- */
-static bool structFullyManifested(const Struct *spiceStruct, const ASTNode *node, std::unordered_set<const Scope *> &visited) {
-  for (const QualType &fieldType : spiceStruct->fieldTypes) {
-    if (!fieldType.is(TY_STRUCT))
-      continue;
-    const Struct *fieldStruct = fieldType.getStruct(node);
-    if (fieldStruct == nullptr)
-      return false;
-    // Recurse into each field struct once. A containment cycle (already visited) is fine here - it is reported
-    // separately as an infinite-size error. Leaf structs never touch the set, so the common case stays allocation-free.
-    if (visited.insert(fieldStruct->scope).second && !structFullyManifested(fieldStruct, node, visited))
-      return false;
-  }
-  return true;
-}
-
 std::any TypeChecker::visitEntry(EntryNode *node) {
   // Initialize
   currentScope = rootScope;
@@ -51,22 +29,11 @@ std::any TypeChecker::visitEntry(EntryNode *node) {
   // Visit children
   visitChildren(node);
 
-  // Check which implicit structures we need for each struct, defined in this source file
-  if (isPrepare) {
-    const std::vector<const Struct *> manifestations = rootScope->getAllStructManifestationsInDeclarationOrder();
-    for (const Struct *manifestation : manifestations) {
-      // Skip while a by-value struct field is (transitively) not manifested yet (circular import still in progress). A
-      // genuine infinite-size cycle among such structs is reported by the infinite-size check during preparation.
-      std::unordered_set<const Scope *> visitedScopes;
-      if (!structFullyManifested(manifestation, node, visitedScopes))
-        continue;
-      // Check if we need to create a default ctor, copy ctor, move ctor or dtor
-      createDefaultCtorIfRequired(*manifestation, manifestation->scope);
-      createDefaultCopyCtorIfRequired(*manifestation, manifestation->scope);
-      createDefaultMoveCtorIfRequired(*manifestation, manifestation->scope);
-      createDefaultDtorIfRequired(*manifestation, manifestation->scope);
-    }
-  }
+  // Check which implicit structures we need for each struct, defined in this source file. Manifestations that are
+  // substantiated after this point are decided on directly at their creation (see createImplicitDefaultMembers).
+  if (isPrepare)
+    for (Struct *manifestation : rootScope->getAllStructManifestationsInDeclarationOrder())
+      createImplicitDefaultMembers(*manifestation, node);
 
   return nullptr;
 }

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -25,6 +25,34 @@ enum TypeCheckerMode : bool {
 };
 
 /**
+ * Global switch that tells StructManager whether a freshly substantiated struct manifestation may still be given its
+ * compiler-generated default members (ctor, copy ctor, move ctor, dtor).
+ *
+ * Creating those mutates the symbol table and registers new functions, which is only valid while the middle end runs.
+ * The back end reaches StructManager::match as well - through QualType::getStruct, on multiple threads - but by then
+ * every manifestation exists already, so those calls never take the creation path anyway. The switch makes that an
+ * invariant instead of an assumption.
+ */
+inline bool structDefaultMembersDecidable = false;
+
+/**
+ * RAII marker for the section of the compiler in which struct manifestations are still allowed to receive their
+ * compiler-generated default members, i.e. the middle end.
+ */
+class DefaultMemberCreationSection final {
+public:
+  // Constructors
+  DefaultMemberCreationSection() { structDefaultMembersDecidable = true; }
+
+  // Prevent copy
+  DefaultMemberCreationSection(const DefaultMemberCreationSection &) = delete;
+  DefaultMemberCreationSection &operator=(const DefaultMemberCreationSection &) = delete;
+
+  // Destructor
+  ~DefaultMemberCreationSection() { structDefaultMembersDecidable = false; }
+};
+
+/**
  * Jobs:
  * - Ensure that all actual types match the expected types
  * - Perform type inference
@@ -169,12 +197,13 @@ private:
   void softError(const ASTNode *node, SemanticErrorType errorType, const std::string &message) const;
 
   // Implicit code generation
-  void createDefaultStructMethod(const Struct &spiceStruct, const std::string &entryName, const std::string &name,
-                                 const ParamList &params) const;
-  void createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
-  void createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
-  void createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
-  void createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope) const;
+  static void createImplicitDefaultMembers(Struct &spiceStruct, const ASTNode *node, bool withMoveCtor = true);
+  static void createDefaultStructMethod(const Struct &spiceStruct, const std::string &entryName, const std::string &name,
+                                        const ParamList &params);
+  static void createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
+  static void createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
+  static void createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Scope *structScope);
+  static void createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope);
   void createCtorBodyPreamble(const Scope *bodyScope) const;
   void createCopyCtorBodyPreamble(const Scope *bodyScope) const;
   void createMoveCtorBodyPreamble(const Scope *bodyScope) const;

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -207,7 +207,7 @@ private:
   void createCtorBodyPreamble(const Scope *bodyScope) const;
   void createCopyCtorBodyPreamble(const Scope *bodyScope) const;
   void createMoveCtorBodyPreamble(const Scope *bodyScope) const;
-  void createDtorBodyPreamble(const Scope *bodyScope) const;
+  void createDtorBodyPreamble(const Scope *bodyScope, const ASTNode *node) const;
   Function *implicitlyCallStructMethod(const SymbolTableEntry *entry, const std::string &methodName, const ArgList &args,
                                        const ASTNode *node) const;
   Function *implicitlyCallStructMethod(QualType thisType, const std::string &methodName, const ArgList &args,

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -2,6 +2,8 @@
 
 #include "TypeChecker.h"
 
+#include <unordered_set>
+
 #include <SourceFile.h>
 #include <ast/ASTBuilder.h>
 #include <ast/ASTNodes.h>
@@ -18,6 +20,74 @@ namespace spice::compiler {
 static const char *const FCT_NAME_DEALLOC = "sDealloc";
 
 /**
+ * Check whether the given struct and all of its by-value struct fields are manifested, transitively. While a circular
+ * import is still being prepared, a by-value struct field may (transitively) reference a struct that is not manifested
+ * yet; generating implicit special members for such a struct recurses through isTriviallyConstructible and would
+ * dereference a null struct lookup. A genuine infinite-size containment cycle among these structs is reported
+ * separately by the infinite-size check during struct preparation, so a containment cycle here is treated as manifested.
+ */
+static bool structFullyManifested(const Struct *spiceStruct, const ASTNode *node, std::unordered_set<const Scope *> &visited) {
+  for (const QualType &fieldType : spiceStruct->fieldTypes) {
+    if (!fieldType.is(TY_STRUCT))
+      continue;
+    const Struct *fieldStruct = fieldType.getStruct(node);
+    if (fieldStruct == nullptr)
+      return false;
+    // Recurse into each field struct once. A containment cycle (already visited) is fine here - it is reported
+    // separately as an infinite-size error. Leaf structs never touch the set, so the common case stays allocation-free.
+    if (visited.insert(fieldStruct->scope).second && !structFullyManifested(fieldStruct, node, visited))
+      return false;
+  }
+  return true;
+}
+
+/**
+ * Decide which compiler-generated default members (ctor, copy ctor, move ctor, dtor) the given struct manifestation
+ * needs and create them.
+ *
+ * This decision depends on the concrete field types, so it has to be taken once per manifestation and not once per
+ * struct declaration: whether e.g. HashEntry<K, V> needs a dtor is unanswerable while K and V are still generic, but
+ * well-defined for HashEntry<int, String>. It is therefore taken as soon as a manifestation comes into existence -
+ * either by the one-shot sweep over the manifestations that already exist when a source file is prepared
+ * (TypeChecker::visitEntry), or, for manifestations that are substantiated later on, right at the point where
+ * StructManager::match creates them. Deciding any later would be too late for all the reactive lookups that ask a
+ * struct for its default members (FunctionManager::match/::lookup, doScopeCleanup, ...), since a function body is
+ * type-checked exactly once and would not pick up a dtor that appears afterward.
+ *
+ * The default move ctor is decided about only when the caller asks for it. A manifestation that is substantiated after
+ * its file was prepared does not get one, which keeps it at the behavior it had before this decision was taken per
+ * manifestation at all. Synthesizing one would require the move ctor of each struct-typed field to be resolvable for
+ * the concrete manifestation, which the raw manifestation scan behind it (FunctionManager::findMoveCtor) cannot do for
+ * a generic field type - it returns the generic preset that the manifestation scope inherited. Without a move ctor,
+ * moving such a struct falls back to copying it, which is correct, just less efficient.
+ *
+ * @param spiceStruct Struct manifestation to decide the default members for
+ * @param node AST node for error messages
+ * @param withMoveCtor Also decide about the default move ctor
+ */
+void TypeChecker::createImplicitDefaultMembers(Struct &spiceStruct, const ASTNode *node, bool withMoveCtor) {
+  // Take the decision only once per manifestation
+  if (spiceStruct.implicitDefaultMembersDecided)
+    return;
+
+  // Skip while a by-value struct field is (transitively) not manifested yet (circular import still in progress). A
+  // genuine infinite-size cycle among such structs is reported by the infinite-size check during preparation. The
+  // manifestation stays undecided and is picked up again by the fallback sweep in visitStructDefCheck.
+  std::unordered_set<const Scope *> visitedScopes;
+  if (!structFullyManifested(&spiceStruct, node, visitedScopes))
+    return;
+
+  spiceStruct.implicitDefaultMembersDecided = true;
+
+  // Check if we need to create a default ctor, copy ctor, move ctor or dtor
+  createDefaultCtorIfRequired(spiceStruct, spiceStruct.scope);
+  createDefaultCopyCtorIfRequired(spiceStruct, spiceStruct.scope);
+  if (withMoveCtor)
+    createDefaultMoveCtorIfRequired(spiceStruct, spiceStruct.scope);
+  createDefaultDtorIfRequired(spiceStruct, spiceStruct.scope);
+}
+
+/**
  * Create a default struct method
  * Checks if the given struct scope already has a user-defined constructor and creates a default one if not.
  *
@@ -27,8 +97,9 @@ static const char *const FCT_NAME_DEALLOC = "sDealloc";
  * @param params Parameter types of the method
  */
 void TypeChecker::createDefaultStructMethod(const Struct &spiceStruct, const std::string &entryName, const std::string &name,
-                                            const ParamList &params) const {
+                                            const ParamList &params) {
   Scope *structScope = spiceStruct.scope;
+  SourceFile *sourceFile = structScope->sourceFile;
   ASTNode *node = spiceStruct.declNode;
   const SymbolTableEntry *structEntry = spiceStruct.entry;
   const QualType &structType = structEntry->getQualType();
@@ -42,8 +113,12 @@ void TypeChecker::createDefaultStructMethod(const Struct &spiceStruct, const std
   SymbolTableEntry *procEntry = structScope->insert(entryName, structEntry->declNode);
   procEntry->updateType(procedureType, true);
 
-  // Add to external name registry
-  sourceFile->addNameRegistryEntry(fqFctName, TY_PROCEDURE, procEntry, structScope, true);
+  // Add to external name registry. Only the generic preset does this: the registry is keyed by the plain struct name,
+  // so an entry added for one manifestation would be indistinguishable from a user-defined member and would wrongly
+  // suppress the default member of every sibling manifestation (e.g. HashEntry<int, String> vs. HashEntry<int, int>).
+  // Manifestation-level default members are only ever looked up through their struct scope anyway.
+  if (!spiceStruct.isGenericSubstantiation())
+    sourceFile->addNameRegistryEntry(fqFctName, TY_PROCEDURE, procEntry, structScope, true);
 
   // Create the default method
   const std::vector<GenericType> templateTypes = spiceStruct.templateTypes;
@@ -69,6 +144,13 @@ void TypeChecker::createDefaultStructMethod(const Struct &spiceStruct, const std
 
   // Hand it off to the function manager to register the function
   FunctionManager::insert(structScope, defaultMethod, structEntry->declNode->getFctManifestations(name));
+
+  // The body of a default member is not prepared here, but in visitStructDefCheck, which runs over all manifestations
+  // of the struct. For a manifestation that was substantiated after its file was already checked, that run is long
+  // over, so ask for another one - otherwise the member would end up without a body preamble, and the IR generator
+  // would e.g. not find the copy ctor of a field it is supposed to copy. During the prepare stage the flag is set
+  // anyway, so this is a no-op there.
+  sourceFile->reVisitRequested = true;
 }
 
 /**
@@ -80,15 +162,20 @@ void TypeChecker::createDefaultStructMethod(const Struct &spiceStruct, const std
  * @param spiceStruct Struct instance
  * @param structScope Scope of the struct
  */
-void TypeChecker::createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const {
+void TypeChecker::createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *structScope) {
   const auto node = spice_pointer_cast<StructDefNode *>(spiceStruct.declNode);
   assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
+  const SourceFile *sourceFile = structScope->sourceFile;
 
-  // Abort if the struct already has a user-defined constructor
+  // Abort if the struct already has a constructor. The name registry is the authoritative source here: it is filled by
+  // the symbol table builder, so it already knows about every user-defined ctor, even one that is declared further down
+  // in the file and therefore has not been registered in the struct scope yet. It also covers a ctor that the generic
+  // preset received, which every manifestation inherits through its copied scope. The scope scan on top of it only
+  // guards against creating a second ctor into a scope that visibly has one already.
   const SymbolTableEntry *structEntry = spiceStruct.entry;
   const QualType &structType = structEntry->getQualType();
   const std::string fqFctName = structType.getSubType() + MEMBER_ACCESS_TOKEN + CTOR_FUNCTION_NAME;
-  if (sourceFile->getNameRegistryEntry(fqFctName))
+  if (sourceFile->getNameRegistryEntry(fqFctName) || FunctionManager::hasAnyCtor(structScope))
     return;
 
   // Check if we have fields, that require us to do anything in the ctor
@@ -158,7 +245,7 @@ void TypeChecker::createDefaultCtorIfRequired(const Struct &spiceStruct, Scope *
  * @param spiceStruct Struct instance
  * @param structScope Scope of the struct
  */
-void TypeChecker::createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const {
+void TypeChecker::createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Scope *structScope) {
   const auto node = spice_pointer_cast<const StructDefNode *>(spiceStruct.declNode);
   assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
 
@@ -231,7 +318,7 @@ void TypeChecker::createDefaultCopyCtorIfRequired(const Struct &spiceStruct, Sco
  * @param spiceStruct Struct instance
  * @param structScope Scope of the struct
  */
-void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Scope *structScope) const {
+void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Scope *structScope) {
   const auto node = spice_pointer_cast<const StructDefNode *>(spiceStruct.declNode);
   assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
 
@@ -312,15 +399,17 @@ void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Sco
  * @param spiceStruct Struct instance
  * @param structScope Scope of the struct
  */
-void TypeChecker::createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope) const {
+void TypeChecker::createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope) {
   const ASTNode *node = spiceStruct.declNode;
+  SourceFile *sourceFile = structScope->sourceFile;
   assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
 
-  // Abort if the struct already has a user-defined destructor
+  // Abort if the struct already has a destructor. See createDefaultCtorIfRequired for why the name registry is asked
+  // first and the struct scope only on top of it.
   const SymbolTableEntry *structEntry = spiceStruct.entry;
   const QualType &structType = structEntry->getQualType();
   const std::string fqFctName = structType.getSubType() + MEMBER_ACCESS_TOKEN + DTOR_FUNCTION_NAME;
-  if (sourceFile->getNameRegistryEntry(fqFctName))
+  if (sourceFile->getNameRegistryEntry(fqFctName) || FunctionManager::hasDtor(structScope))
     return;
 
   // Check we have field types, that require use to do anything in the destructor

--- a/src/typechecker/TypeCheckerImplicit.cpp
+++ b/src/typechecker/TypeCheckerImplicit.cpp
@@ -401,7 +401,7 @@ void TypeChecker::createDefaultMoveCtorIfRequired(const Struct &spiceStruct, Sco
  */
 void TypeChecker::createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *structScope) {
   const ASTNode *node = spiceStruct.declNode;
-  SourceFile *sourceFile = structScope->sourceFile;
+  const SourceFile *sourceFile = structScope->sourceFile;
   assert(structScope != nullptr && structScope->type == ScopeType::STRUCT);
 
   // Abort if the struct already has a destructor. See createDefaultCtorIfRequired for why the name registry is asked
@@ -449,25 +449,10 @@ void TypeChecker::createDefaultDtorIfRequired(const Struct &spiceStruct, Scope *
   if (!hasFieldsToDeAllocate && !hasFieldsToDestruct)
     return;
 
-  // Create the default dtor function
+  // Create the default dtor function. The memory runtime that the generated body needs for its de-allocations is not
+  // requested here, but only when that body is prepared (see createDtorBodyPreamble) - see the comment there.
   const std::string entryName = Function::getSymbolTableEntryNameDefaultDtor(node->codeLoc);
   createDefaultStructMethod(spiceStruct, entryName, DTOR_FUNCTION_NAME, {});
-
-  // Request memory runtime if we have fields, that are allocated on the heap
-  // The string runtime does not use it, but allocates manually to avoid circular dependencies
-  if (hasFieldsToDeAllocate && !sourceFile->isStringRT()) {
-    const SourceFile *memoryRT = sourceFile->requestRuntimeModule(MEMORY_RT);
-    assert(memoryRT != nullptr);
-    Scope *matchScope = memoryRT->globalScope.get();
-    // Set dealloc function to used
-    const QualType thisType(TY_DYN);
-    QualType bytePtrRefType = QualType(TY_BYTE).toPtr(node).toRef(node);
-    bytePtrRefType.makeHeap();
-    const ArgList args = {{bytePtrRefType, false /* we always have the field as storage */}};
-    Function *deallocFct = FunctionManager::match(matchScope, FCT_NAME_DEALLOC, thisType, args, {}, true, node);
-    assert(deallocFct != nullptr);
-    deallocFct->used = true;
-  }
 }
 
 /**
@@ -580,13 +565,17 @@ void TypeChecker::createMoveCtorBodyPreamble(const Scope *bodyScope) const {
 
 /**
  * Prepare the generation of the dtor body preamble. This preamble is used to destruct all fields and to free all heap fields.
+ *
+ * @param bodyScope Body scope of the dtor
+ * @param node Struct definition node for error messages
  */
-void TypeChecker::createDtorBodyPreamble(const Scope *bodyScope) const {
+void TypeChecker::createDtorBodyPreamble(const Scope *bodyScope, const ASTNode *node) const {
   // Retrieve struct scope
   Scope *structScope = bodyScope->parent;
   assert(structScope != nullptr);
 
   const size_t fieldCount = structScope->getFieldCount();
+  bool hasFieldsToDeAllocate = false;
   for (size_t i = 0; i < fieldCount; i++) {
     const size_t fieldIdx = fieldCount - 1 - i; // Destruct fields in reverse order
     const SymbolTableEntry *fieldSymbol = structScope->lookupField(fieldIdx);
@@ -598,12 +587,36 @@ void TypeChecker::createDtorBodyPreamble(const Scope *bodyScope) const {
     if (fieldType.hasAnyGenericParts())
       TypeMatcher::substantiateTypeWithTypeMapping(fieldType, typeMapping, fieldSymbol->declNode);
 
+    hasFieldsToDeAllocate |= fieldType.needsDeAllocation();
+
     if (fieldType.is(TY_STRUCT)) {
       const auto fieldNode = spice_pointer_cast<const FieldNode *>(fieldSymbol->declNode);
       // Match ctor function, create the concrete manifestation and set it to used
       Scope *matchScope = fieldType.getBodyScope();
       FunctionManager::match(matchScope, DTOR_FUNCTION_NAME, fieldType, {}, {}, false, fieldNode);
     }
+  }
+
+  // Request the memory runtime for the de-allocations that the generated body will contain, and mark its sDealloc as
+  // used so that a definition is emitted for it. This deliberately happens here and not where the dtor is created
+  // (createDefaultDtorIfRequired): a manifestation can come into existence while memory_rt.spice is itself still being
+  // pre-checked - sAlloc() returns Result<heap byte*>, so the very first Result manifestation is substantiated from
+  // memory_rt's own signature list. Asking that half-prepared file for sDealloc, which is declared further down in it,
+  // would come up empty. By the time a default member's body is prepared, every runtime module is fully pre-checked.
+  // The string runtime does not use sDealloc, but frees manually to avoid a circular dependency.
+  SourceFile *structSourceFile = structScope->sourceFile;
+  if (hasFieldsToDeAllocate && !structSourceFile->isStringRT()) {
+    const SourceFile *memoryRT = structSourceFile->requestRuntimeModule(MEMORY_RT);
+    assert(memoryRT != nullptr);
+    Scope *matchScope = memoryRT->globalScope.get();
+    // Set dealloc function to used
+    const QualType thisType(TY_DYN);
+    QualType bytePtrRefType = QualType(TY_BYTE).toPtr(node).toRef(node);
+    bytePtrRefType.makeHeap();
+    const ArgList args = {{bytePtrRefType, false /* we always have the field as storage */}};
+    Function *deallocFct = FunctionManager::match(matchScope, FCT_NAME_DEALLOC, thisType, args, {}, true, node);
+    assert(deallocFct != nullptr);
+    deallocFct->used = true;
   }
 }
 

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -276,7 +276,7 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
     // Check default dtor body if required
     const Function *dtorFunc = FunctionManager::lookup(currentScope, DTOR_FUNCTION_NAME, structType, {}, true);
     if (dtorFunc != nullptr && dtorFunc->implicitDefault)
-      createDtorBodyPreamble(dtorFunc->bodyScope);
+      createDtorBodyPreamble(dtorFunc->bodyScope, node);
 
     // Reset field symbols to declared state for the next manifestation
     manifestation->resetFieldSymbolsToDeclared(node);

--- a/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
+++ b/src/typechecker/TypeCheckerTopLevelDefinitionsCheck.cpp
@@ -171,12 +171,17 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
   manIdx = 0; // Reset the manifestation index
 
   // Get all manifestations for this procedure definition
-  for (const Struct *manifestation : node->structManifestations) {
+  for (Struct *manifestation : node->structManifestations) {
     // Skip non-substantiated or already checked procedures
     if (!manifestation->isFullySubstantiated()) {
       manIdx++; // Increase the manifestation index
       continue;
     }
+
+    // Fallback for manifestations that could not be decided on when they were created, because a by-value struct field
+    // was not manifested yet at that point (circular import). By now the whole import graph is prepared, so the
+    // decision can be taken - late, but still before the struct's own default member bodies are prepared below.
+    createImplicitDefaultMembers(*manifestation, node, /*withMoveCtor=*/false);
 
     // Change to struct scope
     changeToScope(manifestation->scope, ScopeType::STRUCT);
@@ -262,7 +267,8 @@ std::any TypeChecker::visitStructDefCheck(StructDefNode *node) {
 
     // Check default move ctor body if required. findMoveCtor scans the manifestations directly to avoid the
     // constify-based false-positive that FunctionManager::lookup with a non-const ref arg can produce.
-    if (const Function *moveCtorFunc = FunctionManager::findMoveCtor(currentScope); moveCtorFunc && moveCtorFunc->implicitDefault) {
+    if (const Function *moveCtorFunc = FunctionManager::findMoveCtor(currentScope);
+        moveCtorFunc && moveCtorFunc->implicitDefault) {
       createMoveCtorBodyPreamble(moveCtorFunc->bodyScope);
       assert(manifestation->areAllFieldsInitialized() == nullptr);
     }

--- a/std/data/bitset.spice
+++ b/std/data/bitset.spice
@@ -36,7 +36,7 @@ public p BitSet.ctor(unsigned long numBits = 0l) {
     if this.numWords == 0l { return; }
     unsafe {
         Result<heap byte*> allocResult = sAlloc(sizeof<unsigned long>() * this.numWords);
-        this.words = cast<heap unsigned long*>(allocResult.unwrap());
+        this.words = cast<heap unsigned long*>(sMove(allocResult.unwrap()));
     }
     this.clearAll();
 }
@@ -92,7 +92,7 @@ public p operator=(BitSet& this, const BitSet& newValue) {
         } else {
             unsafe {
                 Result<heap byte*> allocResult = sRealloc(cast<heap byte*>(this.words), sizeof<unsigned long>() * newValue.numWords);
-                this.words = cast<heap unsigned long*>(allocResult.unwrap());
+                this.words = cast<heap unsigned long*>(sMove(allocResult.unwrap()));
             }
         }
     }

--- a/std/data/deque.spice
+++ b/std/data/deque.spice
@@ -68,7 +68,7 @@ public p Deque.ctor(unsigned long initAllocItems = 0l) {
     const long itemSize = sizeof<T>();
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     this.capacity = initAllocItems;
 }
@@ -113,7 +113,7 @@ public p operator=<T>(Deque<T>& this, const Deque<T>& newValue) {
         } else {
             unsafe {
                 Result<heap byte*> allocResult = sRealloc(cast<heap byte*>(this.contents), itemSize * newValue.capacity);
-                this.contents = cast<heap T*>(allocResult.unwrap());
+                this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
             }
         }
         this.capacity = newValue.capacity;
@@ -348,7 +348,7 @@ p Deque.resize(unsigned long itemCount) {
         Result<heap byte*> allocResult = sAlloc(newSize);
         // Take ownership of the old pointer to free it at the end of the scope
         heap T* oldAddress = this.contents;
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
         // Copy data over to new memory chunk
         for unsigned long newIndex = 0l; newIndex < this.size; newIndex++ {
             unsigned long oldIndex = this.idxFront + newIndex;

--- a/std/data/doubly-linked-list.spice
+++ b/std/data/doubly-linked-list.spice
@@ -298,7 +298,7 @@ f<heap Node<T>*> DoublyLinkedList.createNode(const T& value) {
     heap Node<T>* newNode;
     unsafe {
         Result<heap byte*> allocResult = sAlloc(sizeof<Node<T>>());
-        newNode = cast<heap Node<T>*>(allocResult.unwrap());
+        newNode = cast<heap Node<T>*>(sMove(allocResult.unwrap()));
     }
     newNode.value = value;
     newNode.prev = nil<Node<T>*>;

--- a/std/data/hash-table.spice
+++ b/std/data/hash-table.spice
@@ -30,11 +30,6 @@ public p HashEntry.ctor(const HashEntry<K, V>& original) {
     this.value = original.value;
 }
 
-public p HashEntry.dtor() {
-    sDestruct(this.key);
-    sDestruct(this.value);
-}
-
 /**
  * A hash table in Spice is a commonly used data structure, which stores key-value pairs and allows
  * fast access to a value by its key. Collisions are resolved via separate chaining, where each

--- a/std/data/linked-list.spice
+++ b/std/data/linked-list.spice
@@ -322,7 +322,7 @@ f<heap Node<T>*> LinkedList.createNode(const T& value) {
     heap Node<T>* newNode;
     unsafe {
         Result<heap byte*> allocResult = sAlloc(sizeof<Node<T>>());
-        newNode = cast<heap Node<T>*>(allocResult.unwrap());
+        newNode = cast<heap Node<T>*>(sMove(allocResult.unwrap()));
     }
     newNode.value = value;
     newNode.next = nil<heap Node<T>*>;

--- a/std/data/priority-queue.spice
+++ b/std/data/priority-queue.spice
@@ -64,7 +64,7 @@ public p PriorityQueue.ctor(unsigned long initAllocItems = 0l) {
     const unsigned long itemSize = sizeof<T>();
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     this.capacity = initAllocItems;
 }
@@ -103,7 +103,7 @@ public p operator=<T>(PriorityQueue<T>& this, const PriorityQueue<T>& newValue) 
         } else {
             unsafe {
                 Result<heap byte*> allocResult = sRealloc(cast<heap byte*>(this.contents), itemSize * newValue.capacity);
-                this.contents = cast<heap T*>(allocResult.unwrap());
+                this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
             }
         }
         this.capacity = newValue.capacity;
@@ -326,7 +326,7 @@ p PriorityQueue.resize(unsigned long itemCount) {
         heap byte*& oldAddress = cast<heap byte*>(this.contents);
         unsigned long newSize = cast<unsigned long>(itemSize * itemCount);
         Result<heap byte*> allocResult = sRealloc(oldAddress, newSize);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     // Set new capacity
     this.capacity = itemCount;

--- a/std/data/queue.spice
+++ b/std/data/queue.spice
@@ -65,7 +65,7 @@ public p Queue.ctor(unsigned long initAllocItems = 0l) {
     const long itemSize = sizeof<T>();
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     this.capacity = initAllocItems;
 }
@@ -110,7 +110,7 @@ public p operator=<T>(Queue<T>& this, const Queue<T>& newValue) {
         } else {
             unsafe {
                 Result<heap byte*> allocResult = sRealloc(cast<heap byte*>(this.contents), itemSize * newValue.capacity);
-                this.contents = cast<heap T*>(allocResult.unwrap());
+                this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
             }
         }
         this.capacity = newValue.capacity;
@@ -300,7 +300,7 @@ p Queue.resize(unsigned long itemCount) {
         Result<heap byte*> allocResult = sAlloc(newSize);
         // Take ownership of the old pointer to free it at the end of the scope
         heap T* oldAddress = this.contents;
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
         // Copy data over to new memory chunk in logical order
         for unsigned long newIndex = 0l; newIndex < this.size; newIndex++ {
             unsigned long oldIndex = this.idxFront + newIndex;

--- a/std/data/stack.spice
+++ b/std/data/stack.spice
@@ -62,7 +62,7 @@ public p Stack.ctor(unsigned long initAllocItems = 0l) {
     const unsigned long itemSize = sizeof<T>();
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initAllocItems);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     this.capacity = initAllocItems;
 }
@@ -100,7 +100,7 @@ public p operator=<T>(Stack<T>& this, const Stack<T>& newValue) {
         } else {
             unsafe {
                 Result<heap byte*> allocResult = sRealloc(cast<heap byte*>(this.contents), itemSize * newValue.capacity);
-                this.contents = cast<heap T*>(allocResult.unwrap());
+                this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
             }
         }
         this.capacity = newValue.capacity;
@@ -241,7 +241,7 @@ p Stack.resize(unsigned long itemCount) {
         heap byte*& oldAddress = cast<heap byte*>(this.contents);
         unsigned long newSize = cast<unsigned long>(itemSize * itemCount);
         Result<heap byte*> allocResult = sRealloc(oldAddress, newSize);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     // Set new capacity
     this.capacity = itemCount;

--- a/std/data/vector.spice
+++ b/std/data/vector.spice
@@ -42,7 +42,7 @@ public p Vector.ctor(unsigned long initialCapacity = 0l) {
     assert itemSize > 0l;
     unsafe {
         Result<heap byte*> allocResult = sAlloc(itemSize * initialCapacity);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     this.capacity = initialCapacity;
 }
@@ -117,7 +117,7 @@ public p operator=<T>(Vector<T>& this, const Vector<T>& newValue) {
         } else {
             unsafe {
                 Result<heap byte*> allocResult = sRealloc(cast<heap byte*>(this.contents), itemSize * newValue.capacity);
-                this.contents = cast<heap T*>(allocResult.unwrap());
+                this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
             }
         }
         this.capacity = newValue.capacity;
@@ -411,7 +411,7 @@ p Vector.resize(unsigned long itemCount) {
         heap byte*& oldAddress = cast<heap byte*>(this.contents);
         unsigned long newSize = cast<unsigned long>(itemSize * itemCount);
         Result<heap byte*> allocResult = sRealloc(oldAddress, newSize);
-        this.contents = cast<heap T*>(allocResult.unwrap());
+        this.contents = cast<heap T*>(sMove(allocResult.unwrap()));
     }
     // Set new capacity
     this.capacity = itemCount;

--- a/std/runtime/memory_rt.spice
+++ b/std/runtime/memory_rt.spice
@@ -70,14 +70,18 @@ public f<heap byte*> sReallocUnsafe(heap byte* ptr, unsigned long size) {
   * @param oldPtr The pointer to the block to copy.
   * @param newPtr The pointer to the new block to copy to.
   * @param size The size of the block to copy.
-  * @return A pointer to the copied block, or an error if the copy failed.
+  * @return A non-owning pointer to the copied block, or an error if the copy failed. The destination block keeps
+  *         belonging to the caller, so the returned pointer is deliberately not heap-qualified - a Result<heap byte*>
+  *         would free the caller's block as soon as it goes out of scope.
   */
-public f<Result<heap byte*>> sCopy(heap byte* oldPtr, heap byte* newPtr, unsigned long size) {
+public f<Result<byte*>> sCopy(heap byte* oldPtr, heap byte* newPtr, unsigned long size) {
     if oldPtr == nil<heap byte*> | newPtr == nil<heap byte*> {
-        return err<heap byte*>("Cannot copy from or to nil pointer!");
+        return err<byte*>("Cannot copy from or to nil pointer!");
     }
     memcpy(newPtr, oldPtr, size);
-    return ok(newPtr);
+    unsafe {
+        return ok<byte*>(cast<byte*>(newPtr));
+    }
 }
 
 /**

--- a/std/runtime/result_rt.spice
+++ b/std/runtime/result_rt.spice
@@ -31,14 +31,12 @@ public p Result.ctor(const Error& error) {
     this.error = error;
 }
 
-// Work-around: Currently the compiler does not generate this default dtor
-public p Result.dtor() {
-    sDestruct(this.data);
-}
-
 /**
  * Returns the stored data object.
  * If an error is present, this function will panic.
+ *
+ * The returned reference is borrowed - the result stays the owner of the data and destructs it when it goes out of
+ * scope. To take ownership of a heap payload, move it out of the result: `heap byte* p = sMove(result.unwrap());`
  */
 public inline f<T&> Result.unwrap() {
     if this.error.code != 0 { panic(this.error); }

--- a/test/test-files/benchmark/success-fibonacci-threaded/type-registry.out
+++ b/test/test-files/benchmark/success-fibonacci-threaded/type-registry.out
@@ -17,7 +17,12 @@ Pthread_attr_t*
 Pthread_t
 Result<T>
 Result<T>
+Result<T>
 Result<T>*
+Result<byte*>
+Result<byte*>
+Result<byte*>&
+Result<byte*>*
 Result<heap byte*>
 Result<heap byte*>
 Result<heap byte*>&
@@ -45,7 +50,7 @@ f<Result<T>>(const Error&)
 f<Result<T>>(const T&)
 f<Result<T>>(int,string)
 f<Result<T>>(string)
-f<Result<heap byte*>>(heap byte*,heap byte*,unsigned long)
+f<Result<byte*>>(heap byte*,heap byte*,unsigned long)
 f<Result<heap byte*>>(heap byte*,unsigned long)
 f<Result<heap byte*>>(unsigned long)
 f<S>()

--- a/test/test-files/irgenerator/imports/success-same-name-struct-across-modules/source2.spice
+++ b/test/test-files/irgenerator/imports/success-same-name-struct-across-modules/source2.spice
@@ -15,7 +15,7 @@ public p StackA.push<T>(const T& v) {
     heap Node<T>* newNode;
     unsafe {
         Result<heap byte*> allocResult = sAlloc(sizeof<Node<T>>());
-        newNode = cast<heap Node<T>*>(allocResult.unwrap());
+        newNode = cast<heap Node<T>*>(sMove(allocResult.unwrap()));
     }
     newNode.value = v;
     newNode.next = this.top;

--- a/test/test-files/irgenerator/imports/success-same-name-struct-across-modules/source3.spice
+++ b/test/test-files/irgenerator/imports/success-same-name-struct-across-modules/source3.spice
@@ -14,7 +14,7 @@ public p StackB.push<T>(const T& v) {
     heap Node<T>* newNode;
     unsafe {
         Result<heap byte*> allocResult = sAlloc(sizeof<Node<T>>());
-        newNode = cast<heap Node<T>*>(allocResult.unwrap());
+        newNode = cast<heap Node<T>*>(sMove(allocResult.unwrap()));
     }
     newNode.value = v;
     newNode.next = this.top;

--- a/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-default-dtor/ir-code.ll
@@ -31,7 +31,7 @@ define internal void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align
   %4 = load ptr, ptr %this, align 8
   %data.addr = getelementptr inbounds %struct.StructWithHeapFields, ptr %4, i64 0, i32 0
   %5 = call noundef ptr @_ZN6ResultIPVhE6unwrapEv(ptr noundef nonnull align 8 dereferenceable(24) %res)
-  %6 = load ptr, ptr %5, align 8
+  %6 = call noundef ptr @_Z5sMoveIVhEPVhRPVh(ptr noundef %5)
   store ptr %6, ptr %data.addr, align 8
   call void @_ZN6ResultIPVhE4dtorEv(ptr noundef nonnull align 8 dereferenceable(24) %res)
   ret void
@@ -40,6 +40,8 @@ define internal void @_ZN20StructWithHeapFields4ctorEv(ptr noundef nonnull align
 declare %struct.Result @_Z6sAllocm(i64)
 
 declare ptr @_ZN6ResultIPVhE6unwrapEv(ptr)
+
+declare ptr @_Z5sMoveIVhEPVhRPVh(ptr)
 
 declare void @_ZN6ResultIPVhE4dtorEv(ptr noundef nonnull align 8 dereferenceable(24))
 

--- a/test/test-files/irgenerator/structs/success-default-dtor/source.spice
+++ b/test/test-files/irgenerator/structs/success-default-dtor/source.spice
@@ -5,7 +5,7 @@ type StructWithHeapFields struct {
 p StructWithHeapFields.ctor() {
     dyn res = sAlloc(10l);
     unsafe {
-        this.data = cast<heap int*>(res.unwrap());
+        this.data = cast<heap int*>(sMove(res.unwrap()));
     }
 }
 

--- a/test/test-files/std/bindings/gtk4-with-builder/ir-code.ll
+++ b/test/test-files/std/bindings/gtk4-with-builder/ir-code.ll
@@ -107,7 +107,6 @@ define internal void @_Z8activate14GtkApplicationPh(%struct.GtkApplication nound
   call void @_ZN9GtkWindow10setVisibleEv(ptr noundef nonnull align 8 dereferenceable(8) %window)
   call void @_ZN10GtkBuilder4dtorEv(ptr noundef nonnull align 8 dereferenceable(8) %builder)
   call void @_ZN6String4dtorEv(ptr noundef nonnull align 8 dereferenceable(24) %filePathString)
-  call void @_ZN6ResultIPKcE4dtorEv(ptr noundef nonnull align 8 dereferenceable(24) %spiceStdDir)
   ret void
 }
 
@@ -156,8 +155,6 @@ declare void @_ZN9GtkWindow10setVisibleEv(ptr)
 declare void @_ZN10GtkBuilder4dtorEv(ptr noundef nonnull align 8 dereferenceable(8))
 
 declare void @_ZN6String4dtorEv(ptr noundef nonnull align 8 dereferenceable(24))
-
-declare void @_ZN6ResultIPKcE4dtorEv(ptr noundef nonnull align 8 dereferenceable(24))
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
 define dso_local noundef i32 @main(i32 %0, ptr %1) #1 {

--- a/test/test-files/std/data/container-scope-cleanup-leak/cout.out
+++ b/test/test-files/std/data/container-scope-cleanup-leak/cout.out
@@ -8,5 +8,5 @@ copies hold 2 and 2 elements
 vector copy ok
 iterated 5 map entries
 unordered map ok
-iterated set entries, sum 211
+iterated 3 set entries
 unordered set ok

--- a/test/test-files/std/data/container-scope-cleanup-leak/source.spice
+++ b/test/test-files/std/data/container-scope-cleanup-leak/source.spice
@@ -90,19 +90,18 @@ f<int> main() {
         // reference-typed local variable in Spice assigns through the reference, it does not rebind it.
         // A handful of entries spread across the default 100 buckets still exercises the iterator's
         // "skip empty buckets" logic, which is where the corruption used to happen.
-        // Note: keys/values are trivial (int) here on purpose. HashTable's own element type
-        // (HashEntry<K, V>) currently never gets its default dtor generated when V is non-trivial, since
-        // it is only ever reached indirectly as a nested generic field (Vector<LinkedList<HashEntry<K,
-        // V>>>), never instantiated by name directly - a separate, pre-existing gap in the compiler's
-        // generic-manifestation collection, not covered by this test.
-        UnorderedMap<int, int> map = UnorderedMap<int, int>();
-        map.upsert(3, 3 * 3);
-        map.upsert(17, 17 * 17);
-        map.upsert(42, 42 * 42);
-        map.upsert(58, 58 * 58);
-        map.upsert(91, 91 * 91);
+        // The values are non-trivial on purpose: HashTable's own element type (HashEntry<K, V>) is only
+        // ever reached indirectly as a nested generic field (Vector<LinkedList<HashEntry<K, V>>>) and is
+        // never instantiated by name, so its compiler-generated default dtor used to be missing and every
+        // stored value leaked (see #1297).
+        UnorderedMap<int, String> map = UnorderedMap<int, String>();
+        map.upsert(3, String("first heap-allocated map value"));
+        map.upsert(17, String("second heap-allocated map value"));
+        map.upsert(42, String("third heap-allocated map value"));
+        map.upsert(58, String("fourth heap-allocated map value"));
+        map.upsert(91, String("fifth heap-allocated map value"));
         int count = 0;
-        foreach Pair<int&, int&> entry : map {
+        foreach Pair<int&, String&> entry : map {
             count++;
         }
         printf("iterated %d map entries\n", count);
@@ -110,17 +109,16 @@ f<int> main() {
     printf("unordered map ok\n");
 
     {
-        UnorderedSet<int> set = UnorderedSet<int>();
-        set.insert(3);
-        set.insert(17);
-        set.insert(42);
-        set.insert(58);
-        set.insert(91);
+        // Same as above, but for UnorderedSet, which stores its values as the *keys* of a HashTable<V, bool>
+        UnorderedSet<String> set = UnorderedSet<String>();
+        set.insert(String("first heap-allocated set value"));
+        set.insert(String("second heap-allocated set value"));
+        set.insert(String("third heap-allocated set value"));
         int count = 0;
-        foreach int value : set {
-            count += value;
+        foreach String value : set {
+            count += value.getLength() > 0l ? 1 : 0;
         }
-        printf("iterated set entries, sum %d\n", count);
+        printf("iterated %d set entries\n", count);
     }
     printf("unordered set ok\n");
 

--- a/test/test-files/std/runtime/result-heap-payload/cout.out
+++ b/test/test-files/std/runtime/result-heap-payload/cout.out
@@ -1,0 +1,12 @@
+alloc ok: 1
+buffer valid: 1
+payload taken out: 1
+buffer released
+owned buffer valid: 1
+owned buffer released
+payload ok: 1, id: 1
+destructing payload 1
+destructing payload 1
+payload result done
+failed ok: 0, code: 7
+done

--- a/test/test-files/std/runtime/result-heap-payload/source.spice
+++ b/test/test-files/std/runtime/result-heap-payload/source.spice
@@ -1,0 +1,50 @@
+// Result<T> owns what it wraps, and the compiler-generated dtor is what enforces that: for a heap payload it frees the
+// block, for a struct payload it runs the payload's dtor. That generated dtor is what allowed the hand-written
+// work-around dtor to be dropped from std/runtime/result_rt.spice.
+//
+// Because the result owns the payload, a caller that wants to keep a heap payload alive past the result's scope has to
+// take it out with sMove(). That nils the payload inside the result, so the result's dtor finds nothing left to free
+// and ownership ends up with exactly one holder.
+
+public type Payload struct {
+    int id
+}
+
+public p Payload.ctor(int id) {
+    this.id = id;
+}
+
+public p Payload.dtor() {
+    printf("destructing payload %d\n", this.id);
+}
+
+f<int> main() {
+    // Moving the payload out makes the caller the owner: the result's dtor sees a nil payload and does nothing
+    Result<heap byte*> allocResult = sAlloc(16l);
+    printf("alloc ok: %d\n", allocResult.isOk());
+    heap byte* buffer = sMove(allocResult.unwrap());
+    printf("buffer valid: %d\n", buffer != nil<heap byte*>);
+    printf("payload taken out: %d\n", allocResult.unwrap() == nil<heap byte*>);
+    sDealloc(buffer);
+    printf("buffer released\n");
+
+    // Without the sMove, the result stays the owner and frees the block when it goes out of scope
+    {
+        Result<heap byte*> ownedResult = sAlloc(32l);
+        printf("owned buffer valid: %d\n", ownedResult.unwrap() != nil<heap byte*>);
+    }
+    printf("owned buffer released\n");
+
+    // A struct payload is destructed by the same generated dtor
+    {
+        Result<Payload> payloadResult = ok<Payload>(Payload(1));
+        printf("payload ok: %d, id: %d\n", payloadResult.isOk(), payloadResult.unwrap().id);
+    }
+    printf("payload result done\n");
+
+    // An error result with a trivial payload needs no dtor at all
+    Result<int> failed = err<int>(7, "nothing here");
+    printf("failed ok: %d, code: %d\n", failed.isOk(), failed.getErr().code);
+
+    printf("done\n");
+}

--- a/test/test-files/typechecker/generics/success-nested-generic-default-members/container.spice
+++ b/test/test-files/typechecker/generics/success-nested-generic-default-members/container.spice
@@ -1,0 +1,32 @@
+// Generic types for key and value
+type K dyn;
+type V dyn;
+
+/**
+ * A generic struct that declares no special members at all, so it fully relies on the compiler-generated ones.
+ * Whether it needs any of them depends on the concrete K and V, which is unanswerable here.
+ */
+public type Entry<K, V> struct {
+    K key
+    V value
+}
+
+/**
+ * Entry<K, V> is never instantiated by name anywhere - it only ever comes into existence as this field type, which
+ * means its concrete manifestations are substantiated indirectly from whichever file uses Box<K, V> (see #1297).
+ */
+public type Box<K, V> struct {
+    Entry<K, V> entry
+}
+
+public p Box.ctor(const K& key, const V& value) {
+    this.entry = Entry<K, V>{key, value};
+}
+
+public f<const K&> Box.getKey() {
+    return this.entry.key;
+}
+
+public f<const V&> Box.getValue() {
+    return this.entry.value;
+}

--- a/test/test-files/typechecker/generics/success-nested-generic-default-members/cout.out
+++ b/test/test-files/typechecker/generics/success-nested-generic-default-members/cout.out
@@ -1,0 +1,10 @@
+key: 1, value id: 11
+destructing payload 11
+destructing payload 11
+box with payload value done
+key id: 22, value: 2
+destructing payload 22
+destructing payload 22
+box with payload key done
+key: 3, value: 33
+box with trivial payload done

--- a/test/test-files/typechecker/generics/success-nested-generic-default-members/source.spice
+++ b/test/test-files/typechecker/generics/success-nested-generic-default-members/source.spice
@@ -1,0 +1,45 @@
+import "container";
+
+// A type with an observable, non-trivial lifecycle, used as a template argument from this file. The struct that ends up
+// holding it (Entry<K, V> in container.spice) has to receive its compiler-generated default dtor, even though its
+// manifestation only comes into existence here, long after container.spice was prepared (see #1297).
+public type Payload struct {
+    int id
+}
+
+public p Payload.ctor(int id) {
+    this.id = id;
+}
+
+public p Payload.dtor() {
+    printf("destructing payload %d\n", this.id);
+}
+
+f<int> main() {
+    // Two destruct lines are expected per payload below: one for the temporary that is passed to Box.ctor and one for
+    // the copy that the box stores. Both only appear if Entry<K, V> got its default dtor.
+
+    // The value is the non-trivial one
+    {
+        Box<int, Payload> box = Box<int, Payload>(1, Payload(11));
+        printf("key: %d, value id: %d\n", box.getKey(), box.getValue().id);
+    }
+    printf("box with payload value done\n");
+
+    // The key is the non-trivial one. A second manifestation of the same generic struct must get its own default
+    // members - the first one must not suppress them.
+    {
+        Box<Payload, int> box = Box<Payload, int>(Payload(22), 2);
+        printf("key id: %d, value: %d\n", box.getKey().id, box.getValue());
+    }
+    printf("box with payload key done\n");
+
+    // Both template arguments are trivial, so nothing has to be destructed here
+    {
+        Box<int, int> box = Box<int, int>(3, 33);
+        printf("key: %d, value: %d\n", box.getKey(), box.getValue());
+    }
+    printf("box with trivial payload done\n");
+
+    return 0;
+}


### PR DESCRIPTION
## What changed

- The decision about which compiler-generated default members (ctor, copy ctor, dtor) a struct needs is now taken **once per manifestation**, at the point where `StructManager::match` creates it, instead of once per source file in the one-shot sweep at the end of its prepare run.
- Fixed three pre-existing issues in `FunctionManager` / `Function` that this newly reachable code path runs into (see the first commit — none of them is reachable on `main` today).
- Removed the `HashEntry.dtor()` work-around from #1309 again, since the compiler now generates that dtor itself.

## Why

Whether a struct needs a default dtor depends on its concrete field types, so the answer is unanswerable while they are still generic: `HashEntry<K, V>` cannot say whether it needs one, `HashEntry<int, String>` can. Deciding once per source file meant that every manifestation substantiated *after* that file's sweep silently ended up with no default members at all — which is exactly what happens whenever a manifestation is only reached indirectly, as a nested generic field of another struct. `HashEntry<K, V>` only ever exists as the value type of `LinkedList`'s `Node`, so `UnorderedMap`, `UnorderedSet` and `Graph` leaked every stored value that owned heap memory.

The decision cannot be deferred any later than manifestation creation: a function body is type-checked exactly once, and every lookup that asks a struct for its default members (`FunctionManager::match`/`::lookup`, `doScopeCleanup`, the `foreach` temporary bookkeeping) is reactive and one-shot, so a dtor that appears afterwards is never called. Nested field manifestations are decided on first, through their own recursive `match()` call, so a field's dtor is in place by the time the enclosing struct is asked whether it needs one.

## How it was validated

- `cmake --build cmake-build-debug --target spice spicetest` — clean.
- Full suite, `rm -rf test/test-tmp` first, from `test/`: **611/640 pass**. The 27 failures are byte-for-byte the same set as on unpatched `e2e8ff78` (verified by rebuilding the baseline compiler and diffing the sorted failure lists) and are environment-only on this machine: 10 `BootstrapCompilerTests` + `StdTests.bindings_llvm` fail to link with `mold: fatal: library not found: LLVMIREmbUtils` (not present in the local LLVM install), and 16 `DriverTest.*` are induced by the `SPICE_STD_DIR`/`LLVM_LIB_DIR` env vars the bootstrap tests need. **CI should be the authority here.**
- The issue's repro, with the `HashEntry.dtor()` work-around removed:
  ```
  spice build -g repro.spice -o repro && valgrind --leak-check=full ./repro
  → All heap blocks were freed -- no leaks are possible
  ```
  `nm -C repro` now shows `HashEntry<int, String>::dtor()`. Same result for a `Graph<int>` + `addVertex`/`addEdge` repro and for the minimal two-file repro from the issue.
- New test `test/test-files/typechecker/generics/success-nested-generic-default-members`: two files, a generic `Entry<K, V>` that only ever exists as `Box<K, V>`'s field type. Verified it discriminates — the unpatched compiler prints one destruct line per payload (the temporary), the patched one prints two (temporary + stored copy).
- `test/test-files/std/data/container-scope-cleanup-leak` switched its `UnorderedMap`/`UnorderedSet` sections from trivial `int` values to `String`, so the ASan run in that test now covers this. The stale comment pointing at this bug is gone.
- Compile time on a large program (`standalone-scope-test`, 3 runs each, cold `/tmp/spice`): 4.55–4.59 s with the change vs 4.65–4.69 s without — no regression.

## Follow-up / known limitations

- **Default move ctors are still not synthesized for manifestations substantiated after their file was prepared**, which keeps them exactly at their current behavior. Synthesizing one requires the move ctor of each struct-typed field to be resolvable for the concrete manifestation, and `FunctionManager::findMoveCtor` is a raw manifestation scan that returns the *generic preset* the manifestation scope inherited; `createMoveCtorBodyPreamble` then re-points the field symbol's body scope at the generic struct scope, which trips `assert(copyCtor != nullptr)` in `generateCopyCtorBodyPreamble`. Falling back to copying is correct, just less efficient. That gap is a separate, pre-existing problem and deserves its own change.
- Unrelated pre-existing limitation confirmed while writing the test: a **non-public** struct used as a template argument for an imported generic cannot have its dtor called cross-module (`undefined symbol: Payload::dtor()`). Reproduces on `main` with `LinkedList<Payload>`, so the test uses a public type.

Fixes #1297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
