### PR TITLE
Rewrite the HTTP client and server in std

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -31,7 +31,7 @@ Spice bindings for common external libraries, allowing them to be called from Sp
 | Module            | Description                                                            |
 |-------------------|------------------------------------------------------------------------|
 | `gtk/gtk4`        | Bindings for the GTK 4 GUI toolkit.                                    |
-| `libcurl/libcurl` | Bindings for libcurl, used for network transfers (see `std/net/http`). |
+| `libcurl/libcurl` | Bindings for libcurl, used for network transfers that need https.     |
 | `llvm/llvm`       | Bindings for the LLVM C API, plus linker flags and a target wrapper.   |
 
 ### `std/data`
@@ -88,10 +88,15 @@ Mathematical operations, constants, hashing, and randomness.
 ### `std/net`
 Network communication via sockets and HTTP.
 
-| Module   | Description                                                                        |
-|----------|------------------------------------------------------------------------------------|
-| `socket` | Cross-platform socket abstraction (with `_linux`, `_darwin`, `_windows` variants). |
-| `http`   | HTTP client built on top of `std/bindings/libcurl`.                                |
+| Module        | Description                                                                                  |
+|---------------|----------------------------------------------------------------------------------------------|
+| `socket`      | Cross-platform socket abstraction (with `_linux`, `_darwin`, `_windows` variants).           |
+| `http`        | HTTP/1.1 message model (methods, status codes, header fields, URLs) plus its wire transport. |
+| `http-client` | Blocking HTTP/1.1 client, built on `std/net/socket`.                                         |
+| `http-server` | Blocking HTTP/1.1 server with route registration, built on `std/net/socket`.                  |
+
+The HTTP modules speak plain http only, since the socket layer carries no TLS. Use the libcurl
+bindings in `std/bindings/libcurl` when a request has to go over https.
 
 ### `std/os`
 Interacting with the underlying operating system: processes, threads, memory, environment, and raw syscalls.

--- a/std/net/http-client.spice
+++ b/std/net/http-client.spice
@@ -1,0 +1,306 @@
+// Imports
+import "std/net/http";
+import "std/net/socket";
+
+/**
+ * A blocking HTTP/1.1 client, built on the plain TCP sockets of "std/net/socket".
+ *
+ * Every request opens its own connection, announces `Connection: close` and closes the connection
+ * again once the response has been read, so no connection state survives a call. Responses framed by
+ * Content-Length, by the chunked transfer coding, or by the connection close of an HTTP/1.0 server
+ * are all understood.
+ *
+ * There is no TLS underneath, so https URLs are rejected instead of being silently downgraded. Use
+ * the libcurl bindings in "std/bindings/libcurl" when a request has to go over https.
+ */
+public type HttpClient struct {
+    public HttpHeaders defaultHeaders     // Fields that are added to every request that lacks them
+    public unsigned long timeoutMillis    // Per read/write timeout, 0 to block indefinitely
+    public unsigned long maxMessageSize   // Upper bound on the size of a response
+    public unsigned int maxRedirects      // Number of redirects to follow, 0 to hand 3xx back as-is
+}
+
+// Default identification of the client, sent unless the caller sets its own User-Agent
+public const string DEFAULT_USER_AGENT = "SpiceHttpClient/1.0";
+
+const unsigned long DEFAULT_TIMEOUT_MILLIS = 30000l;
+const unsigned int DEFAULT_MAX_REDIRECTS = 5u;
+
+/**
+ * Constructs a client with the default timeout, message size limit and redirect budget
+ */
+public p HttpClient.ctor() {
+    this.timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+    this.maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+    this.maxRedirects = DEFAULT_MAX_REDIRECTS;
+    this.defaultHeaders.set(HEADER_USER_AGENT, DEFAULT_USER_AGENT);
+    this.defaultHeaders.set(HEADER_ACCEPT, "*/*");
+}
+
+/**
+ * Adds or replaces a header field that is sent with every request
+ *
+ * @param name Field name
+ * @param value Field value
+ */
+public p HttpClient.setDefaultHeader(string name, string value) {
+    this.defaultHeaders.set(name, value);
+}
+
+/**
+ * Performs a GET request
+ *
+ * @param url Absolute URL to request
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.get(string url) {
+    const String emptyBody = String();
+    return this.request(HttpMethod::GET, url, emptyBody, CONTENT_TYPE_TEXT);
+}
+
+/**
+ * Performs a HEAD request, which yields the head of the response without its body
+ *
+ * @param url Absolute URL to request
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.head(string url) {
+    const String emptyBody = String();
+    return this.request(HttpMethod::HEAD, url, emptyBody, CONTENT_TYPE_TEXT);
+}
+
+/**
+ * Performs a POST request
+ *
+ * @param url Absolute URL to request
+ * @param body Payload to send
+ * @param contentType Media type of the payload
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.post(string url, const String& body, string contentType = CONTENT_TYPE_TEXT) {
+    return this.request(HttpMethod::POST, url, body, contentType);
+}
+
+/**
+ * Performs a PUT request
+ *
+ * @param url Absolute URL to request
+ * @param body Payload to send
+ * @param contentType Media type of the payload
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.put(string url, const String& body, string contentType = CONTENT_TYPE_TEXT) {
+    return this.request(HttpMethod::PUT, url, body, contentType);
+}
+
+/**
+ * Performs a PATCH request
+ *
+ * @param url Absolute URL to request
+ * @param body Payload to send
+ * @param contentType Media type of the payload
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.patch(string url, const String& body, string contentType = CONTENT_TYPE_TEXT) {
+    return this.request(HttpMethod::PATCH, url, body, contentType);
+}
+
+/**
+ * Performs a DELETE request
+ *
+ * @param url Absolute URL to request
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.delete(string url) {
+    const String emptyBody = String();
+    return this.request(HttpMethod::DELETE, url, emptyBody, CONTENT_TYPE_TEXT);
+}
+
+/**
+ * Performs a request with the given method, following redirects along the way
+ *
+ * @param method Request method
+ * @param url Absolute URL to request
+ * @param body Payload to send, may be empty
+ * @param contentType Media type of the payload
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.request(HttpMethod method, string url, const String& body,
+                                                  string contentType = CONTENT_TYPE_TEXT) {
+    HttpRequest request = HttpRequest(method, "/");
+    if !body.isEmpty() { request.setBody(body, contentType); }
+    const String rawUrl = String(url);
+    return this.send(request, rawUrl);
+}
+
+/**
+ * Sends a prepared request to the given URL, following redirects along the way.
+ *
+ * The request target, the Host field and the fields of `defaultHeaders` are filled in from the URL
+ * and the client configuration, so the caller only has to provide method, body and any extra header
+ * fields it cares about.
+ *
+ * @param request Request to send
+ * @param url Absolute URL to send it to
+ * @return The response, or an error describing why the exchange failed
+ */
+public f<Result<HttpResponse>> HttpClient.send(const HttpRequest& request, const String& url) {
+    HttpResponse response = HttpResponse();
+    HttpRequest currentRequest = HttpRequest();
+    currentRequest = request;
+    String currentUrl = String();
+    currentUrl = url;
+    string errorMessage = "";
+
+    unsigned int remainingRedirects = this.maxRedirects;
+    bool done = false;
+    while !done {
+        const Result<Url> urlResult = parseUrl(currentUrl);
+        if urlResult.isErr() {
+            errorMessage = urlResult.getErr().message;
+            done = true;
+        } else {
+            const Url& target = urlResult.unwrap();
+            const Result<HttpResponse> exchangeResult = this.exchange(currentRequest, target);
+            if exchangeResult.isErr() {
+                errorMessage = exchangeResult.getErr().message;
+                done = true;
+            } else {
+                const HttpResponse& received = exchangeResult.unwrap();
+                response = received;
+                // Follow the redirect if there is budget left and the response points somewhere
+                const String location = response.headers.get(HEADER_LOCATION);
+                if !response.isRedirect() || remainingRedirects == 0u || location.isEmpty() {
+                    done = true;
+                } else {
+                    currentUrl = resolveLocation(target, location);
+                    applyRedirectMethod(currentRequest, response.statusCode);
+                    remainingRedirects--;
+                }
+            }
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(response) : err<HttpResponse>(error);
+}
+
+/**
+ * Runs a single request/response exchange over a freshly opened connection
+ *
+ * @param request Request to send, completed with the fields the exchange needs
+ * @param url Target of the request
+ * @return The response, or an error describing why the exchange failed
+ */
+f<Result<HttpResponse>> HttpClient.exchange(HttpRequest& request, const Url& url) {
+    HttpResponse response = HttpResponse();
+    string errorMessage = "";
+
+    if url.scheme == "https" {
+        errorMessage = "HTTPS is not supported by std/net/http-client, since the socket layer carries no TLS";
+    } else {
+        const Result<Socket> socketResult = openClientSocket(url.host.getRaw(), url.port);
+        if socketResult.isErr() {
+            errorMessage = socketResult.getErr().message;
+        } else {
+            Socket socket = socketResult.unwrap();
+            if this.timeoutMillis != 0l { socket.setTimeout(this.timeoutMillis); }
+            this.completeRequest(request, url);
+
+            if !sendRequest(socket, request) {
+                errorMessage = "Could not send the request";
+            } else {
+                const bool expectBody = request.method != HttpMethod::HEAD;
+                const Result<HttpResponse> responseResult = receiveResponse(socket, expectBody, this.maxMessageSize);
+                if responseResult.isErr() {
+                    errorMessage = responseResult.getErr().message;
+                } else {
+                    const HttpResponse& received = responseResult.unwrap();
+                    response = received;
+                }
+            }
+            socket.close();
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(response) : err<HttpResponse>(error);
+}
+
+/**
+ * Fills in the fields of a request that follow from the target URL and the client configuration
+ *
+ * @param request Request to complete
+ * @param url Target of the request
+ */
+p HttpClient.completeRequest(HttpRequest& request, const Url& url) {
+    request.target = url.getRequestTarget();
+
+    // Add the configured default fields, without overwriting what the caller set explicitly
+    const unsigned long defaultCount = this.defaultHeaders.getSize();
+    for unsigned long i = 0l; i < defaultCount; i++ {
+        HttpHeader& entry = this.defaultHeaders.getAt(i);
+        if !request.headers.contains(entry.name.getRaw()) {
+            request.headers.set(entry.name.getRaw(), entry.value.getRaw());
+        }
+    }
+
+    // Host is mandatory in HTTP/1.1 and has to match the connection that carries the request
+    const String authority = url.getAuthority();
+    request.headers.set(HEADER_HOST, authority);
+    // Without keep-alive support, every exchange ends with its connection
+    request.headers.set(HEADER_CONNECTION, "close");
+}
+
+/**
+ * Turns the value of a Location field into an absolute URL, resolving it against the URL the
+ * redirect came from if it is relative
+ *
+ * @param base URL the redirect was received from
+ * @param location Value of the Location field
+ * @return Absolute URL to follow
+ */
+f<String> resolveLocation(const Url& base, const String& location) {
+    result = String();
+    if location.contains("://") {
+        // Already absolute
+        result = location;
+    } else {
+        result.append(base.scheme);
+        result.append("://");
+        const String authority = base.getAuthority();
+        result.append(authority);
+        if location.startsWith("/") {
+            // Absolute path, replacing the path of the base URL
+            result.append(location);
+        } else {
+            // Relative path, resolved against the directory of the base path
+            const long lastSlash = base.path.rfind('/');
+            String directory = String("/");
+            if lastSlash != -1l { directory = base.path.getSubstring(0l, lastSlash + 1l); }
+            result.append(directory);
+            result.append(location);
+        }
+    }
+}
+
+/**
+ * Adjusts the method of a request that is about to be replayed against a redirect target.
+ *
+ * 303 always turns into a GET, and 301 and 302 do so for anything but GET and HEAD, which is what
+ * RFC 9110 section 15.4 permits and what every browser does. 307 and 308 keep method and body.
+ *
+ * @param request Request to adjust
+ * @param statusCode Status code of the redirect
+ */
+p applyRedirectMethod(HttpRequest& request, unsigned short statusCode) {
+    const bool isSafeMethod = request.method == HttpMethod::GET || request.method == HttpMethod::HEAD;
+    const bool rewritesToGet = statusCode == STATUS_SEE_OTHER
+                            || ((statusCode == STATUS_MOVED_PERMANENTLY || statusCode == STATUS_FOUND) && !isSafeMethod);
+    if rewritesToGet {
+        request.method = HttpMethod::GET;
+        request.body = String();
+        request.headers.remove(HEADER_CONTENT_LENGTH);
+        request.headers.remove(HEADER_CONTENT_TYPE);
+    }
+}

--- a/std/net/http-server.spice
+++ b/std/net/http-server.spice
@@ -1,0 +1,438 @@
+// Imports
+import "std/data/vector";
+import "std/net/http";
+import "std/net/socket";
+import "std/type/lambda";
+import "std/type/type-conversion";
+
+/**
+ * A registered route: the method and path it answers, plus what answers it - either a handler, or a
+ * fixed piece of content that the route carries itself
+ */
+type HttpRoute struct {
+    HttpMethod method
+    String path
+    bool isStatic
+    String staticContent
+    String staticContentType
+    Lambda<p(const HttpRequest&, HttpResponse&)> handler
+}
+
+/**
+ * A blocking HTTP/1.1 server, built on the plain TCP sockets of "std/net/socket".
+ *
+ * Requests are served one at a time on the thread that drives the server: `run` keeps serving until
+ * `stop` is called, while `handleNextRequest` serves a single connection and hands control back, so
+ * the caller can weave the server into a loop of its own. Every connection is answered with
+ * `Connection: close` and closed afterwards.
+ *
+ * Routing is exact-match on the path of the request target, so "/a" and "/a/" are different routes
+ * and the query string never takes part in the match. A path that is registered for some other
+ * method answers 405 instead of 404, and a HEAD request falls back to the GET route of the same
+ * path, with the body dropped again afterwards.
+ *
+ * There is no TLS underneath, so the server speaks plain http only.
+ *
+ * Note on handlers: a handler is stored in a `Lambda` (see "std/type/lambda"), which relocates the
+ * captures of the lambda onto the heap with a shallow copy. A handler may therefore capture plain
+ * values, but it must not capture a `String`, a container or anything else that owns memory, since
+ * only the owner itself would free it. Fixed content belongs into `serve`, and anything else into a
+ * global or into the request itself.
+ */
+public type HttpServer struct {
+    public unsigned short port          // Port the server listens on
+    public String serverIdent           // Value of the Server field of every response
+    public unsigned long maxMessageSize // Upper bound on the size of a request
+    public unsigned long timeoutMillis  // Per read/write timeout of a connection, 0 to block indefinitely
+    Socket socket
+    Vector<HttpRoute> routes
+    Lambda<p(const HttpRequest&, HttpResponse&)> notFoundHandler
+    bool hasNotFoundHandler
+    bool listening
+    bool running
+}
+
+// Default identification of the server, sent unless the caller sets its own
+public const string DEFAULT_SERVER_IDENT = "SpiceHttpServer/1.0";
+
+// Maximum number of connections that may wait in the accept queue
+public const int DEFAULT_CONNECTION_BACKLOG = 50;
+
+const unsigned long DEFAULT_TIMEOUT_MILLIS = 30000l;
+
+/**
+ * Constructs a server for the given port. Nothing is bound yet - that happens in `start`.
+ *
+ * @param port Port to listen on
+ */
+public p HttpServer.ctor(unsigned short port = HTTP_PORT_FALLBACK) {
+    this.port = port;
+    this.serverIdent = String(DEFAULT_SERVER_IDENT);
+    this.maxMessageSize = DEFAULT_MAX_MESSAGE_SIZE;
+    this.timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+    this.hasNotFoundHandler = false;
+    this.listening = false;
+    this.running = false;
+}
+
+/**
+ * Closes the listening socket if the server is still up
+ */
+public p HttpServer.dtor() {
+    this.close();
+}
+
+// ================================================ Route registration =================================================
+
+/**
+ * Registers a handler for a method and path
+ *
+ * @param method Method the route answers
+ * @param path Path the route answers, matched exactly
+ * @param handler Handler that fills in the response
+ */
+public p HttpServer.route(HttpMethod method, string path, p(const HttpRequest&, HttpResponse&) handler) {
+    const HttpRoute newRoute = HttpRoute {
+        method,
+        String(path),
+        /*isStatic=*/false,
+        String(),
+        String(),
+        Lambda<p(const HttpRequest&, HttpResponse&)>(handler)
+    };
+    this.routes.pushBack(newRoute);
+}
+
+/**
+ * Registers a GET handler for a path. HEAD requests for the same path are answered from it as well.
+ *
+ * @param path Path the route answers, matched exactly
+ * @param handler Handler that fills in the response
+ */
+public p HttpServer.get(string path, p(const HttpRequest&, HttpResponse&) handler) {
+    this.route(HttpMethod::GET, path, handler);
+}
+
+/**
+ * Registers a POST handler for a path
+ *
+ * @param path Path the route answers, matched exactly
+ * @param handler Handler that fills in the response
+ */
+public p HttpServer.post(string path, p(const HttpRequest&, HttpResponse&) handler) {
+    this.route(HttpMethod::POST, path, handler);
+}
+
+/**
+ * Registers a PUT handler for a path
+ *
+ * @param path Path the route answers, matched exactly
+ * @param handler Handler that fills in the response
+ */
+public p HttpServer.put(string path, p(const HttpRequest&, HttpResponse&) handler) {
+    this.route(HttpMethod::PUT, path, handler);
+}
+
+/**
+ * Registers a PATCH handler for a path
+ *
+ * @param path Path the route answers, matched exactly
+ * @param handler Handler that fills in the response
+ */
+public p HttpServer.patch(string path, p(const HttpRequest&, HttpResponse&) handler) {
+    this.route(HttpMethod::PATCH, path, handler);
+}
+
+/**
+ * Registers a DELETE handler for a path
+ *
+ * @param path Path the route answers, matched exactly
+ * @param handler Handler that fills in the response
+ */
+public p HttpServer.delete(string path, p(const HttpRequest&, HttpResponse&) handler) {
+    this.route(HttpMethod::DELETE, path, handler);
+}
+
+/**
+ * Registers a route that answers a path with a fixed piece of content
+ *
+ * @param path Path the route answers, matched exactly
+ * @param content Content to respond with
+ * @param contentType Media type of the content
+ */
+public p HttpServer.serve(string path, string content, string contentType = CONTENT_TYPE_HTML) {
+    // The content is owned by the route rather than captured by a lambda, since lambda captures are
+    // shallow copies and would not keep a String alive past this call
+    const HttpRoute newRoute = HttpRoute {
+        HttpMethod::GET,
+        String(path),
+        /*isStatic=*/true,
+        String(content),
+        String(contentType),
+        Lambda<p(const HttpRequest&, HttpResponse&)>()
+    };
+    this.routes.pushBack(newRoute);
+}
+
+/**
+ * Registers a route that answers a path with a fixed piece of content
+ *
+ * @param path Path the route answers, matched exactly
+ * @param content Content to respond with
+ * @param contentType Media type of the content
+ */
+public p HttpServer.serve(string path, const String& content, string contentType = CONTENT_TYPE_HTML) {
+    this.serve(path, content.getRaw(), contentType);
+}
+
+/**
+ * Registers the handler that answers requests no route matches. Without one, unmatched requests are
+ * answered with a plain 404.
+ *
+ * @param handler Handler that fills in the response
+ */
+public p HttpServer.setNotFoundHandler(p(const HttpRequest&, HttpResponse&) handler) {
+    this.notFoundHandler = Lambda<p(const HttpRequest&, HttpResponse&)>(handler);
+    this.hasNotFoundHandler = true;
+}
+
+// ================================================== Server lifecycle =================================================
+
+/**
+ * Binds the configured port and starts listening on it
+ *
+ * @param connectionBacklog Maximum number of connections that may wait in the accept queue
+ * @return true once the server listens, or an error describing why it could not
+ */
+public f<Result<bool>> HttpServer.start(int connectionBacklog = DEFAULT_CONNECTION_BACKLOG) {
+    string errorMessage = "";
+    if this.listening {
+        errorMessage = "Server is already listening";
+    } else {
+        const Result<Socket> socketResult = openServerSocket(this.port, connectionBacklog);
+        if socketResult.isErr() {
+            errorMessage = socketResult.getErr().message;
+        } else {
+            this.socket = socketResult.unwrap();
+            this.listening = true;
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(true) : err<bool>(error);
+}
+
+/**
+ * Accepts a single connection, answers the request on it and closes it again.
+ *
+ * A request that cannot be parsed is answered with 400 rather than being dropped silently, so a
+ * confused client learns what happened.
+ *
+ * @return true if a request was served, or an error if the connection could not be accepted
+ */
+public f<Result<bool>> HttpServer.handleNextRequest() {
+    string errorMessage = "";
+    bool served = false;
+
+    if !this.listening {
+        errorMessage = "Server is not listening, call start() first";
+    } else {
+        const Result<int> connectionResult = this.socket.acceptConnection();
+        if connectionResult.isErr() {
+            errorMessage = connectionResult.getErr().message;
+        } else {
+            if this.timeoutMillis != 0l { this.socket.setTimeout(this.timeoutMillis); }
+
+            HttpResponse response = HttpResponse();
+            const Result<HttpRequest> requestResult = receiveRequest(this.socket, this.maxMessageSize);
+            if requestResult.isErr() {
+                // The request never arrived in one piece, so all we can say is that it was bad
+                response.setStatus(STATUS_BAD_REQUEST);
+                const String reasonBody = String(requestResult.getErr().message);
+                response.setBody(reasonBody, CONTENT_TYPE_TEXT);
+            } else {
+                const HttpRequest& request = requestResult.unwrap();
+                this.dispatch(request, response);
+            }
+
+            this.completeResponse(response);
+            served = sendResponse(this.socket, response);
+            this.socket.closeConnection();
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(served) : err<bool>(error);
+}
+
+/**
+ * Serves connections until `stop` is called or a connection cannot be accepted.
+ *
+ * The stop flag is checked between connections, so a `stop` from another thread takes effect once
+ * the connection that is currently being served is done.
+ *
+ * @return true if the loop ended through `stop`, or an error if a connection could not be accepted
+ */
+public f<Result<bool>> HttpServer.run() {
+    string errorMessage = "";
+    if !this.listening {
+        errorMessage = "Server is not listening, call start() first";
+    } else {
+        this.running = true;
+        while this.running && errorMessage == "" {
+            const Result<bool> requestResult = this.handleNextRequest();
+            if requestResult.isErr() {
+                errorMessage = requestResult.getErr().message;
+            }
+        }
+        this.running = false;
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(true) : err<bool>(error);
+}
+
+/**
+ * Asks a running `run` loop to end once the connection it is serving is done
+ */
+public p HttpServer.stop() {
+    this.running = false;
+}
+
+/**
+ * Checks whether a `run` loop is currently serving
+ */
+public f<bool> HttpServer.isRunning() {
+    return this.running;
+}
+
+/**
+ * Checks whether the server holds a listening socket
+ */
+public f<bool> HttpServer.isListening() {
+    return this.listening;
+}
+
+/**
+ * Closes the listening socket. The server can be started again afterwards.
+ *
+ * @return Closing the socket was successful or not
+ */
+public p HttpServer.close() {
+    this.running = false;
+    if this.listening {
+        this.socket.close();
+        this.listening = false;
+    }
+}
+
+// ==================================================== Dispatching ====================================================
+
+/**
+ * Picks the route that answers a request and lets it fill in the response
+ *
+ * @param request Request to answer
+ * @param response Response to fill in
+ */
+p HttpServer.dispatch(const HttpRequest& request, HttpResponse& response) {
+    const String path = request.getPath();
+    // A HEAD request is served from the GET route of the same path if it has no route of its own
+    const bool isHead = request.method == HttpMethod::HEAD;
+    long routeIndex = this.findRoute(request.method, path);
+    if routeIndex == -1l && isHead {
+        routeIndex = this.findRoute(HttpMethod::GET, path);
+    }
+
+    if routeIndex != -1l {
+        HttpRoute& route = this.routes.get(cast<unsigned long>(routeIndex));
+        if route.isStatic {
+            response.setBody(route.staticContent, route.staticContentType.getRaw());
+        } else {
+            // A stored lambda cannot be called through the field directly, so it goes through a local
+            p(const HttpRequest&, HttpResponse&) handler = route.handler.get();
+            handler(request, response);
+        }
+        // A response to HEAD carries the header fields of the GET response, but never its body
+        if isHead { response.body = String(); }
+    } else if this.hasPathWithOtherMethod(path) {
+        response.setStatus(STATUS_METHOD_NOT_ALLOWED);
+        const String allowed = this.getAllowedMethods(path);
+        response.headers.set("Allow", allowed);
+        const String message = String("Method not allowed for this path");
+        response.setBody(message, CONTENT_TYPE_TEXT);
+    } else if this.hasNotFoundHandler {
+        response.setStatus(STATUS_NOT_FOUND);
+        p(const HttpRequest&, HttpResponse&) handler = this.notFoundHandler.get();
+        handler(request, response);
+    } else {
+        response.setStatus(STATUS_NOT_FOUND);
+        const String message = String("Not found");
+        response.setBody(message, CONTENT_TYPE_TEXT);
+    }
+}
+
+/**
+ * Returns the index of the route that answers the given method and path
+ *
+ * @param method Method to match
+ * @param path Path to match
+ * @return Index of the route, or -1 if there is none
+ */
+f<long> HttpServer.findRoute(HttpMethod method, const String& path) {
+    const unsigned long routeCount = cast<unsigned long>(this.routes.getSize());
+    for unsigned long i = 0l; i < routeCount; i++ {
+        HttpRoute& route = this.routes.get(i);
+        if route.method == method && route.path == path { return cast<long>(i); }
+    }
+    return -1l;
+}
+
+/**
+ * Checks whether the path is registered at all, no matter for which method
+ *
+ * @param path Path to look for
+ */
+f<bool> HttpServer.hasPathWithOtherMethod(const String& path) {
+    const unsigned long routeCount = cast<unsigned long>(this.routes.getSize());
+    for unsigned long i = 0l; i < routeCount; i++ {
+        HttpRoute& route = this.routes.get(i);
+        if route.path == path { return true; }
+    }
+    return false;
+}
+
+/**
+ * Builds the value of the Allow field for a path, i.e. the methods it is registered for
+ *
+ * @param path Path to collect the methods of
+ * @return Comma separated method list, e.g. "GET, POST"
+ */
+f<String> HttpServer.getAllowedMethods(const String& path) {
+    result = String();
+    const unsigned long routeCount = cast<unsigned long>(this.routes.getSize());
+    for unsigned long i = 0l; i < routeCount; i++ {
+        HttpRoute& route = this.routes.get(i);
+        if route.path == path {
+            if !result.isEmpty() { result.append(", "); }
+            result.append(getMethodName(route.method));
+        }
+    }
+}
+
+/**
+ * Adds the header fields that every response of this server carries
+ *
+ * @param response Response to complete
+ */
+p HttpServer.completeResponse(HttpResponse& response) {
+    if !response.headers.contains(HEADER_SERVER) {
+        response.headers.set(HEADER_SERVER, this.serverIdent);
+    }
+    // Without keep-alive support, every response ends its connection
+    response.headers.set(HEADER_CONNECTION, "close");
+    // A client needs to know where the body ends, even when a handler left it empty
+    if !response.headers.contains(HEADER_CONTENT_LENGTH) && !response.headers.isChunked() {
+        const String bodyLength = toString(cast<long>(response.body.getLength()));
+        response.headers.set(HEADER_CONTENT_LENGTH, bodyLength);
+    }
+}

--- a/std/net/http.spice
+++ b/std/net/http.spice
@@ -1,52 +1,1602 @@
-import "socket_linux";
+// Imports
+import "std/data/pair";
+import "std/data/vector";
+import "std/net/socket";
+import "std/text/analysis";
+import "std/text/format";
+import "std/type/type-conversion";
 
-const string SERVER_IDENT = "Spice HTTP Server/0.0.0";
-const unsigned int CONNECTIONS_LIMIT = 50;
+/**
+ * Message model of HTTP/1.1 (RFC 9110/9112): methods, status codes, header fields, URLs, requests
+ * and responses, together with the routines that turn them into wire format and back.
+ *
+ * On top of the message model it provides the wire transport: reading a complete message off a
+ * socket and writing one back, including the Content-Length and chunked framing rules of RFC 9112
+ * section 6. "std/net/http-client" and "std/net/http-server" build the actual client and server on
+ * top of that.
+ */
 
-public const string ADDR_LOCAL = "localhost";
-public const string ADDR_INET = "0.0.0.0";
+// ===================================================== Constants =====================================================
+
+public const string HTTP_VERSION_1_0 = "HTTP/1.0";
+public const string HTTP_VERSION_1_1 = "HTTP/1.1";
+
+public const string ADDR_LOCAL = "127.0.0.1"; // Loopback interface, only reachable from the same machine
+public const string ADDR_INET = "0.0.0.0";    // All interfaces
 
 public const unsigned short HTTP_PORT_DEFAULT = 80s;
 public const unsigned short HTTP_PORT_FALLBACK = 8080s;
 public const unsigned short HTTPS_PORT_DEFAULT = 443s;
 
+// Status codes. Only the commonly used ones are named here, every other code can be used as a plain number.
+public const unsigned short STATUS_CONTINUE = 100s;
+public const unsigned short STATUS_OK = 200s;
+public const unsigned short STATUS_CREATED = 201s;
+public const unsigned short STATUS_ACCEPTED = 202s;
+public const unsigned short STATUS_NO_CONTENT = 204s;
+public const unsigned short STATUS_MOVED_PERMANENTLY = 301s;
+public const unsigned short STATUS_FOUND = 302s;
+public const unsigned short STATUS_SEE_OTHER = 303s;
+public const unsigned short STATUS_NOT_MODIFIED = 304s;
+public const unsigned short STATUS_TEMPORARY_REDIRECT = 307s;
+public const unsigned short STATUS_PERMANENT_REDIRECT = 308s;
+public const unsigned short STATUS_BAD_REQUEST = 400s;
+public const unsigned short STATUS_UNAUTHORIZED = 401s;
+public const unsigned short STATUS_FORBIDDEN = 403s;
+public const unsigned short STATUS_NOT_FOUND = 404s;
+public const unsigned short STATUS_METHOD_NOT_ALLOWED = 405s;
+public const unsigned short STATUS_REQUEST_TIMEOUT = 408s;
+public const unsigned short STATUS_CONFLICT = 409s;
+public const unsigned short STATUS_CONTENT_TOO_LARGE = 413s;
+public const unsigned short STATUS_URI_TOO_LONG = 414s;
+public const unsigned short STATUS_UNSUPPORTED_MEDIA_TYPE = 415s;
+public const unsigned short STATUS_TOO_MANY_REQUESTS = 429s;
+public const unsigned short STATUS_INTERNAL_SERVER_ERROR = 500s;
+public const unsigned short STATUS_NOT_IMPLEMENTED = 501s;
+public const unsigned short STATUS_BAD_GATEWAY = 502s;
+public const unsigned short STATUS_SERVICE_UNAVAILABLE = 503s;
+public const unsigned short STATUS_GATEWAY_TIMEOUT = 504s;
+public const unsigned short STATUS_VERSION_NOT_SUPPORTED = 505s;
+
+// Frequently used media types, ready to be handed to setBody
+public const string CONTENT_TYPE_TEXT = "text/plain; charset=utf-8";
+public const string CONTENT_TYPE_HTML = "text/html; charset=utf-8";
+public const string CONTENT_TYPE_CSS = "text/css; charset=utf-8";
+public const string CONTENT_TYPE_JS = "text/javascript; charset=utf-8";
+public const string CONTENT_TYPE_JSON = "application/json";
+public const string CONTENT_TYPE_XML = "application/xml";
+public const string CONTENT_TYPE_FORM = "application/x-www-form-urlencoded";
+public const string CONTENT_TYPE_BINARY = "application/octet-stream";
+
+// Header field names that the client and the server have to reason about
+public const string HEADER_HOST = "Host";
+public const string HEADER_CONNECTION = "Connection";
+public const string HEADER_CONTENT_LENGTH = "Content-Length";
+public const string HEADER_CONTENT_TYPE = "Content-Type";
+public const string HEADER_TRANSFER_ENCODING = "Transfer-Encoding";
+public const string HEADER_LOCATION = "Location";
+public const string HEADER_USER_AGENT = "User-Agent";
+public const string HEADER_SERVER = "Server";
+public const string HEADER_ACCEPT = "Accept";
+public const string HEADER_DATE = "Date";
+
+const string CRLF = "\r\n";
+
+// ===================================================== HttpMethod ====================================================
+
 /**
- * Struct, representing a simple HTTP server
+ * Request method, as defined in RFC 9110 section 9
  */
-public type HttpServer struct {
-    Socket socket       // Underlying TCP socket
-    unsigned short port // Exposed port
-    bool initialized    // true if the server was initialized
+public type HttpMethod enum {
+    GET,
+    HEAD,
+    POST,
+    PUT,
+    DELETE,
+    CONNECT,
+    OPTIONS,
+    TRACE,
+    PATCH
 }
 
 /**
- * Used to initialize a HTTP server instance, listening on a specific port for incoming requests
- */
-public p HttpServer.ctor(unsigned short port = HTTP_PORT_DEFAULT) {
-    this.port = port;
-    this.initialized = true;
-}
-
-/**
+ * Returns the wire representation of the given request method
  *
+ * @param method Request method
+ * @return Method name, e.g. "GET"
  */
-public f<bool> HttpServer.start() {
-    // Check if the server is initialized
-    if !this.initialized { return false; }
-
-    // Setup TCP socket
-    this.socket = openServerSocket(this.port, CONNECTIONS_LIMIT);
-
+public f<string> getMethodName(HttpMethod method) {
+    switch method {
+        case HttpMethod::GET: { return "GET"; }
+        case HttpMethod::HEAD: { return "HEAD"; }
+        case HttpMethod::POST: { return "POST"; }
+        case HttpMethod::PUT: { return "PUT"; }
+        case HttpMethod::DELETE: { return "DELETE"; }
+        case HttpMethod::CONNECT: { return "CONNECT"; }
+        case HttpMethod::OPTIONS: { return "OPTIONS"; }
+        case HttpMethod::TRACE: { return "TRACE"; }
+        case HttpMethod::PATCH: { return "PATCH"; }
+        default: { return "GET"; }
+    }
 }
 
 /**
- * Register a route on the server that responds with the given HTML content
+ * Parses a request method from its wire representation
  *
- * @param path Request path to serve
- * @param htmlContent HTML content to respond with
- * @return true if the route was registered successfully, false otherwise
+ * @param name Method name, e.g. "GET"
+ * @return The parsed method, or an error if the name denotes no known method
  */
-public f<bool> HttpServer.serve(string path, string htmlContent) {
+public f<Result<HttpMethod>> parseMethodName(const String& name) {
+    HttpMethod method = HttpMethod::GET;
+    bool known = true;
+    if name == "GET" {
+        method = HttpMethod::GET;
+    } else if name == "HEAD" {
+        method = HttpMethod::HEAD;
+    } else if name == "POST" {
+        method = HttpMethod::POST;
+    } else if name == "PUT" {
+        method = HttpMethod::PUT;
+    } else if name == "DELETE" {
+        method = HttpMethod::DELETE;
+    } else if name == "CONNECT" {
+        method = HttpMethod::CONNECT;
+    } else if name == "OPTIONS" {
+        method = HttpMethod::OPTIONS;
+    } else if name == "TRACE" {
+        method = HttpMethod::TRACE;
+    } else if name == "PATCH" {
+        method = HttpMethod::PATCH;
+    } else {
+        known = false;
+    }
+    const Error error = Error("Unknown request method");
+    result = known ? ok(method) : err<HttpMethod>(error);
+}
 
-    return false;
+// ==================================================== Status codes ===================================================
+
+/**
+ * Returns the reason phrase that belongs to the given status code. Unknown codes fall back to the
+ * generic phrase of their status class, so every code yields a usable status line.
+ *
+ * @param statusCode Status code, e.g. 404
+ * @return Reason phrase, e.g. "Not Found"
+ */
+public f<string> getReasonPhrase(unsigned short statusCode) {
+    switch statusCode {
+        case 100s: { return "Continue"; }
+        case 101s: { return "Switching Protocols"; }
+        case 200s: { return "OK"; }
+        case 201s: { return "Created"; }
+        case 202s: { return "Accepted"; }
+        case 203s: { return "Non-Authoritative Information"; }
+        case 204s: { return "No Content"; }
+        case 205s: { return "Reset Content"; }
+        case 206s: { return "Partial Content"; }
+        case 300s: { return "Multiple Choices"; }
+        case 301s: { return "Moved Permanently"; }
+        case 302s: { return "Found"; }
+        case 303s: { return "See Other"; }
+        case 304s: { return "Not Modified"; }
+        case 307s: { return "Temporary Redirect"; }
+        case 308s: { return "Permanent Redirect"; }
+        case 400s: { return "Bad Request"; }
+        case 401s: { return "Unauthorized"; }
+        case 402s: { return "Payment Required"; }
+        case 403s: { return "Forbidden"; }
+        case 404s: { return "Not Found"; }
+        case 405s: { return "Method Not Allowed"; }
+        case 406s: { return "Not Acceptable"; }
+        case 407s: { return "Proxy Authentication Required"; }
+        case 408s: { return "Request Timeout"; }
+        case 409s: { return "Conflict"; }
+        case 410s: { return "Gone"; }
+        case 411s: { return "Length Required"; }
+        case 412s: { return "Precondition Failed"; }
+        case 413s: { return "Content Too Large"; }
+        case 414s: { return "URI Too Long"; }
+        case 415s: { return "Unsupported Media Type"; }
+        case 416s: { return "Range Not Satisfiable"; }
+        case 417s: { return "Expectation Failed"; }
+        case 418s: { return "I'm a teapot"; }
+        case 422s: { return "Unprocessable Content"; }
+        case 426s: { return "Upgrade Required"; }
+        case 429s: { return "Too Many Requests"; }
+        case 431s: { return "Request Header Fields Too Large"; }
+        case 500s: { return "Internal Server Error"; }
+        case 501s: { return "Not Implemented"; }
+        case 502s: { return "Bad Gateway"; }
+        case 503s: { return "Service Unavailable"; }
+        case 504s: { return "Gateway Timeout"; }
+        case 505s: { return "HTTP Version Not Supported"; }
+        default: { return getStatusClassPhrase(statusCode); }
+    }
+}
+
+f<string> getStatusClassPhrase(unsigned short statusCode) {
+    if statusCode >= 100s && statusCode < 200s { return "Informational"; }
+    if statusCode >= 200s && statusCode < 300s { return "Success"; }
+    if statusCode >= 300s && statusCode < 400s { return "Redirection"; }
+    if statusCode >= 400s && statusCode < 500s { return "Client Error"; }
+    if statusCode >= 500s && statusCode < 600s { return "Server Error"; }
+    return "Unknown";
+}
+
+// ==================================================== URL encoding ===================================================
+
+/**
+ * Percent-encodes everything in the given text that is not an unreserved URI character (RFC 3986
+ * section 2.3), so that the result can be used as a path segment, query key or query value.
+ *
+ * @param input Text to encode
+ * @return Percent-encoded text
+ */
+public f<String> urlEncode(const String& input) {
+    result = String();
+    const unsigned long length = input.getLength();
+    result.reserve(length);
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = input[i];
+        if isAlphaNum(c) || isUnreservedExtra(c) {
+            result.append(c);
+        } else {
+            result.append('%');
+            result.append(getHexDigit((cast<int>(c) >> 4) & 0xF));
+            result.append(getHexDigit(cast<int>(c) & 0xF));
+        }
+    }
+}
+
+/**
+ * Reverses `urlEncode`: turns percent escapes back into their bytes and, since query strings are
+ * form-encoded, also turns '+' back into a space.
+ * Malformed escapes at the end of the input are passed through verbatim.
+ *
+ * @param input Percent-encoded text
+ * @return Decoded text
+ */
+public f<String> urlDecode(const String& input) {
+    result = String();
+    const unsigned long length = input.getLength();
+    result.reserve(length);
+    unsigned long i = 0l;
+    while i < length {
+        const char c = input[i];
+        if c == '+' {
+            result.append(' ');
+            i++;
+        } else if c == '%' && i + 2l < length && isHexDigit(input[i + 1l]) && isHexDigit(input[i + 2l]) {
+            const int high = getHexDigitValue(input[i + 1l]);
+            const int low = getHexDigitValue(input[i + 2l]);
+            result.append(cast<char>((high << 4) | low));
+            i += 3l;
+        } else {
+            result.append(c);
+            i++;
+        }
+    }
+}
+
+f<bool> isAuthorityDelimiter(char c) {
+    return c == '/' || c == '?' || c == '#';
+}
+
+f<bool> isUnreservedExtra(char c) {
+    return c == '-' || c == '_' || c == '.' || c == '~';
+}
+
+f<char> getHexDigit(int value) {
+    return value < 10 ? cast<char>(cast<int>('0') + value) : cast<char>(cast<int>('A') + value - 10);
+}
+
+f<int> getHexDigitValue(char c) {
+    if isDigit(c) { return cast<int>(c) - cast<int>('0'); }
+    if c >= 'a' && c <= 'f' { return cast<int>(c) - cast<int>('a') + 10; }
+    if c >= 'A' && c <= 'F' { return cast<int>(c) - cast<int>('A') + 10; }
+    return 0;
+}
+
+/**
+ * Compares two raw strings while ignoring the case of ASCII letters. Header field names are
+ * case-insensitive, so every lookup goes through this.
+ *
+ * @param lhs First string
+ * @param rhs Second string
+ * @return true if both strings are equal, ignoring case
+ */
+public f<bool> equalsIgnoreCase(string lhs, string rhs) {
+    unsafe {
+        char* rawLhs = cast<char*>(lhs);
+        char* rawRhs = cast<char*>(rhs);
+        // An empty String hands out a nil buffer, so both sides have to be checked for it
+        if rawLhs == nil<char*> || rawRhs == nil<char*> { return rawLhs == rawRhs; }
+        unsigned long i = 0l;
+        while rawLhs[i] != '\0' && rawRhs[i] != '\0' {
+            if toLower(rawLhs[i]) != toLower(rawRhs[i]) { return false; }
+            i++;
+        }
+        return rawLhs[i] == rawRhs[i];
+    }
+}
+
+// ==================================================== HttpHeaders ====================================================
+
+/**
+ * A single header field
+ */
+public type HttpHeader struct {
+    public String name  // Field name, in the casing it was given in
+    public String value // Field value
+}
+
+/**
+ * Constructs a header field
+ *
+ * @param name Field name
+ * @param value Field value
+ */
+public p HttpHeader.ctor(string name, string value) {
+    this.name = String(name);
+    this.value = String(value);
+}
+
+/**
+ * Copy-constructs a header field, deep-copying both of its strings
+ */
+public p HttpHeader.ctor(const HttpHeader& original) {
+    this.name = original.name;
+    this.value = original.value;
+}
+
+/**
+ * Deep-copy assignment, so that header fields survive being shifted around inside a vector
+ */
+public p operator=(HttpHeader& this, const HttpHeader& original) {
+    // Guard against self-assignment, which would free the strings we copy from
+    if &this == &original { return; }
+    this.name = original.name;
+    this.value = original.value;
+}
+
+/**
+ * Header field list of a request or a response.
+ *
+ * Fields keep the order in which they were added and their names keep the case they were given in,
+ * while all lookups are case-insensitive, as required by RFC 9110 section 5.1. A name may appear
+ * more than once - use `add` for that and `set` when a field is meant to be unique.
+ */
+public type HttpHeaders struct {
+    public Vector<HttpHeader> entries
+}
+
+/**
+ * Returns the index of the first field with the given name
+ *
+ * @param name Field name, compared case-insensitively
+ * @return Index of the field, or -1 if there is no such field
+ */
+public f<long> HttpHeaders.indexOf(string name) {
+    const unsigned long entryCount = cast<unsigned long>(this.entries.getSize());
+    for unsigned long i = 0l; i < entryCount; i++ {
+        HttpHeader& entry = this.entries.get(i);
+        if equalsIgnoreCase(entry.name.getRaw(), name) { return cast<long>(i); }
+    }
+    return -1l;
+}
+
+/**
+ * Checks whether a field with the given name is present
+ *
+ * @param name Field name, compared case-insensitively
+ * @return true if the field is present
+ */
+public f<bool> HttpHeaders.contains(string name) {
+    return this.indexOf(name) != -1l;
+}
+
+/**
+ * Returns the value of the first field with the given name
+ *
+ * @param name Field name, compared case-insensitively
+ * @return Field value, or an empty string if the field is not present
+ */
+public f<String> HttpHeaders.get(string name) {
+    result = String();
+    const long index = this.indexOf(name);
+    if index != -1l {
+        HttpHeader& entry = this.entries.get(cast<unsigned long>(index));
+        result = entry.value;
+    }
+}
+
+/**
+ * Returns the value of the first field with the given name, or the given fallback if the field is
+ * not present
+ *
+ * @param name Field name, compared case-insensitively
+ * @param fallback Value to return if the field is not present
+ * @return Field value or fallback
+ */
+public f<String> HttpHeaders.getOrDefault(string name, string fallback) {
+    result = String(fallback);
+    const long index = this.indexOf(name);
+    if index != -1l {
+        HttpHeader& entry = this.entries.get(cast<unsigned long>(index));
+        result = entry.value;
+    }
+}
+
+/**
+ * Sets a field, replacing the value of the first field with that name if it already exists
+ *
+ * @param name Field name
+ * @param value Field value
+ */
+public p HttpHeaders.set(string name, string value) {
+    const long index = this.indexOf(name);
+    if index != -1l {
+        HttpHeader& entry = this.entries.get(cast<unsigned long>(index));
+        entry.value = String(value);
+    } else {
+        this.entries.pushBack(HttpHeader(name, value));
+    }
+}
+
+/**
+ * Sets a field, replacing the value of the first field with that name if it already exists
+ *
+ * @param name Field name
+ * @param value Field value
+ */
+public p HttpHeaders.set(string name, const String& value) {
+    this.set(name, value.getRaw());
+}
+
+/**
+ * Appends a field, keeping any field with the same name that is already present. This is what
+ * repeatable fields such as Set-Cookie need.
+ *
+ * @param name Field name
+ * @param value Field value
+ */
+public p HttpHeaders.add(string name, string value) {
+    this.entries.pushBack(HttpHeader(name, value));
+}
+
+/**
+ * Removes all fields with the given name
+ *
+ * @param name Field name, compared case-insensitively
+ */
+public p HttpHeaders.remove(string name) {
+    long index = this.indexOf(name);
+    while index != -1l {
+        this.entries.removeAt(cast<unsigned long>(index));
+        index = this.indexOf(name);
+    }
+}
+
+/**
+ * Returns the field at the given index, in insertion order
+ *
+ * @param index Index of the field
+ * @return Name/value pair of the field
+ */
+public f<HttpHeader&> HttpHeaders.getAt(unsigned long index) {
+    return this.entries.get(index);
+}
+
+/**
+ * Returns the number of fields
+ */
+public f<unsigned long> HttpHeaders.getSize() {
+    return cast<unsigned long>(this.entries.getSize());
+}
+
+/**
+ * Checks if there is no field at all
+ */
+public f<bool> HttpHeaders.isEmpty() {
+    return this.entries.isEmpty();
+}
+
+/**
+ * Drops all fields
+ */
+public p HttpHeaders.clear() {
+    this.entries.clear();
+}
+
+/**
+ * Serializes all fields into the wire format, including the terminating CRLF of the last field but
+ * without the empty line that ends the header block
+ *
+ * @return Serialized header block
+ */
+public f<String> HttpHeaders.serialize() {
+    result = String();
+    const unsigned long entryCount = cast<unsigned long>(this.entries.getSize());
+    for unsigned long i = 0l; i < entryCount; i++ {
+        HttpHeader& entry = this.entries.get(i);
+        result.append(entry.name);
+        result.append(": ");
+        result.append(entry.value);
+        result.append(CRLF);
+    }
+}
+
+/**
+ * Returns the body length announced by the Content-Length field
+ *
+ * @return Announced body length, or -1 if the field is absent or malformed
+ */
+public f<long> HttpHeaders.getContentLength() {
+    result = -1l;
+    const long index = this.indexOf(HEADER_CONTENT_LENGTH);
+    if index != -1l {
+        HttpHeader& entry = this.entries.get(cast<unsigned long>(index));
+        if isDecimalNumber(entry.value) {
+            result = toLong(entry.value.getRaw());
+        }
+    }
+}
+
+/**
+ * Checks whether the message body is chunked, i.e. whether the Transfer-Encoding field ends in
+ * "chunked" (RFC 9112 section 6.1)
+ */
+public f<bool> HttpHeaders.isChunked() {
+    result = false;
+    const long index = this.indexOf(HEADER_TRANSFER_ENCODING);
+    if index != -1l {
+        HttpHeader& entry = this.entries.get(cast<unsigned long>(index));
+        const String lowered = toLower(entry.value);
+        result = lowered.endsWith("chunked");
+    }
+}
+
+f<bool> isDecimalNumber(const String& text) {
+    const unsigned long length = text.getLength();
+    if length == 0l { return false; }
+    for unsigned long i = 0l; i < length; i++ {
+        if !isDigit(text[i]) { return false; }
+    }
+    return true;
+}
+
+// ======================================================== Url ========================================================
+
+/**
+ * An absolute HTTP(S) URL, split into the parts a client needs to open a connection and to build a
+ * request line from
+ */
+public type Url struct {
+    public String scheme        // "http" or "https", always lower case
+    public String host          // Host name or IPv4 address, without the port
+    public unsigned short port  // Port, defaulted from the scheme if the URL carries none
+    public String path          // Path, always starting with a '/'
+    public String query         // Query string, without the leading '?'
+    public String fragment      // Fragment, without the leading '#'
+}
+
+/**
+ * Constructs an empty http URL that points at the root path of no host yet
+ */
+public p Url.ctor() {
+    this.scheme = String("http");
+    this.port = HTTP_PORT_DEFAULT;
+    this.path = String("/");
+}
+
+/**
+ * Parses an absolute URL such as "http://example.com:8080/a/b?x=1#top".
+ * Relative URLs are rejected, since a client cannot connect anywhere without an authority.
+ *
+ * @param raw URL to parse
+ * @return The parsed URL, or an error describing why it could not be parsed
+ */
+public f<Result<Url>> parseUrl(const String& raw) {
+    Url url = Url();
+    const string errorMessage = parseUrlInto(raw, url);
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(url) : err<Url>(error);
+}
+
+/**
+ * Parses an absolute URL into the given URL object
+ *
+ * @param raw URL to parse
+ * @param url URL object to fill in
+ * @return An empty string on success, otherwise the reason why the URL could not be parsed
+ */
+f<string> parseUrlInto(const String& raw, Url& url) {
+    result = "";
+    const long schemeEnd = raw.find("://");
+    if schemeEnd == -1l {
+        result = "URL is missing a scheme";
+    } else {
+        const String scheme = raw.getSubstring(0l, schemeEnd);
+        url.scheme = toLower(scheme);
+        if url.scheme != "http" && url.scheme != "https" {
+            result = "URL scheme is neither http nor https";
+        } else {
+            url.port = url.scheme == "https" ? HTTPS_PORT_DEFAULT : HTTP_PORT_DEFAULT;
+
+            // The authority reaches up to the first delimiter that starts one of the following parts
+            const unsigned long authorityStart = cast<unsigned long>(schemeEnd) + 3l;
+            const unsigned long authorityEnd = findAuthorityEnd(raw, authorityStart);
+            const String authority = raw.getSubstring(authorityStart, cast<long>(authorityEnd - authorityStart));
+            result = parseAuthorityInto(authority, url);
+
+            if result == "" {
+                const String remainder = raw.getSubstring(authorityEnd);
+                parseTargetInto(remainder, url);
+            }
+        }
+    }
+}
+
+/**
+ * Returns the index at which the authority of a URL ends, i.e. the index of the first delimiter that
+ * starts the path, the query or the fragment
+ *
+ * @param raw URL to scan
+ * @param authorityStart Index the authority starts at
+ * @return Index one behind the last character of the authority
+ */
+f<unsigned long> findAuthorityEnd(const String& raw, unsigned long authorityStart) {
+    const unsigned long rawLength = raw.getLength();
+    unsigned long authorityEnd = authorityStart;
+    while authorityEnd < rawLength && !isAuthorityDelimiter(raw[authorityEnd]) {
+        authorityEnd++;
+    }
+    return authorityEnd;
+}
+
+/**
+ * Parses the authority of a URL, i.e. its optional userinfo, its host and its optional port.
+ * The userinfo is dropped, since the client does not act on it.
+ *
+ * @param authority Authority to parse
+ * @param url URL object to fill in
+ * @return An empty string on success, otherwise the reason why the authority could not be parsed
+ */
+f<string> parseAuthorityInto(const String& authority, Url& url) {
+    result = "";
+    if authority.isEmpty() {
+        result = "URL is missing a host";
+    } else {
+        // Userinfo is not supported, so everything up to an '@' is dropped
+        const long userInfoEnd = authority.rfind('@');
+        const unsigned long hostStart = userInfoEnd == -1l ? 0l : cast<unsigned long>(userInfoEnd) + 1l;
+        const String hostAndPort = authority.getSubstring(hostStart);
+        const long portStart = hostAndPort.rfind(':');
+        if portStart == -1l {
+            url.host = hostAndPort;
+        } else {
+            url.host = hostAndPort.getSubstring(0l, portStart);
+            const String portText = hostAndPort.getSubstring(cast<unsigned long>(portStart) + 1l);
+            if !isDecimalNumber(portText) {
+                result = "URL carries a malformed port";
+            } else {
+                url.port = cast<unsigned short>(toLong(portText.getRaw()));
+            }
+        }
+        if result == "" && url.host.isEmpty() {
+            result = "URL is missing a host";
+        }
+    }
+}
+
+/**
+ * Splits everything behind the authority of a URL into path, query and fragment
+ *
+ * @param target Part of the URL behind its authority, may be empty
+ * @param url URL object to fill in
+ */
+p parseTargetInto(const String& target, Url& url) {
+    String remainder = String();
+    remainder = target;
+    const long fragmentStart = remainder.find('#');
+    if fragmentStart != -1l {
+        url.fragment = remainder.getSubstring(cast<unsigned long>(fragmentStart) + 1l);
+        remainder = remainder.getSubstring(0l, fragmentStart);
+    }
+    const long queryStart = remainder.find('?');
+    if queryStart != -1l {
+        url.query = remainder.getSubstring(cast<unsigned long>(queryStart) + 1l);
+        remainder = remainder.getSubstring(0l, queryStart);
+    }
+    if remainder.isEmpty() {
+        url.path = String("/");
+    } else {
+        url.path = remainder;
+    }
+}
+
+/**
+ * Returns the request target of this URL, i.e. the path together with the query string. This is the
+ * middle part of the request line of an origin-form request.
+ *
+ * @return Request target, e.g. "/a/b?x=1"
+ */
+public f<String> Url.getRequestTarget() {
+    result = String("/");
+    if !this.path.isEmpty() { result = this.path; }
+    if !this.query.isEmpty() {
+        result.append('?');
+        result.append(this.query);
+    }
+}
+
+/**
+ * Returns the authority of this URL, i.e. the host plus the port if it deviates from the default
+ * port of the scheme. This is what the Host header field carries.
+ *
+ * @return Authority, e.g. "example.com:8080"
+ */
+public f<String> Url.getAuthority() {
+    result = this.host;
+    const unsigned short defaultPort = this.scheme == "https" ? HTTPS_PORT_DEFAULT : HTTP_PORT_DEFAULT;
+    if this.port != defaultPort {
+        result.append(':');
+        const String portText = toString(cast<long>(this.port));
+        result.append(portText);
+    }
+}
+
+/**
+ * Reassembles the URL into its textual form
+ */
+public f<String> Url.toString() {
+    result = this.scheme;
+    result.append("://");
+    const String authority = this.getAuthority();
+    result.append(authority);
+    const String requestTarget = this.getRequestTarget();
+    result.append(requestTarget);
+    if !this.fragment.isEmpty() {
+        result.append('#');
+        result.append(this.fragment);
+    }
+}
+
+// ==================================================== HttpRequest ====================================================
+
+/**
+ * A request message: request line, header fields and body
+ */
+public type HttpRequest struct {
+    public HttpMethod method
+    public String target       // Request target in origin form, e.g. "/a/b?x=1"
+    public String version
+    public HttpHeaders headers
+    public String body
+}
+
+/**
+ * Constructs a request with an empty header block and an empty body
+ *
+ * @param method Request method
+ * @param target Request target in origin form, e.g. "/a/b?x=1"
+ */
+public p HttpRequest.ctor(HttpMethod method = HttpMethod::GET, string target = "/") {
+    this.method = method;
+    this.target = String(target);
+    this.version = String(HTTP_VERSION_1_1);
+}
+
+/**
+ * Returns the path of the request target, i.e. the target without the query string
+ *
+ * @return Path, e.g. "/a/b"
+ */
+public f<String> HttpRequest.getPath() {
+    result = this.target;
+    const long queryStart = this.target.find('?');
+    if queryStart != -1l {
+        result = this.target.getSubstring(0l, queryStart);
+    }
+}
+
+/**
+ * Returns the query string of the request target, without the leading '?'
+ *
+ * @return Query string, e.g. "x=1&y=2"
+ */
+public f<String> HttpRequest.getQuery() {
+    result = String();
+    const long queryStart = this.target.find('?');
+    if queryStart != -1l {
+        result = this.target.getSubstring(cast<unsigned long>(queryStart) + 1l);
+    }
+}
+
+/**
+ * Returns the value of a query parameter, percent-decoded
+ *
+ * @param name Parameter name
+ * @return Parameter value, or an empty string if the parameter is not present
+ */
+public f<String> HttpRequest.getQueryParam(string name) {
+    const String query = this.getQuery();
+    result = getFormValue(query, name);
+}
+
+/**
+ * Checks whether the request target carries the given query parameter
+ *
+ * @param name Parameter name
+ */
+public f<bool> HttpRequest.hasQueryParam(string name) {
+    const String query = this.getQuery();
+    result = containsFormKey(query, name);
+}
+
+/**
+ * Sets the body of the request and the header fields that describe it
+ *
+ * @param body Body payload
+ * @param contentType Media type of the payload
+ */
+public p HttpRequest.setBody(const String& body, string contentType = CONTENT_TYPE_TEXT) {
+    this.body = body;
+    this.headers.set(HEADER_CONTENT_TYPE, contentType);
+    const String bodyLength = toString(cast<long>(this.body.getLength()));
+    this.headers.set(HEADER_CONTENT_LENGTH, bodyLength);
+}
+
+/**
+ * Serializes the request into the wire format
+ *
+ * @return Serialized request, ready to be written to a socket
+ */
+public f<String> HttpRequest.serialize() {
+    result = String();
+    result.append(getMethodName(this.method));
+    result.append(' ');
+    result.append(this.target.isEmpty() ? "/" : this.target.getRaw());
+    result.append(' ');
+    result.append(this.version);
+    result.append(CRLF);
+    const String headerBlock = this.headers.serialize();
+    result.append(headerBlock);
+    result.append(CRLF);
+    // The body may carry arbitrary bytes, so it is appended with an explicit length
+    result.append(this.body.getRaw(), this.body.getLength());
+}
+
+// =================================================== HttpResponse ====================================================
+
+/**
+ * A response message: status line, header fields and body
+ */
+public type HttpResponse struct {
+    public String version
+    public unsigned short statusCode
+    public String reason
+    public HttpHeaders headers
+    public String body
+}
+
+/**
+ * Constructs a response with the reason phrase that belongs to the given status code, an empty
+ * header block and an empty body
+ *
+ * @param statusCode Status code of the response
+ */
+public p HttpResponse.ctor(unsigned short statusCode = STATUS_OK) {
+    this.version = String(HTTP_VERSION_1_1);
+    this.statusCode = statusCode;
+    this.reason = String(getReasonPhrase(statusCode));
+}
+
+/**
+ * Sets the status code together with its default reason phrase
+ *
+ * @param statusCode Status code of the response
+ */
+public p HttpResponse.setStatus(unsigned short statusCode) {
+    this.statusCode = statusCode;
+    this.reason = String(getReasonPhrase(statusCode));
+}
+
+/**
+ * Sets the body of the response and the header fields that describe it
+ *
+ * @param body Body payload
+ * @param contentType Media type of the payload
+ */
+public p HttpResponse.setBody(const String& body, string contentType = CONTENT_TYPE_TEXT) {
+    this.body = body;
+    this.headers.set(HEADER_CONTENT_TYPE, contentType);
+    const String bodyLength = toString(cast<long>(this.body.getLength()));
+    this.headers.set(HEADER_CONTENT_LENGTH, bodyLength);
+}
+
+/**
+ * Sets an HTML body, a shorthand for `setBody(html, CONTENT_TYPE_HTML)`
+ *
+ * @param html HTML payload
+ */
+public p HttpResponse.setHtmlBody(const String& html) {
+    this.setBody(html, CONTENT_TYPE_HTML);
+}
+
+/**
+ * Sets a JSON body, a shorthand for `setBody(json, CONTENT_TYPE_JSON)`
+ *
+ * @param json JSON payload
+ */
+public p HttpResponse.setJsonBody(const String& json) {
+    this.setBody(json, CONTENT_TYPE_JSON);
+}
+
+/**
+ * Turns the response into a redirect to the given location
+ *
+ * @param location Target of the redirect
+ * @param statusCode Redirect status code to use
+ */
+public p HttpResponse.redirectTo(string location, unsigned short statusCode = STATUS_FOUND) {
+    this.setStatus(statusCode);
+    this.headers.set(HEADER_LOCATION, location);
+}
+
+/**
+ * Checks whether the status code denotes success (2xx)
+ */
+public f<bool> HttpResponse.isSuccess() {
+    return this.statusCode >= 200s && this.statusCode < 300s;
+}
+
+/**
+ * Checks whether the status code denotes a redirect (3xx)
+ */
+public f<bool> HttpResponse.isRedirect() {
+    return this.statusCode >= 300s && this.statusCode < 400s;
+}
+
+/**
+ * Checks whether the status code denotes a client error (4xx)
+ */
+public f<bool> HttpResponse.isClientError() {
+    return this.statusCode >= 400s && this.statusCode < 500s;
+}
+
+/**
+ * Checks whether the status code denotes a server error (5xx)
+ */
+public f<bool> HttpResponse.isServerError() {
+    return this.statusCode >= 500s && this.statusCode < 600s;
+}
+
+/**
+ * Serializes the response into the wire format
+ *
+ * @return Serialized response, ready to be written to a socket
+ */
+public f<String> HttpResponse.serialize() {
+    result = String();
+    result.append(this.version);
+    result.append(' ');
+    const String statusText = toString(cast<long>(this.statusCode));
+    result.append(statusText);
+    result.append(' ');
+    result.append(this.reason);
+    result.append(CRLF);
+    const String headerBlock = this.headers.serialize();
+    result.append(headerBlock);
+    result.append(CRLF);
+    // The body may carry arbitrary bytes, so it is appended with an explicit length
+    result.append(this.body.getRaw(), this.body.getLength());
+}
+
+// ====================================================== Parsing ======================================================
+
+/**
+ * Splits a head block into its lines, accepting both CRLF and bare LF line endings
+ *
+ * @param head Head block to split
+ * @return The lines, without their line endings
+ */
+f<Vector<String>> splitHeadLines(const String& head) {
+    result = Vector<String>();
+    const unsigned long length = head.getLength();
+    unsigned long lineStart = 0l;
+    for unsigned long i = 0l; i < length; i++ {
+        if head[i] == '\n' {
+            unsigned long lineEnd = i;
+            if lineEnd > lineStart && head[lineEnd - 1l] == '\r' { lineEnd--; }
+            result.pushBack(head.getSubstring(lineStart, cast<long>(lineEnd - lineStart)));
+            lineStart = i + 1l;
+        }
+    }
+    if lineStart < length {
+        result.pushBack(head.getSubstring(lineStart, cast<long>(length - lineStart)));
+    }
+}
+
+/**
+ * Parses a header block into a header list. Field lines that carry no colon are skipped, and
+ * leading as well as trailing whitespace is stripped off the field values.
+ *
+ * @param lines Lines of the head block
+ * @param firstLineIndex Index of the first field line, i.e. the line after the start line
+ * @param headers Header list to fill
+ */
+p parseHeaderLines(Vector<String>& lines, unsigned long firstLineIndex, HttpHeaders& headers) {
+    const unsigned long lineCount = cast<unsigned long>(lines.getSize());
+    for unsigned long i = firstLineIndex; i < lineCount; i++ {
+        String& line = lines.get(i);
+        if !line.isEmpty() {
+            const long colonIndex = line.find(':');
+            if colonIndex > 0l {
+                const String fieldName = line.getSubstring(0l, colonIndex);
+                const String rawValue = line.getSubstring(cast<unsigned long>(colonIndex) + 1l);
+                const String fieldValue = rawValue.trim();
+                headers.add(fieldName.getRaw(), fieldValue.getRaw());
+            }
+        }
+    }
+}
+
+/**
+ * Parses the head of a request, i.e. its request line plus its header block. The body is not part of
+ * the head and stays empty.
+ *
+ * @param head Head block, with or without the terminating empty line
+ * @return The parsed request, or an error describing why it could not be parsed
+ */
+public f<Result<HttpRequest>> parseRequestHead(const String& head) {
+    HttpRequest request = HttpRequest();
+    string errorMessage = "";
+
+    Vector<String> lines = splitHeadLines(head);
+    if lines.isEmpty() {
+        errorMessage = "Request head is empty";
+    } else {
+        String& requestLine = lines.get(0l);
+        const long methodEnd = requestLine.find(' ');
+        const long targetEnd = methodEnd == -1l ? -1l : requestLine.find(' ', cast<unsigned long>(methodEnd) + 1l);
+        if methodEnd == -1l || targetEnd == -1l {
+            errorMessage = "Malformed request line";
+        } else {
+            const String methodName = requestLine.getSubstring(0l, methodEnd);
+            const Result<HttpMethod> methodResult = parseMethodName(methodName);
+            if methodResult.isErr() {
+                errorMessage = "Unknown request method";
+            } else {
+                request.method = methodResult.unwrap();
+                const unsigned long targetStart = cast<unsigned long>(methodEnd) + 1l;
+                request.target = requestLine.getSubstring(targetStart, targetEnd - methodEnd - 1l);
+                request.version = requestLine.getSubstring(cast<unsigned long>(targetEnd) + 1l);
+                if request.target.isEmpty() {
+                    errorMessage = "Request line carries an empty request target";
+                } else {
+                    parseHeaderLines(lines, 1l, request.headers);
+                }
+            }
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(request) : err<HttpRequest>(error);
+}
+
+/**
+ * Parses the head of a response, i.e. its status line plus its header block. The body is not part of
+ * the head and stays empty.
+ *
+ * @param head Head block, with or without the terminating empty line
+ * @return The parsed response, or an error describing why it could not be parsed
+ */
+public f<Result<HttpResponse>> parseResponseHead(const String& head) {
+    HttpResponse response = HttpResponse();
+    string errorMessage = "";
+
+    Vector<String> lines = splitHeadLines(head);
+    if lines.isEmpty() {
+        errorMessage = "Response head is empty";
+    } else {
+        String& statusLine = lines.get(0l);
+        const long versionEnd = statusLine.find(' ');
+        if versionEnd == -1l {
+            errorMessage = "Malformed status line";
+        } else {
+            response.version = statusLine.getSubstring(0l, versionEnd);
+            const unsigned long codeStart = cast<unsigned long>(versionEnd) + 1l;
+            const long codeEnd = statusLine.find(' ', codeStart);
+            const long codeLength = codeEnd == -1l ? -1l : codeEnd - versionEnd - 1l;
+            const String codeText = statusLine.getSubstring(codeStart, codeLength);
+            if !isDecimalNumber(codeText) {
+                errorMessage = "Status line carries a malformed status code";
+            } else {
+                response.statusCode = cast<unsigned short>(toLong(codeText.getRaw()));
+                if codeEnd == -1l {
+                    // A status line is allowed to omit the reason phrase
+                    response.reason = String(getReasonPhrase(response.statusCode));
+                } else {
+                    response.reason = statusLine.getSubstring(cast<unsigned long>(codeEnd) + 1l);
+                }
+                parseHeaderLines(lines, 1l, response.headers);
+            }
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(response) : err<HttpResponse>(error);
+}
+
+/**
+ * Parses a complete request message, head and body.
+ *
+ * The body is taken as everything behind the empty line that ends the head, which makes this the
+ * right entry point for messages that are already fully in memory. Reading a message off a socket
+ * goes through the client and the server instead, since those have to know when to stop reading.
+ *
+ * @param raw Complete request message
+ * @return The parsed request, or an error describing why it could not be parsed
+ */
+public f<Result<HttpRequest>> parseRequest(const String& raw) {
+    const long headEnd = findHeadEnd(raw);
+    String head = String(raw);
+    if headEnd != -1l { head = raw.getSubstring(0l, headEnd); }
+    Result<HttpRequest> parseResult = parseRequestHead(head);
+    if parseResult.isOk() && headEnd != -1l {
+        HttpRequest& request = parseResult.unwrap();
+        request.body = raw.getSubstring(cast<unsigned long>(headEnd) + 4l);
+    }
+    return parseResult;
+}
+
+/**
+ * Parses a complete response message, head and body.
+ *
+ * The body is taken as everything behind the empty line that ends the head, which makes this the
+ * right entry point for messages that are already fully in memory. Reading a message off a socket
+ * goes through the client and the server instead, since those have to know when to stop reading.
+ *
+ * @param raw Complete response message
+ * @return The parsed response, or an error describing why it could not be parsed
+ */
+public f<Result<HttpResponse>> parseResponse(const String& raw) {
+    const long headEnd = findHeadEnd(raw);
+    String head = String(raw);
+    if headEnd != -1l { head = raw.getSubstring(0l, headEnd); }
+    Result<HttpResponse> parseResult = parseResponseHead(head);
+    if parseResult.isOk() && headEnd != -1l {
+        HttpResponse& response = parseResult.unwrap();
+        response.body = raw.getSubstring(cast<unsigned long>(headEnd) + 4l);
+    }
+    return parseResult;
+}
+
+/**
+ * Returns the index of the empty line that separates head and body
+ *
+ * @param raw Message to scan
+ * @return Index of the CRLFCRLF sequence, or -1 if the head is not terminated yet
+ */
+public f<long> findHeadEnd(const String& raw) {
+    return raw.find("\r\n\r\n");
+}
+
+// ================================================= Form encoded data =================================================
+
+/**
+ * Returns the value that belongs to the given key in a form-encoded body or query string, i.e. in a
+ * "key=value&key2=value2" sequence. Both the key and the returned value are percent-decoded.
+ *
+ * @param formData Form-encoded data
+ * @param name Key to look up
+ * @return Decoded value, or an empty string if the key is not present
+ */
+public f<String> getFormValue(const String& formData, string name) {
+    result = String();
+    Vector<Pair<String, String>> pairs = parseFormData(formData);
+    const unsigned long pairCount = cast<unsigned long>(pairs.getSize());
+    bool found = false;
+    for unsigned long i = 0l; i < pairCount && !found; i++ {
+        Pair<String, String>& entry = pairs.get(i);
+        String& key = entry.getFirst();
+        if key == name {
+            result = entry.getSecond();
+            found = true;
+        }
+    }
+}
+
+/**
+ * Checks whether a form-encoded body or query string carries the given key
+ *
+ * @param formData Form-encoded data
+ * @param name Key to look up
+ */
+public f<bool> containsFormKey(const String& formData, string name) {
+    result = false;
+    Vector<Pair<String, String>> pairs = parseFormData(formData);
+    const unsigned long pairCount = cast<unsigned long>(pairs.getSize());
+    for unsigned long i = 0l; i < pairCount && !result; i++ {
+        Pair<String, String>& entry = pairs.get(i);
+        String& key = entry.getFirst();
+        result = key == name;
+    }
+}
+
+/**
+ * Splits a form-encoded body or query string into its decoded key/value pairs. Keys without a '='
+ * yield an empty value, and empty segments are skipped.
+ *
+ * @param formData Form-encoded data
+ * @return Decoded key/value pairs, in the order they appear
+ */
+public f<Vector<Pair<String, String>>> parseFormData(const String& formData) {
+    result = Vector<Pair<String, String>>();
+    const unsigned long length = formData.getLength();
+    unsigned long segmentStart = 0l;
+    while segmentStart <= length {
+        long segmentEnd = formData.find('&', segmentStart);
+        if segmentEnd == -1l { segmentEnd = cast<long>(length); }
+        if cast<unsigned long>(segmentEnd) > segmentStart {
+            const String segment = formData.getSubstring(segmentStart, segmentEnd - cast<long>(segmentStart));
+            const long assignIndex = segment.find('=');
+            String rawKey = segment;
+            String rawValue = String();
+            if assignIndex != -1l {
+                rawKey = segment.getSubstring(0l, assignIndex);
+                rawValue = segment.getSubstring(cast<unsigned long>(assignIndex) + 1l);
+            }
+            const String key = urlDecode(rawKey);
+            const String value = urlDecode(rawValue);
+            result.pushBack(Pair<String, String>(key, value));
+        }
+        segmentStart = cast<unsigned long>(segmentEnd) + 1l;
+    }
+}
+
+// ================================================== Message transport ================================================
+
+// Size of a single socket read. Messages are assembled from as many of these as it takes.
+const long READ_CHUNK_SIZE = 4096l;
+
+// Upper bound on how much of a message is kept in memory before it is rejected, 8 MiB by default
+public const unsigned long DEFAULT_MAX_MESSAGE_SIZE = 8388608l;
+
+/**
+ * Writes a request to the socket
+ *
+ * @param socket Socket to write to
+ * @param request Request to write
+ * @return true if the whole request reached the peer
+ */
+public f<bool> sendRequest(Socket& socket, const HttpRequest& request) {
+    const String wire = request.serialize();
+    result = writeString(socket, wire);
+}
+
+/**
+ * Writes a response to the socket
+ *
+ * @param socket Socket to write to
+ * @param response Response to write
+ * @return true if the whole response reached the peer
+ */
+public f<bool> sendResponse(Socket& socket, const HttpResponse& response) {
+    const String wire = response.serialize();
+    result = writeString(socket, wire);
+}
+
+/**
+ * Reads a complete request off the socket.
+ *
+ * The body is framed by the Content-Length field, or by the chunked transfer coding. A request that
+ * announces neither carries no body, since a server may not wait for the connection to close to
+ * find the end of a request.
+ *
+ * @param socket Socket to read from
+ * @param maxSize Maximum number of bytes to accept for head and body each
+ * @return The received request, or an error describing why it could not be received
+ */
+public f<Result<HttpRequest>> receiveRequest(Socket& socket, unsigned long maxSize = DEFAULT_MAX_MESSAGE_SIZE) {
+    HttpRequest request = HttpRequest();
+    String buffer = String();
+    string errorMessage = "";
+
+    const Result<String> headResult = readHead(socket, buffer, maxSize);
+    if headResult.isErr() {
+        errorMessage = headResult.getErr().message;
+    } else {
+        const String& head = headResult.unwrap();
+        Result<HttpRequest> headParseResult = parseRequestHead(head);
+        if headParseResult.isErr() {
+            errorMessage = headParseResult.getErr().message;
+        } else {
+            HttpRequest& parsedRequest = headParseResult.unwrap();
+            request = parsedRequest;
+            const Result<String> bodyResult = readBody(socket, request.headers, buffer, maxSize, false);
+            if bodyResult.isErr() {
+                errorMessage = bodyResult.getErr().message;
+            } else {
+                const String& body = bodyResult.unwrap();
+                request.body = body;
+            }
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(request) : err<HttpRequest>(error);
+}
+
+/**
+ * Reads a complete response off the socket.
+ *
+ * The body is framed by the Content-Length field or by the chunked transfer coding. A response that
+ * announces neither runs until the peer closes the connection, as HTTP/1.0 servers do.
+ *
+ * @param socket Socket to read from
+ * @param expectBody Whether the response carries a body at all - a response to HEAD never does
+ * @param maxSize Maximum number of bytes to accept for head and body each
+ * @return The received response, or an error describing why it could not be received
+ */
+public f<Result<HttpResponse>> receiveResponse(Socket& socket, bool expectBody = true,
+                                               unsigned long maxSize = DEFAULT_MAX_MESSAGE_SIZE) {
+    HttpResponse response = HttpResponse();
+    String buffer = String();
+    string errorMessage = "";
+
+    const Result<String> headResult = readHead(socket, buffer, maxSize);
+    if headResult.isErr() {
+        errorMessage = headResult.getErr().message;
+    } else {
+        const String& head = headResult.unwrap();
+        Result<HttpResponse> headParseResult = parseResponseHead(head);
+        if headParseResult.isErr() {
+            errorMessage = headParseResult.getErr().message;
+        } else {
+            HttpResponse& parsedResponse = headParseResult.unwrap();
+            response = parsedResponse;
+            // Responses to HEAD and bodyless status codes are complete with their head
+            const bool hasBody = expectBody && !isBodylessStatus(response.statusCode);
+            if hasBody {
+                const Result<String> bodyResult = readBody(socket, response.headers, buffer, maxSize, true);
+                if bodyResult.isErr() {
+                    errorMessage = bodyResult.getErr().message;
+                } else {
+                    const String& body = bodyResult.unwrap();
+                    response.body = body;
+                }
+            }
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(response) : err<HttpResponse>(error);
+}
+
+/**
+ * Checks whether a status code rules out a message body (RFC 9112 section 6.3)
+ */
+f<bool> isBodylessStatus(unsigned short statusCode) {
+    return (statusCode >= 100s && statusCode < 200s) || statusCode == STATUS_NO_CONTENT || statusCode == STATUS_NOT_MODIFIED;
+}
+
+/**
+ * Writes a string to the socket in full
+ */
+f<bool> writeString(Socket& socket, const String& text) {
+    result = true;
+    const unsigned long length = text.getLength();
+    if length != 0l {
+        unsafe {
+            result = socket.writeAll(cast<byte*>(text.getRaw()), length);
+        }
+    }
+}
+
+/**
+ * Appends one socket read to the buffer
+ *
+ * @param socket Socket to read from
+ * @param buffer Buffer to append to
+ * @return true if bytes arrived, false if the peer closed the connection or the read timed out
+ */
+f<bool> readChunkInto(Socket& socket, String& buffer) {
+    byte[4096] chunk;
+    long bytesRead = 0l;
+    unsafe {
+        bytesRead = socket.read(cast<byte*>(&chunk), READ_CHUNK_SIZE);
+        if bytesRead > 0l {
+            buffer.append(cast<string>(&chunk), cast<unsigned long>(bytesRead));
+        }
+    }
+    return bytesRead > 0l;
+}
+
+/**
+ * Reads until the empty line that ends the head has arrived.
+ *
+ * @param socket Socket to read from
+ * @param buffer Receives the body bytes that arrived together with the head
+ * @param maxSize Maximum number of head bytes to accept
+ * @return The head block, without its terminating empty line
+ */
+f<Result<String>> readHead(Socket& socket, String& buffer, unsigned long maxSize) {
+    String head = String();
+    String pending = String();
+    string errorMessage = "";
+    long headEnd = -1l;
+    bool done = false;
+
+    while !done {
+        if !readChunkInto(socket, pending) {
+            errorMessage = "Connection closed before the message head was complete";
+            done = true;
+        } else {
+            headEnd = findHeadEnd(pending);
+            if headEnd != -1l {
+                done = true;
+            } else if pending.getLength() > maxSize {
+                errorMessage = "Message head exceeds the maximum message size";
+                done = true;
+            }
+        }
+    }
+
+    if errorMessage == "" {
+        head = pending.getSubstring(0l, headEnd);
+        buffer = pending.getSubstring(cast<unsigned long>(headEnd) + 4l);
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(head) : err<String>(error);
+}
+
+/**
+ * Reads the body of a message that the head announced.
+ *
+ * @param socket Socket to read from
+ * @param headers Header fields of the message, which decide how the body is framed
+ * @param buffer Body bytes that already arrived together with the head
+ * @param maxSize Maximum number of body bytes to accept
+ * @param readUntilClose Whether a message without any framing runs until the connection closes
+ * @return The body
+ */
+f<Result<String>> readBody(Socket& socket, HttpHeaders& headers, String& buffer, unsigned long maxSize,
+                           bool readUntilClose) {
+    String body = String();
+    string errorMessage = "";
+
+    if headers.isChunked() {
+        const Result<String> chunkedResult = readChunkedBody(socket, buffer, maxSize);
+        if chunkedResult.isErr() {
+            errorMessage = chunkedResult.getErr().message;
+        } else {
+            const String& decoded = chunkedResult.unwrap();
+            body = decoded;
+        }
+    } else {
+        const long contentLength = headers.getContentLength();
+        if contentLength > 0l {
+            if cast<unsigned long>(contentLength) > maxSize {
+                errorMessage = "Message body exceeds the maximum message size";
+            } else {
+                // Keep reading until the announced number of bytes has arrived
+                bool connectionAlive = true;
+                while buffer.getLength() < cast<unsigned long>(contentLength) && connectionAlive {
+                    connectionAlive = readChunkInto(socket, buffer);
+                }
+                if buffer.getLength() < cast<unsigned long>(contentLength) {
+                    errorMessage = "Connection closed before the announced body was complete";
+                } else {
+                    body = buffer.getSubstring(0l, contentLength);
+                }
+            }
+        } else if contentLength == -1l && readUntilClose {
+            // No framing at all, so the body ends with the connection
+            bool connectionAlive = true;
+            while connectionAlive && buffer.getLength() <= maxSize {
+                connectionAlive = readChunkInto(socket, buffer);
+            }
+            if buffer.getLength() > maxSize {
+                errorMessage = "Message body exceeds the maximum message size";
+            } else {
+                body = buffer;
+            }
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(body) : err<String>(error);
+}
+
+/**
+ * Reads and decodes a chunked body (RFC 9112 section 7.1). Chunk extensions and the trailer section
+ * are parsed but discarded.
+ *
+ * @param socket Socket to read from
+ * @param buffer Body bytes that already arrived together with the head
+ * @param maxSize Maximum number of decoded body bytes to accept
+ * @return The decoded body
+ */
+f<Result<String>> readChunkedBody(Socket& socket, String& buffer, unsigned long maxSize) {
+    String body = String();
+    string errorMessage = "";
+    unsigned long pos = 0l;
+    bool done = false;
+
+    while !done {
+        // The chunk size line ends at the next CRLF, so wait until we have seen one
+        long lineEnd = buffer.find(CRLF, pos);
+        while lineEnd == -1l && errorMessage == "" {
+            if !readChunkInto(socket, buffer) {
+                errorMessage = "Connection closed inside a chunked body";
+            } else {
+                lineEnd = buffer.find(CRLF, pos);
+            }
+        }
+
+        if errorMessage != "" {
+            done = true;
+        } else {
+            // Everything behind a ';' is a chunk extension, which carries no data
+            const String sizeLine = buffer.getSubstring(pos, lineEnd - cast<long>(pos));
+            const long extensionStart = sizeLine.find(';');
+            String sizeText = String();
+            if extensionStart == -1l {
+                sizeText = sizeLine;
+            } else {
+                sizeText = sizeLine.getSubstring(0l, extensionStart);
+            }
+            const long chunkSize = parseHexNumber(sizeText);
+            if chunkSize < 0l {
+                errorMessage = "Malformed chunk size";
+                done = true;
+            } else if chunkSize == 0l {
+                // The last chunk is followed by an optional trailer and a final empty line
+                done = true;
+            } else if body.getLength() + cast<unsigned long>(chunkSize) > maxSize {
+                errorMessage = "Message body exceeds the maximum message size";
+                done = true;
+            } else {
+                // Wait until the chunk data plus its trailing CRLF has arrived
+                const unsigned long dataStart = cast<unsigned long>(lineEnd) + 2l;
+                const unsigned long chunkEnd = dataStart + cast<unsigned long>(chunkSize) + 2l;
+                bool connectionAlive = true;
+                while buffer.getLength() < chunkEnd && connectionAlive {
+                    connectionAlive = readChunkInto(socket, buffer);
+                }
+                if buffer.getLength() < chunkEnd {
+                    errorMessage = "Connection closed inside a chunked body";
+                    done = true;
+                } else {
+                    const String chunkData = buffer.getSubstring(dataStart, chunkSize);
+                    body.append(chunkData.getRaw(), chunkData.getLength());
+                    pos = chunkEnd;
+                }
+            }
+        }
+    }
+
+    const Error error = Error(errorMessage);
+    result = errorMessage == "" ? ok(body) : err<String>(error);
+}
+
+/**
+ * Parses a hexadecimal number such as a chunk size
+ *
+ * @param text Hexadecimal digits, without any prefix
+ * @return The parsed value, or -1 if the text is empty or carries a non-hex digit
+ */
+f<long> parseHexNumber(const String& text) {
+    const unsigned long length = text.getLength();
+    if length == 0l { return -1l; }
+    long value = 0l;
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = text[i];
+        if !isHexDigit(c) { return -1l; }
+        value = value * 16l + cast<long>(getHexDigitValue(c));
+    }
+    return value;
 }

--- a/std/net/socket.spice
+++ b/std/net/socket.spice
@@ -11,4 +11,5 @@ public const int SOCK_STREAM = 1; // Stream socket
 public const int SOCK_DGRAM = 2;  // Datagram socket
 public const int IPPROTO_IP = 0;
 public const int IPPROTO_UDP = 17;
-public const int INADDR_ANY = 0;
+public const InAddrT INADDR_ANY = 0u;
+public const InAddrT INADDR_NONE = 0xFFFFFFFFu; // returned by inet_addr for malformed addresses

--- a/std/net/socket_darwin.spice
+++ b/std/net/socket_darwin.spice
@@ -117,6 +117,16 @@ public type Socket struct {
 }
 
 /**
+ * Returns the value the `sinLen` field of a socket address has to carry. The size is taken from the
+ * struct itself, but has to pass through an int on the way, since there is no long to byte cast.
+ *
+ * @return Size of SockAddrIn, as a byte
+ */
+f<unsigned byte> getSockAddrInLen() {
+    return cast<unsigned byte>(cast<int>(sizeof<SockAddrIn>()));
+}
+
+/**
  * Accept an incoming connection to the socket and save the connection file desceiptor
  * to the socket object.
  *
@@ -294,7 +304,7 @@ public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingCon
 
     // Construct socket object
     const Socket s = Socket { sockFd, /*connFd*/ 0 };
-    const SockAddrIn servAddr = SockAddrIn { cast<unsigned byte>(sizeof<SockAddrIn>()), cast<SAFamilyT>(AF_INET), htons(port), InAddr { INADDR_ANY }, 0ul };
+    const SockAddrIn servAddr = SockAddrIn { getSockAddrInLen(), cast<SAFamilyT>(AF_INET), htons(port), InAddr { INADDR_ANY }, 0ul };
 
     // Bind to target address
     const int bindResult = bind(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));
@@ -331,7 +341,7 @@ public f<Result<Socket>> openClientSocket(string host, unsigned short port) {
 
     // Construct socket object. A client talks over the socket itself, so socket and connection descriptor are the same.
     const Socket s = Socket { sockFd, /*connFd*/ sockFd };
-    const SockAddrIn servAddr = SockAddrIn { cast<unsigned byte>(sizeof<SockAddrIn>()), cast<SAFamilyT>(AF_INET), htons(port), InAddr { hostAddr }, 0ul };
+    const SockAddrIn servAddr = SockAddrIn { getSockAddrInLen(), cast<SAFamilyT>(AF_INET), htons(port), InAddr { hostAddr }, 0ul };
 
     // Connect to server
     const int connectResult = connect(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));

--- a/std/net/socket_darwin.spice
+++ b/std/net/socket_darwin.spice
@@ -4,16 +4,24 @@
 import "std/net/socket";
 
 // Type defs
-type SAFamilyT alias unsigned int;
+type SAFamilyT alias unsigned byte;
 type SockLenT alias unsigned int;
 
+// Constants
+public const int SOL_SOCKET = 65535; // Option level for socket-level options (0xFFFF)
+public const int SO_REUSEADDR = 4;   // Allow binding to a local address that is still in TIME_WAIT
+public const int SO_RCVTIMEO = 4102; // Timeout for receive operations
+public const int SO_SNDTIMEO = 4101; // Timeout for send operations
+
 type SockAddr struct {
-    SAFamilyT saFamily // Address family
-    char[]    saData   // Socket address
+    unsigned byte saLen    // Total length of the struct
+    SAFamilyT     saFamily // Address family
+    char[]        saData   // Socket address
 }
 
 type SockAddrStorage struct {
-    SAFamilyT ssFamily // Address family
+    unsigned byte ssLen    // Total length of the struct
+    SAFamilyT     ssFamily // Address family
 }
 
 /**
@@ -31,32 +39,58 @@ public type In6Addr struct {
 }
 
 /**
- * Socket address for an IPv4 (AF_INET) endpoint
+ * Socket address for an IPv4 (AF_INET) endpoint.
+ *
+ * The field order and the field widths mirror `struct sockaddr_in` from the C headers one to one, so
+ * that the struct can be handed to the socket syscalls without any conversion in between.
  */
 public type SockAddrIn struct {
-    SAFamilyT    sinFamily // AF_INET
-    InAddr       sinAddr   // IPv4 address
-    InPortT      sinPort   // Port number
-    unsigned long sinZero  // Padding (this is a byte[8] in the original implementation)
+    unsigned byte sinLen    // Total length of the struct
+    SAFamilyT     sinFamily // AF_INET
+    InPortT       sinPort   // Port number (network byte order)
+    InAddr        sinAddr   // IPv4 address (network byte order)
+    unsigned long sinZero   // Padding (this is a char[8] in the original implementation)
 }
 
 /**
  * Socket address for an IPv6 (AF_INET6) endpoint
  */
 public type SockAddrIn6 struct {
-    SAFamilyT    sin6Family   // AF_INET6
-    InPortT      sin6Port     // Port number
-    unsigned int sin6FlowInfo // IPv6 flow info
-    In6Addr      sin6Addr     // IPv6 address
-    unsigned int sin6ScopeId  // Set of interfaces for a scope
+    unsigned byte sin6Len      // Total length of the struct
+    SAFamilyT     sin6Family   // AF_INET6
+    InPortT       sin6Port     // Port number
+    unsigned int  sin6FlowInfo // IPv6 flow info
+    In6Addr       sin6Addr     // IPv6 address
+    unsigned int  sin6ScopeId  // Set of interfaces for a scope
 }
 
 /**
  * Socket address for a Unix domain (AF_UNIX) endpoint
  */
 public type SockAddrUn struct {
-    SAFamilyT sunFamily // Address family
-    char[]    sunPath   // Socket pathname
+    unsigned byte sunLen    // Total length of the struct
+    SAFamilyT     sunFamily // Address family
+    char[]        sunPath   // Socket pathname
+}
+
+/**
+ * Time span with microsecond resolution, as taken by the timeout socket options. Mirrors
+ * `struct timeval` from the C headers.
+ */
+type TimeVal struct {
+    long tvSec  // Whole seconds
+    long tvUsec // Microseconds
+}
+
+/**
+ * Host entry as returned by `gethostbyname`. Mirrors `struct hostent` from the C headers.
+ */
+type HostEnt struct {
+    string  hName     // Official name of the host
+    string* hAliases  // Alias list, terminated by a nil entry
+    int     hAddrType // Address type (AF_INET for IPv4)
+    int     hLength   // Length of an address, in bytes
+    byte**  hAddrList // Address list, terminated by a nil entry
 }
 
 // External functions
@@ -64,12 +98,14 @@ ext f<int> socket(int /*domain*/, int /*type*/, int /*protocol*/);
 ext f<int> bind(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT /*address_len*/);
 ext f<int> listen(int /*sockfd*/, int /*backlog*/);
 ext f<int> accept(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT* /*address_len*/);
+ext f<int> setsockopt(int /*sockfd*/, int /*level*/, int /*optname*/, byte* /*optval*/, SockLenT /*optlen*/);
 ext f<long> read(int /*fd*/, byte* /*buf*/, unsigned long /*length*/);
 ext f<long> write(int /*fd*/, byte* /*buf*/, unsigned long /*length*/);
 ext f<int> close(int /*fd*/);
 ext f<unsigned int> htonl(unsigned int /*hostlong*/);      // Fairly simple to re-implement in Spice
 ext f<unsigned short> htons(unsigned short /*hostshort*/); // Fairly simple to re-implement in Spice
 ext f<InAddrT> inet_addr(string /*cp*/);
+ext f<HostEnt*> gethostbyname(string /*name*/);
 ext f<int> connect(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT /*address_len*/);
 
 /**
@@ -88,7 +124,7 @@ public type Socket struct {
  */
 public f<Result<int>> Socket.acceptConnection() {
     SockAddrIn cliAddr = SockAddrIn {};
-    SockLenT addrLen = 16u /* hardcoded sizeof(cliAddr) */;
+    SockLenT addrLen = cast<SockLenT>(sizeof<SockAddrIn>());
     this.connFd = accept(this.sockFd, &cliAddr, &addrLen);
     if this.connFd < 0 { return err<int>(Error("Error while accepting connection")); }
     return ok(this.connFd);
@@ -124,6 +160,29 @@ public f<long> Socket.write(byte* content, unsigned long size) {
 }
 
 /**
+ * Write an array of bytes to the socket, retrying until either all of them were handed over to the
+ * kernel or the connection breaks. A single `write` call is free to accept only a part of the buffer,
+ * so anything that must arrive in full has to go through this method.
+ * Note: The given buffer needs to be at least of the given size.
+ *
+ * @param content Buffer of bytes to send
+ * @param size Number of bytes from the buffer to send
+ * @return true if all bytes were written, false if the connection broke in between
+ */
+public f<bool> Socket.writeAll(byte* content, unsigned long size) {
+    unsigned long bytesWritten = 0l;
+    while bytesWritten < size {
+        long written = 0l;
+        unsafe {
+            written = write(this.connFd, content + bytesWritten, size - bytesWritten);
+        }
+        if written <= 0l { return false; }
+        bytesWritten += cast<unsigned long>(written);
+    }
+    return true;
+}
+
+/**
  * Read n bytes from the socket to the given buffer.
  * Note: The given buffer needs to be at least of the given size.
  *
@@ -136,12 +195,79 @@ public f<long> Socket.read(byte* buffer, long size) {
 }
 
 /**
+ * Limits how long a single read or write on this socket may block. Without a timeout a peer that
+ * connects but never sends anything keeps the caller waiting forever.
+ * The timeout applies to the current connection, which for a client socket is the socket itself.
+ *
+ * @param milliseconds Timeout in milliseconds, 0 to block indefinitely again
+ * @return Setting the timeout was successful or not
+ */
+public f<bool> Socket.setTimeout(unsigned long milliseconds) {
+    TimeVal timeout = TimeVal { cast<long>(milliseconds / 1000l), cast<long>((milliseconds % 1000l) * 1000l) };
+    const int targetFd = this.connFd != 0 ? this.connFd : this.sockFd;
+    int receiveResult = 0;
+    int sendResult = 0;
+    unsafe {
+        const SockLenT optLen = cast<SockLenT>(sizeof<TimeVal>());
+        receiveResult = setsockopt(targetFd, SOL_SOCKET, SO_RCVTIMEO, cast<byte*>(&timeout), optLen);
+        sendResult = setsockopt(targetFd, SOL_SOCKET, SO_SNDTIMEO, cast<byte*>(&timeout), optLen);
+    }
+    return receiveResult == 0 && sendResult == 0;
+}
+
+/**
+ * Closes the current connection of the socket, while keeping the socket itself open. This is what a
+ * server does after it has finished serving a single client.
+ *
+ * @return Closing the connection was successful or not
+ */
+public f<bool> Socket.closeConnection() {
+    // A client socket uses the same descriptor for the socket and the connection, so closing the
+    // connection there would take the socket down with it.
+    if this.connFd == 0 || this.connFd == this.sockFd { return true; }
+    const bool success = close(this.connFd) == 0;
+    this.connFd = 0;
+    return success;
+}
+
+/**
  * Closes the socket. This method should always be called by the user before exiting the program.
  *
  * @return Closing the connection was successful or not
  */
 public f<bool> Socket.close() {
-    return close(this.sockFd) == 0;
+    const bool connectionClosed = this.closeConnection();
+    return close(this.sockFd) == 0 && connectionClosed;
+}
+
+/**
+ * Resolves a host given as either a dotted IPv4 address or a hostname to a raw IPv4 address in
+ * network byte order.
+ * Note: The DNS lookup is performed via `gethostbyname`, which is not thread-safe.
+ *
+ * @param host Dotted IPv4 address (e.g. "127.0.0.1") or hostname (e.g. "example.com")
+ * @return IPv4 address in network byte order
+ */
+public f<Result<InAddrT>> resolveHost(string host) {
+    // A dotted IPv4 address needs no name server round trip
+    const InAddrT numericAddr = inet_addr(host);
+    if numericAddr != INADDR_NONE { return ok<InAddrT>(numericAddr); }
+
+    // Fall back to a name lookup
+    HostEnt* entry = gethostbyname(host);
+    if entry == nil<HostEnt*> { return err<InAddrT>(Error("Could not resolve host name")); }
+    if entry.hAddrType != AF_INET { return err<InAddrT>(Error("Host name does not resolve to an IPv4 address")); }
+
+    InAddrT resolvedAddr = 0u;
+    unsafe {
+        byte** addrList = entry.hAddrList;
+        if addrList == nil<byte**> || addrList[0] == nil<byte*> {
+            return err<InAddrT>(Error("Host name resolved to an empty address list"));
+        }
+        InAddrT* firstAddr = cast<InAddrT*>(addrList[0]);
+        resolvedAddr = *firstAddr;
+    }
+    return ok<InAddrT>(resolvedAddr);
 }
 
 /**
@@ -160,17 +286,29 @@ public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingCon
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error creating socket")); }
 
+    // Allow rebinding the port right away instead of waiting out the TIME_WAIT of the previous socket
+    int reuseAddr = 1;
+    unsafe {
+        setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, cast<byte*>(&reuseAddr), cast<SockLenT>(sizeof<int>()));
+    }
+
     // Construct socket object
     const Socket s = Socket { sockFd, /*connFd*/ 0 };
-    const SockAddrIn servAddr = SockAddrIn { AF_INET, InAddr { INADDR_ANY }, htons(port), 0ul};
+    const SockAddrIn servAddr = SockAddrIn { cast<unsigned byte>(sizeof<SockAddrIn>()), cast<SAFamilyT>(AF_INET), htons(port), InAddr { INADDR_ANY }, 0ul };
 
     // Bind to target address
-    const int bindResult = bind(sockFd, &servAddr, 16u /* hardcoded sizeof(servaddr) */);
-    if bindResult < 0 { return err<Socket>(Error("Error binding to address")); }
+    const int bindResult = bind(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));
+    if bindResult < 0 {
+        close(sockFd);
+        return err<Socket>(Error("Error binding to address"));
+    }
 
     // Start listening for incoming connections
     const int listenResult = listen(sockFd, maxWaitingConnections);
-    if listenResult < 0 { return err<Socket>(Error("Error listening on address")); }
+    if listenResult < 0 {
+        close(sockFd);
+        return err<Socket>(Error("Error listening on address"));
+    }
 
     return ok(s);
 }
@@ -178,21 +316,29 @@ public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingCon
 /**
  * Opens a TCP client socket and tries to connect it to a server socket.
  *
- * @param host Host to connect to
+ * @param host Host to connect to, either as dotted IPv4 address or as hostname
  * @param port Post to connect to
  * @return Socket file descriptor
  */
 public f<Result<Socket>> openClientSocket(string host, unsigned short port) {
+    // Resolve the host before spending a file descriptor on it
+    const Result<InAddrT> addrResult = resolveHost(host);
+    if addrResult.isErr() { return err<Socket>(addrResult.getErr()); }
+    const InAddrT hostAddr = addrResult.unwrap();
+
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error opening socket client connection")); }
 
-    // Construct socket object
-    const Socket s = Socket { sockFd, /*connFd*/ 0 };
-    const SockAddrIn cliAddr = SockAddrIn { AF_INET, InAddr { inet_addr(host) }, htons(port), 0ul};
+    // Construct socket object. A client talks over the socket itself, so socket and connection descriptor are the same.
+    const Socket s = Socket { sockFd, /*connFd*/ sockFd };
+    const SockAddrIn servAddr = SockAddrIn { cast<unsigned byte>(sizeof<SockAddrIn>()), cast<SAFamilyT>(AF_INET), htons(port), InAddr { hostAddr }, 0ul };
 
     // Connect to server
-    const int connectResult = connect(sockFd, &cliAddr, 16u /* hardcoded sizeof(cliAddr) */);
-    if connectResult < 0 { return err<Socket>(Error("Error connecting to socket")); }
+    const int connectResult = connect(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));
+    if connectResult < 0 {
+        close(sockFd);
+        return err<Socket>(Error("Error connecting to socket"));
+    }
 
     return ok(s);
 }

--- a/std/net/socket_linux.spice
+++ b/std/net/socket_linux.spice
@@ -4,8 +4,14 @@
 import "std/net/socket";
 
 // Type defs
-type SAFamilyT alias unsigned int;
+type SAFamilyT alias unsigned short;
 type SockLenT alias unsigned int;
+
+// Constants
+public const int SOL_SOCKET = 1;   // Option level for socket-level options
+public const int SO_REUSEADDR = 2; // Allow binding to a local address that is still in TIME_WAIT
+public const int SO_RCVTIMEO = 20; // Timeout for receive operations
+public const int SO_SNDTIMEO = 21; // Timeout for send operations
 
 type SockAddr struct {
     SAFamilyT saFamily // Address family
@@ -31,13 +37,16 @@ public type In6Addr struct {
 }
 
 /**
- * Socket address for an IPv4 (AF_INET) endpoint
+ * Socket address for an IPv4 (AF_INET) endpoint.
+ *
+ * The field order and the field widths mirror `struct sockaddr_in` from the C headers one to one, so
+ * that the struct can be handed to the socket syscalls without any conversion in between.
  */
 public type SockAddrIn struct {
-    SAFamilyT    sinFamily // AF_INET
-    InAddr       sinAddr   // IPv4 address
-    InPortT      sinPort   // Port number
-    unsigned long sinZero  // Padding (this is a byte[8] in the original implementation)
+    SAFamilyT     sinFamily // AF_INET
+    InPortT       sinPort   // Port number (network byte order)
+    InAddr        sinAddr   // IPv4 address (network byte order)
+    unsigned long sinZero   // Padding (this is a char[8] in the original implementation)
 }
 
 /**
@@ -59,17 +68,39 @@ public type SockAddrUn struct {
     char[]    sunPath   // Socket pathname
 }
 
+/**
+ * Time span with microsecond resolution, as taken by the timeout socket options. Mirrors
+ * `struct timeval` from the C headers.
+ */
+type TimeVal struct {
+    long tvSec  // Whole seconds
+    long tvUsec // Microseconds
+}
+
+/**
+ * Host entry as returned by `gethostbyname`. Mirrors `struct hostent` from the C headers.
+ */
+type HostEnt struct {
+    string  hName     // Official name of the host
+    string* hAliases  // Alias list, terminated by a nil entry
+    int     hAddrType // Address type (AF_INET for IPv4)
+    int     hLength   // Length of an address, in bytes
+    byte**  hAddrList // Address list, terminated by a nil entry
+}
+
 // External functions
 ext f<int> socket(int /*domain*/, int /*type*/, int /*protocol*/);
 ext f<int> bind(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT /*address_len*/);
 ext f<int> listen(int /*sockfd*/, int /*backlog*/);
 ext f<int> accept(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT* /*address_len*/);
+ext f<int> setsockopt(int /*sockfd*/, int /*level*/, int /*optname*/, byte* /*optval*/, SockLenT /*optlen*/);
 ext f<long> read(int /*fd*/, byte* /*buf*/, unsigned long /*length*/);
 ext f<long> write(int /*fd*/, byte* /*buf*/, unsigned long /*length*/);
 ext f<int> close(int /*fd*/);
 ext f<unsigned int> htonl(unsigned int /*hostlong*/);      // Fairly simple to re-implement in Spice
 ext f<unsigned short> htons(unsigned short /*hostshort*/); // Fairly simple to re-implement in Spice
 ext f<InAddrT> inet_addr(string /*cp*/);
+ext f<HostEnt*> gethostbyname(string /*name*/);
 ext f<int> connect(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT /*address_len*/);
 
 /**
@@ -88,7 +119,7 @@ public type Socket struct {
  */
 public f<Result<int>> Socket.acceptConnection() {
     SockAddrIn cliAddr = SockAddrIn {};
-    SockLenT addrLen = 16u /* hardcoded sizeof(cliAddr) */;
+    SockLenT addrLen = cast<SockLenT>(sizeof<SockAddrIn>());
     this.connFd = accept(this.sockFd, &cliAddr, &addrLen);
     if this.connFd < 0 { return err<int>(Error("Error while accepting connection")); }
     return ok(this.connFd);
@@ -124,6 +155,29 @@ public f<long> Socket.write(byte* content, unsigned long size) {
 }
 
 /**
+ * Write an array of bytes to the socket, retrying until either all of them were handed over to the
+ * kernel or the connection breaks. A single `write` call is free to accept only a part of the buffer,
+ * so anything that must arrive in full has to go through this method.
+ * Note: The given buffer needs to be at least of the given size.
+ *
+ * @param content Buffer of bytes to send
+ * @param size Number of bytes from the buffer to send
+ * @return true if all bytes were written, false if the connection broke in between
+ */
+public f<bool> Socket.writeAll(byte* content, unsigned long size) {
+    unsigned long bytesWritten = 0l;
+    while bytesWritten < size {
+        long written = 0l;
+        unsafe {
+            written = write(this.connFd, content + bytesWritten, size - bytesWritten);
+        }
+        if written <= 0l { return false; }
+        bytesWritten += cast<unsigned long>(written);
+    }
+    return true;
+}
+
+/**
  * Read n bytes from the socket to the given buffer.
  * Note: The given buffer needs to be at least of the given size.
  *
@@ -136,12 +190,79 @@ public f<long> Socket.read(byte* buffer, long size) {
 }
 
 /**
+ * Limits how long a single read or write on this socket may block. Without a timeout a peer that
+ * connects but never sends anything keeps the caller waiting forever.
+ * The timeout applies to the current connection, which for a client socket is the socket itself.
+ *
+ * @param milliseconds Timeout in milliseconds, 0 to block indefinitely again
+ * @return Setting the timeout was successful or not
+ */
+public f<bool> Socket.setTimeout(unsigned long milliseconds) {
+    TimeVal timeout = TimeVal { cast<long>(milliseconds / 1000l), cast<long>((milliseconds % 1000l) * 1000l) };
+    const int targetFd = this.connFd != 0 ? this.connFd : this.sockFd;
+    int receiveResult = 0;
+    int sendResult = 0;
+    unsafe {
+        const SockLenT optLen = cast<SockLenT>(sizeof<TimeVal>());
+        receiveResult = setsockopt(targetFd, SOL_SOCKET, SO_RCVTIMEO, cast<byte*>(&timeout), optLen);
+        sendResult = setsockopt(targetFd, SOL_SOCKET, SO_SNDTIMEO, cast<byte*>(&timeout), optLen);
+    }
+    return receiveResult == 0 && sendResult == 0;
+}
+
+/**
+ * Closes the current connection of the socket, while keeping the socket itself open. This is what a
+ * server does after it has finished serving a single client.
+ *
+ * @return Closing the connection was successful or not
+ */
+public f<bool> Socket.closeConnection() {
+    // A client socket uses the same descriptor for the socket and the connection, so closing the
+    // connection there would take the socket down with it.
+    if this.connFd == 0 || this.connFd == this.sockFd { return true; }
+    const bool success = close(this.connFd) == 0;
+    this.connFd = 0;
+    return success;
+}
+
+/**
  * Closes the socket. This method should always be called by the user before exiting the program.
  *
  * @return Closing the connection was successful or not
  */
 public f<bool> Socket.close() {
-    return close(this.sockFd) == 0;
+    const bool connectionClosed = this.closeConnection();
+    return close(this.sockFd) == 0 && connectionClosed;
+}
+
+/**
+ * Resolves a host given as either a dotted IPv4 address or a hostname to a raw IPv4 address in
+ * network byte order.
+ * Note: The DNS lookup is performed via `gethostbyname`, which is not thread-safe.
+ *
+ * @param host Dotted IPv4 address (e.g. "127.0.0.1") or hostname (e.g. "example.com")
+ * @return IPv4 address in network byte order
+ */
+public f<Result<InAddrT>> resolveHost(string host) {
+    // A dotted IPv4 address needs no name server round trip
+    const InAddrT numericAddr = inet_addr(host);
+    if numericAddr != INADDR_NONE { return ok<InAddrT>(numericAddr); }
+
+    // Fall back to a name lookup
+    HostEnt* entry = gethostbyname(host);
+    if entry == nil<HostEnt*> { return err<InAddrT>(Error("Could not resolve host name")); }
+    if entry.hAddrType != AF_INET { return err<InAddrT>(Error("Host name does not resolve to an IPv4 address")); }
+
+    InAddrT resolvedAddr = 0u;
+    unsafe {
+        byte** addrList = entry.hAddrList;
+        if addrList == nil<byte**> || addrList[0] == nil<byte*> {
+            return err<InAddrT>(Error("Host name resolved to an empty address list"));
+        }
+        InAddrT* firstAddr = cast<InAddrT*>(addrList[0]);
+        resolvedAddr = *firstAddr;
+    }
+    return ok<InAddrT>(resolvedAddr);
 }
 
 /**
@@ -160,17 +281,29 @@ public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingCon
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error creating socket")); }
 
+    // Allow rebinding the port right away instead of waiting out the TIME_WAIT of the previous socket
+    int reuseAddr = 1;
+    unsafe {
+        setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, cast<byte*>(&reuseAddr), cast<SockLenT>(sizeof<int>()));
+    }
+
     // Construct socket object
     const Socket s = Socket { sockFd, /*connFd*/ 0 };
-    const SockAddrIn servAddr = SockAddrIn { AF_INET, InAddr { INADDR_ANY }, htons(port), 0ul};
+    const SockAddrIn servAddr = SockAddrIn { cast<SAFamilyT>(AF_INET), htons(port), InAddr { INADDR_ANY }, 0ul };
 
     // Bind to target address
-    const int bindResult = bind(sockFd, &servAddr, 16u /* hardcoded sizeof(servaddr) */);
-    if bindResult < 0 { return err<Socket>(Error("Error binding to address")); }
+    const int bindResult = bind(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));
+    if bindResult < 0 {
+        close(sockFd);
+        return err<Socket>(Error("Error binding to address"));
+    }
 
     // Start listening for incoming connections
     const int listenResult = listen(sockFd, maxWaitingConnections);
-    if listenResult < 0 { return err<Socket>(Error("Error listening on address")); }
+    if listenResult < 0 {
+        close(sockFd);
+        return err<Socket>(Error("Error listening on address"));
+    }
 
     return ok(s);
 }
@@ -178,21 +311,29 @@ public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingCon
 /**
  * Opens a TCP client socket and tries to connect it to a server socket.
  *
- * @param host Host to connect to
+ * @param host Host to connect to, either as dotted IPv4 address or as hostname
  * @param port Post to connect to
  * @return Socket file descriptor
  */
 public f<Result<Socket>> openClientSocket(string host, unsigned short port) {
+    // Resolve the host before spending a file descriptor on it
+    const Result<InAddrT> addrResult = resolveHost(host);
+    if addrResult.isErr() { return err<Socket>(addrResult.getErr()); }
+    const InAddrT hostAddr = addrResult.unwrap();
+
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error opening socket client connection")); }
 
-    // Construct socket object
-    const Socket s = Socket { sockFd, /*connFd*/ 0 };
-    const SockAddrIn cliAddr = SockAddrIn { AF_INET, InAddr { inet_addr(host) }, htons(port), 0ul};
+    // Construct socket object. A client talks over the socket itself, so socket and connection descriptor are the same.
+    const Socket s = Socket { sockFd, /*connFd*/ sockFd };
+    const SockAddrIn servAddr = SockAddrIn { cast<SAFamilyT>(AF_INET), htons(port), InAddr { hostAddr }, 0ul };
 
     // Connect to server
-    const int connectResult = connect(sockFd, &cliAddr, 16u /* hardcoded sizeof(cliAddr) */);
-    if connectResult < 0 { return err<Socket>(Error("Error connecting to socket")); }
+    const int connectResult = connect(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));
+    if connectResult < 0 {
+        close(sockFd);
+        return err<Socket>(Error("Error connecting to socket"));
+    }
 
     return ok(s);
 }

--- a/std/net/socket_windows.spice
+++ b/std/net/socket_windows.spice
@@ -1,14 +1,19 @@
 // Link WinSock library
-#![core.linux.linker.flag = "-lws2_32"]
+#![core.windows.linker.flag = "-lws2_32"]
 
 // Import common logic
 import "std/net/socket";
 
 // Type defs
 type SAFamilyT alias unsigned short;
+type SockLenT alias int; // Winsock takes plain ints where POSIX takes socklen_t
 
 // Constants
 const unsigned short REQUESTED_WSA_VERSION = 514s;
+public const int SOL_SOCKET = 65535; // Option level for socket-level options (0xFFFF)
+public const int SO_REUSEADDR = 4;   // Allow binding to a local address that is still in TIME_WAIT
+public const int SO_RCVTIMEO = 4102; // Timeout for receive operations
+public const int SO_SNDTIMEO = 4101; // Timeout for send operations
 
 type WSAData struct {
     unsigned short wVersion
@@ -19,17 +24,6 @@ type WSAData struct {
     char[257] szDescription
     char[129] szSystemStatus
 }
-
-// External functions
-ext f<int> WSAStartup(short, WSAData*);
-ext f<int> WSACleanup();
-ext f<int> socket(int /*sockfd*/, int /*type*/, int /*protocol*/);
-ext f<int> bind(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT /*address_len*/);
-ext f<int> listen(int /*sockfd*/, int /*backlog*/);
-ext f<int> accept(int /*sockfd*/, SockAddrIn*, SockLenT /*address_len*/);
-ext f<int> close(int /*sockfd*/);
-ext f<unsigned int> htonl(unsigned int /*hostlong*/);      // Fairly simple to re-implement in Spice
-ext f<unsigned short> htons(unsigned short /*hostshort*/); // Fairly simple to re-implement in Spice
 
 type SockAddr struct {
     SAFamilyT saFamily // Address family
@@ -55,22 +49,26 @@ public type In6Addr struct {
 }
 
 /**
- * Socket address for an IPv4 (AF_INET) endpoint
+ * Socket address for an IPv4 (AF_INET) endpoint.
+ *
+ * The field order and the field widths mirror `SOCKADDR_IN` from the Winsock headers one to one, so
+ * that the struct can be handed to the socket calls without any conversion in between.
  */
 public type SockAddrIn struct {
-    unsigned short sinFamily // AF_INET
-    InPortT sinPort          // Port number
-    InAddr sinAddr           // IPv4 address
+    SAFamilyT     sinFamily // AF_INET
+    InPortT       sinPort   // Port number (network byte order)
+    InAddr        sinAddr   // IPv4 address (network byte order)
+    unsigned long sinZero   // Padding (this is a char[8] in the original implementation)
 }
 
 /**
  * Socket address for an IPv6 (AF_INET6) endpoint
  */
 public type SockAddrIn6 struct {
-    unsigned short sin6Family // AF_INET6
-    InPortT sin6Port          // Port number
+    SAFamilyT    sin6Family   // AF_INET6
+    InPortT      sin6Port     // Port number
     unsigned int sin6FlowInfo // IPv6 flow info
-    In6Addr sin6Addr          // IPv6 address
+    In6Addr      sin6Addr     // IPv6 address
     unsigned int sin6ScopeId  // Set of interfaces for a scope
 }
 
@@ -78,8 +76,37 @@ public type SockAddrIn6 struct {
  * Socket address for a Unix domain (AF_UNIX) endpoint
  */
 public type SockAddrUn struct {
-
+    SAFamilyT sunFamily // Address family
+    char[]    sunPath   // Socket pathname
 }
+
+/**
+ * Host entry as returned by `gethostbyname`. Mirrors `struct hostent` from the Winsock headers.
+ */
+type HostEnt struct {
+    string  hName     // Official name of the host
+    string* hAliases  // Alias list, terminated by a nil entry
+    short   hAddrType // Address type (AF_INET for IPv4)
+    short   hLength   // Length of an address, in bytes
+    byte**  hAddrList // Address list, terminated by a nil entry
+}
+
+// External functions
+ext f<int> WSAStartup(short /*versionRequested*/, WSAData* /*wsaData*/);
+ext f<int> WSACleanup();
+ext f<int> socket(int /*domain*/, int /*type*/, int /*protocol*/);
+ext f<int> bind(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT /*address_len*/);
+ext f<int> listen(int /*sockfd*/, int /*backlog*/);
+ext f<int> accept(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT* /*address_len*/);
+ext f<int> setsockopt(int /*sockfd*/, int /*level*/, int /*optname*/, byte* /*optval*/, SockLenT /*optlen*/);
+ext f<int> recv(int /*sockfd*/, byte* /*buf*/, int /*length*/, int /*flags*/);
+ext f<int> send(int /*sockfd*/, byte* /*buf*/, int /*length*/, int /*flags*/);
+ext f<int> closesocket(int /*sockfd*/);
+ext f<unsigned int> htonl(unsigned int /*hostlong*/);      // Fairly simple to re-implement in Spice
+ext f<unsigned short> htons(unsigned short /*hostshort*/); // Fairly simple to re-implement in Spice
+ext f<InAddrT> inet_addr(string /*cp*/);
+ext f<HostEnt*> gethostbyname(string /*name*/);
+ext f<int> connect(int /*sockfd*/, SockAddrIn* /*address*/, SockLenT /*address_len*/);
 
 /**
  * A network socket, wrapping the listening socket file descriptor and the current connection
@@ -97,18 +124,164 @@ public type Socket struct {
  */
 public f<Result<int>> Socket.acceptConnection() {
     SockAddrIn cliAddr = SockAddrIn {};
-    this.connFd = accept(this.sockFd, &cliAddr, 16u /* hardcoded sizeof(cliAddr) */);
+    SockLenT addrLen = cast<SockLenT>(sizeof<SockAddrIn>());
+    this.connFd = accept(this.sockFd, &cliAddr, &addrLen);
     if this.connFd == -1 { return err<int>(Error("Error while accepting connection")); }
     return ok(this.connFd);
 }
 
 /**
+ * Write a raw string to the socket.
+ *
+ * @param message Content of the message
+ * @return Number of bytes written
+ */
+public f<long> Socket.write(string message) {
+    const unsigned long messageLength = len(message);
+    if messageLength == 0l { return 0l; }
+    byte* messageBytes = nil<byte*>;
+    unsafe {
+        messageBytes = cast<byte*>(message);
+    }
+    return cast<long>(send(this.connFd, messageBytes, cast<int>(messageLength), 0));
+}
+
+/**
+ * Write an array of bytes to the socket.
+ * Note: The given buffer needs to be at least of the given size.
+ *
+ * @param content Buffer of bytes to send
+ * @param size Number of bytes from the buffer to send
+ * @return Number of bytes written
+ */
+public f<long> Socket.write(byte* content, unsigned long size) {
+    if size == 0l { return 0l; }
+    return cast<long>(send(this.connFd, content, cast<int>(size), 0));
+}
+
+/**
+ * Write an array of bytes to the socket, retrying until either all of them were handed over to the
+ * network stack or the connection breaks. A single `send` call is free to accept only a part of the
+ * buffer, so anything that must arrive in full has to go through this method.
+ * Note: The given buffer needs to be at least of the given size.
+ *
+ * @param content Buffer of bytes to send
+ * @param size Number of bytes from the buffer to send
+ * @return true if all bytes were written, false if the connection broke in between
+ */
+public f<bool> Socket.writeAll(byte* content, unsigned long size) {
+    unsigned long bytesWritten = 0l;
+    while bytesWritten < size {
+        int written = 0;
+        unsafe {
+            written = send(this.connFd, content + bytesWritten, cast<int>(size - bytesWritten), 0);
+        }
+        if written <= 0 { return false; }
+        bytesWritten += cast<unsigned long>(written);
+    }
+    return true;
+}
+
+/**
+ * Read n bytes from the socket to the given buffer.
+ * Note: The given buffer needs to be at least of the given size.
+ *
+ * @param buffer Buffer to write the result into
+ * @param size Number of bytes to read
+ * @return Number of bytes written
+ */
+public f<long> Socket.read(byte* buffer, long size) {
+    return cast<long>(recv(this.connFd, buffer, cast<int>(size), 0));
+}
+
+/**
+ * Limits how long a single read or write on this socket may block. Without a timeout a peer that
+ * connects but never sends anything keeps the caller waiting forever.
+ * The timeout applies to the current connection, which for a client socket is the socket itself.
+ * Note: Winsock takes the timeout as a plain millisecond count instead of a timeval.
+ *
+ * @param milliseconds Timeout in milliseconds, 0 to block indefinitely again
+ * @return Setting the timeout was successful or not
+ */
+public f<bool> Socket.setTimeout(unsigned long milliseconds) {
+    int timeout = cast<int>(milliseconds);
+    const int targetFd = this.connFd != 0 ? this.connFd : this.sockFd;
+    int receiveResult = 0;
+    int sendResult = 0;
+    unsafe {
+        const SockLenT optLen = cast<SockLenT>(sizeof<int>());
+        receiveResult = setsockopt(targetFd, SOL_SOCKET, SO_RCVTIMEO, cast<byte*>(&timeout), optLen);
+        sendResult = setsockopt(targetFd, SOL_SOCKET, SO_SNDTIMEO, cast<byte*>(&timeout), optLen);
+    }
+    return receiveResult == 0 && sendResult == 0;
+}
+
+/**
+ * Closes the current connection of the socket, while keeping the socket itself open. This is what a
+ * server does after it has finished serving a single client.
+ *
+ * @return Closing the connection was successful or not
+ */
+public f<bool> Socket.closeConnection() {
+    // A client socket uses the same descriptor for the socket and the connection, so closing the
+    // connection there would take the socket down with it.
+    if this.connFd == 0 || this.connFd == this.sockFd { return true; }
+    const bool success = closesocket(this.connFd) == 0;
+    this.connFd = 0;
+    return success;
+}
+
+/**
  * Closes the socket. This method should always be called by the user before exiting the program.
+ * Note: Winsock itself is not shut down here, since other sockets of the process may still be in
+ * use. Windows reclaims it when the process exits.
  *
  * @return Closing the connection was successful or not
  */
 public f<bool> Socket.close() {
-    return close(this.sockFd) == 0 && WSACleanup() == 0;
+    const bool connectionClosed = this.closeConnection();
+    return closesocket(this.sockFd) == 0 && connectionClosed;
+}
+
+/**
+ * Resolves a host given as either a dotted IPv4 address or a hostname to a raw IPv4 address in
+ * network byte order.
+ * Note: The DNS lookup is performed via `gethostbyname`, which is not thread-safe.
+ *
+ * @param host Dotted IPv4 address (e.g. "127.0.0.1") or hostname (e.g. "example.com")
+ * @return IPv4 address in network byte order
+ */
+public f<Result<InAddrT>> resolveHost(string host) {
+    // A dotted IPv4 address needs no name server round trip
+    const InAddrT numericAddr = inet_addr(host);
+    if numericAddr != INADDR_NONE { return ok<InAddrT>(numericAddr); }
+
+    // Fall back to a name lookup
+    HostEnt* entry = gethostbyname(host);
+    if entry == nil<HostEnt*> { return err<InAddrT>(Error("Could not resolve host name")); }
+    if cast<int>(entry.hAddrType) != AF_INET { return err<InAddrT>(Error("Host name does not resolve to an IPv4 address")); }
+
+    InAddrT resolvedAddr = 0u;
+    unsafe {
+        byte** addrList = entry.hAddrList;
+        if addrList == nil<byte**> || addrList[0] == nil<byte*> {
+            return err<InAddrT>(Error("Host name resolved to an empty address list"));
+        }
+        InAddrT* firstAddr = cast<InAddrT*>(addrList[0]);
+        resolvedAddr = *firstAddr;
+    }
+    return ok<InAddrT>(resolvedAddr);
+}
+
+/**
+ * Initializes Winsock for this process. Repeated calls are cheap, since Winsock only keeps a
+ * reference count.
+ *
+ * @return Initialization was successful or not
+ */
+f<bool> startupWinsock() {
+    WSAData wsaData = WSAData{};
+    return WSAStartup(cast<short>(REQUESTED_WSA_VERSION), &wsaData) == 0;
 }
 
 /**
@@ -124,24 +297,68 @@ public f<bool> Socket.close() {
  */
 public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingConnections = 5) {
     // Initialize WSA
-    WSAData wsaData = WSAData{};
-    if WSAStartup(REQUESTED_WSA_VERSION, &wsaData) != 0 { return err<Socket>(Error("Error initializing WSA")); }
+    if !startupWinsock() { return err<Socket>(Error("Error initializing WSA")); }
 
     // Create socket file descriptor
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error creating socket")); }
 
+    // Allow rebinding the port right away instead of waiting out the TIME_WAIT of the previous socket
+    int reuseAddr = 1;
+    unsafe {
+        setsockopt(sockFd, SOL_SOCKET, SO_REUSEADDR, cast<byte*>(&reuseAddr), cast<SockLenT>(sizeof<int>()));
+    }
+
     // Construct socket object
     const Socket s = Socket { sockFd, /*connFd*/ 0 };
-    SockAddrIn servAddr = SockAddrIn { cast<short>(AF_INET), htons(port), InAddr { INADDR_ANY }};
+    const SockAddrIn servAddr = SockAddrIn { cast<SAFamilyT>(AF_INET), htons(port), InAddr { INADDR_ANY }, 0ul };
 
     // Bind to target address
-    int bindResult = bind(sockFd, &servAddr, 16u /* hardcoded sizeof(servaddr) */);
-    if bindResult != 0 { return err<Socket>(Error("Error binding to address")); }
+    const int bindResult = bind(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));
+    if bindResult != 0 {
+        closesocket(sockFd);
+        return err<Socket>(Error("Error binding to address"));
+    }
 
     // Start listening for incoming connections
-    int listenResult = listen(s.sockFd, maxWaitingConnections);
-    if listenResult != 0 { return err<Socket>(Error("Error listening on address")); }
+    const int listenResult = listen(sockFd, maxWaitingConnections);
+    if listenResult != 0 {
+        closesocket(sockFd);
+        return err<Socket>(Error("Error listening on address"));
+    }
+
+    return ok(s);
+}
+
+/**
+ * Opens a TCP client socket and tries to connect it to a server socket.
+ *
+ * @param host Host to connect to, either as dotted IPv4 address or as hostname
+ * @param port Post to connect to
+ * @return Socket file descriptor
+ */
+public f<Result<Socket>> openClientSocket(string host, unsigned short port) {
+    // Initialize WSA
+    if !startupWinsock() { return err<Socket>(Error("Error initializing WSA")); }
+
+    // Resolve the host before spending a socket handle on it
+    const Result<InAddrT> addrResult = resolveHost(host);
+    if addrResult.isErr() { return err<Socket>(addrResult.getErr()); }
+    const InAddrT hostAddr = addrResult.unwrap();
+
+    const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
+    if sockFd == -1 { return err<Socket>(Error("Error opening socket client connection")); }
+
+    // Construct socket object. A client talks over the socket itself, so socket and connection descriptor are the same.
+    const Socket s = Socket { sockFd, /*connFd*/ sockFd };
+    const SockAddrIn servAddr = SockAddrIn { cast<SAFamilyT>(AF_INET), htons(port), InAddr { hostAddr }, 0ul };
+
+    // Connect to server
+    const int connectResult = connect(sockFd, &servAddr, cast<SockLenT>(sizeof<SockAddrIn>()));
+    if connectResult != 0 {
+        closesocket(sockFd);
+        return err<Socket>(Error("Error connecting to socket"));
+    }
 
     return ok(s);
 }

--- a/std/runtime/string_rt.spice
+++ b/std/runtime/string_rt.spice
@@ -195,6 +195,31 @@ public p String.append(const String& appendix) {
 }
 
 /**
+ * Appends the first `appendixLength` bytes of the given string to the current one.
+ *
+ * In contrast to the single-argument overload, the appendix is not required to be null-terminated
+ * and may contain embedded null bytes. This makes the overload the right choice for raw payloads
+ * that were read from a file, a socket or any other byte source.
+ *
+ * @param appendix Buffer to be appended
+ * @param appendixLength Number of bytes to append from the buffer
+ */
+public p String.append(const string appendix, unsigned long appendixLength) {
+    if appendixLength == 0l { return; }
+    // Check if we need to re-allocate memory
+    this.ensureCapacity(this.length + appendixLength);
+
+    // Save data. The terminator is written separately, since the appendix does not need to carry one.
+    unsafe {
+        memcpy(this.contents + this.length, cast<char*>(appendix), appendixLength);
+    }
+    this.length += appendixLength;
+    unsafe {
+        this.contents[this.length] = '\0';
+    }
+}
+
+/**
  * Appends the given char to the string and resize it if needed
  *
  * @param c Char to append

--- a/test/test-files/std/net/http-message/cout.out
+++ b/test/test-files/std/net/http-message/cout.out
@@ -1,0 +1,20 @@
+encoded: a%20b%26c%3Dd%2Fe~f
+url: http://example.com/a/b?x=1&y=2#frag
+headers:
+Content-Type: text/html
+Content-Length: 42
+request:
+PUT /things/1 HTTP/1.1
+Host: example.com
+Content-Type: application/json
+Content-Length: 7
+
+{"a":1}
+response:
+HTTP/1.1 200 OK
+Content-Type: text/html; charset=utf-8
+Content-Length: 15
+Server: Spice
+
+<html>hi</html>
+form: John Doe is 30

--- a/test/test-files/std/net/http-message/source.spice
+++ b/test/test-files/std/net/http-message/source.spice
@@ -1,0 +1,166 @@
+import "std/net/http";
+
+/**
+ * Returns the given wire format message with its CRLF line endings turned into plain line feeds
+ */
+f<String> normalizeLineEndings(const String& wire) {
+    result = String();
+    result = wire;
+    result.replaceAll("\r\n", "\n");
+}
+
+f<int> main() {
+    // ----- Methods -----
+    assert getMethodName(HttpMethod::GET) == "GET";
+    assert getMethodName(HttpMethod::DELETE) == "DELETE";
+    assert getMethodName(HttpMethod::PATCH) == "PATCH";
+    Result<HttpMethod> methodRes = parseMethodName(String("POST"));
+    assert methodRes.isOk();
+    assert methodRes.unwrap() == HttpMethod::POST;
+    Result<HttpMethod> unknownMethodRes = parseMethodName(String("BREW"));
+    assert unknownMethodRes.isErr();
+
+    // ----- Status codes -----
+    assert isRawEqual(getReasonPhrase(200s), "OK");
+    assert isRawEqual(getReasonPhrase(404s), "Not Found");
+    assert isRawEqual(getReasonPhrase(418s), "I'm a teapot");
+    assert isRawEqual(getReasonPhrase(599s), "Server Error");
+
+    // ----- URL encoding -----
+    String encoded = urlEncode(String("a b&c=d/e~f"));
+    printf("encoded: %s\n", encoded);
+    String decoded = urlDecode(encoded);
+    assert decoded == "a b&c=d/e~f";
+    String plusDecoded = urlDecode(String("Hello+World%21"));
+    assert plusDecoded == "Hello World!";
+
+    // ----- URL parsing -----
+    Result<Url> urlRes = parseUrl(String("http://example.com/a/b?x=1&y=2#frag"));
+    assert urlRes.isOk();
+    Url url = urlRes.unwrap();
+    assert url.scheme == "http";
+    assert url.host == "example.com";
+    assert url.port == 80s;
+    assert url.path == "/a/b";
+    assert url.query == "x=1&y=2";
+    assert url.fragment == "frag";
+    String target = url.getRequestTarget();
+    assert target == "/a/b?x=1&y=2";
+    String rebuilt = url.toString();
+    printf("url: %s\n", rebuilt);
+
+    Result<Url> urlRes2 = parseUrl(String("https://user:pw@localhost:8443"));
+    assert urlRes2.isOk();
+    Url url2 = urlRes2.unwrap();
+    assert url2.host == "localhost";
+    assert url2.port == 8443s;
+    assert url2.path == "/";
+    String authority = url2.getAuthority();
+    assert authority == "localhost:8443";
+
+    Result<Url> badScheme = parseUrl(String("ftp://example.com"));
+    assert badScheme.isErr();
+    Result<Url> noScheme = parseUrl(String("example.com/a"));
+    assert noScheme.isErr();
+    Result<Url> noHost = parseUrl(String("http://"));
+    assert noHost.isErr();
+
+    // ----- Header fields -----
+    HttpHeaders headers;
+    headers.set("Content-Type", "text/plain");
+    headers.set("content-type", "text/html"); // replaces, matched case-insensitively
+    headers.add("Set-Cookie", "a=1");
+    headers.add("Set-Cookie", "b=2");
+    headers.set("Content-Length", "42");
+    assert headers.getSize() == 4l;
+    String contentType = headers.get("CONTENT-TYPE");
+    assert contentType == "text/html";
+    assert headers.getContentLength() == 42l;
+    assert headers.contains("set-cookie");
+    assert !headers.contains("X-Missing");
+    String fallback = headers.getOrDefault("X-Missing", "fallback");
+    assert fallback == "fallback";
+    headers.remove("Set-Cookie");
+    assert headers.getSize() == 2l;
+    String headerBlock = headers.serialize();
+    assert headerBlock.startsWith("Content-Type: text/html\r\n");
+    assert headerBlock.endsWith("Content-Length: 42\r\n");
+    // Printed with the line endings normalized, so that the reference output does not hinge on
+    // carriage returns surviving a checkout
+    printf("headers:\n%s", normalizeLineEndings(headerBlock));
+
+    // ----- Request parsing -----
+    String rawRequest = String("POST /submit?a=1&b=two HTTP/1.1\r\nHost: localhost\r\nContent-Length: 11\r\n\r\nhello world");
+    Result<HttpRequest> requestRes = parseRequest(rawRequest);
+    assert requestRes.isOk();
+    HttpRequest request = requestRes.unwrap();
+    assert request.method == HttpMethod::POST;
+    assert request.target == "/submit?a=1&b=two";
+    assert request.version == "HTTP/1.1";
+    assert request.body == "hello world";
+    String path = request.getPath();
+    assert path == "/submit";
+    String paramB = request.getQueryParam("b");
+    assert paramB == "two";
+    assert request.hasQueryParam("a");
+    assert !request.hasQueryParam("c");
+    String host = request.headers.get("host");
+    assert host == "localhost";
+
+    Result<HttpRequest> badMethod = parseRequest(String("NOPE / HTTP/1.1\r\n\r\n"));
+    assert badMethod.isErr();
+    Result<HttpRequest> badLine = parseRequest(String("GET\r\n\r\n"));
+    assert badLine.isErr();
+
+    // ----- Response parsing -----
+    String rawResponse = String("HTTP/1.1 404 Not Found\r\nContent-Type: text/html\r\nTransfer-Encoding: chunked\r\n\r\n<h1>nope</h1>");
+    Result<HttpResponse> responseRes = parseResponse(rawResponse);
+    assert responseRes.isOk();
+    HttpResponse response = responseRes.unwrap();
+    assert response.statusCode == 404s;
+    assert response.reason == "Not Found";
+    assert response.headers.isChunked();
+    assert response.isClientError();
+    assert !response.isSuccess();
+    assert response.body == "<h1>nope</h1>";
+
+    Result<HttpResponse> badStatus = parseResponse(String("HTTP/1.1 abc Bad\r\n\r\n"));
+    assert badStatus.isErr();
+
+    // ----- Building messages -----
+    HttpRequest outRequest = HttpRequest(HttpMethod::PUT, "/things/1");
+    outRequest.headers.set(HEADER_HOST, "example.com");
+    String payload = String("{\"a\":1}");
+    outRequest.setBody(payload, CONTENT_TYPE_JSON);
+    String requestWire = outRequest.serialize();
+    assert requestWire.startsWith("PUT /things/1 HTTP/1.1\r\n");
+    assert requestWire.endsWith("\r\n\r\n{\"a\":1}");
+    printf("request:\n%s\n", normalizeLineEndings(requestWire));
+
+    HttpResponse outResponse = HttpResponse(STATUS_OK);
+    String html = String("<html>hi</html>");
+    outResponse.setHtmlBody(html);
+    outResponse.headers.set(HEADER_SERVER, "Spice");
+    String responseWire = outResponse.serialize();
+    assert responseWire.startsWith("HTTP/1.1 200 OK\r\n");
+    assert responseWire.endsWith("\r\n\r\n<html>hi</html>");
+    printf("response:\n%s\n", normalizeLineEndings(responseWire));
+
+    HttpResponse redirect = HttpResponse();
+    redirect.redirectTo("http://example.com/new", STATUS_MOVED_PERMANENTLY);
+    assert redirect.statusCode == 301s;
+    assert redirect.isRedirect();
+    String location = redirect.headers.get(HEADER_LOCATION);
+    assert location == "http://example.com/new";
+
+    // ----- Form encoded data -----
+    String form = String("name=John+Doe&age=30&flag");
+    String name = getFormValue(form, "name");
+    assert name == "John Doe";
+    String age = getFormValue(form, "age");
+    assert age == "30";
+    assert containsFormKey(form, "flag");
+    assert !containsFormKey(form, "missing");
+    printf("form: %s is %s\n", name, age);
+    return 0;
+}

--- a/test/test-files/std/net/http-roundtrip/cout.out
+++ b/test/test-files/std/net/http-roundtrip/cout.out
@@ -1,0 +1,7 @@
+index: 200 OK [<h1>Index</h1>] text/html; charset=utf-8
+greet: 200 [hi Spice]
+echo: 201 Created [echo:payload] application/json
+moved: 200 [hi redirected]
+missing: 404 Not Found
+wrong method: 405 Method Not Allowed allow=GET
+head: 200 body-length=0 announced=14

--- a/test/test-files/std/net/http-roundtrip/source.spice
+++ b/test/test-files/std/net/http-roundtrip/source.spice
@@ -1,0 +1,94 @@
+import "std/net/http";
+import "std/net/http-client";
+import "std/net/http-server";
+import "std/os/thread-pool";
+import "std/time/delay";
+
+/**
+ * Drives a Spice HTTP server and a Spice HTTP client against each other over the loopback
+ * interface. The server stays silent so that the output only depends on the client, which runs its
+ * requests in a fixed order.
+ */
+f<int> main() {
+    ThreadPool pool = ThreadPool(2s);
+
+    pool.enqueue(p() [[async]] {
+        HttpServer server = HttpServer(18085s);
+        server.serve("/", "<h1>Index</h1>");
+        server.get("/greet", p(const HttpRequest& request, HttpResponse& response) {
+            String greeting = String("hi ");
+            String who = request.getQueryParam("who");
+            greeting.append(who);
+            response.setBody(greeting, CONTENT_TYPE_TEXT);
+        });
+        server.post("/echo", p(const HttpRequest& request, HttpResponse& response) {
+            response.setStatus(STATUS_CREATED);
+            String echoed = String("echo:");
+            echoed.append(request.body);
+            response.setBody(echoed, CONTENT_TYPE_JSON);
+        });
+        server.get("/moved", p(const HttpRequest& request, HttpResponse& response) {
+            assert request.method == HttpMethod::GET;
+            response.redirectTo("/greet?who=redirected", STATUS_FOUND);
+        });
+
+        Result<bool> started = server.start();
+        assert started.isOk();
+
+        // index, greet, echo, the redirect plus the request it points at, unknown path,
+        // method mismatch and finally the HEAD request
+        for int i = 0; i < 8; i++ {
+            Result<bool> handled = server.handleNextRequest();
+            assert handled.isOk();
+        }
+        server.close();
+    });
+
+    pool.enqueue(p() [[async]] {
+        delay(500); // give the server time to bind its port
+        HttpClient client = HttpClient();
+
+        Result<HttpResponse> index = client.get("http://127.0.0.1:18085/");
+        HttpResponse& indexResponse = index.unwrap();
+        String indexType = indexResponse.headers.get(HEADER_CONTENT_TYPE);
+        printf("index: %d %s [%s] %s\n", indexResponse.statusCode, indexResponse.reason,
+               indexResponse.body, indexType);
+
+        Result<HttpResponse> greet = client.get("http://127.0.0.1:18085/greet?who=Spice");
+        HttpResponse& greetResponse = greet.unwrap();
+        printf("greet: %d [%s]\n", greetResponse.statusCode, greetResponse.body);
+
+        String payload = String("payload");
+        Result<HttpResponse> echo = client.post("http://127.0.0.1:18085/echo", payload, CONTENT_TYPE_TEXT);
+        HttpResponse& echoResponse = echo.unwrap();
+        String echoType = echoResponse.headers.get(HEADER_CONTENT_TYPE);
+        printf("echo: %d %s [%s] %s\n", echoResponse.statusCode, echoResponse.reason,
+               echoResponse.body, echoType);
+
+        Result<HttpResponse> moved = client.get("http://127.0.0.1:18085/moved");
+        HttpResponse& movedResponse = moved.unwrap();
+        printf("moved: %d [%s]\n", movedResponse.statusCode, movedResponse.body);
+
+        Result<HttpResponse> missing = client.get("http://127.0.0.1:18085/missing");
+        HttpResponse& missingResponse = missing.unwrap();
+        printf("missing: %d %s\n", missingResponse.statusCode, missingResponse.reason);
+
+        String empty = String();
+        Result<HttpResponse> wrongMethod = client.request(HttpMethod::DELETE, "http://127.0.0.1:18085/greet",
+                                                          empty, CONTENT_TYPE_TEXT);
+        HttpResponse& wrongMethodResponse = wrongMethod.unwrap();
+        String allowed = wrongMethodResponse.headers.get("Allow");
+        printf("wrong method: %d %s allow=%s\n", wrongMethodResponse.statusCode,
+               wrongMethodResponse.reason, allowed);
+
+        Result<HttpResponse> head = client.head("http://127.0.0.1:18085/");
+        HttpResponse& headResponse = head.unwrap();
+        String headLength = headResponse.headers.get(HEADER_CONTENT_LENGTH);
+        printf("head: %d body-length=%d announced=%s\n", headResponse.statusCode,
+               headResponse.body.getLength(), headLength);
+    });
+
+    pool.start();
+    pool.join();
+    return 0;
+}


### PR DESCRIPTION
## What changed

- **Fixed the socket layer**, which HTTP could not have worked on top of. `SockAddrIn` did not match C's `struct sockaddr_in` (4-byte `SAFamilyT`, `sinAddr` before `sinPort`), so the kernel read the port out of padding and `openServerSocket(8080s)` bound an arbitrary ephemeral port. `openClientSocket` also left `connFd` at 0, so `Socket.write` on a client socket wrote to **stdin**. Added what a protocol on top needs: `Socket.setTimeout`, `SO_REUSEADDR`, `writeAll`, `closeConnection` and `resolveHost`. `socket_windows` had no read/write/client support at all and is brought to parity via `recv`/`send`/`closesocket`.
- **Replaced the `std/net/http` stub** (`start()` never returned a value, `serve()` always returned `false`, no client) with three modules: `http` (message model + wire transport over a socket), `http-client` (`HttpClient`, redirect following) and `http-server` (`HttpServer`, route registration).
- **Added `String.append(string, length)`** to `std/runtime/string_rt`, since the existing overload derives the length with `strlen` and truncates at the first null byte.
- Added `StdTests.net_httpMessage` and `StdTests.net_httpRoundtrip`, and updated the `std/net` section of the std README.

## Why

`std/net/http` was a stub that could not serve a single request, and the README advertised an HTTP client that did not exist. The socket bugs above meant nothing built on `std/net/socket` could have worked either — `test/test-files/std/net/sockets-basic` is `disabled`, which is consistent with that.

Bodies are framed by `Content-Length`, by the chunked transfer coding, or by the connection close of an HTTP/1.0 peer. The server answers 405 with an `Allow` field when a path is registered under another method, and serves HEAD from the GET route of the same path with the body dropped.

## How it was validated

- `cmake-build-debug/test/spicetest` (full suite) — **619 passed, 27 failed**, which is exactly the pre-existing environmental baseline on this machine (16 `DriverTest` asserting default CLI options that shift when `SPICE_STD_DIR`/`LLVM_LIB_DIR` are set for the bootstrap tests, 10 `BootstrapCompilerTests` + `StdTests.bindings_llvm` failing at link on a missing `libLLVMIREmbUtils.a`). No regressions.
- `cmake-build-debug/test/spicetest --gtest_filter='*net_http*'` — both new tests pass.
- Client against a real `http.server`: Content-Length body, chunked body, absolute and relative redirects, HEAD, POST, DELETE, 404, connection refused, and resolution by host name — all correct.
- Server against `curl`: static route, query parameters, POST body, redirect, custom 404, HEAD (headers only), 405 with `Allow`.
- Edge cases: a 100 KB body assembled across many socket reads, a chunked *request* decoded server-side, and an idle connection timing out instead of wedging the server.
- `spice run --sanitizer=address` on the model, client and server: no use-after-free and no double-free. The remaining leaks are the pre-existing one where assigning a `String` into a struct field leaks a buffer, which a message model does constantly (~61 allocations for one client GET, same order as the existing json-parser test).

## Follow-up / known limitations

- **No TLS.** https URLs are rejected rather than silently downgraded; `std/bindings/libcurl` stays the answer for those.
- **No `Date` response header.** `DateTime`'s fields are private to `std/time/datetime`, so an IMF-fixdate cannot be built from outside it — and `std/time/time.spice:getCurrentSecs()` returns `tvSec * 1000`, which looks like a bug worth a separate PR.
- **Only the Linux socket variant could be tested here.** The Darwin variant (BSD leading `sin_len` byte) and the Windows variant are written from the platform headers and are unverified.
- The server handles one connection at a time and sends `Connection: close` on every response; no keep-alive.
- Three shapes in this code are workarounds for compiler bugs, each worth its own issue:
  - A ternary that copy-constructs from a `const` **parameter** segfaults the compiler with no diagnostic — `matchCopyCtor` returns null at `TypeCheckerExpressions.cpp:175` and `GenExpressions.cpp:129` dereferences it. Repro: `f<String> g(const String& raw, long n) { const String h = n == -1l ? raw : String("x"); return h; }`. A `const` *local* is fine. Under `--sanitizer=address` the same construct can also emit `llvm.lifetime.end` on a non-alloca and fail the verifier. Hence no `String` ternaries anywhere in these modules.
  - `Vector<T>.removeAt` double-frees when `T` is a struct with non-trivial members but no *user-defined* `operator=` — `Vector<Pair<String, String>>` included. The shift loop assigns through a raw pointer index inside `unsafe`, which copies bitwise instead of dispatching to the implicit assignment. Hence the hand-written `HttpHeader` with an explicit copy ctor and `operator=` rather than a `Pair`.
  - Leaving a scope early skips destructors, so every function here that owns a non-trivial local has a single exit.
- `test/test-files/std/net/sockets-basic` is still `disabled`. It would work now, but its expected output depends on how two threads interleave, so re-enabling it would be flaky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AjCWAhFZXWupj5mgC2M9iy