### PR TITLE
ci: run Valgrind workflow weekly and add README badge

### DIFF
--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -2,6 +2,10 @@
 name: Valgrind
 
 on:
+  # Every Sunday at 04:00 UTC
+  schedule:
+    - cron: '0 4 * * 0'
+  # Allow manual triggering
   workflow_dispatch:
 
 env:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 	<a target="_blank" href="https://github.com/spicelang/spice/actions/workflows/ci-cpp.yml"><img alt="CI status" src="https://github.com/spicelang/spice/actions/workflows/ci-cpp.yml/badge.svg"></a>
 	<a target="_blank" href="https://github.com/spicelang/spice/actions/workflows/codeql-analysis.yml"><img alt="CodeQL status" src="https://github.com/spicelang/spice/actions/workflows/codeql-analysis.yml/badge.svg"></a>
 	<a target="_blank" href="https://github.com/spicelang/spice/actions/workflows/ci-asan.yml"><img alt="ASAN status" src="https://github.com/spicelang/spice/actions/workflows/ci-asan.yml/badge.svg"></a>
+	<a target="_blank" href="https://github.com/spicelang/spice/actions/workflows/valgrind.yml"><img alt="Valgrind status" src="https://github.com/spicelang/spice/actions/workflows/valgrind.yml/badge.svg"></a>
     <a target="_blank" href="./LICENSE"><img alt="License" src="https://img.shields.io/github/license/spicelang/spice"></a>
     <a target="_blank" href="https://discord.gg/D6sCsJyWPg"><img alt="Discord server" src="https://dcbadge.limes.pink/api/server/D6sCsJyWPg?style=flat"></a>
   </p>


### PR DESCRIPTION
Schedule the Valgrind leak check to run every Sunday at 04:00 UTC in
addition to manual dispatch, so leaks get caught without someone having
to trigger the workflow by hand. Add a matching status badge to the
README next to the other CI badges.