### PR TITLE
Only run coverage post-submit, use parallel tests pre-submit on Linux/x86_64

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -101,10 +101,17 @@ jobs:
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_ENABLE_TPDE=ON \
             -DSPICE_RUN_COVERAGE=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'ON' || 'OFF' }} \
+            -DSPICE_TEST_ARGS=--is-github-actions \
             ..
           cmake --build . --target spicetest
 
       - name: Run Test target
+        if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
+        working-directory: build
+        run: cmake --build . --target spicetest_parallel
+
+      - name: Run Test target (with coverage)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         working-directory: build/test
         env:
           LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib


### PR DESCRIPTION
## Summary
- The Linux/x86_64 CI job (`build-linux-x86`) previously ran `spicetest` sequentially on every push. Coverage instrumentation (`SPICE_RUN_COVERAGE`) was already gated to post-submit (push to `main`) only, but the sequential-vs-parallel test run wasn't split accordingly.
- Split the "Run Test target" step into two mutually-exclusive steps:
  - `Run Test target (parallel)`: runs pre-submit (everything except push-to-main), using the `spicetest_parallel` target (via `gtest-parallel`), matching what the Linux/AArch64, Windows/x86_64, and macOS jobs already do.
  - `Run Test target (with coverage)`: unchanged sequential `./spicetest` run, now explicitly gated to post-submit only, since gcov coverage collection needs a single-process run.
- Added `-DSPICE_TEST_ARGS=--is-github-actions` to the job's cmake configure step so the parallel path forwards the same flag the other jobs already pass.

## Why
Coverage was already post-submit-only in intent (gated via `SPICE_RUN_COVERAGE`), but the Linux/x86_64 job's test execution stayed serial for all runs, so pre-submit checks on that platform were slower than they needed to be. This makes pre-submit CI use the faster parallel test runner (already proven on the other jobs) while keeping the coverage-only path serial.

## Validation
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-cpp.yml'))"` — YAML parses cleanly.
- No local way to execute the GitHub Actions workflow itself; behavior should be confirmed by the actual CI run on this PR (pre-submit job should show the parallel test step; a push to `main` would exercise the coverage step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBDtFLh4a9Y6btELKrCNwm