### PR TITLE
Add a YAML parser and serializer to the standard library

### DIFF
--- a/std/README.md
+++ b/std/README.md
@@ -143,9 +143,9 @@ Text processing, parsing, and formatted output.
 | `stringstream`                                                              | Stream-style string building.                      |
 | `string-ext`                                                                | Extra string utility functions.                    |
 | `analysis`                                                                  | Text analysis helpers.                             |
-| `csv-parser` / `json-parser` / `toml-parser` / `xml-parser`                 | Parsers for CSV, JSON, TOML, and XML.              |
-| `csv-serializer` / `json-serializer` / `toml-serializer` / `xml-serializer` | Serializers for CSV, JSON, TOML, and XML.          |
-| `json-value` / `toml-value` / `xml-node`                                    | Data models shared by the parsers and serializers. |
+| `csv-parser` / `json-parser` / `toml-parser` / `xml-parser` / `yaml-parser` | Parsers for CSV, JSON, TOML, XML, and YAML.        |
+| `csv-serializer` / `json-serializer` / `toml-serializer` / `xml-serializer` / `yaml-serializer` | Serializers for CSV, JSON, TOML, XML, and YAML. |
+| `json-value` / `toml-value` / `xml-node` / `yaml-value`                     | Data models shared by the parsers and serializers. |
 
 ### `std/time`
 Accessing system time in different formats and measuring durations.

--- a/std/text/yaml/yaml-parser.spice
+++ b/std/text/yaml/yaml-parser.spice
@@ -1,0 +1,1126 @@
+import "std/text/yaml/yaml-value";
+import "std/text/analysis";
+import "std/type/type-conversion";
+import "std/data/vector";
+
+/**
+ * Recursive-descent parser for YAML 1.2.
+ *
+ * Use `parseYaml` for one-shot parsing of a single document and
+ * `parseYamlDocuments` for a multi-document stream; the struct is exposed mainly
+ * so the parser state (position, error message) can be inspected when needed.
+ *
+ * Supported are comments, block mappings and block sequences with the usual
+ * indentation rules, flow sequences (`[a, b]`) and flow mappings (`{a: 1}`),
+ * plain, single-quoted and double-quoted scalars, literal (`|`) and folded (`>`)
+ * block scalars including their chomping and indentation indicators, anchors
+ * (`&name`) and aliases (`*name`), document markers (`---` and `...`) and
+ * directives (`%YAML`), which are skipped.
+ *
+ * Plain scalars are resolved according to the YAML 1.2 core schema, so `null`,
+ * `~` and the empty scalar become a null node, `true`/`false` become booleans,
+ * decimal, `0x` and `0o` literals become integers, and numbers with a fractional
+ * or exponent part as well as `.inf` and `.nan` become floats. Everything else
+ * stays a string, and quoted scalars are always strings. Mapping keys are always
+ * exposed as their literal text.
+ *
+ * Deliberately not supported, since they hardly ever appear in configuration
+ * files and each of them would need a data model of its own: explicit tags
+ * (`!!str`), explicit key indicators (`? key`), merge keys (`<<`), sets (`?`),
+ * anchors inside flow collections, quoted scalars spanning multiple lines and
+ * `--- key: value` with block content on the marker line. An alias resolves to a
+ * deep copy of its anchor, so the resulting tree never shares nodes and can be
+ * released with a single `deleteYamlValue` call.
+ *
+ * The YamlValue data model lives in "std/text/yaml/yaml-value" and serialization
+ * in "std/text/yaml/yaml-serializer".
+ */
+public type YamlParser struct {
+    String input
+    unsigned long pos
+    string errorMessage  // always points to a string literal, so it outlives the parser
+    bool hasError
+    Vector<String> anchorNames     // names of all anchors defined in the current document
+    Vector<YamlValue*> anchorValues // borrowed, the nodes stay owned by the tree being built
+}
+
+/**
+ * Construct a YAML parser over the given input string
+ *
+ * @param input YAML text to parse
+ */
+public p YamlParser.ctor(const String& input) {
+    this.input = input;
+    this.pos = 0l;
+    this.errorMessage = "";
+    this.hasError = false;
+}
+
+/**
+ * Destruct the YAML parser, releasing the bookkeeping it built up while parsing
+ */
+public p YamlParser.dtor() {
+    this.clearAnchors();
+}
+
+/**
+ * Parse the input string into a YAML node tree, expecting exactly one document
+ *
+ * @return Result holding the root node, or an error if the input is malformed
+ */
+public f<Result<YamlValue*>> YamlParser.parse() {
+    this.skipByteOrderMark();
+    YamlValue* root = this.parseSingleDocument();
+    if !this.hasError {
+        this.skipToContentLine();
+        if this.atDocumentBoundary() {
+            this.fail("Input holds more than one document, use parseYamlDocuments instead");
+        } else if !this.atEnd() {
+            this.fail("Unexpected content after the document, check the indentation");
+        }
+    }
+    if this.hasError {
+        // Nothing is handed out, so the partially built tree is ours to release
+        this.clearAnchors();
+        deleteYamlValue(root);
+        return err<YamlValue*>(Error(this.errorMessage));
+    }
+    return ok(root);
+}
+
+/**
+ * Parse the input string into a sequence of YAML node trees, one per document
+ *
+ * @return Result holding a sequence node with one item per document, or an error
+ */
+public f<Result<YamlValue*>> YamlParser.parseAll() {
+    this.skipByteOrderMark();
+    YamlValue* documents = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    bool scanning = true;
+    while scanning && !this.hasError {
+        this.skipToContentLine();
+        if this.atEnd() {
+            scanning = false;
+        } else if documents.getSequenceSize() > 0l && !this.atDocumentBoundary() {
+            // Every document after the first one has to be introduced by its own marker
+            this.fail("Unexpected content after a document, check the indentation");
+        } else {
+            YamlValue* document = this.parseSingleDocument();
+            if this.hasError {
+                deleteYamlValue(document);
+            } else {
+                documents.addSequenceItem(document);
+            }
+            // Anchors are scoped to the document that defines them
+            this.clearAnchors();
+        }
+    }
+    if this.hasError {
+        deleteYamlValue(documents);
+        return err<YamlValue*>(Error(this.errorMessage));
+    }
+    return ok(documents);
+}
+
+/**
+ * Parse a YAML document.
+ *
+ * On success returns the root node, which the caller owns and releases again with
+ * `deleteYamlValue` from "std/text/yaml/yaml-value". On failure the partially
+ * built tree is released by the parser and an error describing the first problem
+ * encountered is returned. An input that holds more than one document is
+ * rejected; use `parseYamlDocuments` for those.
+ */
+public f<Result<YamlValue*>> parseYaml(const String& input) {
+    YamlParser parser = YamlParser(input);
+    return parser.parse();
+}
+
+/**
+ * Parse a multi-document YAML stream.
+ *
+ * On success returns a sequence node holding one item per document, which the
+ * caller owns and releases again with `deleteYamlValue`. An empty stream yields
+ * an empty sequence.
+ */
+public f<Result<YamlValue*>> parseYamlDocuments(const String& input) {
+    YamlParser parser = YamlParser(input);
+    return parser.parseAll();
+}
+
+// --- Character level helpers ----------------------------------------------
+
+f<bool> YamlParser.atEnd() {
+    return this.pos >= this.input.getLength();
+}
+
+// Return the character `offset` positions ahead, or '\0' when out of bounds
+f<char> YamlParser.peekAt(unsigned long offset) {
+    const unsigned long idx = this.pos + offset;
+    if idx >= this.input.getLength() { return '\0'; }
+    return this.input[idx];
+}
+
+f<char> YamlParser.peek() {
+    return this.peekAt(0l);
+}
+
+p YamlParser.fail(string msg) {
+    if !this.hasError {
+        this.errorMessage = msg;
+        this.hasError = true;
+    }
+}
+
+// A leading UTF-8 byte order mark is not part of the stream
+p YamlParser.skipByteOrderMark() {
+    if this.peekAt(0l) == toChar(0xEF) && this.peekAt(1l) == toChar(0xBB) && this.peekAt(2l) == toChar(0xBF) {
+        this.pos += 3l;
+    }
+}
+
+// Skip separation whitespace, but no line breaks
+p YamlParser.skipSpaces() {
+    while true {
+        const char c = this.peek();
+        if c != ' ' && c != '\t' { break; }
+        this.pos++;
+    }
+}
+
+// Advance past the next line break, or to the end of the input
+p YamlParser.skipToNextLine() {
+    while !this.atEnd() {
+        const char c = this.peek();
+        this.pos++;
+        if c == '\n' { return; }
+        if c == '\r' {
+            if this.peek() == '\n' { this.pos++; }
+            return;
+        }
+    }
+}
+
+// Count the spaces that indent the current line. Only valid at the start of a line.
+f<unsigned long> YamlParser.countIndent() {
+    unsigned long count = 0l;
+    while this.peekAt(count) == ' ' { count++; }
+    return count;
+}
+
+// Checks whether nothing but a comment is left on the current line
+f<bool> YamlParser.atLineEndOrComment() {
+    const char c = this.peek();
+    return c == '\0' || c == '\n' || c == '\r' || c == '#';
+}
+
+// Consume the rest of the current line, which may only hold a comment
+p YamlParser.finishLine() {
+    this.skipSpaces();
+    if this.peek() == '#' {
+        while !this.atEnd() && this.peek() != '\n' && this.peek() != '\r' { this.pos++; }
+    }
+    if this.atEnd() { return; }
+    const char c = this.peek();
+    if c == '\n' {
+        this.pos++;
+        return;
+    }
+    if c == '\r' {
+        this.pos++;
+        if this.peek() == '\n' { this.pos++; }
+        return;
+    }
+    this.fail("Unexpected trailing content at the end of a line");
+}
+
+// Skip all blank and comment-only lines. Only valid at the start of a line, and
+// leaves the position at the start of the next line that holds content.
+p YamlParser.skipToContentLine() {
+    bool scanning = true;
+    while scanning && !this.atEnd() {
+        const unsigned long indent = this.countIndent();
+        const char c = this.peekAt(indent);
+        if c == '\0' {
+            this.pos = this.input.getLength(); // nothing but trailing spaces left
+        } else if c == '\n' || c == '\r' || c == '#' {
+            this.skipToNextLine();
+        } else if c == '\t' {
+            // YAML allows tabs to separate tokens, but never to indent a line
+            this.fail("Tabs cannot be used to indent a line");
+            scanning = false;
+        } else {
+            scanning = false;
+        }
+    }
+}
+
+// --- Document structure ----------------------------------------------------
+
+// Checks whether the current line consists of the given three-character marker.
+// Only valid at the start of a line.
+f<bool> YamlParser.lookingAtMarker(string marker) {
+    for unsigned long i = 0l; i < 3l; i++ {
+        if this.peekAt(i) != marker[i] { return false; }
+    }
+    const char after = this.peekAt(3l);
+    return after == '\0' || after == '\n' || after == '\r' || after == ' ' || after == '\t';
+}
+
+// Checks whether the current line ends the enclosing document. Only valid at the
+// start of a line.
+f<bool> YamlParser.atDocumentBoundary() {
+    return this.lookingAtMarker("---") || this.lookingAtMarker("...");
+}
+
+// Directives carry no data for the node tree, so they are skipped over
+p YamlParser.skipDirectives() {
+    bool scanning = true;
+    while scanning {
+        this.skipToContentLine();
+        scanning = !this.atEnd() && this.peek() == '%';
+        if scanning { this.skipToNextLine(); }
+    }
+}
+
+f<YamlValue*> YamlParser.parseSingleDocument() {
+    this.skipDirectives();
+    YamlValue* document = nil<YamlValue*>;
+    if this.lookingAtMarker("---") {
+        this.pos += 3l;
+        this.skipSpaces();
+        if this.atLineEndOrComment() {
+            this.finishLine();
+            if !this.hasError { document = this.parseBlockNode(0l); }
+        } else {
+            document = this.parseLineNode(0l);
+        }
+    } else {
+        document = this.parseBlockNode(0l);
+    }
+    // An explicit end marker belongs to the document it terminates
+    if !this.hasError {
+        this.skipToContentLine();
+        if this.lookingAtMarker("...") { this.skipToNextLine(); }
+    }
+    if this.hasError {
+        deleteYamlValue(document);
+        document = nil<YamlValue*>;
+    }
+    return document;
+}
+
+// --- Nodes -----------------------------------------------------------------
+
+// Parse the next node that is indented by at least `minIndent`. Only valid at the
+// start of a line; an input that holds nothing at that indentation yields a null node.
+f<YamlValue*> YamlParser.parseBlockNode(unsigned long minIndent) {
+    this.skipToContentLine();
+    if this.atEnd() || this.atDocumentBoundary() { return __new<YamlValue>(YamlValueKind::YAML_NULL); }
+    const unsigned long indent = this.countIndent();
+    if indent < minIndent { return __new<YamlValue>(YamlValueKind::YAML_NULL); }
+    this.pos += indent;
+    return this.parseNodeAt(indent, indent);
+}
+
+// Parse the node that starts at the current position, which sits at the first content
+// character of a line. `indent` is the column of that character and therefore the
+// column at which the entries of a block collection line up, while `ownerIndent` is
+// the indentation of the enclosing block, which scalars have to exceed to continue
+// onto the following lines.
+f<YamlValue*> YamlParser.parseNodeAt(unsigned long indent, unsigned long ownerIndent) {
+    if this.startsSequenceEntry() { return this.parseBlockSequence(indent); }
+    if this.findMappingColon() >= 0l { return this.parseBlockMapping(indent); }
+    return this.parseLineNode(ownerIndent);
+}
+
+// Checks whether a block sequence entry starts at the current position
+f<bool> YamlParser.startsSequenceEntry() {
+    if this.peek() != '-' { return false; }
+    const char after = this.peekAt(1l);
+    return after == ' ' || after == '\t' || after == '\n' || after == '\r' || after == '\0';
+}
+
+// Checks whether the line that starts at the current position holds a block sequence
+// entry at the given indentation. Only valid at the start of a line.
+f<bool> YamlParser.lineStartsSequenceEntry(unsigned long indent) {
+    if this.peekAt(indent) != '-' { return false; }
+    const char after = this.peekAt(indent + 1l);
+    return after == ' ' || after == '\t' || after == '\n' || after == '\r' || after == '\0';
+}
+
+// --- Block sequences -------------------------------------------------------
+
+// Parse a block sequence whose entries line up at `indent`. On entry the position
+// sits at the '-' of the first entry, on exit at the start of the first line that
+// no longer belongs to the sequence.
+f<YamlValue*> YamlParser.parseBlockSequence(unsigned long indent) {
+    YamlValue* sequence = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    bool scanning = true;
+    while scanning && !this.hasError {
+        this.parseSequenceEntry(sequence, indent);
+        if !this.hasError {
+            this.skipToContentLine();
+            scanning = !this.atEnd() && !this.atDocumentBoundary() && this.countIndent() == indent
+                       && this.lineStartsSequenceEntry(indent);
+            if scanning { this.pos += indent; }
+        }
+    }
+    if this.hasError {
+        deleteYamlValue(sequence);
+        sequence = nil<YamlValue*>;
+    }
+    return sequence;
+}
+
+p YamlParser.parseSequenceEntry(YamlValue* sequence, unsigned long indent) {
+    const unsigned long dashPos = this.pos;
+    this.pos++; // consume '-'
+    this.skipSpaces();
+    // Everything the dash and the separating spaces occupy shifts the entry to the right
+    const unsigned long itemIndent = indent + (this.pos - dashPos);
+    const String anchor = this.consumeAnchorName();
+    YamlValue* item = nil<YamlValue*>;
+    if !this.hasError {
+        if this.atLineEndOrComment() {
+            this.finishLine();
+            // The entry content sits on the following lines and has to be indented deeper
+            // than the dash itself
+            if !this.hasError { item = this.parseBlockNode(indent + 1l); }
+        } else {
+            item = this.parseNodeAt(itemIndent, indent);
+        }
+    }
+    if this.hasError {
+        deleteYamlValue(item);
+    } else {
+        this.registerAnchor(anchor, item);
+        sequence.addSequenceItem(item);
+    }
+}
+
+// --- Block mappings --------------------------------------------------------
+
+// Parse a block mapping whose entries line up at `indent`. On entry the position
+// sits at the first character of the first key, on exit at the start of the first
+// line that no longer belongs to the mapping.
+f<YamlValue*> YamlParser.parseBlockMapping(unsigned long indent) {
+    YamlValue* mapping = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    bool scanning = true;
+    while scanning && !this.hasError {
+        this.parseMappingEntry(mapping, indent);
+        if !this.hasError {
+            this.skipToContentLine();
+            scanning = false;
+            if !this.atEnd() && !this.atDocumentBoundary() && this.countIndent() == indent {
+                if this.lineStartsSequenceEntry(indent) {
+                    this.fail("A block sequence cannot start at the indentation of its parent mapping");
+                } else {
+                    this.pos += indent;
+                    if this.findMappingColon() < 0l {
+                        this.fail("Expected ':' after a mapping key");
+                    } else {
+                        scanning = true;
+                    }
+                }
+            }
+        }
+    }
+    if this.hasError {
+        deleteYamlValue(mapping);
+        mapping = nil<YamlValue*>;
+    }
+    return mapping;
+}
+
+p YamlParser.parseMappingEntry(YamlValue* mapping, unsigned long indent) {
+    const String key = this.parseMappingKey();
+    if !this.hasError {
+        if this.peek() != ':' {
+            this.fail("Expected ':' after a mapping key");
+        } else if mapping.hasField(key) {
+            this.fail("Cannot define the same mapping key twice");
+        } else {
+            this.pos++; // consume ':'
+            YamlValue* value = this.parseMappingValue(indent);
+            if this.hasError {
+                deleteYamlValue(value);
+            } else {
+                mapping.addMappingField(key, value);
+            }
+        }
+    }
+}
+
+// Read the key of a mapping entry, leaving the position at its ':'
+f<String> YamlParser.parseMappingKey() {
+    String key;
+    const char quote = this.peek();
+    if quote == '"' || quote == '\'' {
+        key = this.parseQuotedScalar(quote);
+        this.skipSpaces();
+    } else {
+        const long colonOffset = this.findMappingColon();
+        if colonOffset < 0l {
+            this.fail("Expected ':' after a mapping key");
+        } else {
+            // Whitespace between the key and its ':' is separation, not part of the key
+            const unsigned long colonPos = this.pos + cast<unsigned long>(colonOffset);
+            unsigned long end = colonPos;
+            while end > this.pos {
+                const char previous = this.input[end - 1l];
+                if previous != ' ' && previous != '\t' { break; }
+                end--;
+            }
+            for unsigned long i = this.pos; i < end; i++ { key += this.input[i]; }
+            this.pos = colonPos;
+        }
+    }
+    return key;
+}
+
+// Parse the value of a mapping entry whose key is indented by `keyIndent`. On entry
+// the position sits directly behind the ':' of the entry.
+f<YamlValue*> YamlParser.parseMappingValue(unsigned long keyIndent) {
+    this.skipSpaces();
+    const String anchor = this.consumeAnchorName();
+    YamlValue* value = nil<YamlValue*>;
+    if !this.hasError {
+        if this.atLineEndOrComment() {
+            this.finishLine();
+            if !this.hasError {
+                this.skipToContentLine();
+                bool handled = false;
+                // A block sequence may line up with the key it belongs to
+                if !this.atEnd() && !this.atDocumentBoundary() && this.countIndent() == keyIndent
+                   && this.lineStartsSequenceEntry(keyIndent) {
+                    this.pos += keyIndent;
+                    value = this.parseBlockSequence(keyIndent);
+                    handled = true;
+                }
+                if !handled { value = this.parseBlockNode(keyIndent + 1l); }
+            }
+        } else {
+            value = this.parseLineNode(keyIndent);
+        }
+    }
+    if this.hasError {
+        deleteYamlValue(value);
+        value = nil<YamlValue*>;
+    } else {
+        this.registerAnchor(anchor, value);
+    }
+    return value;
+}
+
+// Look for the ':' that turns the current line into a mapping entry and return its
+// offset from the current position, or -1 if the line does not start one
+f<long> YamlParser.findMappingColon() {
+    unsigned long i = 0l;
+    const char first = this.peek();
+    if first == '"' || first == '\'' {
+        // Step over the quoted key without interpreting it
+        i = 1l;
+        bool scanning = true;
+        while scanning {
+            const char c = this.peekAt(i);
+            if c == '\0' || c == '\n' || c == '\r' { return -1l; }
+            if first == '"' && c == '\\' {
+                i += 2l;
+            } else if c == first {
+                i++;
+                if first == '\'' && this.peekAt(i) == '\'' { i++; } else { scanning = false; }
+            } else {
+                i++;
+            }
+        }
+        while this.peekAt(i) == ' ' || this.peekAt(i) == '\t' { i++; }
+        if this.peekAt(i) != ':' { return -1l; }
+        return cast<long>(i);
+    }
+    // A plain key ends at the first ':' that is followed by whitespace, but a ':' that
+    // is nested in a flow collection belongs to that collection
+    unsigned long flowDepth = 0l;
+    while true {
+        const char c = this.peekAt(i);
+        if c == '\0' || c == '\n' || c == '\r' { return -1l; }
+        if c == '#' && i > 0l {
+            const char previous = this.peekAt(i - 1l);
+            if previous == ' ' || previous == '\t' { return -1l; }
+        }
+        if c == '[' || c == '{' {
+            flowDepth++;
+        } else if c == ']' || c == '}' {
+            if flowDepth > 0l { flowDepth--; }
+        } else if c == ':' && flowDepth == 0l {
+            const char after = this.peekAt(i + 1l);
+            if after == '\0' || after == '\n' || after == '\r' || after == ' ' || after == '\t' {
+                return cast<long>(i);
+            }
+        }
+        i++;
+    }
+    return -1l; // not reachable, the loop only leaves through a return
+}
+
+// --- Single-line nodes -----------------------------------------------------
+
+// Parse a node that starts on the current line. `ownerIndent` is the indentation of
+// the enclosing block, which the following lines have to exceed to still belong to
+// this node. On exit the position sits at the start of the first line that does not.
+f<YamlValue*> YamlParser.parseLineNode(unsigned long ownerIndent) {
+    const char c = this.peek();
+    YamlValue* value = nil<YamlValue*>;
+    if c == '|' {
+        value = this.parseBlockScalar(ownerIndent, false);
+    } else if c == '>' {
+        value = this.parseBlockScalar(ownerIndent, true);
+    } else if c == '*' {
+        value = this.parseAlias();
+        if !this.hasError { this.finishLine(); }
+    } else if c == '[' || c == '{' {
+        value = this.parseFlowNode();
+        if !this.hasError { this.finishLine(); }
+    } else if c == '"' || c == '\'' {
+        const String text = this.parseQuotedScalar(c);
+        if !this.hasError { this.finishLine(); }
+        if !this.hasError { value = __new<YamlValue>(text); }
+    } else {
+        const String text = this.parsePlainScalar(ownerIndent);
+        if !this.hasError { value = resolveYamlScalar(text); }
+    }
+    if this.hasError {
+        deleteYamlValue(value);
+        value = nil<YamlValue*>;
+    }
+    return value;
+}
+
+// --- Scalars ---------------------------------------------------------------
+
+// Parse a plain scalar, which may fold over the following lines as long as those are
+// indented deeper than `ownerIndent` and do not start an entry of their own
+f<String> YamlParser.parsePlainScalar(unsigned long ownerIndent) {
+    String text;
+    this.appendPlainLine(text);
+    this.finishLine();
+    bool scanning = !this.hasError;
+    while scanning {
+        scanning = false;
+        // A blank or comment line ends the scalar, so the lines are inspected one by one
+        const unsigned long nextIndent = this.countIndent();
+        const char first = this.peekAt(nextIndent);
+        if first != '\0' && first != '\n' && first != '\r' && first != '#' && nextIndent > ownerIndent {
+            this.pos += nextIndent;
+            if this.startsSequenceEntry() || this.findMappingColon() >= 0l {
+                this.pos -= nextIndent; // the line opens an entry, so it is not a continuation
+            } else {
+                text += ' '; // a folded line break becomes a single space
+                this.appendPlainLine(text);
+                this.finishLine();
+                scanning = !this.hasError;
+            }
+        }
+    }
+    return text;
+}
+
+// Append the plain scalar content of the current line, stripped of the comment that
+// may follow it and of the whitespace in between
+p YamlParser.appendPlainLine(String& out) {
+    String raw;
+    bool scanning = true;
+    while scanning {
+        const char c = this.peek();
+        if c == '\0' || c == '\n' || c == '\r' {
+            scanning = false;
+        } else if c == '#' && !raw.isEmpty() && isSeparationSpace(raw[raw.getLength() - 1l]) {
+            scanning = false;
+        } else {
+            raw += c;
+            this.pos++;
+        }
+    }
+    unsigned long end = raw.getLength();
+    while end > 0l && isSeparationSpace(raw[end - 1l]) { end--; }
+    for unsigned long i = 0l; i < end; i++ { out += raw[i]; }
+}
+
+// Parse a single-quoted or double-quoted scalar. Only single-quoted scalars take their
+// content verbatim, apart from the doubled quote that stands for a quote itself.
+f<String> YamlParser.parseQuotedScalar(char quote) {
+    const bool isDouble = quote == '"';
+    String text;
+    this.pos++; // consume the opening quote
+    bool scanning = true;
+    while scanning {
+        const char c = this.peek();
+        if c == '\0' || c == '\n' || c == '\r' {
+            const string unterminatedMessage = isDouble
+                ? "Unterminated double-quoted scalar"
+                : "Unterminated single-quoted scalar";
+            this.fail(unterminatedMessage);
+            scanning = false;
+        } else if c == quote {
+            this.pos++; // consume the closing quote
+            if !isDouble && this.peek() == '\'' {
+                text += '\''; // a doubled quote stands for a quote
+                this.pos++;
+            } else {
+                scanning = false;
+            }
+        } else if isDouble && c == '\\' {
+            this.pos++;
+            this.appendEscapeSequence(text);
+            if this.hasError { scanning = false; }
+        } else {
+            text += c;
+            this.pos++;
+        }
+    }
+    return text;
+}
+
+p YamlParser.appendEscapeSequence(String& out) {
+    if this.atEnd() {
+        this.fail("Unterminated escape sequence");
+        return;
+    }
+    const char esc = this.peek();
+    this.pos++;
+    if esc == '0' {
+        out += '\0';
+    } else if esc == 'a' {
+        out += toChar(0x07); // Spice has no '\a' char literal
+    } else if esc == 'b' {
+        out += '\b';
+    } else if esc == 't' {
+        out += '\t';
+    } else if esc == 'n' {
+        out += '\n';
+    } else if esc == 'v' {
+        out += '\v';
+    } else if esc == 'f' {
+        out += '\f';
+    } else if esc == 'r' {
+        out += '\r';
+    } else if esc == 'e' {
+        out += toChar(0x1B);
+    } else if esc == ' ' {
+        out += ' ';
+    } else if esc == '"' {
+        out += '"';
+    } else if esc == '/' {
+        out += '/';
+    } else if esc == '\\' {
+        out += '\\';
+    } else if esc == 'x' {
+        this.appendUnicodeEscape(out, 2l);
+    } else if esc == 'u' {
+        this.appendUnicodeEscape(out, 4l);
+    } else if esc == 'U' {
+        this.appendUnicodeEscape(out, 8l);
+    } else {
+        this.fail("Unsupported escape sequence");
+    }
+}
+
+p YamlParser.appendUnicodeEscape(String& out, unsigned long digitCount) {
+    long codePoint = 0l;
+    for unsigned long i = 0l; i < digitCount; i++ {
+        const char c = this.peek();
+        if !isHexDigit(c) {
+            this.fail("Invalid unicode escape sequence");
+            return;
+        }
+        codePoint = codePoint * 16l + hexDigitValue(c);
+        this.pos++;
+    }
+    if !appendCodePointUtf8(out, codePoint) {
+        this.fail("Invalid unicode scalar value in escape sequence");
+    }
+}
+
+// --- Block scalars ---------------------------------------------------------
+
+// Parse a literal ('|') or folded ('>') block scalar. Its content is made up of all
+// following lines that are indented deeper than `ownerIndent`.
+f<YamlValue*> YamlParser.parseBlockScalar(unsigned long ownerIndent, bool folded) {
+    this.pos++; // consume '|' or '>'
+
+    // Header: a chomping indicator and an explicit indentation indicator, in any order
+    int chomping = 0; // 0 clips the trailing line break, -1 strips it, 1 keeps all of them
+    unsigned long explicitIndent = 0l;
+    for unsigned int i = 0u; i < 2u; i++ {
+        const char c = this.peek();
+        if c == '-' {
+            chomping = -1;
+            this.pos++;
+        } else if c == '+' {
+            chomping = 1;
+            this.pos++;
+        } else if c >= '1' && c <= '9' {
+            explicitIndent = cast<unsigned long>(toLong(c) - toLong('0'));
+            this.pos++;
+        } else {
+            break;
+        }
+    }
+    this.finishLine();
+
+    String text;
+    unsigned long contentIndent = explicitIndent == 0l ? 0l : ownerIndent + explicitIndent;
+    bool sawContent = false;
+    unsigned long pendingBreaks = 0l;
+    bool previousWasMoreIndented = false;
+    bool scanning = !this.hasError;
+    while scanning {
+        const unsigned long lineIndent = this.countIndent();
+        const char first = this.peekAt(lineIndent);
+        bool takeLine = false;
+        if first == '\0' {
+            scanning = false; // the input ends here
+        } else if first == '\n' || first == '\r' {
+            pendingBreaks++; // an empty line, which only counts once the next content line is known
+            this.skipToNextLine();
+        } else if contentIndent == 0l {
+            // The first content line fixes the indentation of the whole block
+            if lineIndent > ownerIndent { contentIndent = lineIndent; } else { scanning = false; }
+            takeLine = scanning;
+        } else if lineIndent < contentIndent {
+            scanning = false;
+        } else {
+            takeLine = true;
+        }
+        if takeLine {
+            this.pos += contentIndent;
+            String lineText;
+            while !this.atEnd() && this.peek() != '\n' && this.peek() != '\r' {
+                lineText += this.peek();
+                this.pos++;
+            }
+            const bool moreIndented = !lineText.isEmpty() && isSeparationSpace(lineText[0l]);
+            if !sawContent {
+                text += lineText;
+                sawContent = true;
+            } else if folded && pendingBreaks == 0l && !moreIndented && !previousWasMoreIndented {
+                text += ' '; // a line break between two plain lines folds to a space
+                text += lineText;
+            } else {
+                // A literal block keeps the break of the preceding content line on top of
+                // the one each empty line contributes, while a folded block swallows it
+                unsigned long breakCount = pendingBreaks + 1l;
+                if folded && pendingBreaks > 0l { breakCount = pendingBreaks; }
+                for unsigned long i = 0l; i < breakCount; i++ { text += '\n'; }
+                text += lineText;
+            }
+            pendingBreaks = 0l;
+            previousWasMoreIndented = moreIndented;
+            this.skipToNextLine();
+        }
+    }
+
+    YamlValue* value = nil<YamlValue*>;
+    if !this.hasError {
+        if chomping > 0 {
+            // Keep every trailing line break, including the one of the last content line
+            if sawContent { text += '\n'; }
+            for unsigned long i = 0l; i < pendingBreaks; i++ { text += '\n'; }
+        } else if chomping == 0 && sawContent {
+            text += '\n'; // clip down to a single trailing line break
+        }
+        value = __new<YamlValue>(text);
+    }
+    return value;
+}
+
+// --- Flow collections ------------------------------------------------------
+
+// Skip whitespace, line breaks and comments, all of which may appear anywhere inside
+// a flow collection
+p YamlParser.skipFlowBlanks() {
+    bool scanning = true;
+    while scanning && !this.atEnd() {
+        const char c = this.peek();
+        if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+            this.pos++;
+        } else if c == '#' {
+            this.skipToNextLine();
+        } else {
+            scanning = false;
+        }
+    }
+}
+
+f<YamlValue*> YamlParser.parseFlowNode() {
+    const char c = this.peek();
+    if c == '[' { return this.parseFlowSequence(); }
+    if c == '{' { return this.parseFlowMapping(); }
+    if c == '*' { return this.parseAlias(); }
+    return this.parseFlowScalar();
+}
+
+f<YamlValue*> YamlParser.parseFlowSequence() {
+    this.pos++; // consume '['
+    YamlValue* sequence = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    bool scanning = true;
+    while scanning && !this.hasError {
+        this.skipFlowBlanks();
+        if this.atEnd() {
+            this.fail("Unterminated flow sequence");
+        } else if this.peek() == ']' {
+            this.pos++;
+            scanning = false;
+        } else {
+            YamlValue* item = this.parseFlowNode();
+            if this.hasError {
+                deleteYamlValue(item);
+            } else {
+                sequence.addSequenceItem(item);
+                this.skipFlowBlanks();
+                const char separator = this.peek();
+                if separator == ',' {
+                    this.pos++;
+                } else if separator == ']' {
+                    this.pos++;
+                    scanning = false;
+                } else {
+                    this.fail("Expected ',' or ']' in a flow sequence");
+                }
+            }
+        }
+    }
+    if this.hasError {
+        deleteYamlValue(sequence);
+        sequence = nil<YamlValue*>;
+    }
+    return sequence;
+}
+
+f<YamlValue*> YamlParser.parseFlowMapping() {
+    this.pos++; // consume '{'
+    YamlValue* mapping = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    bool scanning = true;
+    while scanning && !this.hasError {
+        this.skipFlowBlanks();
+        if this.atEnd() {
+            this.fail("Unterminated flow mapping");
+        } else if this.peek() == '}' {
+            this.pos++;
+            scanning = false;
+        } else {
+            this.parseFlowMappingEntry(mapping);
+            if !this.hasError {
+                this.skipFlowBlanks();
+                const char separator = this.peek();
+                if separator == ',' {
+                    this.pos++;
+                } else if separator == '}' {
+                    this.pos++;
+                    scanning = false;
+                } else {
+                    this.fail("Expected ',' or '}' in a flow mapping");
+                }
+            }
+        }
+    }
+    if this.hasError {
+        deleteYamlValue(mapping);
+        mapping = nil<YamlValue*>;
+    }
+    return mapping;
+}
+
+p YamlParser.parseFlowMappingEntry(YamlValue* mapping) {
+    const char quote = this.peek();
+    String key;
+    if quote == '"' || quote == '\'' {
+        key = this.parseQuotedScalar(quote);
+    } else {
+        key = this.parseFlowPlainScalar();
+    }
+    if !this.hasError {
+        this.skipFlowBlanks();
+        YamlValue* value = nil<YamlValue*>;
+        const char c = this.peek();
+        if c == ',' || c == '}' {
+            value = __new<YamlValue>(YamlValueKind::YAML_NULL); // an entry without a value
+        } else if c != ':' {
+            this.fail("Expected ':' in a flow mapping");
+        } else {
+            this.pos++; // consume ':'
+            this.skipFlowBlanks();
+            const char next = this.peek();
+            if next == ',' || next == '}' {
+                value = __new<YamlValue>(YamlValueKind::YAML_NULL);
+            } else {
+                value = this.parseFlowNode();
+            }
+        }
+        if this.hasError {
+            deleteYamlValue(value);
+        } else if mapping.hasField(key) {
+            this.fail("Cannot define the same mapping key twice");
+            deleteYamlValue(value);
+        } else {
+            mapping.addMappingField(key, value);
+        }
+    }
+}
+
+f<YamlValue*> YamlParser.parseFlowScalar() {
+    const char quote = this.peek();
+    YamlValue* value = nil<YamlValue*>;
+    if quote == '"' || quote == '\'' {
+        const String text = this.parseQuotedScalar(quote);
+        if !this.hasError { value = __new<YamlValue>(text); } // a quoted scalar is always a string
+    } else {
+        const String text = this.parseFlowPlainScalar();
+        if !this.hasError { value = resolveYamlScalar(text); }
+    }
+    return value;
+}
+
+// Read a plain scalar inside a flow collection, which ends at the first character that
+// structures the collection
+f<String> YamlParser.parseFlowPlainScalar() {
+    String raw;
+    bool scanning = true;
+    while scanning {
+        const char c = this.peek();
+        if c == '\0' || c == '\n' || c == '\r' || c == ',' || c == '[' || c == ']' || c == '{' || c == '}' {
+            scanning = false;
+        } else if c == '#' && !raw.isEmpty() && isSeparationSpace(raw[raw.getLength() - 1l]) {
+            scanning = false;
+        } else if c == ':' && isFlowScalarEnd(this.peekAt(1l)) {
+            scanning = false;
+        } else {
+            raw += c;
+            this.pos++;
+        }
+    }
+    String text;
+    unsigned long end = raw.getLength();
+    while end > 0l && isSeparationSpace(raw[end - 1l]) { end--; }
+    for unsigned long i = 0l; i < end; i++ { text += raw[i]; }
+    if text.isEmpty() { this.fail("Expected a value in a flow collection"); }
+    return text;
+}
+
+// --- Anchors and aliases ---------------------------------------------------
+
+// Consume an optional '&name' anchor in front of a node and return its name
+f<String> YamlParser.consumeAnchorName() {
+    String name;
+    if this.peek() == '&' {
+        this.pos++;
+        while isAnchorChar(this.peek()) {
+            name += this.peek();
+            this.pos++;
+        }
+        if name.isEmpty() {
+            this.fail("Expected an anchor name after '&'");
+        } else {
+            this.skipSpaces();
+        }
+    }
+    return name;
+}
+
+p YamlParser.registerAnchor(const String& name, YamlValue* value) {
+    if name.isEmpty() { return; }
+    this.anchorNames.pushBack(name);
+    this.anchorValues.pushBack(value);
+}
+
+// Look up the node an anchor refers to. A name that was used more than once refers to
+// the most recent definition, so the search runs backwards.
+f<YamlValue*> YamlParser.lookupAnchor(const String& name) {
+    unsigned long i = this.anchorNames.getSize();
+    while i > 0l {
+        i--;
+        if this.anchorNames.get(i) == name { return this.anchorValues.get(i); }
+    }
+    return nil<YamlValue*>;
+}
+
+p YamlParser.clearAnchors() {
+    // Vector does not destruct the items it holds, so the names have to be released by hand
+    for unsigned long i = 0l; i < this.anchorNames.getSize(); i++ {
+        String& name = this.anchorNames.get(i);
+        name.dtor();
+    }
+    this.anchorNames.clear();
+    // The nodes themselves are owned by the tree that is being built, so they are only dropped
+    this.anchorValues.clear();
+}
+
+// Resolve a '*name' alias against its anchor, which yields a deep copy of the anchored node
+f<YamlValue*> YamlParser.parseAlias() {
+    this.pos++; // consume '*'
+    String name;
+    while isAnchorChar(this.peek()) {
+        name += this.peek();
+        this.pos++;
+    }
+    YamlValue* value = nil<YamlValue*>;
+    if name.isEmpty() {
+        this.fail("Expected an anchor name after '*'");
+    } else {
+        YamlValue* anchored = this.lookupAnchor(name);
+        if anchored == nil<YamlValue*> {
+            this.fail("Reference to an anchor that was never defined");
+        } else {
+            value = copyYamlValue(anchored);
+        }
+    }
+    return value;
+}
+
+// --- Free helpers ----------------------------------------------------------
+
+// Checks whether the given character separates tokens without ending the line
+inline f<bool> isSeparationSpace(char c) {
+    return c == ' ' || c == '\t';
+}
+
+// Checks whether a ':' followed by the given character ends a plain scalar inside a
+// flow collection
+inline f<bool> isFlowScalarEnd(char c) {
+    return c == '\0' || c == '\n' || c == '\r' || c == ' ' || c == '\t' || c == ','
+           || c == ']' || c == '}';
+}
+
+// Checks whether the given character may appear in an anchor name
+inline f<bool> isAnchorChar(char c) {
+    return isAlphaNum(c) || c == '_' || c == '-';
+}
+
+inline f<long> hexDigitValue(char c) {
+    if isDigit(c) { return toLong(c) - toLong('0'); }
+    if isLower(c) { return toLong(c) - toLong('a') + 10l; }
+    return toLong(c) - toLong('A') + 10l;
+}
+
+// Encode a unicode scalar value as UTF-8. Returns false for values outside the
+// unicode range as well as for surrogates, which are not scalar values.
+f<bool> appendCodePointUtf8(String& out, long codePoint) {
+    if codePoint < 0l || codePoint > 0x10FFFFl { return false; }
+    if codePoint >= 0xD800l && codePoint <= 0xDFFFl { return false; }
+    if codePoint < 0x80l {
+        out += toChar(codePoint);
+    } else if codePoint < 0x800l {
+        out += toChar(0xC0l | (codePoint >> 6));
+        out += toChar(0x80l | (codePoint & 0x3Fl));
+    } else if codePoint < 0x10000l {
+        out += toChar(0xE0l | (codePoint >> 12));
+        out += toChar(0x80l | ((codePoint >> 6) & 0x3Fl));
+        out += toChar(0x80l | (codePoint & 0x3Fl));
+    } else {
+        out += toChar(0xF0l | (codePoint >> 18));
+        out += toChar(0x80l | ((codePoint >> 12) & 0x3Fl));
+        out += toChar(0x80l | ((codePoint >> 6) & 0x3Fl));
+        out += toChar(0x80l | (codePoint & 0x3Fl));
+    }
+    return true;
+}

--- a/std/text/yaml/yaml-serializer.spice
+++ b/std/text/yaml/yaml-serializer.spice
@@ -1,0 +1,325 @@
+import "std/text/yaml/yaml-value";
+import "std/type/type-conversion";
+
+ext f<int> snprintf(char*, unsigned long, string, ...);
+
+/**
+ * Serializer for YAML output.
+ *
+ * By default nested mappings and sequences are emitted in block style, which is how
+ * YAML documents are usually written, with `indentWidth` spaces per level. With
+ * `flowStyle` enabled everything is emitted on a single line using flow collections
+ * (`{a: 1, b: [2, 3]}`) instead.
+ *
+ * Scalars are written plain wherever that is unambiguous and double-quoted otherwise,
+ * so a string that would be read back as a number, a boolean or null keeps its type.
+ * Either way the result round-trips through `parseYaml` from
+ * "std/text/yaml/yaml-parser".
+ */
+public type YamlSerializer struct {
+    unsigned long indentWidth
+    bool flowStyle
+}
+
+/**
+ * Construct a YAML serializer
+ *
+ * @param indentWidth Number of spaces per indentation level, at least one
+ * @param flowStyle Emit everything inline using flow collections instead of block style
+ */
+public p YamlSerializer.ctor(unsigned long indentWidth = 2l, bool flowStyle = false) {
+    this.indentWidth = indentWidth < 1l ? 1l : indentWidth;
+    this.flowStyle = flowStyle;
+}
+
+/**
+ * Construct a YAML serializer
+ *
+ * @param indentWidth Number of spaces per indentation level, at least one
+ * @param flowStyle Emit everything inline using flow collections instead of block style
+ */
+public p YamlSerializer.ctor(unsigned int indentWidth, bool flowStyle = false) {
+    this.indentWidth = indentWidth < 1 ? 1l : cast<unsigned long>(indentWidth);
+    this.flowStyle = flowStyle;
+}
+
+/**
+ * Serializes a YAML node into a YAML document
+ *
+ * @param root Root node to serialize
+ * @return YAML representation
+ */
+public f<String> YamlSerializer.serialize(YamlValue& root) {
+    return this.serialize(&root);
+}
+
+/**
+ * Serializes a YAML node into a YAML document
+ *
+ * @param root Root node to serialize
+ * @return YAML representation
+ */
+public f<String> YamlSerializer.serialize(YamlValue* root) {
+    String out;
+    this.serializeDocumentBody(root, out);
+    return out;
+}
+
+/**
+ * Serializes a sequence of YAML nodes into a multi-document YAML stream, with one
+ * `---` marker per document. This is the counterpart of `parseYamlDocuments` from
+ * "std/text/yaml/yaml-parser".
+ *
+ * @param documents Sequence node holding one item per document
+ * @return YAML representation
+ */
+public f<String> YamlSerializer.serializeDocuments(YamlValue* documents) {
+    assert documents.isSequence();
+    String out;
+    const unsigned long size = documents.getSequenceSize();
+    for unsigned long i = 0l; i < size; i++ {
+        out += "---\n";
+        YamlValue* document = documents.getSequenceItem(i);
+        this.serializeDocumentBody(document, out);
+    }
+    return out;
+}
+
+/**
+ * Serializes a single YAML node in its inline form, as it would appear on the right
+ * hand side of a `key: value` pair
+ *
+ * @param value Node to serialize
+ * @return YAML representation
+ */
+public f<String> YamlSerializer.serializeValue(YamlValue* value) {
+    String out;
+    this.serializeInlineValue(value, out);
+    return out;
+}
+
+// --- Internal serializer helpers --------------------------------------------
+
+p YamlSerializer.serializeDocumentBody(YamlValue* root, String& out) {
+    if this.flowStyle || !hasBlockBody(root) {
+        this.serializeInlineValue(root, out);
+        out += '\n';
+    } else if root.isMapping() {
+        this.serializeBlockMapping(root, 0l, false, out);
+    } else {
+        this.serializeBlockSequence(root, 0l, false, out);
+    }
+}
+
+// Emit a mapping in block style. `indent` is the column its keys line up at; when
+// `firstKeyPrefixed` is set, the caller has already written the start of the first line.
+p YamlSerializer.serializeBlockMapping(YamlValue* mapping, unsigned long indent, bool firstKeyPrefixed,
+                                       String& out) {
+    const unsigned long size = mapping.getMappingSize();
+    for unsigned long i = 0l; i < size; i++ {
+        if i > 0l || !firstKeyPrefixed { appendIndent(out, indent); }
+        const String& key = mapping.getMappingKey(i);
+        serializeYamlScalar(out, key);
+        out += ':';
+        YamlValue* value = mapping.getMappingValue(i);
+        if hasBlockBody(value) {
+            // A nested collection gets a block of its own, one level further in
+            out += '\n';
+            if value.isMapping() {
+                this.serializeBlockMapping(value, indent + this.indentWidth, false, out);
+            } else {
+                this.serializeBlockSequence(value, indent + this.indentWidth, false, out);
+            }
+        } else {
+            out += ' ';
+            this.serializeInlineValue(value, out);
+            out += '\n';
+        }
+    }
+}
+
+// Emit a sequence in block style. `indent` is the column its dashes line up at; when
+// `firstItemPrefixed` is set, the caller has already written the start of the first line.
+p YamlSerializer.serializeBlockSequence(YamlValue* sequence, unsigned long indent, bool firstItemPrefixed,
+                                        String& out) {
+    const unsigned long size = sequence.getSequenceSize();
+    for unsigned long i = 0l; i < size; i++ {
+        if i > 0l || !firstItemPrefixed { appendIndent(out, indent); }
+        out += "- ";
+        YamlValue* item = sequence.getSequenceItem(i);
+        if hasBlockBody(item) {
+            // The dash and its separating space shift the nested block two columns right
+            if item.isMapping() {
+                this.serializeBlockMapping(item, indent + 2l, true, out);
+            } else {
+                this.serializeBlockSequence(item, indent + 2l, true, out);
+            }
+        } else {
+            this.serializeInlineValue(item, out);
+            out += '\n';
+        }
+    }
+}
+
+p YamlSerializer.serializeInlineValue(YamlValue* value, String& out) {
+    const YamlValueKind kind = value.getKind();
+    if kind == YamlValueKind::YAML_NULL {
+        out += "null";
+    } else if kind == YamlValueKind::YAML_BOOL {
+        out += value.getBool() ? "true" : "false";
+    } else if kind == YamlValueKind::YAML_INTEGER {
+        out += toString(value.getInteger());
+    } else if kind == YamlValueKind::YAML_FLOAT {
+        out += serializeYamlFloat(value.getFloat());
+    } else if kind == YamlValueKind::YAML_STRING {
+        serializeYamlScalar(out, value.getString());
+    } else if kind == YamlValueKind::YAML_SEQUENCE {
+        const unsigned long size = value.getSequenceSize();
+        out += '[';
+        for unsigned long i = 0l; i < size; i++ {
+            if i > 0l { out += ", "; }
+            YamlValue* item = value.getSequenceItem(i);
+            this.serializeInlineValue(item, out);
+        }
+        out += ']';
+    } else {
+        const unsigned long size = value.getMappingSize();
+        out += '{';
+        for unsigned long i = 0l; i < size; i++ {
+            if i > 0l { out += ", "; }
+            const String& key = value.getMappingKey(i);
+            serializeYamlScalar(out, key);
+            out += ": ";
+            YamlValue* entry = value.getMappingValue(i);
+            this.serializeInlineValue(entry, out);
+        }
+        out += '}';
+    }
+}
+
+// A collection only earns a block of its own once it actually holds something; an empty
+// one is written as `[]` or `{}`, since a block form of it does not exist.
+f<bool> hasBlockBody(YamlValue* value) {
+    if value.isMapping() { return value.getMappingSize() > 0l; }
+    if value.isSequence() { return value.getSequenceSize() > 0l; }
+    return false;
+}
+
+p appendIndent(String& out, unsigned long width) {
+    for unsigned long i = 0l; i < width; i++ { out += ' '; }
+}
+
+// Emit a scalar plain if that reads back as the very same string, and double-quoted otherwise
+p serializeYamlScalar(String& out, const String& text) {
+    if isPlainSafe(text) {
+        out += text;
+        return;
+    }
+    serializeYamlQuotedScalar(out, text);
+}
+
+f<bool> isPlainSafe(const String& text) {
+    const unsigned long length = text.getLength();
+    if length == 0l { return false; }
+    // A plain scalar that resolves to another kind has to be quoted to stay a string
+    if yamlPlainScalarKind(text) != YamlValueKind::YAML_STRING { return false; }
+    // Leading and trailing whitespace would be stripped away again
+    if isBlankChar(text[0l]) || isBlankChar(text[length - 1l]) { return false; }
+    if startsWithIndicator(text) { return false; }
+    if text == "<<" { return false; } // the merge key
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = text[i];
+        // Control characters, line breaks included, have no plain representation. Bytes of
+        // multi-byte UTF-8 sequences are excluded, no matter whether char is signed or not.
+        if (c >= '\0' && c < ' ') || cast<int>(c) == 0x7F { return false; }
+        // A ':' that is followed by whitespace would open a mapping entry
+        if c == ':' && (i + 1l == length || isBlankChar(text[i + 1l])) { return false; }
+        // A '#' that follows whitespace would open a comment
+        if c == '#' && i > 0l && isBlankChar(text[i - 1l]) { return false; }
+    }
+    return true;
+}
+
+// Checks whether the scalar starts with a character that YAML reads as an indicator
+f<bool> startsWithIndicator(const String& text) {
+    const char c = text[0l];
+    if c == ',' || c == '[' || c == ']' || c == '{' || c == '}' || c == '#' || c == '&' || c == '*'
+       || c == '!' || c == '|' || c == '>' || c == '\'' || c == '"' || c == '%' || c == '@' || c == '`' {
+        return true;
+    }
+    // These only open a block entry when whitespace follows them
+    if c == '-' || c == '?' || c == ':' {
+        return text.getLength() == 1l || isBlankChar(text[1l]);
+    }
+    return false;
+}
+
+inline f<bool> isBlankChar(char c) {
+    return c == ' ' || c == '\t';
+}
+
+// Serialize a scalar as a double-quoted one, i.e. with surrounding quotes and escaping
+p serializeYamlQuotedScalar(String& out, const String& text) {
+    out += '"';
+    const unsigned long length = text.getLength();
+    for unsigned long i = 0l; i < length; i++ {
+        const char c = text[i];
+        if c == '"' {
+            out += "\\\"";
+        } else if c == '\\' {
+            out += "\\\\";
+        } else if c == '\n' {
+            out += "\\n";
+        } else if c == '\r' {
+            out += "\\r";
+        } else if c == '\t' {
+            out += "\\t";
+        } else if c == '\b' {
+            out += "\\b";
+        } else if c == '\f' {
+            out += "\\f";
+        } else if c == '\0' {
+            out += "\\0";
+        } else if (c >= '\0' && c < ' ') || cast<int>(c) == 0x7F {
+            // All other control characters are emitted as \u00XX escapes.
+            // Bytes of multi-byte UTF-8 sequences are passed through unchanged.
+            string hexDigits = "0123456789ABCDEF";
+            const int code = cast<int>(c);
+            out += "\\u00";
+            out += hexDigits[(code >> 4) & 0xF];
+            out += hexDigits[code & 0xF];
+        } else {
+            out += c;
+        }
+    }
+    out += '"';
+}
+
+// Serialize a float, making sure the output is always recognizable as a YAML float.
+// Integral values therefore get a ".0" suffix, and non-integral values use 17 significant
+// digits ("%.17g"), which is enough to round-trip any double exactly.
+f<String> serializeYamlFloat(double value) {
+    if yamlIsNaN(value) { return String(".nan"); }
+    const double infinity = yamlInfinity();
+    if value == infinity { return String(".inf"); }
+    if value == -infinity { return String("-.inf"); }
+
+    // Only take the integral shortcut while the value is safely inside the long range
+    if value >= -9.0e18 && value <= 9.0e18 {
+        const long asLong = cast<long>(value);
+        if cast<double>(asLong) == value {
+            String integral = toString(asLong);
+            integral += ".0";
+            return integral;
+        }
+    }
+
+    const int length = snprintf(nil<char*>, 0l, "%.17g", value);
+    String out = String(length);
+    snprintf(cast<char*>(out.getRaw()), cast<unsigned long>(length + 1), "%.17g", value);
+    // Very large magnitudes may print without a fractional or exponent part
+    if out.find('.') < 0l && out.find('e') < 0l && out.find('E') < 0l {
+        out += ".0";
+    }
+    return out;
+}

--- a/std/text/yaml/yaml-value.spice
+++ b/std/text/yaml/yaml-value.spice
@@ -1,0 +1,616 @@
+import "std/data/vector";
+import "std/text/analysis";
+import "std/type/type-conversion";
+
+/**
+ * Tag for the variant stored inside a YamlValue.
+ */
+public type YamlValueKind enum {
+    YAML_NULL,
+    YAML_STRING,
+    YAML_INTEGER,
+    YAML_FLOAT,
+    YAML_BOOL,
+    YAML_SEQUENCE,
+    YAML_MAPPING
+}
+
+/**
+ * Represents a single YAML node.
+ *
+ * Composite nodes (sequences and mappings) own their children as heap pointers,
+ * so a YamlValue is always reached via `YamlValue*` once it has been parsed.
+ * Destroying a node recursively destroys everything below it, so a whole tree
+ * is released with a single `deleteYamlValue` call on its root. Accessors like
+ * `getField` hand out borrowed pointers that stay owned by their parent, while
+ * `addSequenceItem` and `addMappingField` take ownership of what they are given.
+ *
+ * Note that the root cannot simply be held in a `heap YamlValue*` and left to
+ * the compiler: the `heap` qualifier only emits a raw deallocation when the
+ * variable goes out of scope and never runs the destructor of the pointee, so
+ * the children below the root would be lost.
+ *
+ * Following the YAML 1.2 core schema, plain scalars resolve to null, booleans,
+ * integers or floats and everything else stays a string, while quoted scalars
+ * are always strings. Mapping entries preserve document order, and unlike TOML
+ * tables a mapping may hold an explicit null value.
+ *
+ * Parsing lives in "std/text/yaml/yaml-parser" and serialization in
+ * "std/text/yaml/yaml-serializer", so programs only pull in what they use.
+ */
+public type YamlValue struct {
+    YamlValueKind kind
+    bool boolValue
+    long intValue
+    double floatValue
+    String stringValue
+    Vector<YamlValue*> sequenceItems
+    Vector<String> mappingKeys
+    Vector<YamlValue*> mappingValues
+}
+
+/**
+ * Construct an empty YAML mapping, which is what a YAML document is usually rooted at
+ */
+public p YamlValue.ctor() {
+    this.kind = YamlValueKind::YAML_MAPPING;
+}
+
+/**
+ * Construct an empty YAML node of the given kind. Useful for building sequences
+ * and mappings from scratch.
+ *
+ * @param kind Kind of the node
+ */
+public p YamlValue.ctor(YamlValueKind kind) {
+    this.kind = kind;
+}
+
+/**
+ * Construct a YAML string node
+ *
+ * @param value String value
+ */
+public p YamlValue.ctor(const String& value) {
+    this.kind = YamlValueKind::YAML_STRING;
+    this.stringValue = value;
+}
+
+/**
+ * Construct a YAML boolean node
+ *
+ * @param value Boolean value
+ */
+public p YamlValue.ctor(bool value) {
+    this.kind = YamlValueKind::YAML_BOOL;
+    this.boolValue = value;
+}
+
+/**
+ * Construct a YAML integer node
+ *
+ * @param value Integer value
+ */
+public p YamlValue.ctor(long value) {
+    this.kind = YamlValueKind::YAML_INTEGER;
+    this.intValue = value;
+}
+
+/**
+ * Construct a YAML float node
+ *
+ * @param value Float value
+ */
+public p YamlValue.ctor(double value) {
+    this.kind = YamlValueKind::YAML_FLOAT;
+    this.floatValue = value;
+}
+
+/**
+ * Destruct the YAML node, releasing every sequence item and mapping entry it owns.
+ * Since the children are destroyed the same way, this tears down the whole subtree
+ * below the node.
+ */
+public p YamlValue.dtor() {
+    for unsigned long i = 0l; i < this.sequenceItems.getSize(); i++ {
+        deleteYamlValue(this.sequenceItems.get(i));
+    }
+    for unsigned long i = 0l; i < this.mappingValues.getSize(); i++ {
+        deleteYamlValue(this.mappingValues.get(i));
+    }
+    // Vector does not destruct its items, so the keys have to be released by hand
+    for unsigned long i = 0l; i < this.mappingKeys.getSize(); i++ {
+        String& key = this.mappingKeys.get(i);
+        key.dtor();
+    }
+}
+
+/**
+ * Destroys a heap-allocated YAML node together with everything it owns and sets
+ * the given handle to nil, so releasing a whole tree only takes one call on its root.
+ *
+ * Note that this is what `sDelete` would normally be used for. It cannot be used
+ * here, because a node tree is destroyed recursively and the compiler does not
+ * emit an explicit dtor that is only reached through `sDestruct`.
+ *
+ * @param value Handle of the node to destroy
+ */
+public p deleteYamlValue(YamlValue*& value) {
+    if value == nil<YamlValue*> { return; }
+    value.dtor();
+    unsafe {
+        heap byte* raw = cast<heap byte*>(value);
+        sDealloc(raw);
+    }
+    value = nil<YamlValue*>;
+}
+
+/**
+ * Creates a deep copy of the given node, which the caller owns and releases again
+ * with `deleteYamlValue`. This is what the parser uses to resolve an alias against
+ * its anchor, so that the resulting tree stays free of shared nodes.
+ *
+ * @param value Node to copy
+ * @return Pointer to the freshly allocated copy
+ */
+public f<YamlValue*> copyYamlValue(YamlValue* value) {
+    if value == nil<YamlValue*> { return nil<YamlValue*>; }
+    YamlValue* copy = __new<YamlValue>(value.kind);
+    copy.boolValue = value.boolValue;
+    copy.intValue = value.intValue;
+    copy.floatValue = value.floatValue;
+    copy.stringValue = value.stringValue;
+    for unsigned long i = 0l; i < value.sequenceItems.getSize(); i++ {
+        copy.sequenceItems.pushBack(copyYamlValue(value.sequenceItems.get(i)));
+    }
+    for unsigned long i = 0l; i < value.mappingKeys.getSize(); i++ {
+        copy.mappingKeys.pushBack(value.mappingKeys.get(i));
+        copy.mappingValues.pushBack(copyYamlValue(value.mappingValues.get(i)));
+    }
+    return copy;
+}
+
+// --- Kind inspection -------------------------------------------------------
+
+/**
+ * Retrieve the kind of the YAML node
+ *
+ * @return Kind of the node
+ */
+public f<YamlValueKind> YamlValue.getKind() { return this.kind; }
+/**
+ * Check whether the YAML node is null
+ *
+ * @return true if the node is null, false otherwise
+ */
+public f<bool> YamlValue.isNull()     { return this.kind == YamlValueKind::YAML_NULL; }
+/**
+ * Check whether the YAML node is a string
+ *
+ * @return true if the node is a string, false otherwise
+ */
+public f<bool> YamlValue.isString()   { return this.kind == YamlValueKind::YAML_STRING; }
+/**
+ * Check whether the YAML node is an integer
+ *
+ * @return true if the node is an integer, false otherwise
+ */
+public f<bool> YamlValue.isInteger()  { return this.kind == YamlValueKind::YAML_INTEGER; }
+/**
+ * Check whether the YAML node is a float
+ *
+ * @return true if the node is a float, false otherwise
+ */
+public f<bool> YamlValue.isFloat()    { return this.kind == YamlValueKind::YAML_FLOAT; }
+/**
+ * Check whether the YAML node is a boolean
+ *
+ * @return true if the node is a boolean, false otherwise
+ */
+public f<bool> YamlValue.isBool()     { return this.kind == YamlValueKind::YAML_BOOL; }
+/**
+ * Check whether the YAML node is a sequence
+ *
+ * @return true if the node is a sequence, false otherwise
+ */
+public f<bool> YamlValue.isSequence() { return this.kind == YamlValueKind::YAML_SEQUENCE; }
+/**
+ * Check whether the YAML node is a mapping
+ *
+ * @return true if the node is a mapping, false otherwise
+ */
+public f<bool> YamlValue.isMapping()  { return this.kind == YamlValueKind::YAML_MAPPING; }
+
+// --- Scalar accessors (panic on wrong kind) --------------------------------
+
+/**
+ * Retrieve the string payload. Panics if the node is not a string.
+ *
+ * @return String value
+ */
+public f<const String&> YamlValue.getString() {
+    assert this.kind == YamlValueKind::YAML_STRING;
+    return this.stringValue;
+}
+
+/**
+ * Retrieve the integer payload. Panics if the node is not an integer.
+ *
+ * @return Integer value
+ */
+public f<long> YamlValue.getInteger() {
+    assert this.kind == YamlValueKind::YAML_INTEGER;
+    return this.intValue;
+}
+
+/**
+ * Retrieve the float payload. Panics if the node is not a float.
+ *
+ * @return Float value
+ */
+public f<double> YamlValue.getFloat() {
+    assert this.kind == YamlValueKind::YAML_FLOAT;
+    return this.floatValue;
+}
+
+/**
+ * Retrieve the boolean payload. Panics if the node is not a boolean.
+ *
+ * @return Boolean value
+ */
+public f<bool> YamlValue.getBool() {
+    assert this.kind == YamlValueKind::YAML_BOOL;
+    return this.boolValue;
+}
+
+// --- Sequence operations ---------------------------------------------------
+
+/**
+ * Retrieve the number of items in the sequence. Panics if the node is not a sequence.
+ *
+ * @return Number of sequence items
+ */
+public f<unsigned long> YamlValue.getSequenceSize() {
+    assert this.kind == YamlValueKind::YAML_SEQUENCE;
+    return this.sequenceItems.getSize();
+}
+
+/**
+ * Retrieve the sequence item at the given index. Panics if the node is not a sequence.
+ *
+ * @param idx Index of the item
+ * @return Pointer to the sequence item
+ */
+public f<YamlValue*> YamlValue.getSequenceItem(unsigned long idx) {
+    assert this.kind == YamlValueKind::YAML_SEQUENCE;
+    return this.sequenceItems.get(idx);
+}
+
+/**
+ * Retrieve the sequence item at the given index. Panics if the node is not a sequence.
+ *
+ * @param idx Index of the item
+ * @return Pointer to the sequence item
+ */
+public f<YamlValue*> YamlValue.getSequenceItem(unsigned int idx) {
+    return this.getSequenceItem(cast<unsigned long>(idx));
+}
+
+/**
+ * Append an item to the sequence. Panics if the node is not a sequence.
+ * The sequence takes ownership of the heap-allocated item.
+ *
+ * @param item Item to append
+ */
+public p YamlValue.addSequenceItem(YamlValue* item) {
+    assert this.kind == YamlValueKind::YAML_SEQUENCE;
+    this.sequenceItems.pushBack(item);
+}
+
+// --- Mapping operations ----------------------------------------------------
+
+/**
+ * Retrieve the number of entries in the mapping. Panics if the node is not a mapping.
+ *
+ * @return Number of mapping entries
+ */
+public f<unsigned long> YamlValue.getMappingSize() {
+    assert this.kind == YamlValueKind::YAML_MAPPING;
+    return this.mappingKeys.getSize();
+}
+
+/**
+ * Retrieve the key of the mapping entry at the given index, in document order.
+ * Panics if the node is not a mapping.
+ *
+ * @param idx Index of the entry
+ * @return Entry key
+ */
+public f<const String&> YamlValue.getMappingKey(unsigned long idx) {
+    assert this.kind == YamlValueKind::YAML_MAPPING;
+    return this.mappingKeys.get(idx);
+}
+
+/**
+ * Retrieve the value of the mapping entry at the given index, in document order.
+ * Panics if the node is not a mapping.
+ *
+ * @param idx Index of the entry
+ * @return Pointer to the entry value
+ */
+public f<YamlValue*> YamlValue.getMappingValue(unsigned long idx) {
+    assert this.kind == YamlValueKind::YAML_MAPPING;
+    return this.mappingValues.get(idx);
+}
+
+/**
+ * Check whether the mapping contains an entry with the given key
+ *
+ * @param key Entry key to look for
+ * @return true if the entry exists, false otherwise
+ */
+public f<bool> YamlValue.hasField(const String& key) {
+    if this.kind != YamlValueKind::YAML_MAPPING { return false; }
+    for unsigned long i = 0l; i < this.mappingKeys.getSize(); i++ {
+        if this.mappingKeys.get(i) == key { return true; }
+    }
+    return false;
+}
+
+/**
+ * Check whether the mapping contains an entry with the given key
+ *
+ * @param key Entry key to look for
+ * @return true if the entry exists, false otherwise
+ */
+public f<bool> YamlValue.hasField(string key) {
+    return this.hasField(String(key));
+}
+
+/**
+ * Retrieve the value of the mapping entry with the given key, or nil if the node
+ * is not a mapping or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value, or nil
+ */
+public f<YamlValue*> YamlValue.getFieldOrNil(const String& key) {
+    if this.kind != YamlValueKind::YAML_MAPPING { return nil<YamlValue*>; }
+    for unsigned long i = 0l; i < this.mappingKeys.getSize(); i++ {
+        if this.mappingKeys.get(i) == key {
+            return this.mappingValues.get(i);
+        }
+    }
+    return nil<YamlValue*>;
+}
+
+/**
+ * Retrieve the value of the mapping entry with the given key, or nil if the node
+ * is not a mapping or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value, or nil
+ */
+public f<YamlValue*> YamlValue.getFieldOrNil(string key) {
+    return this.getFieldOrNil(String(key));
+}
+
+/**
+ * Retrieve the value of the mapping entry with the given key. Panics if the node
+ * is not a mapping or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value
+ */
+public f<YamlValue*> YamlValue.getField(const String& key) {
+    assert this.kind == YamlValueKind::YAML_MAPPING;
+    YamlValue* value = this.getFieldOrNil(key);
+    if value == nil<YamlValue*> {
+        panic(Error("YAML mapping has no such entry"));
+    }
+    return value;
+}
+
+/**
+ * Retrieve the value of the mapping entry with the given key. Panics if the node
+ * is not a mapping or the entry does not exist.
+ *
+ * @param key Entry key to look up
+ * @return Pointer to the entry value
+ */
+public f<YamlValue*> YamlValue.getField(string key) {
+    return this.getField(String(key));
+}
+
+/**
+ * Append an entry to the mapping. Panics if the node is not a mapping.
+ * The mapping takes ownership of the heap-allocated entry value.
+ *
+ * @param key Entry key
+ * @param value Entry value
+ */
+public p YamlValue.addMappingField(const String& key, YamlValue* value) {
+    assert this.kind == YamlValueKind::YAML_MAPPING;
+    this.mappingKeys.pushBack(key);
+    this.mappingValues.pushBack(value);
+}
+
+// --- Core schema resolution ------------------------------------------------
+
+/**
+ * Determine which kind a plain scalar resolves to under the YAML 1.2 core schema.
+ * Both the parser and the serializer go through this, so that a string which would
+ * be read back as another kind can be quoted when it is written out again.
+ *
+ * @param text Literal text of the plain scalar
+ * @return Kind the scalar resolves to, never YAML_SEQUENCE or YAML_MAPPING
+ */
+public f<YamlValueKind> yamlPlainScalarKind(const String& text) {
+    if isNullText(text) { return YamlValueKind::YAML_NULL; }
+    if text == "true" || text == "True" || text == "TRUE" { return YamlValueKind::YAML_BOOL; }
+    if text == "false" || text == "False" || text == "FALSE" { return YamlValueKind::YAML_BOOL; }
+    if isInfinityText(text) || isNaNText(text) { return YamlValueKind::YAML_FLOAT; }
+    if looksLikeInteger(text) { return YamlValueKind::YAML_INTEGER; }
+    if looksLikeFloat(text) { return YamlValueKind::YAML_FLOAT; }
+    return YamlValueKind::YAML_STRING;
+}
+
+/**
+ * Build the node a plain scalar denotes under the YAML 1.2 core schema. The caller owns
+ * the returned node and releases it again with `deleteYamlValue`.
+ *
+ * @param text Literal text of the plain scalar
+ * @return Pointer to the freshly allocated node
+ */
+public f<YamlValue*> resolveYamlScalar(const String& text) {
+    const YamlValueKind kind = yamlPlainScalarKind(text);
+    if kind == YamlValueKind::YAML_NULL { return __new<YamlValue>(YamlValueKind::YAML_NULL); }
+    if kind == YamlValueKind::YAML_BOOL {
+        const bool value = text == "true" || text == "True" || text == "TRUE";
+        return __new<YamlValue>(value);
+    }
+    if kind == YamlValueKind::YAML_INTEGER { return __new<YamlValue>(parseYamlInteger(text)); }
+    if kind == YamlValueKind::YAML_FLOAT { return __new<YamlValue>(parseYamlFloat(text)); }
+    return __new<YamlValue>(text);
+}
+
+inline f<bool> isNullText(const String& text) {
+    return text.isEmpty() || text == "~" || text == "null" || text == "Null" || text == "NULL";
+}
+
+inline f<bool> isInfinityText(const String& text) {
+    return text == ".inf" || text == ".Inf" || text == ".INF"
+        || text == "+.inf" || text == "+.Inf" || text == "+.INF"
+        || text == "-.inf" || text == "-.Inf" || text == "-.INF";
+}
+
+inline f<bool> isNaNText(const String& text) {
+    return text == ".nan" || text == ".NaN" || text == ".NAN";
+}
+
+f<bool> looksLikeInteger(const String& text) {
+    const unsigned long length = text.getLength();
+    if length == 0l { return false; }
+    // Literals with a radix prefix never carry a sign
+    if length > 2l && text[0l] == '0' && (text[1l] == 'x' || text[1l] == 'X') {
+        return allDigitsForBase(text, 2l, 16);
+    }
+    if length > 2l && text[0l] == '0' && (text[1l] == 'o' || text[1l] == 'O') {
+        return allDigitsForBase(text, 2l, 8);
+    }
+    const unsigned long start = text[0l] == '+' || text[0l] == '-' ? 1l : 0l;
+    return allDigitsForBase(text, start, 10);
+}
+
+f<bool> allDigitsForBase(const String& text, unsigned long start, int base) {
+    const unsigned long length = text.getLength();
+    if start >= length { return false; }
+    for unsigned long i = start; i < length; i++ {
+        const char c = text[i];
+        if base == 16 {
+            if !isHexDigit(c) { return false; }
+        } else if base == 8 {
+            if !isOctDigit(c) { return false; }
+        } else {
+            if !isDigit(c) { return false; }
+        }
+    }
+    return true;
+}
+
+// A plain scalar is a float if it carries a fractional or an exponent part and nothing
+// but digits and signs besides
+f<bool> looksLikeFloat(const String& text) {
+    const unsigned long length = text.getLength();
+    unsigned long i = 0l;
+    if i < length && (text[i] == '+' || text[i] == '-') { i++; }
+    unsigned long mantissaDigits = 0l;
+    while i < length && isDigit(text[i]) {
+        i++;
+        mantissaDigits++;
+    }
+    bool hasFraction = false;
+    if i < length && text[i] == '.' {
+        hasFraction = true;
+        i++;
+        while i < length && isDigit(text[i]) {
+            i++;
+            mantissaDigits++;
+        }
+    }
+    if mantissaDigits == 0l { return false; }
+    bool hasExponent = false;
+    if i < length && (text[i] == 'e' || text[i] == 'E') {
+        hasExponent = true;
+        i++;
+        if i < length && (text[i] == '+' || text[i] == '-') { i++; }
+        unsigned long exponentDigits = 0l;
+        while i < length && isDigit(text[i]) {
+            i++;
+            exponentDigits++;
+        }
+        if exponentDigits == 0l { return false; }
+    }
+    if i != length { return false; }
+    return hasFraction || hasExponent;
+}
+
+f<long> parseYamlInteger(const String& text) {
+    long parsed = 0l;
+    if text.startsWith("0x") || text.startsWith("0X") {
+        const String digits = text.getSubstring(2ul);
+        parsed = toLong(digits.getRaw(), 16);
+    } else if text.startsWith("0o") || text.startsWith("0O") {
+        const String digits = text.getSubstring(2ul);
+        parsed = toLong(digits.getRaw(), 8);
+    } else {
+        parsed = toLong(text.getRaw(), 10);
+    }
+    return parsed;
+}
+
+f<double> parseYamlFloat(const String& text) {
+    double parsed = 0.0;
+    if isInfinityText(text) {
+        parsed = yamlInfinity();
+        if text[0l] == '-' { parsed = -parsed; }
+    } else if isNaNText(text) {
+        parsed = yamlNaN();
+    } else {
+        parsed = toDouble(text.getRaw());
+    }
+    return parsed;
+}
+
+// --- Special float values --------------------------------------------------
+
+/**
+ * Retrieve positive infinity, which YAML spells `.inf`. Spice has no literal
+ * for it, so it is provided here for building and inspecting float values.
+ *
+ * @return Positive infinity
+ */
+public f<double> yamlInfinity() {
+    return toDouble("inf");
+}
+
+/**
+ * Retrieve a quiet NaN, which YAML spells `.nan`. Spice has no literal for it,
+ * so it is provided here for building float values.
+ *
+ * @return Not a number
+ */
+public f<double> yamlNaN() {
+    return toDouble("nan");
+}
+
+/**
+ * Checks whether the given float is a NaN. The usual `value != value` trick does
+ * not work in Spice, since its float comparisons are ordered ones.
+ *
+ * @param value Float value to check
+ * @return true if the value is a NaN, false otherwise
+ */
+public f<bool> yamlIsNaN(double value) {
+    return !(value == value);
+}

--- a/test/test-files/std/text/yaml-parser/cout.out
+++ b/test/test-files/std/text/yaml-parser/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/yaml-parser/source.spice
+++ b/test/test-files/std/text/yaml-parser/source.spice
@@ -1,0 +1,440 @@
+import "std/text/yaml/yaml-value";
+import "std/text/yaml/yaml-parser";
+
+f<int> main() {
+    // Block mapping with nested mappings and sequences
+    String doc = String("name: spice\n");
+    doc += "version: 1.2\n";
+    doc += "tags:\n";
+    doc += "  - fast\n";
+    doc += "  - safe\n";
+    doc += "meta:\n";
+    doc += "  author: chillibits\n";
+    doc += "  stars: 42\n";
+    Result<YamlValue*> docRes = parseYaml(doc);
+    assert docRes.isOk();
+    YamlValue* docRoot = docRes.unwrap();
+    assert docRoot.isMapping();
+    assert docRoot.getMappingSize() == 4l;
+    YamlValue* name = docRoot.getField("name");
+    assert name.isString();
+    assert name.getString() == String("spice");
+    YamlValue* version = docRoot.getField("version");
+    assert version.isFloat();
+    YamlValue* tags = docRoot.getField("tags");
+    assert tags.isSequence();
+    assert tags.getSequenceSize() == 2l;
+    YamlValue* firstTag = tags.getSequenceItem(0l);
+    assert firstTag.getString() == String("fast");
+    YamlValue* meta = docRoot.getField("meta");
+    assert meta.isMapping();
+    YamlValue* stars = meta.getField("stars");
+    assert stars.getInteger() == 42l;
+    assert !docRoot.hasField("missing");
+    YamlValue* missing = docRoot.getFieldOrNil("missing");
+    assert missing == nil<YamlValue*>;
+
+    // A block sequence may line up with the key it belongs to, and its entries may
+    // start a mapping right behind the dash
+    String compactDoc = String("items:\n");
+    compactDoc += "- id: 1\n";
+    compactDoc += "  label: one\n";
+    compactDoc += "- id: 2\n";
+    compactDoc += "  label: two\n";
+    Result<YamlValue*> compactRes = parseYaml(compactDoc);
+    assert compactRes.isOk();
+    YamlValue* compactRoot = compactRes.unwrap();
+    YamlValue* items = compactRoot.getField("items");
+    assert items.isSequence();
+    assert items.getSequenceSize() == 2l;
+    YamlValue* secondItem = items.getSequenceItem(1l);
+    assert secondItem.isMapping();
+    YamlValue* secondLabel = secondItem.getField("label");
+    assert secondLabel.getString() == String("two");
+
+    // Nested sequences
+    Result<YamlValue*> nestedSeqRes = parseYaml(String("a:\n  - - 1\n    - 2\n  - x\n"));
+    assert nestedSeqRes.isOk();
+    YamlValue* nestedSeqRoot = nestedSeqRes.unwrap();
+    YamlValue* nestedSeq = nestedSeqRoot.getField("a");
+    assert nestedSeq.getSequenceSize() == 2l;
+    YamlValue* innerSeq = nestedSeq.getSequenceItem(0l);
+    assert innerSeq.isSequence();
+    assert innerSeq.getSequenceSize() == 2l;
+
+    // Deeply nested mappings
+    Result<YamlValue*> deepRes = parseYaml(String("a:\n  b:\n    c:\n      d: deep\n"));
+    assert deepRes.isOk();
+    YamlValue* deepRoot = deepRes.unwrap();
+    YamlValue* deepA = deepRoot.getField("a");
+    YamlValue* deepB = deepA.getField("b");
+    YamlValue* deepC = deepB.getField("c");
+    YamlValue* deepD = deepC.getField("d");
+    assert deepD.getString() == String("deep");
+
+    // Flow collections, including the JSON-like spelling and empty ones
+    Result<YamlValue*> flowRes = parseYaml(String("a: [1, 2, 3]\nb: {x: 1, y: two}\nc: []\nd: {}\n"));
+    assert flowRes.isOk();
+    YamlValue* flowRoot = flowRes.unwrap();
+    YamlValue* flowSeq = flowRoot.getField("a");
+    assert flowSeq.getSequenceSize() == 3l;
+    YamlValue* flowSeqItem = flowSeq.getSequenceItem(2l);
+    assert flowSeqItem.getInteger() == 3l;
+    YamlValue* flowMap = flowRoot.getField("b");
+    assert flowMap.isMapping();
+    YamlValue* flowMapY = flowMap.getField("y");
+    assert flowMapY.getString() == String("two");
+    YamlValue* emptySeq = flowRoot.getField("c");
+    assert emptySeq.isSequence();
+    assert emptySeq.getSequenceSize() == 0l;
+    YamlValue* emptyMap = flowRoot.getField("d");
+    assert emptyMap.isMapping();
+    assert emptyMap.getMappingSize() == 0l;
+
+    Result<YamlValue*> jsonRes = parseYaml(String("{\"a\": 1, \"b\": [2, 3]}\n"));
+    assert jsonRes.isOk();
+    YamlValue* jsonRoot = jsonRes.unwrap();
+    assert jsonRoot.getMappingSize() == 2l;
+    YamlValue* jsonB = jsonRoot.getField("b");
+    assert jsonB.getSequenceSize() == 2l;
+
+    // A flow collection may span several lines
+    Result<YamlValue*> multiLineFlowRes = parseYaml(String("a: [\n  1,\n  2,\n]\n"));
+    assert multiLineFlowRes.isOk();
+    YamlValue* multiLineFlowRoot = multiLineFlowRes.unwrap();
+    YamlValue* multiLineFlow = multiLineFlowRoot.getField("a");
+    assert multiLineFlow.getSequenceSize() == 2l;
+
+    // An entry of a flow mapping may come without a value
+    Result<YamlValue*> flowNullRes = parseYaml(String("a: {x}\n"));
+    assert flowNullRes.isOk();
+    YamlValue* flowNullRoot = flowNullRes.unwrap();
+    YamlValue* flowNullMap = flowNullRoot.getField("a");
+    YamlValue* flowNullEntry = flowNullMap.getField("x");
+    assert flowNullEntry.isNull();
+
+    // Scalars resolve according to the core schema
+    String scalarDoc = String("n1: null\nn2: ~\nn3:\nb1: true\nb2: False\n");
+    scalarDoc += "i1: 42\ni2: -7\ni3: 0x1F\ni4: 0o17\n";
+    scalarDoc += "f1: 3.5\nf2: -1.0e3\nf3: .inf\nf4: -.inf\nf5: .nan\n";
+    scalarDoc += "s1: 'it''s'\ns2: \"a\\tb\"\ns3: plain text\ns4: 1.2.3\n";
+    Result<YamlValue*> scalarRes = parseYaml(scalarDoc);
+    assert scalarRes.isOk();
+    YamlValue* scalarRoot = scalarRes.unwrap();
+    YamlValue* nullWord = scalarRoot.getField("n1");
+    assert nullWord.isNull();
+    YamlValue* nullTilde = scalarRoot.getField("n2");
+    assert nullTilde.isNull();
+    YamlValue* nullEmpty = scalarRoot.getField("n3");
+    assert nullEmpty.isNull();
+    YamlValue* boolTrue = scalarRoot.getField("b1");
+    assert boolTrue.isBool();
+    assert boolTrue.getBool();
+    YamlValue* boolFalse = scalarRoot.getField("b2");
+    assert !boolFalse.getBool();
+    YamlValue* intDec = scalarRoot.getField("i1");
+    assert intDec.isInteger();
+    assert intDec.getInteger() == 42l;
+    YamlValue* intNeg = scalarRoot.getField("i2");
+    assert intNeg.getInteger() == -7l;
+    YamlValue* intHex = scalarRoot.getField("i3");
+    assert intHex.getInteger() == 31l;
+    YamlValue* intOct = scalarRoot.getField("i4");
+    assert intOct.getInteger() == 15l;
+    YamlValue* floatPlain = scalarRoot.getField("f1");
+    assert floatPlain.isFloat();
+    assert floatPlain.getFloat() == 3.5;
+    YamlValue* floatExp = scalarRoot.getField("f2");
+    assert floatExp.getFloat() == -1000.0;
+    YamlValue* floatInf = scalarRoot.getField("f3");
+    assert floatInf.getFloat() == yamlInfinity();
+    YamlValue* floatNegInf = scalarRoot.getField("f4");
+    assert floatNegInf.getFloat() == -yamlInfinity();
+    YamlValue* floatNaN = scalarRoot.getField("f5");
+    assert yamlIsNaN(floatNaN.getFloat());
+    YamlValue* singleQuoted = scalarRoot.getField("s1");
+    assert singleQuoted.getString() == String("it's");
+    YamlValue* doubleQuoted = scalarRoot.getField("s2");
+    assert doubleQuoted.getString() == String("a\tb");
+    YamlValue* plainText = scalarRoot.getField("s3");
+    assert plainText.getString() == String("plain text");
+    // Something that only looks like a number stays a string
+    YamlValue* notANumber = scalarRoot.getField("s4");
+    assert notANumber.isString();
+
+    // Unicode escapes are encoded as UTF-8, raw multi-byte UTF-8 passes through unchanged
+    Result<YamlValue*> unicodeRes = parseYaml(String("a: \"\\u00E9\\U0001F600\"\nb: \303\251\n"));
+    assert unicodeRes.isOk();
+    YamlValue* unicodeRoot = unicodeRes.unwrap();
+    YamlValue* escaped = unicodeRoot.getField("a");
+    assert escaped.getString() == String("\303\251\360\237\230\200");
+    YamlValue* raw = unicodeRoot.getField("b");
+    assert raw.getString() == String("\303\251");
+
+    // Literal block scalars, with all three chomping modes
+    Result<YamlValue*> literalRes = parseYaml(String("text: |\n  line one\n  line two\nnext: 1\n"));
+    assert literalRes.isOk();
+    YamlValue* literalRoot = literalRes.unwrap();
+    YamlValue* literal = literalRoot.getField("text");
+    assert literal.getString() == String("line one\nline two\n");
+    // The entry behind the block scalar is picked up again
+    YamlValue* afterLiteral = literalRoot.getField("next");
+    assert afterLiteral.getInteger() == 1l;
+
+    Result<YamlValue*> stripRes = parseYaml(String("a: |-\n  x\n  y\n"));
+    assert stripRes.isOk();
+    YamlValue* stripRoot = stripRes.unwrap();
+    YamlValue* stripped = stripRoot.getField("a");
+    assert stripped.getString() == String("x\ny");
+
+    Result<YamlValue*> keepRes = parseYaml(String("a: |+\n  x\n\n"));
+    assert keepRes.isOk();
+    YamlValue* keepRoot = keepRes.unwrap();
+    YamlValue* kept = keepRoot.getField("a");
+    assert kept.getString() == String("x\n\n");
+
+    // An empty line inside a literal block turns into a line break of its own
+    Result<YamlValue*> literalBlankRes = parseYaml(String("a: |\n  x\n\n  y\n"));
+    assert literalBlankRes.isOk();
+    YamlValue* literalBlankRoot = literalBlankRes.unwrap();
+    YamlValue* literalBlank = literalBlankRoot.getField("a");
+    assert literalBlank.getString() == String("x\n\ny\n");
+
+    // Folded block scalars fold single line breaks into spaces
+    Result<YamlValue*> foldedRes = parseYaml(String("a: >\n  fold me\n  please\n\n  new para\n"));
+    assert foldedRes.isOk();
+    YamlValue* foldedRoot = foldedRes.unwrap();
+    YamlValue* folded = foldedRoot.getField("a");
+    assert folded.getString() == String("fold me please\nnew para\n");
+
+    // A more indented line inside a folded block keeps its line breaks
+    Result<YamlValue*> foldedIndentRes = parseYaml(String("a: >\n  normal\n    indented\n  normal2\n"));
+    assert foldedIndentRes.isOk();
+    YamlValue* foldedIndentRoot = foldedIndentRes.unwrap();
+    YamlValue* foldedIndent = foldedIndentRoot.getField("a");
+    assert foldedIndent.getString() == String("normal\n  indented\nnormal2\n");
+
+    // An explicit indentation indicator keeps the leading spaces of the content
+    Result<YamlValue*> explicitIndentRes = parseYaml(String("a: |2\n    two spaces kept\n"));
+    assert explicitIndentRes.isOk();
+    YamlValue* explicitIndentRoot = explicitIndentRes.unwrap();
+    YamlValue* explicitIndent = explicitIndentRoot.getField("a");
+    assert explicitIndent.getString() == String("  two spaces kept\n");
+
+    // A tab inside block scalar content is preserved
+    Result<YamlValue*> blockTabRes = parseYaml(String("a: |\n  x\ty\n"));
+    assert blockTabRes.isOk();
+    YamlValue* blockTabRoot = blockTabRes.unwrap();
+    YamlValue* blockTab = blockTabRoot.getField("a");
+    assert blockTab.getString() == String("x\ty\n");
+
+    // A plain scalar folds over the following, deeper indented lines
+    Result<YamlValue*> plainFoldRes = parseYaml(String("a: one\n  two\n  three\nb: 2\n"));
+    assert plainFoldRes.isOk();
+    YamlValue* plainFoldRoot = plainFoldRes.unwrap();
+    YamlValue* plainFold = plainFoldRoot.getField("a");
+    assert plainFold.getString() == String("one two three");
+    YamlValue* afterPlainFold = plainFoldRoot.getField("b");
+    assert afterPlainFold.getInteger() == 2l;
+
+    // An alias yields a deep copy of the node its anchor marks
+    String anchorDoc = String("base: &base\n  a: 1\n  b: 2\ncopy: *base\n");
+    Result<YamlValue*> anchorRes = parseYaml(anchorDoc);
+    assert anchorRes.isOk();
+    YamlValue* anchorRoot = anchorRes.unwrap();
+    YamlValue* anchorCopy = anchorRoot.getField("copy");
+    assert anchorCopy.isMapping();
+    YamlValue* anchorCopyB = anchorCopy.getField("b");
+    assert anchorCopyB.getInteger() == 2l;
+
+    Result<YamlValue*> scalarAnchorRes = parseYaml(String("x: &v hello\ny: *v\n"));
+    assert scalarAnchorRes.isOk();
+    YamlValue* scalarAnchorRoot = scalarAnchorRes.unwrap();
+    YamlValue* scalarAlias = scalarAnchorRoot.getField("y");
+    assert scalarAlias.getString() == String("hello");
+
+    Result<YamlValue*> seqAnchorRes = parseYaml(String("s:\n  - &i 5\n  - *i\n"));
+    assert seqAnchorRes.isOk();
+    YamlValue* seqAnchorRoot = seqAnchorRes.unwrap();
+    YamlValue* anchoredSeq = seqAnchorRoot.getField("s");
+    YamlValue* seqAlias = anchoredSeq.getSequenceItem(1l);
+    assert seqAlias.getInteger() == 5l;
+
+    // Comments and blank lines are not part of the data
+    String commentDoc = String("# leading comment\n\na: 1  # trailing\n\n# another\nb: 2\n");
+    Result<YamlValue*> commentRes = parseYaml(commentDoc);
+    assert commentRes.isOk();
+    YamlValue* commentRoot = commentRes.unwrap();
+    assert commentRoot.getMappingSize() == 2l;
+    YamlValue* commented = commentRoot.getField("a");
+    assert commented.getInteger() == 1l;
+    // A '#' that is not preceded by whitespace belongs to the scalar
+    Result<YamlValue*> hashRes = parseYaml(String("a: b#c\n"));
+    assert hashRes.isOk();
+    YamlValue* hashRoot = hashRes.unwrap();
+    YamlValue* hashValue = hashRoot.getField("a");
+    assert hashValue.getString() == String("b#c");
+    // The same goes for a ':' that is not followed by whitespace
+    Result<YamlValue*> urlRes = parseYaml(String("url: http://spicelang.com/docs\n"));
+    assert urlRes.isOk();
+    YamlValue* urlRoot = urlRes.unwrap();
+    YamlValue* url = urlRoot.getField("url");
+    assert url.getString() == String("http://spicelang.com/docs");
+
+    // Quoted keys, a byte order mark, directives, CRLF line endings and a missing
+    // trailing line break are all handled
+    Result<YamlValue*> quotedKeyRes = parseYaml(String("\"a b\": 1\n'c d': 2\n"));
+    assert quotedKeyRes.isOk();
+    YamlValue* quotedKeyRoot = quotedKeyRes.unwrap();
+    assert quotedKeyRoot.hasField("a b");
+    assert quotedKeyRoot.hasField("c d");
+
+    Result<YamlValue*> bomRes = parseYaml(String("\357\273\277a: 1\n"));
+    assert bomRes.isOk();
+    YamlValue* bomRoot = bomRes.unwrap();
+    assert bomRoot.hasField("a");
+
+    Result<YamlValue*> directiveRes = parseYaml(String("%YAML 1.2\n---\na: 1\n"));
+    assert directiveRes.isOk();
+    YamlValue* directiveRoot = directiveRes.unwrap();
+    assert directiveRoot.hasField("a");
+
+    Result<YamlValue*> crlfRes = parseYaml(String("a: 1\r\nb: 2\r\n"));
+    assert crlfRes.isOk();
+    YamlValue* crlfRoot = crlfRes.unwrap();
+    assert crlfRoot.getMappingSize() == 2l;
+
+    Result<YamlValue*> noBreakRes = parseYaml(String("a: 1"));
+    assert noBreakRes.isOk();
+    YamlValue* noBreakRoot = noBreakRes.unwrap();
+    YamlValue* noBreakValue = noBreakRoot.getField("a");
+    assert noBreakValue.getInteger() == 1l;
+
+    // A tab may separate tokens, it just cannot indent a line
+    Result<YamlValue*> tabSeparatorRes = parseYaml(String("a:\tvalue\n"));
+    assert tabSeparatorRes.isOk();
+    YamlValue* tabSeparatorRoot = tabSeparatorRes.unwrap();
+    YamlValue* tabSeparated = tabSeparatorRoot.getField("a");
+    assert tabSeparated.getString() == String("value");
+
+    // Document markers, a root level sequence, a root level scalar and an empty input
+    Result<YamlValue*> markerRes = parseYaml(String("---\na: 1\n...\n"));
+    assert markerRes.isOk();
+    YamlValue* markerRoot = markerRes.unwrap();
+    YamlValue* markerValue = markerRoot.getField("a");
+    assert markerValue.getInteger() == 1l;
+
+    Result<YamlValue*> rootSeqRes = parseYaml(String("- a\n- b\n"));
+    assert rootSeqRes.isOk();
+    YamlValue* rootSeq = rootSeqRes.unwrap();
+    assert rootSeq.isSequence();
+    assert rootSeq.getSequenceSize() == 2l;
+
+    Result<YamlValue*> rootScalarRes = parseYaml(String("just a scalar\n"));
+    assert rootScalarRes.isOk();
+    YamlValue* rootScalar = rootScalarRes.unwrap();
+    assert rootScalar.getString() == String("just a scalar");
+
+    Result<YamlValue*> emptyRes = parseYaml(String(""));
+    assert emptyRes.isOk();
+    YamlValue* emptyRoot = emptyRes.unwrap();
+    assert emptyRoot.isNull();
+
+    Result<YamlValue*> commentOnlyRes = parseYaml(String("# nothing but a comment\n"));
+    assert commentOnlyRes.isOk();
+    YamlValue* commentOnlyRoot = commentOnlyRes.unwrap();
+    assert commentOnlyRoot.isNull();
+
+    // Multi-document streams
+    Result<YamlValue*> streamRes = parseYamlDocuments(String("---\na: 1\n---\nb: 2\n---\n- 1\n- 2\n"));
+    assert streamRes.isOk();
+    YamlValue* stream = streamRes.unwrap();
+    assert stream.isSequence();
+    assert stream.getSequenceSize() == 3l;
+    YamlValue* secondDoc = stream.getSequenceItem(1l);
+    YamlValue* secondDocValue = secondDoc.getField("b");
+    assert secondDocValue.getInteger() == 2l;
+    YamlValue* thirdDoc = stream.getSequenceItem(2l);
+    assert thirdDoc.isSequence();
+    assert thirdDoc.getSequenceSize() == 2l;
+
+    // The first document of a stream does not need a marker
+    Result<YamlValue*> impliedStreamRes = parseYamlDocuments(String("a: 1\n---\nb: 2\n"));
+    assert impliedStreamRes.isOk();
+    YamlValue* impliedStream = impliedStreamRes.unwrap();
+    assert impliedStream.getSequenceSize() == 2l;
+
+    // An empty stream yields an empty sequence
+    Result<YamlValue*> emptyStreamRes = parseYamlDocuments(String(""));
+    assert emptyStreamRes.isOk();
+    YamlValue* emptyStream = emptyStreamRes.unwrap();
+    assert emptyStream.isSequence();
+    assert emptyStream.getSequenceSize() == 0l;
+
+    // Malformed inputs are rejected
+    Result<YamlValue*> duplicateKeyRes = parseYaml(String("a: 1\na: 2\n"));
+    assert !duplicateKeyRes.isOk();
+    Result<YamlValue*> unterminatedFlowRes = parseYaml(String("a: [1, 2\n"));
+    assert !unterminatedFlowRes.isOk();
+    Result<YamlValue*> unterminatedQuoteRes = parseYaml(String("a: 'unterminated\n"));
+    assert !unterminatedQuoteRes.isOk();
+    Result<YamlValue*> unknownAliasRes = parseYaml(String("a: *nope\n"));
+    assert !unknownAliasRes.isOk();
+    Result<YamlValue*> badEscapeRes = parseYaml(String("a: \"bad \\q\"\n"));
+    assert !badEscapeRes.isOk();
+    Result<YamlValue*> tabIndentRes = parseYaml(String("a:\n\tb: 1\n"));
+    assert !tabIndentRes.isOk();
+    Result<YamlValue*> badDedentRes = parseYaml(String("a:\n    b: 1\n  c: 2\n"));
+    assert !badDedentRes.isOk();
+    Result<YamlValue*> seqInMappingRes = parseYaml(String("a: 1\n- 2\n"));
+    assert !seqInMappingRes.isOk();
+    // A single document parser rejects a whole stream
+    Result<YamlValue*> streamRejectedRes = parseYaml(String("a: 1\n---\nb: 2\n"));
+    assert !streamRejectedRes.isOk();
+    // A document of a stream that is missing its marker is rejected as well
+    Result<YamlValue*> badStreamRes = parseYamlDocuments(String("a:\n    b: 1\n  c: 2\n"));
+    assert !badStreamRes.isOk();
+
+    // Every parsed tree is owned by the caller, so release them all again
+    deleteYamlValue(docRoot);
+    deleteYamlValue(compactRoot);
+    deleteYamlValue(nestedSeqRoot);
+    deleteYamlValue(deepRoot);
+    deleteYamlValue(flowRoot);
+    deleteYamlValue(jsonRoot);
+    deleteYamlValue(multiLineFlowRoot);
+    deleteYamlValue(flowNullRoot);
+    deleteYamlValue(scalarRoot);
+    deleteYamlValue(unicodeRoot);
+    deleteYamlValue(literalRoot);
+    deleteYamlValue(stripRoot);
+    deleteYamlValue(keepRoot);
+    deleteYamlValue(literalBlankRoot);
+    deleteYamlValue(foldedRoot);
+    deleteYamlValue(foldedIndentRoot);
+    deleteYamlValue(explicitIndentRoot);
+    deleteYamlValue(blockTabRoot);
+    deleteYamlValue(plainFoldRoot);
+    deleteYamlValue(anchorRoot);
+    deleteYamlValue(scalarAnchorRoot);
+    deleteYamlValue(seqAnchorRoot);
+    deleteYamlValue(commentRoot);
+    deleteYamlValue(hashRoot);
+    deleteYamlValue(urlRoot);
+    deleteYamlValue(quotedKeyRoot);
+    deleteYamlValue(bomRoot);
+    deleteYamlValue(directiveRoot);
+    deleteYamlValue(crlfRoot);
+    deleteYamlValue(noBreakRoot);
+    deleteYamlValue(tabSeparatorRoot);
+    deleteYamlValue(markerRoot);
+    deleteYamlValue(rootSeq);
+    deleteYamlValue(rootScalar);
+    deleteYamlValue(emptyRoot);
+    deleteYamlValue(commentOnlyRoot);
+    deleteYamlValue(stream);
+    deleteYamlValue(impliedStream);
+    deleteYamlValue(emptyStream);
+
+    printf("All assertions passed!");
+}

--- a/test/test-files/std/text/yaml-serializer/cout.out
+++ b/test/test-files/std/text/yaml-serializer/cout.out
@@ -1,0 +1,1 @@
+All assertions passed!

--- a/test/test-files/std/text/yaml-serializer/source.spice
+++ b/test/test-files/std/text/yaml-serializer/source.spice
@@ -1,0 +1,240 @@
+import "std/text/yaml/yaml-value";
+import "std/text/yaml/yaml-parser";
+import "std/text/yaml/yaml-serializer";
+
+// Compare two node trees structurally, so that a document can be checked against the
+// one it turns into after a serialize and parse round trip
+f<bool> sameTree(YamlValue* lhs, YamlValue* rhs) {
+    if lhs.getKind() != rhs.getKind() { return false; }
+    if lhs.isString() { return lhs.getString() == rhs.getString(); }
+    if lhs.isInteger() { return lhs.getInteger() == rhs.getInteger(); }
+    if lhs.isBool() { return lhs.getBool() == rhs.getBool(); }
+    if lhs.isFloat() {
+        if yamlIsNaN(lhs.getFloat()) { return yamlIsNaN(rhs.getFloat()); }
+        return lhs.getFloat() == rhs.getFloat();
+    }
+    if lhs.isSequence() {
+        if lhs.getSequenceSize() != rhs.getSequenceSize() { return false; }
+        for unsigned long i = 0l; i < lhs.getSequenceSize(); i++ {
+            YamlValue* lhsItem = lhs.getSequenceItem(i);
+            YamlValue* rhsItem = rhs.getSequenceItem(i);
+            if !sameTree(lhsItem, rhsItem) { return false; }
+        }
+        return true;
+    }
+    if lhs.isMapping() {
+        if lhs.getMappingSize() != rhs.getMappingSize() { return false; }
+        for unsigned long i = 0l; i < lhs.getMappingSize(); i++ {
+            if !(lhs.getMappingKey(i) == rhs.getMappingKey(i)) { return false; }
+            YamlValue* lhsValue = lhs.getMappingValue(i);
+            YamlValue* rhsValue = rhs.getMappingValue(i);
+            if !sameTree(lhsValue, rhsValue) { return false; }
+        }
+        return true;
+    }
+    return true; // two null nodes
+}
+
+// Parse a document, write it out again and check that reading the output back yields
+// the very same tree
+f<bool> roundTrips(const String& source, bool flowStyle) {
+    Result<YamlValue*> parsed = parseYaml(source);
+    if !parsed.isOk() { return false; }
+    YamlValue* tree = parsed.unwrap();
+    YamlSerializer serializer = YamlSerializer(2l, flowStyle);
+    const String text = serializer.serialize(tree);
+    Result<YamlValue*> reparsed = parseYaml(text);
+    bool equal = false;
+    if reparsed.isOk() {
+        YamlValue* reparsedTree = reparsed.unwrap();
+        equal = sameTree(tree, reparsedTree);
+        deleteYamlValue(reparsedTree);
+    }
+    deleteYamlValue(tree);
+    return equal;
+}
+
+f<int> main() {
+    YamlSerializer serializer = YamlSerializer();
+
+    // A flat mapping, one entry per line
+    YamlValue* flat = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    flat.addMappingField(String("name"), __new<YamlValue>(String("spice")));
+    flat.addMappingField(String("count"), __new<YamlValue>(3l));
+    flat.addMappingField(String("ratio"), __new<YamlValue>(1.5));
+    flat.addMappingField(String("ok"), __new<YamlValue>(true));
+    flat.addMappingField(String("nothing"), __new<YamlValue>(YamlValueKind::YAML_NULL));
+    const String flatText = serializer.serialize(flat);
+    assert flatText == String("name: spice\ncount: 3\nratio: 1.5\nok: true\nnothing: null\n");
+
+    // Nested collections get a block of their own
+    YamlValue* nested = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    YamlValue* nestedTags = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    nestedTags.addSequenceItem(__new<YamlValue>(String("a")));
+    nestedTags.addSequenceItem(__new<YamlValue>(String("b")));
+    nested.addMappingField(String("tags"), nestedTags);
+    YamlValue* nestedMeta = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    nestedMeta.addMappingField(String("x"), __new<YamlValue>(1l));
+    nested.addMappingField(String("meta"), nestedMeta);
+    const String nestedText = serializer.serialize(nested);
+    assert nestedText == String("tags:\n  - a\n  - b\nmeta:\n  x: 1\n");
+
+    // A mapping inside a sequence starts right behind the dash
+    YamlValue* compact = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    YamlValue* compactFirst = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    compactFirst.addMappingField(String("id"), __new<YamlValue>(1l));
+    compactFirst.addMappingField(String("label"), __new<YamlValue>(String("one")));
+    compact.addSequenceItem(compactFirst);
+    YamlValue* compactSecond = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    compactSecond.addMappingField(String("id"), __new<YamlValue>(2l));
+    compact.addSequenceItem(compactSecond);
+    const String compactText = serializer.serialize(compact);
+    assert compactText == String("- id: 1\n  label: one\n- id: 2\n");
+
+    // A sequence inside a sequence does the same
+    YamlValue* nestedSeq = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    YamlValue* innerSeq = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    innerSeq.addSequenceItem(__new<YamlValue>(1l));
+    innerSeq.addSequenceItem(__new<YamlValue>(2l));
+    nestedSeq.addSequenceItem(innerSeq);
+    nestedSeq.addSequenceItem(__new<YamlValue>(String("x")));
+    const String nestedSeqText = serializer.serialize(nestedSeq);
+    assert nestedSeqText == String("- - 1\n  - 2\n- x\n");
+
+    // Empty collections have no block form, so they stay inline. Strings that would be
+    // read back as another kind, or that carry an indicator, are quoted.
+    YamlValue* quoting = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    quoting.addMappingField(String("emptySeq"), __new<YamlValue>(YamlValueKind::YAML_SEQUENCE));
+    quoting.addMappingField(String("emptyMap"), __new<YamlValue>(YamlValueKind::YAML_MAPPING));
+    quoting.addMappingField(String("numberish"), __new<YamlValue>(String("42")));
+    quoting.addMappingField(String("boolish"), __new<YamlValue>(String("true")));
+    quoting.addMappingField(String("nullish"), __new<YamlValue>(String("null")));
+    quoting.addMappingField(String("empty"), __new<YamlValue>(String("")));
+    quoting.addMappingField(String("colon"), __new<YamlValue>(String("a: b")));
+    quoting.addMappingField(String("hash"), __new<YamlValue>(String("a # b")));
+    quoting.addMappingField(String("dash"), __new<YamlValue>(String("- x")));
+    quoting.addMappingField(String("newline"), __new<YamlValue>(String("a\nb")));
+    quoting.addMappingField(String("padded"), __new<YamlValue>(String(" pad ")));
+    quoting.addMappingField(String("safe"), __new<YamlValue>(String("a-b_c.d")));
+    const String quotingText = serializer.serialize(quoting);
+    String expectedQuoting = String("emptySeq: []\nemptyMap: {}\nnumberish: \"42\"\nboolish: \"true\"\n");
+    expectedQuoting += "nullish: \"null\"\nempty: \"\"\ncolon: \"a: b\"\nhash: \"a # b\"\ndash: \"- x\"\n";
+    expectedQuoting += "newline: \"a\\nb\"\npadded: \" pad \"\nsafe: a-b_c.d\n";
+    assert quotingText == expectedQuoting;
+
+    // A key is quoted by the very same rules
+    YamlValue* keys = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    keys.addMappingField(String("plain"), __new<YamlValue>(1l));
+    keys.addMappingField(String("with space"), __new<YamlValue>(2l));
+    keys.addMappingField(String("42"), __new<YamlValue>(3l));
+    keys.addMappingField(String("a: b"), __new<YamlValue>(4l));
+    const String keysText = serializer.serialize(keys);
+    assert keysText == String("plain: 1\nwith space: 2\n\"42\": 3\n\"a: b\": 4\n");
+
+    // Floats always stay recognizable as floats
+    YamlValue* floats = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    floats.addMappingField(String("inf"), __new<YamlValue>(yamlInfinity()));
+    const double negativeInfinity = -yamlInfinity();
+    floats.addMappingField(String("ninf"), __new<YamlValue>(negativeInfinity));
+    floats.addMappingField(String("nan"), __new<YamlValue>(yamlNaN()));
+    floats.addMappingField(String("whole"), __new<YamlValue>(2.0));
+    const String floatsText = serializer.serialize(floats);
+    assert floatsText == String("inf: .inf\nninf: -.inf\nnan: .nan\nwhole: 2.0\n");
+
+    // Flow style puts the whole document on a single line
+    YamlSerializer flowSerializer = YamlSerializer(2l, true);
+    YamlValue* flow = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    YamlValue* flowSeq = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    flowSeq.addSequenceItem(__new<YamlValue>(1l));
+    flowSeq.addSequenceItem(__new<YamlValue>(2l));
+    flow.addMappingField(String("a"), flowSeq);
+    flow.addMappingField(String("b"), __new<YamlValue>(String("x")));
+    const String flowText = flowSerializer.serialize(flow);
+    assert flowText == String("{a: [1, 2], b: x}\n");
+
+    // The indentation width is configurable
+    YamlSerializer wideSerializer = YamlSerializer(4l);
+    YamlValue* wide = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    YamlValue* wideInner = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    wideInner.addMappingField(String("deep"), __new<YamlValue>(1l));
+    wide.addMappingField(String("outer"), wideInner);
+    const String wideText = wideSerializer.serialize(wide);
+    assert wideText == String("outer:\n    deep: 1\n");
+
+    // serializeValue only emits the inline form of a single node
+    const String inlineText = serializer.serializeValue(flowSeq);
+    assert inlineText == String("[1, 2]");
+
+    // A stream is written with one marker per document
+    YamlValue* documents = __new<YamlValue>(YamlValueKind::YAML_SEQUENCE);
+    YamlValue* firstDocument = __new<YamlValue>(YamlValueKind::YAML_MAPPING);
+    firstDocument.addMappingField(String("a"), __new<YamlValue>(1l));
+    documents.addSequenceItem(firstDocument);
+    documents.addSequenceItem(__new<YamlValue>(String("scalar doc")));
+    const String documentsText = serializer.serializeDocuments(documents);
+    assert documentsText == String("---\na: 1\n---\nscalar doc\n");
+
+    // Whatever the parser reads has to survive a round trip, in both styles
+    String config = String("name: spice\nversion: 1.2\ntags:\n  - fast\n  - safe\n");
+    config += "meta:\n  author: chillibits\n  stars: 42\n  nested:\n    deep: [1, 2, {k: v}]\n";
+    assert roundTrips(config, false);
+    assert roundTrips(config, true);
+
+    String listOfMaps = String("- id: 1\n  label: one\n  sub:\n    - a\n    - b\n- id: 2\n  label: two\n");
+    assert roundTrips(listOfMaps, false);
+    assert roundTrips(listOfMaps, true);
+
+    String scalars = String("n: null\nt: true\nf: false\ni: -12\nx: 0x10\nfl: 2.5\ne: 1e3\n");
+    scalars += "inf: .inf\nninf: -.inf\nnan: .nan\ns: 'quoted'\nempty: ''\n";
+    assert roundTrips(scalars, false);
+    assert roundTrips(scalars, true);
+
+    String awkwardStrings = String("weird:\n  - \"a: b\"\n  - \"# not a comment\"\n  - \"42\"\n");
+    awkwardStrings += "  - \"true\"\n  - \"- dash\"\n  - \"tab\\there\"\n  - \"line\\nbreak\"\n";
+    awkwardStrings += "  - \" padded \"\n";
+    assert roundTrips(awkwardStrings, false);
+    assert roundTrips(awkwardStrings, true);
+
+    String emptyCollections = String("emptySeq: []\nemptyMap: {}\nnestedEmpty:\n  a: []\n  b: {}\n");
+    assert roundTrips(emptyCollections, false);
+    assert roundTrips(emptyCollections, true);
+
+    String blockScalars = String("text: |\n  line one\n  line two\nfolded: >\n  a b\n  c\n");
+    assert roundTrips(blockScalars, false);
+    assert roundTrips(blockScalars, true);
+
+    String nestedSequences = String("deep:\n  - - 1\n    - 2\n  - - 3\n");
+    assert roundTrips(nestedSequences, false);
+    assert roundTrips(nestedSequences, true);
+
+    assert roundTrips(String("just a scalar\n"), false);
+    assert roundTrips(String("just a scalar\n"), true);
+    assert roundTrips(String("- 1\n- 2\n- 3\n"), false);
+    assert roundTrips(String("- 1\n- 2\n- 3\n"), true);
+
+    // A whole stream round-trips as well
+    Result<YamlValue*> streamRes = parseYamlDocuments(String("---\na: 1\n---\n- x\n- y\n---\nplain\n"));
+    assert streamRes.isOk();
+    YamlValue* stream = streamRes.unwrap();
+    const String streamText = serializer.serializeDocuments(stream);
+    Result<YamlValue*> streamReparsedRes = parseYamlDocuments(streamText);
+    assert streamReparsedRes.isOk();
+    YamlValue* streamReparsed = streamReparsedRes.unwrap();
+    assert sameTree(stream, streamReparsed);
+
+    // Every node tree is owned by the caller, so release them all again
+    deleteYamlValue(flat);
+    deleteYamlValue(nested);
+    deleteYamlValue(compact);
+    deleteYamlValue(nestedSeq);
+    deleteYamlValue(quoting);
+    deleteYamlValue(keys);
+    deleteYamlValue(floats);
+    deleteYamlValue(flow);
+    deleteYamlValue(wide);
+    deleteYamlValue(documents);
+    deleteYamlValue(stream);
+    deleteYamlValue(streamReparsed);
+
+    printf("All assertions passed!");
+}


### PR DESCRIPTION
## What changed

`std/text` covered CSV, JSON, TOML and XML — each with a parser, a serializer and a shared data model — but had nothing for YAML. This adds the same trio, laid out like the TOML package so the three files can be pulled in independently:

- **`std/text/yaml/yaml-value`** — the `YamlValue` node model with seven kinds (null, string, integer, float, bool, sequence, mapping). Ownership follows `TomlValue`: composites own their children as heap pointers and a whole tree is released with a single `deleteYamlValue` call on its root. Adds `copyYamlValue` for a deep copy and the YAML 1.2 core schema resolution (`yamlPlainScalarKind`, `resolveYamlScalar`) that both the parser and the serializer go through, so there is one source of truth for how a plain scalar maps to a node kind.
- **`std/text/yaml/yaml-parser`** — a recursive-descent parser covering block mappings and sequences with the usual indentation rules, flow collections (`[a, b]`, `{a: 1}`, including the JSON-like spelling and flow that spans lines), plain / single-quoted / double-quoted scalars, literal (`|`) and folded (`>`) block scalars with their chomping and indentation indicators, anchors (`&name`) and aliases (`*name`), comments, document markers (`---`, `...`), `%YAML` directives, a byte order mark and CRLF line endings. `parseYaml` reads a single document, `parseYamlDocuments` a multi-document stream.
- **`std/text/yaml/yaml-serializer`** — block style output with a configurable `indentWidth` and an optional `flowStyle`, the compact `- key: value` form for mappings inside sequences, `[]`/`{}` for empty collections, `.inf` / `-.inf` / `.nan` and a forced `.0` so floats stay recognizable as floats, and `serializeDocuments` as the counterpart of `parseYamlDocuments`. Any scalar that would be read back as another kind, or that carries an indicator, is double-quoted.

An alias resolves to a deep copy of its anchor, so a parsed tree never shares nodes and the single-`deleteYamlValue` contract of the other value models still holds.

`std/README.md` gains the three new modules in the `std/text` table.

## Why

YAML was the one widely used configuration format the standard library could not read or write, so programs had to shell out or hand-roll a parser for it. Matching the existing TOML package in structure and in API shape keeps the four format packages consistent for anyone who has already used one of them.

## How it was validated

The environment available for this change had LLVM 18 rather than the `llvmorg-23.1.0-rc3` the project pins, so about ten call sites in `src/` were patched locally to get a working compiler. **Those patches were reverted before committing** — the diff contains only the new std modules, the two reference tests and the README rows.

```sh
# Reference tests, through the real runner (run from cmake-build-debug/test)
./spicetest --gtest_filter='*yaml*'
#   [  PASSED  ] 2 tests. (StdTests.text_yamlParser, StdTests.text_yamlSerializer)

# Full std suite, to check for regressions
./spicetest --gtest_filter='StdTests*'
#   120 tests ran: 113 passed, 1 skipped, 6 failed
#   All 6 failures are environmental and unrelated to this change:
#     data_containerScopeCleanupLeak  -> ASan runtime libs missing for LLVM 18
#     bindings_gtk4WithBuilder, bindings_gtk4WithoutBuilder,
#     bindings_libcurlFileDownload, bindings_llvm -> system libs not installed
#     time_highResTimer -> timing sensitive

# Memory checks on both test programs
valgrind --leak-check=full <built test binary>
#   0 errors from 0 contexts, 0 bytes in use at exit, for both
#   (the parser test exercises the failure paths too, so the error cleanup is covered)
```

The serializer test asserts on the exact output for flat mappings, nested collections, quoting, keys, floats, flow style, indentation width and streams, and additionally round-trips nine documents through parse → serialize → parse in **both** block and flow style, comparing the trees structurally.

Two defects found and fixed while testing:
- A tab-indented line was silently misparsed into the wrong structure instead of being rejected; it now fails with `Tabs cannot be used to indent a line`.
- A folded block scalar emitted one line break too many across a blank line, so `a b\n\nc` folded to `a b\n\nc` instead of `a b\nc`.

Bad indentation also used to surface as the misleading `Input holds more than one document`; it now reports `Unexpected content after the document, check the indentation`.

## Known limitations and follow-ups

Deliberately out of scope, since these hardly ever appear in configuration files and each would need a data model of its own. All are listed in the parser's header comment:

- explicit tags (`!!str`)
- explicit key indicators (`? key`) and complex keys
- merge keys (`<<`)
- anchors inside flow collections
- quoted scalars spanning multiple lines
- `--- key: value` with block content on the marker line

Mapping keys are always exposed as their literal text, so `1: a` yields the key `"1"`. Plain scalars are resolved under the YAML 1.2 core schema, which means the YAML 1.1 spellings `yes`/`no`/`on`/`off` stay strings rather than becoming booleans.

Follow-up worth considering: neither this nor the existing `json-value` / `toml-value` models offer a structural `operator==`, which each round-trip test currently has to re-implement. That would be a small, separate change across all four value models.

---
_Generated by [Claude Code](https://claude.ai/code/session_017mw5kS8XWe6mpGhHxrx5mm)_