### PR TITLE
Deduplicate TypeMapping alias into QualType.h

### DIFF
--- a/src/model/Function.h
+++ b/src/model/Function.h
@@ -15,7 +15,6 @@ namespace spice::compiler {
 class ASTNode;
 struct CodeLoc;
 class SymbolTableEntry;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 struct Param {
   QualType qualType;

--- a/src/model/GenericType.h
+++ b/src/model/GenericType.h
@@ -11,9 +11,6 @@
 
 namespace spice::compiler {
 
-// Typedefs
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
-
 class GenericType : public QualType {
 public:
   // Constructors

--- a/src/model/StructBase.h
+++ b/src/model/StructBase.h
@@ -18,7 +18,6 @@ class Scope;
 class ASTNode;
 struct CodeLoc;
 class GenericType;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 class StructBase {
 public:

--- a/src/symboltablebuilder/QualType.h
+++ b/src/symboltablebuilder/QualType.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include <symboltablebuilder/TypeQualifiers.h>
@@ -41,6 +42,7 @@ static constexpr uint64_t TYPE_ID_ITERABLE_INTERFACE = 256;
 
 // Typedefs
 using QualTypeList = std::vector<QualType>;
+using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 /**
  * QualType pairs an interned, immutable type (held behind the dependency-free IType interface) with a set of

--- a/src/typechecker/FunctionManager.h
+++ b/src/typechecker/FunctionManager.h
@@ -17,7 +17,6 @@ class Scope;
 class SymbolTableEntry;
 class ASTNode;
 class GenericType;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 // Typedefs
 using FunctionManifestationList = std::map</*mangledName=*/std::string, Function>;

--- a/src/typechecker/InterfaceManager.h
+++ b/src/typechecker/InterfaceManager.h
@@ -17,7 +17,6 @@ class Interface;
 class Scope;
 class ASTNode;
 class GenericType;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 // Typedefs
 using InterfaceManifestationList = std::map</*mangledName=*/std::string, Interface>;

--- a/src/typechecker/StructManager.h
+++ b/src/typechecker/StructManager.h
@@ -16,7 +16,6 @@ class Struct;
 class Scope;
 class ASTNode;
 class GenericType;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 // Typedefs
 using StructManifestationList = std::map</*mangledName=*/std::string, Struct>;

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -17,7 +17,6 @@ using ParamList = std::vector<Param>;
 using NamedParamList = std::vector<NamedParam>;
 using Arg = std::pair</*type=*/QualType, /*isTemporary=*/bool>;
 using ArgList = std::vector<Arg>;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 enum TypeCheckerMode : bool {
   TC_MODE_PRE,

--- a/src/typechecker/TypeMatcher.h
+++ b/src/typechecker/TypeMatcher.h
@@ -10,7 +10,6 @@ namespace spice::compiler {
 
 // Forward declarations
 class GenericType;
-using TypeMapping = std::unordered_map</*typeName=*/std::string, /*concreteType=*/QualType>;
 
 /**
  * Helper class for FunctionManager and StructManager to match generic types.


### PR DESCRIPTION
## Summary

The type alias `using TypeMapping = std::unordered_map<std::string, QualType>;` was defined **byte-for-byte identically in eight headers**:

- `src/model/Function.h`
- `src/model/GenericType.h`
- `src/model/StructBase.h`
- `src/typechecker/FunctionManager.h`
- `src/typechecker/InterfaceManager.h`
- `src/typechecker/StructManager.h`
- `src/typechecker/TypeChecker.h`
- `src/typechecker/TypeMatcher.h`

This PR moves a single canonical definition next to the related `QualTypeList` alias in `src/symboltablebuilder/QualType.h` (adding the required `#include <unordered_map>`) and removes the eight duplicates.

## Why

Eight copies of the same alias are a maintenance hazard — any change to the mapping's key/value types has to be made in eight places. All former definition sites already reach `QualType.h`, either directly (7 of 8) or transitively (`TypeChecker.h` via `OpRuleManager.h → ExprResult.h → SymbolTableEntry.h → QualType.h`), so no new include coupling is introduced.

## Validation

```
cmake --build build --target spice       # 72/72 TUs, clean
cmake --build build --target spicetest    # clean
```

Pure header-level deduplication — no behavioral change.

## Follow-up

None.