### PR TITLE
Introduce __is_heap builtin

### DIFF
--- a/src/typechecker/Builtins.h
+++ b/src/typechecker/Builtins.h
@@ -47,6 +47,7 @@ static constexpr std::string_view BUILTIN_FCT_NAME_GET_BUILD_VAR = "__get_build_
 static constexpr std::string_view BUILTIN_FCT_NAME_IS_TRIVIALLY_CONSTRUCTIBLE = "__is_trivially_constructible";
 static constexpr std::string_view BUILTIN_FCT_NAME_IS_TRIVIALLY_COPYABLE = "__is_trivially_copyable";
 static constexpr std::string_view BUILTIN_FCT_NAME_IS_TRIVIALLY_DESTRUCTIBLE = "__is_trivially_destructible";
+static constexpr std::string_view BUILTIN_FCT_NAME_IS_HEAP = "__is_heap";
 static constexpr std::string_view BUILTIN_FCT_NAME_NEW = "__new";
 static constexpr std::string_view BUILTIN_FCT_NAME_PLACEMENT_NEW = "__placement_new";
 
@@ -181,6 +182,14 @@ static constexpr std::array BUILTIN_FUNCTIONS = {
             .typeCheckerVisitMethod = &TypeChecker::visitBuiltinIsTriviallyDestructible,
             .minTemplateTypes = 1,
             .maxTemplateTypes = 1,
+        },
+    },
+    BuiltinFunctionEntry{
+        BUILTIN_FCT_NAME_IS_HEAP,
+        BuiltinFunctionInfo{
+          .typeCheckerVisitMethod = &TypeChecker::visitBuiltinIsHeap,
+          .minTemplateTypes = 1,
+          .maxTemplateTypes = 1,
         },
     },
     BuiltinFunctionEntry{

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -141,6 +141,7 @@ public:
   std::any visitBuiltinIsTriviallyConstructible(FctCallNode *node) const;
   std::any visitBuiltinIsTriviallyCopyable(FctCallNode *node) const;
   std::any visitBuiltinIsTriviallyDestructible(FctCallNode *node) const;
+  std::any visitBuiltinIsHeap(FctCallNode *node) const;
   std::any visitBuiltinNewCall(FctCallNode *node) const;
   std::any visitBuiltinPlacementNewCall(FctCallNode *node) const;
 
@@ -177,7 +178,7 @@ private:
   void createCtorBodyPreamble(const Scope *bodyScope) const;
   void createCopyCtorBodyPreamble(const Scope *bodyScope) const;
   void createMoveCtorBodyPreamble(const Scope *bodyScope) const;
-  void createDtorBodyPreamble(const Scope *bodyScope) const;
+  void createDtorBodyPreamble(const Scope *bodyScope, const ASTNode *node) const;
   Function *implicitlyCallStructMethod(const SymbolTableEntry *entry, const std::string &methodName, const ArgList &args,
                                        const ASTNode *node) const;
   Function *implicitlyCallStructMethod(QualType thisType, const std::string &methodName, const ArgList &args,

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -178,7 +178,7 @@ private:
   void createCtorBodyPreamble(const Scope *bodyScope) const;
   void createCopyCtorBodyPreamble(const Scope *bodyScope) const;
   void createMoveCtorBodyPreamble(const Scope *bodyScope) const;
-  void createDtorBodyPreamble(const Scope *bodyScope, const ASTNode *node) const;
+  void createDtorBodyPreamble(const Scope *bodyScope) const;
   Function *implicitlyCallStructMethod(const SymbolTableEntry *entry, const std::string &methodName, const ArgList &args,
                                        const ASTNode *node) const;
   Function *implicitlyCallStructMethod(QualType thisType, const std::string &methodName, const ArgList &args,

--- a/src/typechecker/TypeCheckerBuiltinFunctions.cpp
+++ b/src/typechecker/TypeCheckerBuiltinFunctions.cpp
@@ -490,6 +490,16 @@ std::any TypeChecker::visitBuiltinIsTriviallyDestructible(FctCallNode *node) con
   return ExprResult{node->setEvaluatedSymbolType(QualType(TY_BOOL), manIdx)};
 }
 
+std::any TypeChecker::visitBuiltinIsHeap(FctCallNode *node) const {
+  assert(node->fqFunctionName == BUILTIN_FCT_NAME_IS_HEAP);
+
+  const QualType type = node->templateTypeLst->dataTypes.front()->getEvaluatedSymbolType(manIdx);
+  const bool value = type.isHeap();
+  node->setCompileTimeValue({.boolValue = value}, manIdx);
+
+  return ExprResult{node->setEvaluatedSymbolType(QualType(TY_BOOL), manIdx)};
+}
+
 std::any TypeChecker::visitBuiltinNewCall(FctCallNode *node) const {
   assert(node->fqFunctionName == BUILTIN_FCT_NAME_NEW);
 

--- a/test/test-files/irgenerator/builtins/success-is-heap/cout.out
+++ b/test/test-files/irgenerator/builtins/success-is-heap/cout.out
@@ -1,0 +1,4 @@
+Is heap: 1
+Is heap: 1
+Is heap: 0
+Is heap: 0

--- a/test/test-files/irgenerator/builtins/success-is-heap/ir-code.ll
+++ b/test/test-files/irgenerator/builtins/success-is-heap/ir-code.ll
@@ -1,0 +1,34 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+
+@printf.str.0 = private unnamed_addr constant [13 x i8] c"Is heap: %d\0A\00", align 4
+@printf.str.1 = private unnamed_addr constant [13 x i8] c"Is heap: %d\0A\00", align 4
+@printf.str.2 = private unnamed_addr constant [13 x i8] c"Is heap: %d\0A\00", align 4
+@printf.str.3 = private unnamed_addr constant [13 x i8] c"Is heap: %d\0A\00", align 4
+
+; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
+define dso_local noundef i32 @main() #0 {
+  %result = alloca i32, align 4
+  store i32 0, ptr %result, align 4
+  %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, i32 noundef 1)
+  %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1, i32 noundef 1)
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2, i32 noundef 0)
+  %4 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.3, i32 noundef 0)
+  %5 = load i32, ptr %result, align 4
+  ret i32 %5
+}
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
+
+attributes #0 = { mustprogress noinline norecurse nounwind optnone uwtable }
+attributes #1 = { nofree nounwind }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/builtins/success-is-heap/source.spice
+++ b/test/test-files/irgenerator/builtins/success-is-heap/source.spice
@@ -1,0 +1,6 @@
+f<int> main() {
+    printf("Is heap: %d\n", __is_heap<heap int*>());
+    printf("Is heap: %d\n", __is_heap<heap string*>());
+    printf("Is heap: %d\n", __is_heap<string*>());
+    printf("Is heap: %d\n", __is_heap<String>());
+}

--- a/test/test-files/typechecker/builtins/error-is-heap/exception.out
+++ b/test/test-files/typechecker/builtins/error-is-heap/exception.out
@@ -1,0 +1,20 @@
+[Error|Compiler]:
+Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
+
+[Error|Semantic] ./source.spice:2:5:
+Builtin function argument count mismatch: This builtin expects no argument(s), but got 1
+
+2  __is_heap<heap int*>(76); // With args
+   ^^^^^^^^^^^^^^^^^^^^^^^^
+
+[Error|Semantic] ./source.spice:3:5:
+Builtin function template type count mismatch: This builtin expects 1 template type(s), but got 0
+
+3  __is_heap(); // Too less templa
+   ^^^^^^^^^^^
+
+[Error|Semantic] ./source.spice:4:5:
+Builtin function template type count mismatch: This builtin expects 1 template type(s), but got 2
+
+4  __is_heap<heap double*, int>(); // Too many templa
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/test/test-files/typechecker/builtins/error-is-heap/source.spice
+++ b/test/test-files/typechecker/builtins/error-is-heap/source.spice
@@ -1,0 +1,5 @@
+f<int> main() {
+    __is_heap<heap int*>(76); // With args
+    __is_heap(); // Too less template types
+    __is_heap<heap double*, int>(); // Too many template types
+}


### PR DESCRIPTION
Introduce builtin, that can check if a type is heap-qualified:

```spice
__is_heap<heap int*>(); // true
__is_heap<int*>(); // false
```
This builtin is evaluatable at compile time