### PR TITLE
Reorganize CSV/JSON/TOML/XML std modules into per-format subdirectories

### DIFF
--- a/std/text/csv/csv-parser.spice
+++ b/std/text/csv/csv-parser.spice
@@ -11,7 +11,7 @@ const char DEFAULT_QUOTE     = '"';
  * (by doubling, e.g. `""` inside a quoted field yields a single `"`).
  * Both `\n` and `\r\n` are accepted as line terminators.
  *
- * The matching serializer lives in "std/text/csv-serializer".
+ * The matching serializer lives in "std/text/csv/csv-serializer".
  */
 public type CsvParser struct {
     char delimiter

--- a/std/text/csv/csv-serializer.spice
+++ b/std/text/csv/csv-serializer.spice
@@ -9,7 +9,7 @@ const char DEFAULT_QUOTE     = '"';
  *
  * Fields are quoted when necessary and embedded quotes are escaped by
  * doubling, so the output round-trips through the CsvParser from
- * "std/text/csv-parser" when both use the same control characters.
+ * "std/text/csv/csv-parser" when both use the same control characters.
  */
 public type CsvSerializer struct {
     char delimiter

--- a/std/text/json/json-parser.spice
+++ b/std/text/json/json-parser.spice
@@ -1,4 +1,4 @@
-import "std/text/json-value";
+import "std/text/json/json-value";
 import "std/text/analysis";
 import "std/type/type-conversion";
 
@@ -8,8 +8,8 @@ import "std/type/type-conversion";
  * Use `parseJson` for one-shot parsing; the struct is exposed mainly so the
  * parser state (position, error message) can be inspected when needed.
  *
- * The JsonValue data model lives in "std/text/json-value" and serialization
- * in "std/text/json-serializer".
+ * The JsonValue data model lives in "std/text/json/json-value" and serialization
+ * in "std/text/json/json-serializer".
  */
 public type JsonParser struct {
     String input
@@ -55,7 +55,7 @@ public f<Result<JsonValue*>> JsonParser.parse() {
  * Parse a JSON document.
  *
  * On success returns the root JsonValue, which the caller owns and releases
- * again with `deleteJsonValue` from "std/text/json-value". On failure the
+ * again with `deleteJsonValue` from "std/text/json/json-value". On failure the
  * partially built tree is released by the parser and an error describing the
  * first problem encountered is returned.
  */

--- a/std/text/json/json-serializer.spice
+++ b/std/text/json/json-serializer.spice
@@ -1,4 +1,4 @@
-import "std/text/json-value";
+import "std/text/json/json-value";
 import "std/type/type-conversion";
 
 ext f<int> snprintf(char*, unsigned long, string, ...);
@@ -9,7 +9,7 @@ ext f<int> snprintf(char*, unsigned long, string, ...);
  * In compact mode (the default) the output contains no insignificant
  * whitespace. In pretty mode nested arrays and objects are laid out with
  * two-space indentation. Either way the result round-trips through
- * `parseJson` from "std/text/json-parser".
+ * `parseJson` from "std/text/json/json-parser".
  */
 public type JsonSerializer struct {
     bool pretty

--- a/std/text/json/json-value.spice
+++ b/std/text/json/json-value.spice
@@ -30,8 +30,8 @@ public type JsonValueKind enum {
  * variable goes out of scope and never runs the destructor of the pointee, so
  * the children below the root would be lost.
  *
- * Parsing lives in "std/text/json-parser" and serialization in
- * "std/text/json-serializer", so programs only pull in what they use.
+ * Parsing lives in "std/text/json/json-parser" and serialization in
+ * "std/text/json/json-serializer", so programs only pull in what they use.
  */
 public type JsonValue struct {
     JsonValueKind kind

--- a/std/text/toml/toml-parser.spice
+++ b/std/text/toml/toml-parser.spice
@@ -1,4 +1,4 @@
-import "std/text/toml-value";
+import "std/text/toml/toml-value";
 import "std/text/analysis";
 import "std/type/type-conversion";
 import "std/data/vector";
@@ -18,8 +18,8 @@ const long PATH_SEPARATOR_CODE = 1l;
  * including `inf` and `nan`, booleans, date-times, arrays, inline tables,
  * `[table]` headers and `[[array of table]]` headers.
  *
- * The TomlValue data model lives in "std/text/toml-value" and serialization
- * in "std/text/toml-serializer".
+ * The TomlValue data model lives in "std/text/toml/toml-value" and serialization
+ * in "std/text/toml/toml-serializer".
  */
 public type TomlParser struct {
     String input
@@ -77,7 +77,7 @@ public f<Result<TomlValue*>> TomlParser.parse() {
  * Parse a TOML document.
  *
  * On success returns the root table, which the caller owns and releases again
- * with `deleteTomlValue` from "std/text/toml-value". On failure the partially
+ * with `deleteTomlValue` from "std/text/toml/toml-value". On failure the partially
  * built tree is released by the parser and an error describing the first
  * problem encountered is returned.
  */

--- a/std/text/toml/toml-serializer.spice
+++ b/std/text/toml/toml-serializer.spice
@@ -1,4 +1,4 @@
-import "std/text/toml-value";
+import "std/text/toml/toml-value";
 import "std/text/analysis";
 import "std/type/type-conversion";
 
@@ -13,7 +13,7 @@ ext f<int> snprintf(char*, unsigned long, string, ...);
  * `key = value` lines instead, using inline tables for nested structures.
  *
  * Either way the result round-trips through `parseToml` from
- * "std/text/toml-parser".
+ * "std/text/toml/toml-parser".
  */
 public type TomlSerializer struct {
     bool inlineTables

--- a/std/text/toml/toml-value.spice
+++ b/std/text/toml/toml-value.spice
@@ -34,8 +34,8 @@ public type TomlValueKind enum {
  * emits verbatim. Table entries preserve insertion order and TOML has no
  * null value.
  *
- * Parsing lives in "std/text/toml-parser" and serialization in
- * "std/text/toml-serializer", so programs only pull in what they use.
+ * Parsing lives in "std/text/toml/toml-parser" and serialization in
+ * "std/text/toml/toml-serializer", so programs only pull in what they use.
  */
 public type TomlValue struct {
     TomlValueKind kind

--- a/std/text/xml/xml-node.spice
+++ b/std/text/xml/xml-node.spice
@@ -26,8 +26,8 @@ public type XmlNodeKind enum {
  * goes out of scope and never runs the destructor of the pointee, so the
  * children below the root would be lost.
  *
- * Parsing lives in "std/text/xml-parser" and serialization in
- * "std/text/xml-serializer", so programs only pull in what they use.
+ * Parsing lives in "std/text/xml/xml-parser" and serialization in
+ * "std/text/xml/xml-serializer", so programs only pull in what they use.
  */
 public type XmlNode struct {
     XmlNodeKind kind

--- a/std/text/xml/xml-parser.spice
+++ b/std/text/xml/xml-parser.spice
@@ -1,4 +1,4 @@
-import "std/text/xml-node";
+import "std/text/xml/xml-node";
 import "std/text/analysis";
 
 /**
@@ -11,8 +11,8 @@ import "std/text/analysis";
  * declaration / processing instructions (which are skipped). DTDs,
  * namespaces and external entities are not interpreted.
  *
- * The XmlNode data model lives in "std/text/xml-node" and serialization in
- * "std/text/xml-serializer".
+ * The XmlNode data model lives in "std/text/xml/xml-node" and serialization in
+ * "std/text/xml/xml-serializer".
  */
 public type XmlParser struct {
     String input
@@ -69,7 +69,7 @@ public f<Result<XmlNode*>> XmlParser.parse() {
  * Parse an XML document and return the root element.
  *
  * On success returns the root XmlNode, which the caller owns and releases again
- * with `deleteXmlNode` from "std/text/xml-node". On failure the partially built
+ * with `deleteXmlNode` from "std/text/xml/xml-node". On failure the partially built
  * tree is released by the parser and an error describing the first problem
  * encountered is returned.
  */

--- a/std/text/xml/xml-serializer.spice
+++ b/std/text/xml/xml-serializer.spice
@@ -1,11 +1,11 @@
-import "std/text/xml-node";
+import "std/text/xml/xml-node";
 
 /**
  * Serializer for XML output.
  *
  * Elements without children are written as self-closing tags. Text content
  * and attribute values are escaped with the predefined entities, so the
- * result round-trips through `parseXml` from "std/text/xml-parser".
+ * result round-trips through `parseXml` from "std/text/xml/xml-parser".
  *
  * In pretty mode, elements that contain child elements are laid out with
  * two-space indentation, one node per line; elements containing only text

--- a/test/test-files/std/text/csv-parser/source.spice
+++ b/test/test-files/std/text/csv-parser/source.spice
@@ -1,4 +1,4 @@
-import "std/text/csv-parser";
+import "std/text/csv/csv-parser";
 import "std/data/vector";
 
 f<int> main() {

--- a/test/test-files/std/text/csv-serializer/source.spice
+++ b/test/test-files/std/text/csv-serializer/source.spice
@@ -1,5 +1,5 @@
-import "std/text/csv-serializer";
-import "std/text/csv-parser";
+import "std/text/csv/csv-serializer";
+import "std/text/csv/csv-parser";
 import "std/data/vector";
 
 f<int> main() {

--- a/test/test-files/std/text/json-parser/source.spice
+++ b/test/test-files/std/text/json-parser/source.spice
@@ -1,5 +1,5 @@
-import "std/text/json-value";
-import "std/text/json-parser";
+import "std/text/json/json-value";
+import "std/text/json/json-parser";
 
 f<int> main() {
     // null / true / false

--- a/test/test-files/std/text/json-serializer/source.spice
+++ b/test/test-files/std/text/json-serializer/source.spice
@@ -1,6 +1,6 @@
-import "std/text/json-value";
-import "std/text/json-serializer";
-import "std/text/json-parser";
+import "std/text/json/json-value";
+import "std/text/json/json-serializer";
+import "std/text/json/json-parser";
 
 f<int> main() {
     JsonSerializer serializer;

--- a/test/test-files/std/text/toml-parser/source.spice
+++ b/test/test-files/std/text/toml-parser/source.spice
@@ -1,5 +1,5 @@
-import "std/text/toml-value";
-import "std/text/toml-parser";
+import "std/text/toml/toml-value";
+import "std/text/toml/toml-parser";
 
 f<int> main() {
     // Strings

--- a/test/test-files/std/text/toml-serializer/source.spice
+++ b/test/test-files/std/text/toml-serializer/source.spice
@@ -1,6 +1,6 @@
-import "std/text/toml-value";
-import "std/text/toml-serializer";
-import "std/text/toml-parser";
+import "std/text/toml/toml-value";
+import "std/text/toml/toml-serializer";
+import "std/text/toml/toml-parser";
 
 f<int> main() {
     TomlSerializer serializer;

--- a/test/test-files/std/text/xml-parser/source.spice
+++ b/test/test-files/std/text/xml-parser/source.spice
@@ -1,5 +1,5 @@
-import "std/text/xml-node";
-import "std/text/xml-parser";
+import "std/text/xml/xml-node";
+import "std/text/xml/xml-parser";
 
 f<int> main() {
     // Minimal self-closing root element

--- a/test/test-files/std/text/xml-serializer/source.spice
+++ b/test/test-files/std/text/xml-serializer/source.spice
@@ -1,6 +1,6 @@
-import "std/text/xml-node";
-import "std/text/xml-serializer";
-import "std/text/xml-parser";
+import "std/text/xml/xml-node";
+import "std/text/xml/xml-serializer";
+import "std/text/xml/xml-parser";
 
 f<int> main() {
     XmlSerializer serializer;


### PR DESCRIPTION
## Summary
- Moves `std/text/{csv,json,toml,xml}-*` into `std/text/csv/`, `std/text/json/`, `std/text/toml/` and `std/text/xml/` respectively, grouping each format's parser/serializer/value modules together.
- Updates internal `import` statements and doc-comment cross-references between the moved files.
- Updates the `import` paths in the matching integration tests (`test/test-files/std/text/{csv,json,toml,xml}-*/source.spice`); the test-case directories themselves are unchanged, since the test runner only supports two levels of nesting under `test-files/std/`.

## Why
As `std/text` grows, grouping each data format's files under its own subdirectory keeps related modules together and mirrors the existing pattern of splitting bigger std areas (e.g. `std/net`) into focused files.

## Test plan
- [x] `cmake-build-debug/test/spicetest --gtest_filter='StdTests.text_*'` — all 11 pass
- [x] `cmake-build-debug/test/spicetest --gtest_filter='StdTests.*'` — 111 pass, 1 skipped (`net_socketsBasic`, pre-existing), 1 failed (`bindings_llvm`, pre-existing local environment issue unrelated to this change — missing `libLLVMIREmbUtils.a`)
- [x] Repo-wide grep confirms no other file (docs, CMake) referenced the old flat paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBDtFLh4a9Y6btELKrCNwm