### PR TITLE
Add filter/map/reduce and related algorithms to the standard library

### DIFF
--- a/std/data/algorithm.spice
+++ b/std/data/algorithm.spice
@@ -1,0 +1,212 @@
+import "std/data/vector";
+import "std/data/optional";
+import "std/data/pair";
+
+// Generic type definitions
+type T dyn;
+type R dyn;
+
+/**
+ * Build a new vector containing only the elements of `items` for which `predicate` returns true.
+ *
+ * @param items Vector to filter
+ * @param predicate Function evaluated for each element; an element is kept when it returns true
+ * @return A new vector holding the kept elements, in iteration order
+ */
+public f<Vector<T>> filter<T>(const Vector<T>& items, f<bool>(const T&) predicate) {
+    result = Vector<T>();
+    foreach const T& item : items {
+        if predicate(item) {
+            result.pushBack(item);
+        }
+    }
+}
+
+/**
+ * Build a new vector by applying `transform` to every element of `items`.
+ *
+ * @param items Vector to map over
+ * @param transform Function applied to each element to produce the mapped value
+ * @return A new vector holding the transformed elements, in iteration order
+ */
+public f<Vector<R>> map<T, R>(const Vector<T>& items, f<R>(const T&) transform) {
+    result = Vector<R>();
+    foreach const T& item : items {
+        result.pushBack(transform(item));
+    }
+}
+
+/**
+ * Combine all elements of `items` into a single value, left to right, starting from `initialValue`.
+ *
+ * @param items Vector to reduce
+ * @param initialValue Seed value combined with the first element
+ * @param combine Function combining the running accumulator with the next element
+ * @return The final accumulated value
+ */
+public f<R> reduce<T, R>(const Vector<T>& items, const R& initialValue, f<R>(const R&, const T&) combine) {
+    result = initialValue;
+    foreach const T& item : items {
+        result = combine(result, item);
+    }
+}
+
+/**
+ * Invoke `action` once for every element of `items`, in iteration order.
+ *
+ * @param items Vector to iterate over
+ * @param action Procedure invoked for each element
+ */
+public p forEach<T>(const Vector<T>& items, p(const T&) action) {
+    foreach const T& item : items {
+        action(item);
+    }
+}
+
+/**
+ * Find the first element of `items` for which `predicate` returns true.
+ *
+ * @param items Vector to search
+ * @param predicate Function evaluated for each element
+ * @return The first matching element, or an empty Optional if none match
+ */
+public f<Optional<T>> find<T>(const Vector<T>& items, f<bool>(const T&) predicate) {
+    foreach const T& item : items {
+        if predicate(item) {
+            return Optional<T>(item);
+        }
+    }
+    return Optional<T>();
+}
+
+/**
+ * Check whether at least one element of `items` satisfies `predicate`.
+ *
+ * @param items Vector to check
+ * @param predicate Function evaluated for each element
+ * @return True if any element matches, false if `items` is empty or none match
+ */
+public f<bool> any<T>(const Vector<T>& items, f<bool>(const T&) predicate) {
+    foreach const T& item : items {
+        if predicate(item) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Check whether every element of `items` satisfies `predicate`.
+ *
+ * @param items Vector to check
+ * @param predicate Function evaluated for each element
+ * @return True if all elements match (vacuously true if `items` is empty), false otherwise
+ */
+public f<bool> all<T>(const Vector<T>& items, f<bool>(const T&) predicate) {
+    foreach const T& item : items {
+        if !predicate(item) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Check whether no element of `items` satisfies `predicate`.
+ *
+ * @param items Vector to check
+ * @param predicate Function evaluated for each element
+ * @return True if no element matches (vacuously true if `items` is empty), false otherwise
+ */
+public f<bool> none<T>(const Vector<T>& items, f<bool>(const T&) predicate) {
+    foreach const T& item : items {
+        if predicate(item) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Count how many elements of `items` satisfy `predicate`.
+ *
+ * @param items Vector to inspect
+ * @param predicate Function evaluated for each element
+ * @return The number of matching elements
+ */
+public f<long> count<T>(const Vector<T>& items, f<bool>(const T&) predicate) {
+    result = 0l;
+    foreach const T& item : items {
+        if predicate(item) {
+            result++;
+        }
+    }
+}
+
+/**
+ * Check whether `items` contains an element equal to `value`.
+ *
+ * @param items Vector to search
+ * @param value Value to look for
+ * @return True if an equal element is present, false otherwise
+ */
+public f<bool> contains<T>(const Vector<T>& items, const T& value) {
+    foreach const T& item : items {
+        if item == value {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Find the smallest element of `items`, according to `isLess`.
+ *
+ * @param items Vector to search
+ * @param isLess Strict less-than comparator; isLess(a, b) returns true when a comes before b
+ * @return The smallest element, or an empty Optional if `items` is empty
+ */
+public f<Optional<T>> min<T>(const Vector<T>& items, f<bool>(const T&, const T&) isLess) {
+    result = Optional<T>();
+    foreach const T& item : items {
+        if !result.isPresent() || isLess(item, result.get()) {
+            result.set(item);
+        }
+    }
+}
+
+/**
+ * Find the largest element of `items`, according to `isLess`.
+ *
+ * @param items Vector to search
+ * @param isLess Strict less-than comparator; isLess(a, b) returns true when a comes before b
+ * @return The largest element, or an empty Optional if `items` is empty
+ */
+public f<Optional<T>> max<T>(const Vector<T>& items, f<bool>(const T&, const T&) isLess) {
+    result = Optional<T>();
+    foreach const T& item : items {
+        if !result.isPresent() || isLess(result.get(), item) {
+            result.set(item);
+        }
+    }
+}
+
+/**
+ * Split `items` into two vectors according to `predicate`.
+ *
+ * @param items Vector to partition
+ * @param predicate Function evaluated for each element
+ * @return A pair of (matching elements, non-matching elements), each in iteration order
+ */
+public f<Pair<Vector<T>, Vector<T>>> partition<T>(const Vector<T>& items, f<bool>(const T&) predicate) {
+    Vector<T> matched;
+    Vector<T> unmatched;
+    foreach const T& item : items {
+        if predicate(item) {
+            matched.pushBack(item);
+        } else {
+            unmatched.pushBack(item);
+        }
+    }
+    return Pair<Vector<T>, Vector<T>>(matched, unmatched);
+}

--- a/std/io/cli-subcommand.spice
+++ b/std/io/cli-subcommand.spice
@@ -3,6 +3,7 @@ import "std/text/print";
 import "std/type/lambda";
 import "std/type/type-conversion";
 import "std/data/vector";
+import "std/data/algorithm";
 import "std/os/os";
 import "std/io/filepath";
 import "std/text/stringstream";
@@ -68,12 +69,7 @@ f<bool> CliSubcommand.nameOrAliasMatches(const String& name, const Vector<String
     if name == input {
         return true;
     }
-    foreach const String& a : aliases {
-        if a == input {
-            return true;
-        }
-    }
-    return false;
+    return contains<String>(aliases, String(input));
 }
 
 /**

--- a/test/test-files/std/data/algorithm-smoke/cout.out
+++ b/test/test-files/std/data/algorithm-smoke/cout.out
@@ -1,0 +1,1 @@
+Algorithm smoke tests passed!

--- a/test/test-files/std/data/algorithm-smoke/source.spice
+++ b/test/test-files/std/data/algorithm-smoke/source.spice
@@ -1,0 +1,122 @@
+import "std/data/vector";
+import "std/data/optional";
+import "std/data/pair";
+import "std/data/algorithm";
+
+f<int> main() {
+    Vector<int> numbers;
+    numbers.pushBack(1);
+    numbers.pushBack(2);
+    numbers.pushBack(3);
+    numbers.pushBack(4);
+    numbers.pushBack(5);
+    numbers.pushBack(6);
+
+    // filter: some matches
+    Vector<int> evens = filter<int>(numbers, f<bool>(const int& n) { return n % 2 == 0; });
+    assert evens.getSize() == 3;
+    assert evens[0] == 2;
+    assert evens[1] == 4;
+    assert evens[2] == 6;
+
+    // filter: no matches
+    Vector<int> noMatches = filter<int>(numbers, f<bool>(const int& n) { return n > 100; });
+    assert noMatches.isEmpty();
+
+    // filter: all match
+    Vector<int> allMatch = filter<int>(numbers, f<bool>(const int& n) { return n > 0; });
+    assert allMatch.getSize() == numbers.getSize();
+
+    // filter: empty input
+    Vector<int> empty;
+    Vector<int> filteredEmpty = filter<int>(empty, f<bool>(const int& _n) { return true; });
+    assert filteredEmpty.isEmpty();
+
+    // map: transform to a different type
+    Vector<long> doubled = map<int, long>(numbers, f<long>(const int& n) { return cast<long>(n) * 2l; });
+    assert doubled.getSize() == 6;
+    assert doubled[0] == 2l;
+    assert doubled[5] == 12l;
+
+    // map: empty input
+    Vector<long> mappedEmpty = map<int, long>(empty, f<long>(const int& n) { return cast<long>(n); });
+    assert mappedEmpty.isEmpty();
+
+    // reduce: sum into the same type
+    int sum = reduce<int, int>(numbers, 0, f<int>(const int& acc, const int& n) { return acc + n; });
+    assert sum == 21;
+
+    // reduce: accumulate into a different type
+    long product = reduce<int, long>(numbers, 1l, f<long>(const long& acc, const int& n) { return acc * cast<long>(n); });
+    assert product == 720l;
+
+    // reduce: empty input returns the initial value unchanged
+    int emptySum = reduce<int, int>(empty, 42, f<int>(const int& acc, const int& n) { return acc + n; });
+    assert emptySum == 42;
+
+    // forEach: side effect runs once per element, in order
+    int visitedSum = 0;
+    int visitedCount = 0;
+    forEach<int>(numbers, p(const int& n) { visitedSum += n * 10; visitedCount += 1; });
+    assert visitedCount == 6;
+    assert visitedSum == 210;
+
+    // find: match, no match, empty input
+    Optional<int> foundGreater = find<int>(numbers, f<bool>(const int& n) { return n > 4; });
+    assert foundGreater.isPresent();
+    assert foundGreater.get() == 5;
+    Optional<int> foundNone = find<int>(numbers, f<bool>(const int& n) { return n > 100; });
+    assert !foundNone.isPresent();
+    Optional<int> foundEmpty = find<int>(empty, f<bool>(const int& _n) { return true; });
+    assert !foundEmpty.isPresent();
+
+    // any / all
+    assert any<int>(numbers, f<bool>(const int& n) { return n == 3; });
+    assert !any<int>(numbers, f<bool>(const int& n) { return n == 100; });
+    assert !any<int>(empty, f<bool>(const int& _n) { return true; });
+    assert all<int>(numbers, f<bool>(const int& n) { return n > 0; });
+    assert !all<int>(numbers, f<bool>(const int& n) { return n > 1; });
+    assert all<int>(empty, f<bool>(const int& _n) { return false; });
+
+    // none
+    assert none<int>(numbers, f<bool>(const int& n) { return n == 100; });
+    assert !none<int>(numbers, f<bool>(const int& n) { return n == 3; });
+    assert none<int>(empty, f<bool>(const int& _n) { return true; });
+
+    // count
+    assert count<int>(numbers, f<bool>(const int& n) { return n % 2 == 0; }) == 3l;
+    assert count<int>(empty, f<bool>(const int& _n) { return true; }) == 0l;
+
+    // contains
+    assert contains<int>(numbers, 3);
+    assert !contains<int>(numbers, 42);
+    assert !contains<int>(empty, 1);
+
+    // min / max
+    Optional<int> smallest = min<int>(numbers, f<bool>(const int& a, const int& b) { return a < b; });
+    assert smallest.isPresent();
+    assert smallest.get() == 1;
+    Optional<int> largest = max<int>(numbers, f<bool>(const int& a, const int& b) { return a < b; });
+    assert largest.isPresent();
+    assert largest.get() == 6;
+    Optional<int> minEmpty = min<int>(empty, f<bool>(const int& a, const int& b) { return a < b; });
+    assert !minEmpty.isPresent();
+    Optional<int> maxEmpty = max<int>(empty, f<bool>(const int& a, const int& b) { return a < b; });
+    assert !maxEmpty.isPresent();
+
+    // partition
+    Pair<Vector<int>, Vector<int>> parts = partition<int>(numbers, f<bool>(const int& n) { return n % 2 == 0; });
+    Vector<int> evenPart = parts.getFirst();
+    Vector<int> oddPart = parts.getSecond();
+    assert evenPart.getSize() == 3l;
+    assert oddPart.getSize() == 3l;
+    assert evenPart[0] == 2;
+    assert oddPart[0] == 1;
+    Pair<Vector<int>, Vector<int>> emptyParts = partition<int>(empty, f<bool>(const int& _n) { return true; });
+    Vector<int> emptyPartsFirst = emptyParts.getFirst();
+    Vector<int> emptyPartsSecond = emptyParts.getSecond();
+    assert emptyPartsFirst.isEmpty();
+    assert emptyPartsSecond.isEmpty();
+
+    printf("Algorithm smoke tests passed!\n");
+}


### PR DESCRIPTION
## What changed
- New `std/data/algorithm.spice` module with generic free functions over `Vector<T>`: `filter`, `map`, `reduce`, `forEach`, `find`, `any`, `all`, `none`, `count`, `contains`, `min`, `max`, `partition`.
- New test coverage at `test/test-files/std/data/algorithm-smoke/`.
- `CliSubcommand.nameOrAliasMatches` (`std/io/cli-subcommand.spice`) now uses `contains<String>` instead of a manual linear-search loop, as a first real call site for the new module.

## Why
Adds common functional-style container operations (the filter/map/reduce family) to the standard library.

These are `Vector<T>`-specific rather than generic over `IIterable<T>` (which would let them work across `Set`, `Map`, `HashTable`, `LinkedList`, `Graph`, etc.): a generic free function taking a parameter typed as a generic interface parameterized by the function's own type param currently crashes the compiler with an assertion in `Scope::copyChildScope`. Filed as #1327 with a minimal reproducer.

## How it was validated
- `cmake-build-debug/test/spicetest` (full suite, run from `test/`): 624 passing, only the 27 pre-existing environment-only failures (missing LLVM bindings libs / unset bootstrap env vars) — no regressions.
- New `algorithm-smoke` test exercises all 13 functions: empty input, no-match/all-match/some-match filtering, cross-type `map`/`reduce`, vacuous truth for `any`/`all`/`none` on empty input, `min`/`max` on empty input, and `partition` on empty input.
- `StdTests.io_cliParserSubcommands` passes, exercising the `contains` swap through real subcommand/alias parsing.
- Verified ASan-clean via `spice run --sanitizer=address` on the new test file, and by building `test/test-files/std/io/cli-parser-subcommands/source.spice` with `--sanitizer=address` and running it with its real args (`greet --name World`).

## Follow-up / known limitations
- Only works on `Vector<T>` today, not other `IIterable<T>` containers, pending a fix for #1327.
- `sort`, `reverse`, `rotate`, `shuffle`, `binarySearch`, `distinct`/`unique`, `flatMap`, `findIndex`, `zip`, `groupBy`, `chunk` are not yet implemented — the ones needing random access/in-place mutation need an API decision (mutate vs. return a new vector) before implementing.
- While testing `forEach`, found a separate, more serious compiler issue: capturing a non-trivial/heap-owning local (e.g. `Vector<T>`) by value in a lambda can read back corrupted data and crash on mutation. Not yet filed as a GitHub issue; worked around in tests by capturing only primitives.

Refs #1327