### PR TITLE
Fix compiler crash on a ternary copy-constructing from a const operand

### DIFF
--- a/src/irgenerator/GenExpressions.cpp
+++ b/src/irgenerator/GenExpressions.cpp
@@ -125,7 +125,10 @@ std::any IRGenerator::visitTernaryExpr(const TernaryExprNode *node) {
       truePtr = resolveAddress(trueNode);
     } else if (node->trueSideCallsCopyCtor) { // only true side needs copy ctor call
       llvm::Value *originalPtr = resolveAddress(trueNode);
-      truePtr = insertAlloca(trueNode->getEvaluatedSymbolType(manIdx));
+      // Allocate storage for the copy using the ternary's own result type, not trueNode's own evaluated type:
+      // trueNode may be a reference (e.g. a 'const T&' parameter), whose LLVM type is just a pointer and would
+      // undersize this alloca for the struct value the copy ctor is about to write into it.
+      truePtr = insertAlloca(resultType);
       generateCtorOrDtorCall(truePtr, node->calledCopyCtor, {originalPtr});
     } else { // neither true nor false side need copy ctor call
       trueValue = resolveValue(trueNode);
@@ -142,7 +145,9 @@ std::any IRGenerator::visitTernaryExpr(const TernaryExprNode *node) {
       falsePtr = resolveAddress(falseNode);
     } else if (node->falseSideCallsCopyCtor) { // only false side needs copy ctor call
       llvm::Value *originalPtr = resolveAddress(falseNode);
-      falsePtr = insertAlloca(falseNode->getEvaluatedSymbolType(manIdx));
+      // See the analogous truePtr allocation above: use the ternary's result type, not falseNode's own
+      // (possibly reference-qualified) evaluated type.
+      falsePtr = insertAlloca(resultType);
       generateCtorOrDtorCall(falsePtr, node->calledCopyCtor, {originalPtr});
     } else { // neither true nor false side need copy ctor call
       falseValue = resolveValue(falseNode);

--- a/src/irgenerator/IRGenerator.cpp
+++ b/src/irgenerator/IRGenerator.cpp
@@ -476,12 +476,33 @@ LLVMExprResult IRGenerator::doAssignment(llvm::Value *lhsAddress, const SymbolTa
 
   if (isDecl && rhsSType.is(TY_STRUCT) && rhs.isTemporary()) {
     assert(lhsEntry != nullptr);
-    // Directly set the address to the lhs entry (temp stealing)
     llvm::Value *rhsAddress = resolveAddress(rhs);
-    updateAddress(lhsEntry, rhsAddress);
+    // Only adopt the temporary's storage directly (temp stealing) unless it is a phi merging two independently
+    // materialized pointers (e.g. a ternary whose branches each own their own storage). Lifetime markers require
+    // their operand to be a real alloca, so stealing such a phi here would emit an invalid llvm.lifetime.end
+    // under --sanitizer=address. Any other pointer (a plain alloca, or one derived from it via GEP/load, as in
+    // the foreach-loop item extraction below) denotes a single, stable piece of storage and is safe to adopt.
+    // The temporary's ownership fully transfers to lhsEntry either way (its underlying storage is never
+    // separately destructed), so falling back to a shallow copy into a dedicated alloca is exactly as correct,
+    // just gives up the pointer-adoption optimization for the phi case.
+    if (!llvm::isa<llvm::PHINode>(rhsAddress)) {
+      // Directly set the address to the lhs entry (temp stealing)
+      updateAddress(lhsEntry, rhsAddress);
+      rhs.entry = lhsEntry;
+      // Generate debug info for variable declaration
+      diGenerator.generateLocalVarDebugInfo(lhsEntry->name, rhsAddress);
+      return rhs;
+    }
+    // Size the copy off lhsEntry's own type, not rhsSType: some callers (e.g. the foreach-loop item
+    // extraction below) pass a struct rhsSType only to steer this branch, while rhs itself resolves (through
+    // refPtr indirection) to a differently-typed value; lhsEntry's type is always the authoritative one here.
+    const QualType &lhsQualType = lhsEntry->getQualType();
+    llvm::Value *lhsAddr = insertAlloca(lhsQualType);
+    updateAddress(lhsEntry, lhsAddr);
+    diGenerator.generateLocalVarDebugInfo(lhsEntry->name, lhsAddr);
+    generateShallowCopy(rhsAddress, lhsQualType.toLLVMType(sourceFile), lhsAddr, lhsEntry->isVolatile);
+    rhs.ptr = lhsAddr;
     rhs.entry = lhsEntry;
-    // Generate debug info for variable declaration
-    diGenerator.generateLocalVarDebugInfo(lhsEntry->name, rhsAddress);
     return rhs;
   }
 

--- a/src/typechecker/TypeChecker.cpp
+++ b/src/typechecker/TypeChecker.cpp
@@ -73,14 +73,16 @@ Function *TypeChecker::matchCopyCtor(const QualType &thisType, const ASTNode *no
   Scope *matchScope = thisType.getBodyScope();
   assert(matchScope != nullptr);
   const ArgList args = {{thisType.toConstRef(node), false}};
-  return FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType, args, {}, true, node);
+  // The new instance being constructed is never const, regardless of whether the copy source (thisType) is const
+  return FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType.toNonConst(), args, {}, true, node);
 }
 
 Function *TypeChecker::matchMoveCtor(const QualType &thisType, const ASTNode *node) const {
   Scope *matchScope = thisType.getBodyScope();
   assert(matchScope != nullptr);
   const ArgList args = {{thisType.toNonConst().toRef(node), false}};
-  return FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType, args, {}, true, node);
+  // The new instance being constructed is never const, regardless of whether the move source (thisType) is const
+  return FunctionManager::match(matchScope, CTOR_FUNCTION_NAME, thisType.toNonConst(), args, {}, true, node);
 }
 
 QualType TypeChecker::mapLocalTypeToImportedScopeType(const Scope *targetScope, const QualType &symbolType) const {

--- a/test/test-files/irgenerator/ternary/success-ternary-const-operand/cout.out
+++ b/test/test-files/irgenerator/ternary/success-ternary-const-operand/cout.out
@@ -1,0 +1,14 @@
+Ctor!
+Copy ctor!
+Dtor!
+Ctor!
+Dtor!
+Copy ctor!
+Copy ctor!
+Dtor!
+Dtor!
+Copy ctor!
+Ctor!
+Dtor!
+Dtor!
+Dtor!

--- a/test/test-files/irgenerator/ternary/success-ternary-const-operand/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-const-operand/ir-code.ll
@@ -1,0 +1,146 @@
+; ModuleID = 'source.spice'
+source_filename = "source.spice"
+
+%struct.Thing = type {}
+
+@printf.str.0 = private unnamed_addr constant [7 x i8] c"Ctor!\0A\00", align 4
+@printf.str.1 = private unnamed_addr constant [12 x i8] c"Copy ctor!\0A\00", align 4
+@printf.str.2 = private unnamed_addr constant [7 x i8] c"Dtor!\0A\00", align 4
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal void @_ZN5Thing4ctorEv(ptr noundef nonnull align 1 %0) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
+  ret void
+}
+
+; Function Attrs: nofree nounwind
+declare noundef i32 @printf(ptr noundef readonly captures(none), ...) local_unnamed_addr #1
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal void @_ZN5Thing4ctorERK5Thing(ptr noundef nonnull align 1 %0, ptr noundef %1) #0 {
+  %this = alloca ptr, align 8
+  %_ = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  store ptr %1, ptr %_, align 8
+  %3 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.1)
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %0) #0 {
+  %this = alloca ptr, align 8
+  store ptr %0, ptr %this, align 8
+  %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.2)
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal noundef %struct.Thing @_Z7takeRefRK5Thingb(ptr noundef %0, i1 noundef zeroext %1) #0 {
+  %result = alloca %struct.Thing, align 8
+  %ref = alloca ptr, align 8
+  %cond = alloca i1, align 1
+  %3 = alloca %struct.Thing, align 8
+  %4 = alloca %struct.Thing, align 8
+  %res = alloca %struct.Thing, align 8
+  store ptr %0, ptr %ref, align 8
+  store i1 %1, ptr %cond, align 1
+  %5 = load i1, ptr %cond, align 1
+  br i1 %5, label %cond.true.L13C23, label %cond.false.L13C23
+
+cond.true.L13C23:                                 ; preds = %2
+  %6 = load ptr, ptr %ref, align 8
+  call void @_ZN5Thing4ctorERK5Thing(ptr noundef nonnull align 1 %3, ptr %6)
+  br label %cond.exit.L13C23
+
+cond.false.L13C23:                                ; preds = %2
+  call void @_ZN5Thing4ctorEv(ptr noundef nonnull align 1 %4)
+  br label %cond.exit.L13C23
+
+cond.exit.L13C23:                                 ; preds = %cond.false.L13C23, %cond.true.L13C23
+  %cond.result = phi ptr [ %3, %cond.true.L13C23 ], [ %4, %cond.false.L13C23 ]
+  call void @llvm.memcpy.p0.p0.i64(ptr %res, ptr %cond.result, i64 0, i1 false)
+  %7 = load %struct.Thing, ptr %res, align 1
+  ret %struct.Thing %7
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias writeonly captures(none), ptr noalias readonly captures(none), i64, i1 immarg) #2
+
+; Function Attrs: noinline nounwind optnone uwtable
+define internal noundef %struct.Thing @_Z7takeVal5Thingb(%struct.Thing noundef %0, i1 noundef zeroext %1) #0 {
+  %result = alloca %struct.Thing, align 8
+  %val = alloca %struct.Thing, align 8
+  %cond = alloca i1, align 1
+  %3 = alloca %struct.Thing, align 8
+  %4 = alloca %struct.Thing, align 8
+  %res = alloca %struct.Thing, align 8
+  store %struct.Thing %0, ptr %val, align 1
+  store i1 %1, ptr %cond, align 1
+  %5 = load i1, ptr %cond, align 1
+  br i1 %5, label %cond.true.L19C23, label %cond.false.L19C23
+
+cond.true.L19C23:                                 ; preds = %2
+  call void @_ZN5Thing4ctorERK5Thing(ptr noundef nonnull align 1 %3, ptr %val)
+  br label %cond.exit.L19C23
+
+cond.false.L19C23:                                ; preds = %2
+  call void @_ZN5Thing4ctorEv(ptr noundef nonnull align 1 %4)
+  br label %cond.exit.L19C23
+
+cond.exit.L19C23:                                 ; preds = %cond.false.L19C23, %cond.true.L19C23
+  %cond.result = phi ptr [ %3, %cond.true.L19C23 ], [ %4, %cond.false.L19C23 ]
+  call void @llvm.memcpy.p0.p0.i64(ptr %res, ptr %cond.result, i64 0, i1 false)
+  %6 = load %struct.Thing, ptr %res, align 1
+  ret %struct.Thing %6
+}
+
+; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
+define dso_local noundef i32 @main() #3 {
+  %result = alloca i32, align 4
+  %t = alloca %struct.Thing, align 8
+  %viaRef = alloca %struct.Thing, align 8
+  %viaRefTemp = alloca %struct.Thing, align 8
+  %arg.copy = alloca %struct.Thing, align 8
+  %viaVal = alloca %struct.Thing, align 8
+  %arg.copy1 = alloca %struct.Thing, align 8
+  %viaValTemp = alloca %struct.Thing, align 8
+  store i32 0, ptr %result, align 4
+  call void @_ZN5Thing4ctorEv(ptr noundef nonnull align 1 %t)
+  %1 = call noundef %struct.Thing @_Z7takeRefRK5Thingb(ptr noundef %t, i1 noundef zeroext true)
+  store %struct.Thing %1, ptr %viaRef, align 1
+  call void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %viaRef)
+  %2 = call noundef %struct.Thing @_Z7takeRefRK5Thingb(ptr noundef %t, i1 noundef zeroext false)
+  store %struct.Thing %2, ptr %viaRefTemp, align 1
+  call void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %viaRefTemp)
+  call void @_ZN5Thing4ctorERK5Thing(ptr noundef nonnull align 1 %arg.copy, ptr %t)
+  %3 = load %struct.Thing, ptr %arg.copy, align 1
+  %4 = call noundef %struct.Thing @_Z7takeVal5Thingb(%struct.Thing noundef %3, i1 noundef zeroext true)
+  store %struct.Thing %4, ptr %viaVal, align 1
+  call void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %arg.copy)
+  call void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %viaVal)
+  call void @_ZN5Thing4ctorERK5Thing(ptr noundef nonnull align 1 %arg.copy1, ptr %t)
+  %5 = load %struct.Thing, ptr %arg.copy1, align 1
+  %6 = call noundef %struct.Thing @_Z7takeVal5Thingb(%struct.Thing noundef %5, i1 noundef zeroext false)
+  store %struct.Thing %6, ptr %viaValTemp, align 1
+  call void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %arg.copy1)
+  call void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %viaValTemp)
+  call void @_ZN5Thing4dtorEv(ptr noundef nonnull align 1 %t)
+  %7 = load i32, ptr %result, align 4
+  ret i32 %7
+}
+
+attributes #0 = { noinline nounwind optnone uwtable }
+attributes #1 = { nofree nounwind }
+attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #3 = { mustprogress noinline norecurse nounwind optnone uwtable }
+
+!llvm.module.flags = !{!0, !1, !2, !3}
+!llvm.ident = !{!4}
+
+!0 = !{i32 8, !"PIC Level", i32 2}
+!1 = !{i32 7, !"PIE Level", i32 2}
+!2 = !{i32 7, !"uwtable", i32 2}
+!3 = !{i32 7, !"frame-pointer", i32 2}
+!4 = !{!"spice version dev (https://github.com/spicelang/spice)"}

--- a/test/test-files/irgenerator/ternary/success-ternary-const-operand/source.spice
+++ b/test/test-files/irgenerator/ternary/success-ternary-const-operand/source.spice
@@ -1,0 +1,43 @@
+type Thing struct {}
+
+p Thing.ctor() { printf("Ctor!\n"); }
+p Thing.ctor(const Thing& _) { printf("Copy ctor!\n"); }
+p Thing.dtor() { printf("Dtor!\n"); }
+
+// Regression test: the copy-ctor lookup for a ternary always matches against the *true* branch's type. When
+// that operand is const (a const-ref parameter here), the lookup used to be handed a const 'this' type and
+// silently fail (no diagnostic), leaving a null copy-ctor call that segfaulted the IR generator. The false
+// branch is a fresh temporary, so this also exercises the phi-merge / temp-stealing storage path for the
+// const-copy side (which used to also fail, but only under --sanitizer=address).
+f<Thing> takeRef(const Thing& ref, bool cond) {
+    const Thing res = cond ? ref : Thing();
+    return res;
+}
+
+// Same bug, but with a const *by-value* parameter instead of a const reference.
+f<Thing> takeVal(const Thing val, bool cond) {
+    const Thing res = cond ? val : Thing();
+    return res;
+}
+
+f<int> main() {
+    Thing t; // Ctor call
+
+    {
+        Thing viaRef = takeRef(t, true); // Copy ctor call for the ref side, moved into viaRef
+    } // Dtor call for viaRef
+
+    {
+        Thing viaRefTemp = takeRef(t, false); // Ctor call for the temporary, moved into viaRefTemp
+    } // Dtor call for viaRefTemp
+
+    {
+        Thing viaVal = takeVal(t, true); // Copy ctor call for the by-value param, copy ctor call for the ternary, moved into viaVal
+    } // Dtor call for viaVal
+
+    {
+        Thing viaValTemp = takeVal(t, false); // Copy ctor call for the by-value param, ctor call for the temporary, moved into viaValTemp
+    } // Dtor call for viaValTemp
+
+    // Dtor call for t
+}

--- a/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-temp-vs-ref/ir-code.ll
@@ -42,7 +42,7 @@ define internal noundef %struct.Test @_Z6choosebRK4Test(i1 noundef zeroext %0, p
   %cond = alloca i1, align 1
   %ref = alloca ptr, align 8
   %3 = alloca %struct.Test, align 8
-  %4 = alloca ptr, align 8
+  %4 = alloca %struct.Test, align 8
   store i1 %0, ptr %cond, align 1
   store ptr %1, ptr %ref, align 8
   %5 = load i1, ptr %cond, align 1


### PR DESCRIPTION
## What changed

- `TypeChecker::matchCopyCtor`/`matchMoveCtor` now strip the `const` qualifier from `thisType` before matching the struct-to-construct's own ctor set.
- `IRGenerator::visitTernaryExpr` now sizes the copy-ctor destination alloca off the ternary's own (already-dereferenced) result type instead of the operand's own evaluated type.
- `IRGenerator::doAssignment`'s decl "temp stealing" path now only adopts a temporary's address directly when it isn't a `phi`; otherwise it falls back to a byte copy into a dedicated alloca, sized off the declared variable's own type.

## Why

A ternary whose copied side was `const` (e.g. a `const String&` parameter) segfaulted the compiler with no diagnostic — flagged as a known limitation in #1320:

> A ternary that copy-constructs from a `const` **parameter** segfaults the compiler with no diagnostic — `matchCopyCtor` returns null at `TypeCheckerExpressions.cpp:175` and `GenExpressions.cpp:129` dereferences it. ... Under `--sanitizer=address` the same construct can also emit `llvm.lifetime.end` on a non-alloca and fail the verifier.

Root cause: `matchCopyCtor`/`matchMoveCtor` matched the struct-to-construct's own type using strict qualifier matching without stripping the source's const qualifier, so the lookup always failed (`TypeQualifiers::match`'s `allowConstify` only widens candidate-const→actual-non-const, never the reverse) and `IRGenerator` dereferenced the resulting null copy ctor. The constructed instance is never itself const, regardless of the copy/move *source*'s constness, so both matchers now strip const before matching.

Fixing that surfaced two further, pre-existing bugs in the same construct that were simply unreachable before (the type checker crashed first):

- `visitTernaryExpr` sized the copy-ctor destination alloca off the operand's own evaluated type, which is a bare pointer when the operand is a reference — undersizing the alloca and corrupting the stack. The pre-existing `success-ternary-temp-vs-ref` test never caught this because its struct happens to be empty (size 0).
- Under `--sanitizer=address`, `doAssignment`'s decl "temp stealing" optimization adopted a ternary's result `phi` directly as a new variable's address; ending that variable's lifetime later emitted an invalid `llvm.lifetime.end` on a non-alloca phi, failing the LLVM verifier (`Invalid function: llvm.lifetime.start/end can only be used on alloca or poison`). Any other pointer (a plain alloca, or one derived from it via GEP/load) is a single, stable piece of storage and stays safe to adopt directly, so the fallback is scoped narrowly to the phi case, sized off the declared variable's own type rather than the caller-supplied type (the foreach-loop item-extraction call site passes an unrelated struct type there purely to steer this branch — sizing off it originally caused two regressions, see validation below).

## How it was validated

- `cmake-build-debug/src/spice run --sanitizer=address` on both the PR's const-ref repro and a const-by-value-parameter variant — clean, no crash, no verifier failure.
- `cmake-build-debug/test/spicetest` (full suite) — 635 passed, 12 failed, all environmental (10 `BootstrapCompilerTests` + `StdTests.bindings_llvm` on a missing `libLLVMIREmbUtils.a`, `StdTests.time_currentTime` on a pre-existing empty test-data directory unrelated to this change) — no regressions.
- Added `test/test-files/irgenerator/ternary/success-ternary-const-operand/`: verified it reliably SIGSEGVs the pre-fix compiler (stashed the fix and reran) and passes clean post-fix, including under `--sanitizer=address` and `--leak-detection` (valgrind).
- Regenerated and reviewed the `ir-code.ll` reference for `success-ternary-temp-vs-ref` (one-line diff: an alloca is now correctly typed as the struct instead of an undersized pointer).
- Caught and fixed two regressions during development: an earlier version of the `doAssignment` fix sized the fallback copy off the caller-supplied `rhsSType`, which crashed `StdTests.data_linkedListStress` (SIGSEGV) and corrupted `IRGeneratorTests.foreachLoops_successForeachLoopIndexed`'s output — both verified passing again after sizing off `lhsEntry`'s own type instead.

## Follow-up / known limitations

- `std/net/http*.spice` (introduced in #1320) still avoids `String`/struct ternaries as a defensive style choice; it wasn't reverted back to using them since the workaround causes no harm and reverting wasn't part of this fix.