### PR TITLE
Simplify JSON, TOML and XML parser/serializer internals

### DIFF
--- a/std/text/json-serializer.spice
+++ b/std/text/json-serializer.spice
@@ -31,9 +31,7 @@ public p JsonSerializer.ctor(bool pretty = false) {
  * @return JSON representation
  */
 public f<String> JsonSerializer.serialize(JsonValue& value) {
-    String out;
-    this.serializeInto(&value, out, 0l);
-    return out;
+    return this.serialize(&value);
 }
 
 /**

--- a/std/text/json-value.spice
+++ b/std/text/json-value.spice
@@ -294,11 +294,7 @@ public f<JsonValue*> JsonValue.getObjectValue(unsigned long idx) {
  */
 public f<bool> JsonValue.hasField(string key) {
     if this.kind != JsonValueKind::JSON_OBJECT { return false; }
-    // Comparing against the raw key avoids building a String that would have to be cleaned up
-    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
-        if this.objectKeys.get(i) == key { return true; }
-    }
-    return false;
+    return this.findFieldIndex(key) >= 0l;
 }
 
 /**
@@ -310,13 +306,20 @@ public f<bool> JsonValue.hasField(string key) {
  */
 public f<JsonValue*> JsonValue.getField(string key) {
     assert this.kind == JsonValueKind::JSON_OBJECT;
-    // Comparing against the raw key avoids building a String that would have to be cleaned up
-    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
-        if this.objectKeys.get(i) == key {
-            return this.objectValues.get(i);
-        }
+    const long idx = this.findFieldIndex(key);
+    if idx < 0l {
+        panic(Error("JSON object has no such field"));
     }
-    panic(Error("JSON object has no such field"));
+    return this.objectValues.get(cast<unsigned long>(idx));
+}
+
+// Index of the object field with the given key, or -1 if the object has no such field.
+// Comparing against the raw key avoids building a String that would have to be cleaned up
+f<long> JsonValue.findFieldIndex(string key) {
+    for unsigned long i = 0l; i < this.objectKeys.getSize(); i++ {
+        if this.objectKeys.get(i) == key { return i; }
+    }
+    return -1l;
 }
 
 /**

--- a/std/text/toml-parser.spice
+++ b/std/text/toml-parser.spice
@@ -411,51 +411,40 @@ f<TomlValue*> TomlParser.parseBool() {
 f<TomlValue*> TomlParser.parseArray() {
     this.pos++; // consume '['
     TomlValue* arr = __new<TomlValue>(TomlValueKind::TOML_ARRAY);
-    while true {
+    // Every failure leaves the loop, so the partially built array is released in one place
+    while !this.hasError {
         // Line breaks and comments are allowed anywhere inside an array
         this.skipBlanks();
-        if this.hasError {
-            deleteTomlValue(arr);
-            return nil<TomlValue*>;
-        }
+        if this.hasError { break; }
         if this.atEnd() {
             this.fail("Unterminated array");
-            deleteTomlValue(arr);
-            return nil<TomlValue*>;
+            break;
         }
         if this.peek() == ']' {
             this.pos++;
             return arr;
         }
         TomlValue* item = this.parseValue();
-        if this.hasError {
-            deleteTomlValue(arr);
-            return nil<TomlValue*>;
-        }
+        if this.hasError { break; }
         arr.addArrayItem(item);
         this.skipBlanks();
-        if this.hasError {
-            deleteTomlValue(arr);
-            return nil<TomlValue*>;
-        }
+        if this.hasError { break; }
         if this.atEnd() {
             this.fail("Unterminated array");
-            deleteTomlValue(arr);
-            return nil<TomlValue*>;
+            break;
         }
         const char c = this.peek();
-        if c == ',' {
-            this.pos++;
-            continue;
-        }
         if c == ']' {
             this.pos++;
             return arr;
         }
-        this.fail("Expected ',' or ']' in array");
-        deleteTomlValue(arr);
-        return nil<TomlValue*>;
+        if c != ',' {
+            this.fail("Expected ',' or ']' in array");
+            break;
+        }
+        this.pos++; // consume ','
     }
+    deleteTomlValue(arr);
     return nil<TomlValue*>;
 }
 
@@ -467,34 +456,30 @@ f<TomlValue*> TomlParser.parseInlineTable() {
         this.pos++;
         return table;
     }
-    while true {
+    // Every failure leaves the loop, so the partially built table is released in one place
+    while !this.hasError {
         this.skipSpaces();
         // Inline tables have to stay on a single line and must not have a trailing comma,
         // so parsing the entry rejects both a line break and a closing brace here
         this.parseKeyValuePair(table);
-        if this.hasError {
-            deleteTomlValue(table);
-            return nil<TomlValue*>;
-        }
+        if this.hasError { break; }
         this.skipSpaces();
         if this.atEnd() {
             this.fail("Unterminated inline table");
-            deleteTomlValue(table);
-            return nil<TomlValue*>;
+            break;
         }
         const char c = this.peek();
-        if c == ',' {
-            this.pos++;
-            continue;
-        }
         if c == '}' {
             this.pos++;
             return table;
         }
-        this.fail("Expected ',' or '}' in inline table");
-        deleteTomlValue(table);
-        return nil<TomlValue*>;
+        if c != ',' {
+            this.fail("Expected ',' or '}' in inline table");
+            break;
+        }
+        this.pos++; // consume ','
     }
+    deleteTomlValue(table);
     return nil<TomlValue*>;
 }
 
@@ -503,28 +488,25 @@ f<TomlValue*> TomlParser.parseInlineTable() {
 f<String> TomlParser.parseStringValue() {
     const char quote = this.peek();
     const bool isMultiLine = this.peekAt(1l) == quote && this.peekAt(2l) == quote;
-    if quote == '"' {
-        if isMultiLine { return this.parseMultiLineBasicString(); }
-        return this.parseBasicString();
-    }
-    if isMultiLine { return this.parseMultiLineLiteralString(); }
-    return this.parseLiteralString();
+    if isMultiLine { return this.parseMultiLineString(quote); }
+    return this.parseSingleLineString(quote);
 }
 
-f<String> TomlParser.parseBasicString() {
+// Parse a basic ('"') or literal ('\'') string. Only basic strings interpret escape
+// sequences, literal strings take their content verbatim.
+f<String> TomlParser.parseSingleLineString(char quote) {
+    const bool isBasic = quote == '"';
     String literal;
-    this.pos++; // consume opening '"'
+    this.pos++; // consume the opening quote
     while !this.atEnd() {
         const char c = this.peek();
-        if c == '"' {
-            this.pos++; // consume closing '"'
+        if c == quote {
+            this.pos++; // consume the closing quote
             return literal;
         }
-        if c == '\n' || c == '\r' {
-            this.fail("Unterminated basic string");
-            return literal;
-        }
-        if c == '\\' {
+        // A single-line string has to be terminated on the line it started on
+        if c == '\n' || c == '\r' { break; }
+        if isBasic && c == '\\' {
             this.pos++;
             this.appendEscapeSequence(literal);
             if this.hasError { return literal; }
@@ -537,35 +519,42 @@ f<String> TomlParser.parseBasicString() {
         literal += c;
         this.pos++;
     }
-    this.fail("Unterminated basic string");
+    const string unterminatedMessage = isBasic ? "Unterminated basic string" : "Unterminated literal string";
+    this.fail(unterminatedMessage);
     return literal;
 }
 
-f<String> TomlParser.parseMultiLineBasicString() {
+// Parse a multi-line basic ('"""') or literal ('\'\'\'') string. Only basic strings
+// interpret escape sequences and line-ending backslashes.
+f<String> TomlParser.parseMultiLineString(char quote) {
+    const bool isBasic = quote == '"';
     String literal;
-    this.pos += 3l; // consume opening '"""'
+    this.pos += 3l; // consume the opening delimiter
     this.skipLeadingLineBreak();
     while !this.atEnd() {
         const char c = this.peek();
-        if c == '"' {
+        if c == quote {
             // The delimiter is formed by the last three quotes of a run, so up to two
             // additional quotes still belong to the content
             unsigned long runLength = 0l;
-            while this.peekAt(runLength) == '"' { runLength++; }
+            while this.peekAt(runLength) == quote { runLength++; }
             if runLength >= 3l {
                 if runLength > 5l {
-                    this.fail("Too many quotes at the end of a multi-line basic string");
+                    const string tooManyQuotesMessage = isBasic
+                        ? "Too many quotes at the end of a multi-line basic string"
+                        : "Too many quotes at the end of a multi-line literal string";
+                    this.fail(tooManyQuotesMessage);
                     return literal;
                 }
-                for unsigned long i = 3l; i < runLength; i++ { literal += '"'; }
+                for unsigned long i = 3l; i < runLength; i++ { literal += quote; }
                 this.pos += runLength;
                 return literal;
             }
-            for unsigned long i = 0l; i < runLength; i++ { literal += '"'; }
+            for unsigned long i = 0l; i < runLength; i++ { literal += quote; }
             this.pos += runLength;
             continue;
         }
-        if c == '\\' {
+        if isBasic && c == '\\' {
             // A backslash at the end of a line trims the line break and all following whitespace
             unsigned long lookahead = 1l;
             while this.peekAt(lookahead) == ' ' || this.peekAt(lookahead) == '\t' { lookahead++; }
@@ -587,64 +576,10 @@ f<String> TomlParser.parseMultiLineBasicString() {
         literal += c;
         this.pos++;
     }
-    this.fail("Unterminated multi-line basic string");
-    return literal;
-}
-
-f<String> TomlParser.parseLiteralString() {
-    String literal;
-    this.pos++; // consume opening '\''
-    while !this.atEnd() {
-        const char c = this.peek();
-        if c == '\'' {
-            this.pos++; // consume closing '\''
-            return literal;
-        }
-        if c == '\n' || c == '\r' {
-            this.fail("Unterminated literal string");
-            return literal;
-        }
-        if isTomlDisallowedChar(c) {
-            this.fail("Unescaped control character in string");
-            return literal;
-        }
-        literal += c;
-        this.pos++;
-    }
-    this.fail("Unterminated literal string");
-    return literal;
-}
-
-f<String> TomlParser.parseMultiLineLiteralString() {
-    String literal;
-    this.pos += 3l; // consume opening '\'\'\''
-    this.skipLeadingLineBreak();
-    while !this.atEnd() {
-        const char c = this.peek();
-        if c == '\'' {
-            unsigned long runLength = 0l;
-            while this.peekAt(runLength) == '\'' { runLength++; }
-            if runLength >= 3l {
-                if runLength > 5l {
-                    this.fail("Too many quotes at the end of a multi-line literal string");
-                    return literal;
-                }
-                for unsigned long i = 3l; i < runLength; i++ { literal += '\''; }
-                this.pos += runLength;
-                return literal;
-            }
-            for unsigned long i = 0l; i < runLength; i++ { literal += '\''; }
-            this.pos += runLength;
-            continue;
-        }
-        if c != '\n' && c != '\r' && isTomlDisallowedChar(c) {
-            this.fail("Unescaped control character in string");
-            return literal;
-        }
-        literal += c;
-        this.pos++;
-    }
-    this.fail("Unterminated multi-line literal string");
+    const string unterminatedMessage = isBasic
+        ? "Unterminated multi-line basic string"
+        : "Unterminated multi-line literal string";
+    this.fail(unterminatedMessage);
     return literal;
 }
 

--- a/std/text/xml-node.spice
+++ b/std/text/xml-node.spice
@@ -199,11 +199,7 @@ public f<const String&> XmlNode.getAttributeValue(unsigned long idx) {
  */
 public f<bool> XmlNode.hasAttribute(string name) {
     if this.kind != XmlNodeKind::XML_ELEMENT { return false; }
-    // Comparing against the raw name avoids building a String that would have to be cleaned up
-    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
-        if this.attributeKeys.get(i) == name { return true; }
-    }
-    return false;
+    return this.findAttributeIndex(name) >= 0l;
 }
 
 /**
@@ -215,13 +211,20 @@ public f<bool> XmlNode.hasAttribute(string name) {
  */
 public f<const String&> XmlNode.getAttribute(string name) {
     assert this.kind == XmlNodeKind::XML_ELEMENT;
-    // Comparing against the raw name avoids building a String that would have to be cleaned up
-    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
-        if this.attributeKeys.get(i) == name {
-            return this.attributeValues.get(i);
-        }
+    const long idx = this.findAttributeIndex(name);
+    if idx < 0l {
+        panic(Error("XML element has no such attribute"));
     }
-    panic(Error("XML element has no such attribute"));
+    return this.attributeValues.get(cast<unsigned long>(idx));
+}
+
+// Index of the attribute with the given name, or -1 if the element has no such attribute.
+// Comparing against the raw name avoids building a String that would have to be cleaned up
+f<long> XmlNode.findAttributeIndex(string name) {
+    for unsigned long i = 0l; i < this.attributeKeys.getSize(); i++ {
+        if this.attributeKeys.get(i) == name { return i; }
+    }
+    return -1l;
 }
 
 /**

--- a/std/text/xml-parser.spice
+++ b/std/text/xml-parser.spice
@@ -102,6 +102,17 @@ f<bool> XmlParser.startsWith(string literal) {
     return true;
 }
 
+// Advance past the next occurrence of the given terminator. Fails with the given
+// message if the input ends before the terminator appears.
+p XmlParser.skipUntilAfter(string terminator, string errorMessage) {
+    const long idx = this.input.find(terminator, this.pos);
+    if idx < 0l {
+        this.fail(errorMessage);
+        return;
+    }
+    this.pos = cast<unsigned long>(idx) + getRawLength(terminator);
+}
+
 // Skip everything between the document start and the root element (XML
 // declaration, processing instructions, comments and whitespace). The XML
 // declaration (if present) must appear at the very beginning of the document
@@ -111,14 +122,8 @@ p XmlParser.skipProlog() {
         // XML declaration: only valid as the first thing in the document.
         // Consume up to and including the terminating '?>'.
         this.pos += 5l;
-        while this.pos + 1l < this.input.getLength() && !(this.input[this.pos] == '?' && this.input[this.pos + 1l] == '>') {
-            this.pos++;
-        }
-        if this.pos + 1l >= this.input.getLength() {
-            this.fail("Unterminated XML declaration");
-            return;
-        }
-        this.pos += 2l; // consume '?>'
+        this.skipUntilAfter("?>", "Unterminated XML declaration");
+        if this.hasError { return; }
     }
     this.skipMisc();
 }
@@ -379,41 +384,24 @@ p XmlParser.parseClosingTag(XmlNode* element) {
 // Skip a '<!-- ... -->' comment, including its delimiters
 p XmlParser.skipComment() {
     this.pos += 4l; // consume '<!--'
-    while this.pos + 2l < this.input.getLength() &&
-          !(this.input[this.pos] == '-' && this.input[this.pos + 1l] == '-' && this.input[this.pos + 2l] == '>') {
-        this.pos++;
-    }
-    if this.pos + 2l >= this.input.getLength() {
-        this.fail("Unterminated comment");
-        return;
-    }
-    this.pos += 3l; // consume '-->'
+    this.skipUntilAfter("-->", "Unterminated comment");
 }
 
 // Skip a '<? ... ?>' processing instruction, including its delimiters
 p XmlParser.skipProcessingInstruction() {
     this.pos += 2l; // consume '<?'
-    while this.pos + 1l < this.input.getLength() && !(this.input[this.pos] == '?' && this.input[this.pos + 1l] == '>') {
-        this.pos++;
-    }
-    if this.pos + 1l >= this.input.getLength() {
-        this.fail("Unterminated processing instruction");
-        return;
-    }
-    this.pos += 2l; // consume '?>'
+    this.skipUntilAfter("?>", "Unterminated processing instruction");
 }
 
 p XmlParser.parseCdataSection(XmlNode* element) {
     this.pos += 9l; // consume '<![CDATA['
     const unsigned long start = this.pos;
-    while this.pos + 2l < this.input.getLength() &&
-          !(this.input[this.pos] == ']' && this.input[this.pos + 1l] == ']' && this.input[this.pos + 2l] == '>') {
-        this.pos++;
-    }
-    if this.pos + 2l >= this.input.getLength() {
+    const long end = this.input.find("]]>", this.pos);
+    if end < 0l {
         this.fail("Unterminated CDATA section");
         return;
     }
+    this.pos = cast<unsigned long>(end);
     // `content` has to stay alive until the end of the scope, so that it gets cleaned up
     const String content = this.input.getSubstring(start, this.pos - start);
     this.pos += 3l; // consume ']]>'

--- a/std/text/xml-serializer.spice
+++ b/std/text/xml-serializer.spice
@@ -31,9 +31,7 @@ public p XmlSerializer.ctor(bool pretty = false) {
  * @return XML representation
  */
 public f<String> XmlSerializer.serialize(XmlNode& node) {
-    String out;
-    this.serializeInto(&node, out, 0l);
-    return out;
+    return this.serialize(&node);
 }
 
 /**
@@ -52,7 +50,7 @@ public f<String> XmlSerializer.serialize(XmlNode* node) {
 
 p XmlSerializer.serializeInto(XmlNode* node, String& out, unsigned long depth) {
     if node.getKind() == XmlNodeKind::XML_TEXT {
-        appendXmlEscapedText(out, node.getText());
+        appendXmlEscaped(out, node.getText(), false);
         return;
     }
 
@@ -62,7 +60,7 @@ p XmlSerializer.serializeInto(XmlNode* node, String& out, unsigned long depth) {
         out += ' ';
         out += node.getAttributeKey(i);
         out += "=\"";
-        appendXmlEscapedAttribute(out, node.getAttributeValue(i));
+        appendXmlEscaped(out, node.getAttributeValue(i), true);
         out += '"';
     }
 
@@ -104,25 +102,9 @@ p appendXmlNewlineIndent(String& out, unsigned long depth) {
 }
 
 // Escape character data: '&', '<' and '>' become their predefined entities.
-p appendXmlEscapedText(String& out, const String& text) {
-    const unsigned long length = text.getLength();
-    for unsigned long i = 0l; i < length; i++ {
-        const char c = text[i];
-        if c == '&' {
-            out += "&amp;";
-        } else if c == '<' {
-            out += "&lt;";
-        } else if c == '>' {
-            out += "&gt;";
-        } else {
-            out += c;
-        }
-    }
-}
-
-// Escape an attribute value (delimited by double quotes), additionally
-// escaping the '"' character.
-p appendXmlEscapedAttribute(String& out, const String& value) {
+// Attribute values are delimited by double quotes, so the '"' character is
+// escaped in them as well.
+p appendXmlEscaped(String& out, const String& value, bool escapeQuotes) {
     const unsigned long length = value.getLength();
     for unsigned long i = 0l; i < length; i++ {
         const char c = value[i];
@@ -132,7 +114,7 @@ p appendXmlEscapedAttribute(String& out, const String& value) {
             out += "&lt;";
         } else if c == '>' {
             out += "&gt;";
-        } else if c == '"' {
+        } else if escapeQuotes && c == '"' {
             out += "&quot;";
         } else {
             out += c;

--- a/test/test-files/std/text/toml-parser/source.spice
+++ b/test/test-files/std/text/toml-parser/source.spice
@@ -344,6 +344,22 @@ f<int> main() {
     TomlValue* tabTree = tabRes.unwrap();
     deleteTomlValue(tabTree);
 
+    Result<TomlValue*> unterminatedLitRes = parseToml(String("a = 'oops\n"));
+    assert !unterminatedLitRes.isOk();
+    Result<TomlValue*> unterminatedMlRes = parseToml(String("a = \"\"\"oops\n"));
+    assert !unterminatedMlRes.isOk();
+    Result<TomlValue*> unterminatedMlLitRes = parseToml(String("a = '''oops\n"));
+    assert !unterminatedMlLitRes.isOk();
+    // A run of more than five quotes cannot be split into content and delimiter
+    Result<TomlValue*> tooManyQuotesRes = parseToml(String("a = \"\"\"x\"\"\"\"\"\"\n"));
+    assert !tooManyQuotesRes.isOk();
+
+    // Up to two quotes before the closing delimiter are content in literal strings as well
+    Result<TomlValue*> litQuoteRes = parseToml(String("s = '''a''''\n"));
+    TomlValue* litQuoteRoot = litQuoteRes.unwrap();
+    TomlValue* litQuoted = litQuoteRoot.getField("s");
+    assert litQuoted.getString() == String("a'");
+
     // Arrays and inline tables
     Result<TomlValue*> unterminatedArrRes = parseToml(String("a = [1, 2\n"));
     assert !unterminatedArrRes.isOk();
@@ -369,6 +385,7 @@ f<int> main() {
     deleteTomlValue(contRoot);
     deleteTomlValue(mlLitRoot);
     deleteTomlValue(quoteRoot);
+    deleteTomlValue(litQuoteRoot);
     deleteTomlValue(uniRoot);
     deleteTomlValue(rawRoot);
     deleteTomlValue(intRoot);

--- a/test/test-files/std/text/xml-parser/source.spice
+++ b/test/test-files/std/text/xml-parser/source.spice
@@ -104,12 +104,30 @@ f<int> main() {
     XmlNode* prologRoot = prologRes.unwrap();
     assert prologRoot.getName() == String("root");
 
+    // Unterminated markup constructs are reported instead of being run past
+    Result<XmlNode*> unterminatedDeclRes = parseXml(String("<?xml version=\"1.0\""));
+    assert !unterminatedDeclRes.isOk();
+    Result<XmlNode*> unterminatedCommentRes = parseXml(String("<root><!-- open</root>"));
+    assert !unterminatedCommentRes.isOk();
+    Result<XmlNode*> unterminatedPiRes = parseXml(String("<root><?pi open</root>"));
+    assert !unterminatedPiRes.isOk();
+    Result<XmlNode*> unterminatedCdataRes = parseXml(String("<root><![CDATA[open</root>"));
+    assert !unterminatedCdataRes.isOk();
+
+    // An empty CDATA section yields an empty text node
+    Result<XmlNode*> emptyCdataRes = parseXml(String("<root><![CDATA[]]></root>"));
+    assert emptyCdataRes.isOk();
+    XmlNode* emptyCdataRoot = emptyCdataRes.unwrap();
+    assert emptyCdataRoot.getChildCount() == 1;
+    assert emptyCdataRoot.getInnerText() == String("");
+
     // Every parsed tree is owned by the caller, so release them all again
     deleteXmlNode(empty);
     deleteXmlNode(a);
     deleteXmlNode(msg);
     deleteXmlNode(book);
     deleteXmlNode(prologRoot);
+    deleteXmlNode(emptyCdataRoot);
 
     printf("All assertions passed!\n");
 }


### PR DESCRIPTION
Remove duplicated logic in the std/text modules without changing any
public API or observable behavior:

- xml-parser: replace the four hand-rolled terminator scans (XML
  declaration, comment, processing instruction, CDATA) with a shared
  skipUntilAfter() helper built on String.find()
- xml-serializer: merge appendXmlEscapedText()/appendXmlEscapedAttribute()
  into one routine parameterized on whether '"' is escaped, and let the
  reference overload of serialize() delegate to the pointer one
- xml-node/json-value: route hasAttribute()/getAttribute() and
  hasField()/getField() through a single index lookup instead of walking
  the key vector twice
- json-serializer: let the reference overload of serialize() delegate to
  the pointer one
- toml-parser: fold the four string parsers into one single-line and one
  multi-line variant parameterized on the quote character, and give
  parseArray()/parseInlineTable() a single cleanup path instead of
  repeating it at every error exit

Error messages, ownership rules and parse results are unchanged.

Also cover the rewritten paths in the reference tests: unterminated XML
declarations, comments, processing instructions and CDATA sections, empty
CDATA sections, unterminated TOML literal and multi-line strings,
over-long quote runs, and quote runs in multi-line literal strings.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012nGpMgo4174HTE4X7MbdvD