### PR TITLE
Add gcov-compatible code coverage instrumentation

### DIFF
--- a/docs/docs/cli/build.md
+++ b/docs/docs/cli/build.md
@@ -45,6 +45,7 @@ You can apply following options to the `build` subcommand:
 | `-g`         | `--debug-info`            | Generate debug info to debug the executable in GDB, etc.                                                             |
 | `-b`         | `--build-var`             | Add build variable to parametrize the compiled program (e.g. -v key=value)                                           |
 | -            | `--sanitize`              | Enable instrumentation for sanitizer. <br> Valid values: `none` (default), `address`, `thread`, `memory` and `type`. |
+| -            | `--coverage`              | Instrument code for coverage analysis (gcov-compatible `.gcno`/`.gcda` output). Implies `--debug-info` and is incompatible with `-lto`. |
 | -            | `--static`                | Produce stand-alone executable by linking statically                                                                 |
 | -            | `--no-entry`              | Do not require or generate main function (useful for web assembly target)                                            |
 | -            | `--disable-verifier`      | Disable LLVM module and function verification (only recommended for debugging the compiler)                          |

--- a/docs/docs/cli/run.md
+++ b/docs/docs/cli/run.md
@@ -41,6 +41,7 @@ You can apply following options to the `run` subcommand:
 | `-g`         | `--debug-info`            | Generate debug info to debug the executable in GDB, etc.                                                             |
 | `-b`         | `--build-var`             | Add build variable to parametrize the compiled program (e.g. -v key=value)                                           |
 | -            | `--sanitize`              | Enable instrumentation for sanitizer. <br> Valid values: `none` (default), `address`, `thread`, `memory` and `type`. |
+| -            | `--coverage`              | Instrument code for coverage analysis (gcov-compatible `.gcno`/`.gcda` output). Implies `--debug-info` and is incompatible with `-lto`. |
 | -            | `--disable-verifier`      | Disable LLVM module and function verification (only recommended for debugging the compiler)                          |
 | -            | `--ignore-cache`          | Compile always and ignore the compile cache                                                                          |
 | -            | `--use-lifetime-markers`  | Generate lifetime markers to enhance optimizations                                                                   |

--- a/docs/docs/cli/test.md
+++ b/docs/docs/cli/test.md
@@ -39,6 +39,7 @@ You can apply following options to the `test` subcommand:
 | `-g`         | `--debug-info`            | Generate debug info to debug the executable in GDB, etc.                                                             |
 | `-b`         | `--build-var`             | Add build variable to parametrize the compiled program (e.g. -v key=value)                                           |
 | -            | `--sanitize`              | Enable instrumentation for sanitizer. <br> Valid values: `none` (default), `address`, `thread`, `memory` and `type`. |
+| -            | `--coverage`              | Instrument code for coverage analysis (gcov-compatible `.gcno`/`.gcda` output). Implies `--debug-info` and is incompatible with `-lto`. |
 | -            | `--disable-verifier`      | Disable LLVM module and function verification (only recommended for debugging the compiler)                          |
 | -            | `--ignore-cache`          | Compile always and ignore the compile cache                                                                          |
 | -            | `--use-lifetime-markers`  | Generate lifetime markers to enhance optimizations                                                                   |

--- a/src/driver/Driver.cpp
+++ b/src/driver/Driver.cpp
@@ -169,6 +169,13 @@ void Driver::enrich() const {
   if (sanitizer == Sanitizer::TYPE)
     cliOptions.useTBAAMetadata = true;
 
+  // Code coverage instrumentation needs debug info to map counters back to source locations
+  if (cliOptions.instrumentation.codeCoverage) {
+    cliOptions.instrumentation.generateDebugInfo = true;
+    if (cliOptions.useLTO)
+      throw CliError(INCOMPATIBLE_OPTIONS, "Code coverage instrumentation is not supported in combination with LTO");
+  }
+
   // Infer build vars from other options
   const auto boolToString = [](bool input) { return input ? "true" : "false"; };
   cliOptions.buildVars["spice.is_debug"] = boolToString(cliOptions.buildMode == BuildMode::DEBUG);
@@ -187,6 +194,8 @@ void Driver::enrich() const {
   if (cliOptions.backend == Backend::TPDE) {
     if (cliOptions.useLTO)
       throw CliError(INCOMPATIBLE_OPTIONS, "The TPDE backend does not support LTO");
+    if (cliOptions.instrumentation.codeCoverage)
+      throw CliError(INCOMPATIBLE_OPTIONS, "The TPDE backend does not support code coverage instrumentation");
     if (!cliOptions.targetTriple.isOSLinux())
       throw CliError(FEATURE_NOT_SUPPORTED_FOR_TARGET, "The TPDE backend only supports ELF targets (Linux)");
     const llvm::Triple::ArchType arch = cliOptions.targetTriple.getArch();
@@ -493,6 +502,9 @@ void Driver::addInstrumentationOptions(CLI::App *subCmd) const {
   subCmd->add_flag<bool>("--debug-info,-g", cliOptions.instrumentation.generateDebugInfo, "Generate debug info");
   // --sanitizer
   subCmd->add_option("--sanitizer", sanitizerCallback, "Enable sanitizer: none (default), address, thread, memory, type");
+  // --coverage
+  subCmd->add_flag<bool>("--coverage", cliOptions.instrumentation.codeCoverage,
+                         "Instrument code for coverage analysis (gcov-compatible .gcno/.gcda output)");
 }
 
 /**

--- a/src/driver/Driver.h
+++ b/src/driver/Driver.h
@@ -114,6 +114,7 @@ struct CliOptions {
   bool staticLinking = false;
   struct InstrumentationSettings {
     bool generateDebugInfo = false;
+    bool codeCoverage = false;
     Sanitizer sanitizer = Sanitizer::NONE;
   } instrumentation;
   bool disableVerifier = !SPICE_DEBUG;

--- a/src/global/CacheManager.cpp
+++ b/src/global/CacheManager.cpp
@@ -27,6 +27,7 @@ std::string CacheManager::computeCacheKey(const std::string &sourceCode, const s
   components << static_cast<uint8_t>(cliOptions.optLevel);
   components << static_cast<uint8_t>(cliOptions.instrumentation.sanitizer);
   components << cliOptions.instrumentation.generateDebugInfo;
+  components << cliOptions.instrumentation.codeCoverage;
   components << cliOptions.targetTriple.str();
   components << cliOptions.useLTO;
   // The output container influences codegen (PIC/PIE levels, DSO-local attributes for symbols,

--- a/src/iroptimizer/IROptimizer.cpp
+++ b/src/iroptimizer/IROptimizer.cpp
@@ -8,6 +8,7 @@
 
 #include <llvm/Analysis/ModuleSummaryAnalysis.h>
 #include <llvm/Transforms/Instrumentation/AddressSanitizer.h>
+#include <llvm/Transforms/Instrumentation/GCOVProfiler.h>
 #include <llvm/Transforms/Instrumentation/MemorySanitizer.h>
 #include <llvm/Transforms/Instrumentation/ThreadSanitizer.h>
 #include <llvm/Transforms/Instrumentation/TypeSanitizer.h>
@@ -46,6 +47,7 @@ void IROptimizer::optimizeDefault() {
 
   // Add optional passes
   addInstrumentationPassToPipeline(modulePassMgr);
+  addCoveragePassToPipeline(modulePassMgr);
 
   // Run pipeline
   modulePassMgr.run(*sourceFile->llvmModule, moduleAnalysisMgr);
@@ -117,6 +119,12 @@ void IROptimizer::addInstrumentationPassToPipeline(llvm::ModulePassManager &modu
     break;
   }
   }
+}
+
+void IROptimizer::addCoveragePassToPipeline(llvm::ModulePassManager &modulePassMgr) const {
+  if (!cliOptions.instrumentation.codeCoverage)
+    return;
+  modulePassMgr.addPass(llvm::GCOVProfilerPass(llvm::GCOVOptions::getDefault()));
 }
 
 llvm::OptimizationLevel IROptimizer::getLLVMOptLevelFromSpiceOptLevel() const {

--- a/src/iroptimizer/IROptimizer.h
+++ b/src/iroptimizer/IROptimizer.h
@@ -35,6 +35,7 @@ private:
 
   // Private methods
   void addInstrumentationPassToPipeline(llvm::ModulePassManager& modulePassMgr) const;
+  void addCoveragePassToPipeline(llvm::ModulePassManager &modulePassMgr) const;
   [[nodiscard]] llvm::OptimizationLevel getLLVMOptLevelFromSpiceOptLevel() const;
 };
 

--- a/src/linker/ExternalLinkerInterface.cpp
+++ b/src/linker/ExternalLinkerInterface.cpp
@@ -52,6 +52,10 @@ void ExternalLinkerInterface::prepare() {
     break;
   }
 
+  // Code coverage
+  if (cliOptions.instrumentation.codeCoverage)
+    addLinkerFlag("--coverage");
+
   // Web Assembly
   if (cliOptions.targetTriple.isWasm()) {
     addLinkerFlag("-nostdlib");

--- a/std/os/offset-allocator.spice
+++ b/std/os/offset-allocator.spice
@@ -480,26 +480,23 @@ public const f<StorageReportFull> OffsetAllocator.getStorageReportFull() {
  * Count the number of leading zero bits in a nonzero 32 bit value
  */
 f<unsigned int> lzcntNonzero(unsigned int v) {
-    unsigned int n = 0u;
+    result = 0u;
     unsigned int bit = 0x80000000u;
     while (v & bit) == 0u {
-        n++;
+        result++;
         bit >>= 1u;
     }
-    return n;
 }
 
 /**
  * Count the number of trailing zero bits in a nonzero 32 bit value
  */
 f<unsigned int> tzcntNonzero(unsigned int v) {
-    unsigned int n = 0u;
-    unsigned int x = v;
-    while (x & 1u) == 0u {
-        x >>= 1u;
-        n++;
+    result = 0u;
+    while (v & 1u) == 0u {
+        v >>= 1u;
+        result++;
     }
-    return n;
 }
 
 /**

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -128,6 +128,7 @@ static void execTestCase(const TestCase &testCase) {
       /* staticLinking= */ false,
       CliOptions::InstrumentationSettings{
           /* generateDebugInfo= */ false,
+          /* codeCoverage= */ false,
           /* sanitizer= */ Sanitizer::NONE,
       },
       /* disableVerifier= */ false,
@@ -136,7 +137,7 @@ static void execTestCase(const TestCase &testCase) {
       /* buildVars= */ {},
   };
   static_assert(sizeof(CliOptions::DumpSettings) == 11, "CliOptions::DumpSettings struct size changed");
-  static_assert(sizeof(CliOptions::InstrumentationSettings) == 2, "CliOptions::InstrumentationSettings struct size changed");
+  static_assert(sizeof(CliOptions::InstrumentationSettings) == 3, "CliOptions::InstrumentationSettings struct size changed");
 #if defined(__clang__) && defined(__apple_build_version__)
   // some std types for Apple Clang are smaller than for GCC and Clang
   static_assert(sizeof(CliOptions) == 312, "CliOptions struct size changed");

--- a/test/unittest/UnitDriver.cpp
+++ b/test/unittest/UnitDriver.cpp
@@ -220,6 +220,34 @@ TEST(DriverTest, MemorySanitizerOnlyLinux) {
 #endif
 }
 
+TEST(DriverTest, CoverageImpliesDebugInfo) {
+  const char *argv[] = {"spice", "build", "--coverage", "../../media/test-project/test.spice"};
+  static constexpr int argc = std::size(argv);
+  CliOptions cliOptions;
+  Driver driver(cliOptions, true);
+  ASSERT_EQ(EXIT_SUCCESS, driver.parse(argc, argv));
+  driver.enrich();
+
+  ASSERT_TRUE(cliOptions.instrumentation.codeCoverage);
+  ASSERT_TRUE(cliOptions.instrumentation.generateDebugInfo); // implicitly due to enabled code coverage
+}
+
+TEST(DriverTest, CoverageRejectsLtoCombination) {
+  const char *argv[] = {"spice", "build", "--coverage", "-lto", "../../media/test-project/test.spice"};
+  static constexpr int argc = std::size(argv);
+  CliOptions cliOptions;
+  Driver driver(cliOptions, true);
+  ASSERT_EQ(EXIT_SUCCESS, driver.parse(argc, argv));
+
+  try {
+    driver.enrich();
+    FAIL();
+  } catch (CliError &error) {
+    const auto errorMsg = "[Error|CLI] Incompatible options: Code coverage instrumentation is not supported in combination with LTO";
+    ASSERT_STREQ(errorMsg, error.what());
+  }
+}
+
 TEST(DriverTest, IncompatibleOptions) {
   // --static in combination with --output-container=dylib is not allowed
   const char *argv[] = {"spice", "build", "--static", "--output-container=dylib", "../../media/test-project/test.spice"};
@@ -285,6 +313,26 @@ TEST(DriverTest, BackendTpdeRejectsLtoCombination) {
     FAIL();
   } catch (CliError &error) {
     const auto errorMsg = "[Error|CLI] Incompatible options: The TPDE backend does not support LTO";
+    ASSERT_STREQ(errorMsg, error.what());
+  }
+#endif
+}
+
+TEST(DriverTest, BackendTpdeRejectsCoverageCombination) {
+#ifndef SPICE_ENABLE_TPDE
+  GTEST_SKIP() << "TPDE backend is disabled in this build; combination guard is not exercised.";
+#else
+  const char *argv[] = {"spice", "build", "--backend=tpde", "--coverage", "../../media/test-project/test.spice"};
+  static constexpr int argc = std::size(argv);
+  CliOptions cliOptions;
+  Driver driver(cliOptions, true);
+  ASSERT_EQ(EXIT_SUCCESS, driver.parse(argc, argv));
+
+  try {
+    driver.enrich();
+    FAIL();
+  } catch (CliError &error) {
+    const auto errorMsg = "[Error|CLI] Incompatible options: The TPDE backend does not support code coverage instrumentation";
     ASSERT_STREQ(errorMsg, error.what());
   }
 #endif


### PR DESCRIPTION
## What changed
- New `--coverage` flag on the `build`, `run`, and `test` subcommands that instruments compiled code for coverage analysis via LLVM's `GCOVProfilerPass`, mirroring the existing `--sanitizer` instrumentation wiring (`Driver` → `IROptimizer` → `ExternalLinkerInterface` → `CacheManager`).
- `--coverage` implies `--debug-info` (GCOV needs line tables to map counters back to source) and is rejected in combination with `-lto` or the experimental TPDE backend.
- The linker now passes `--coverage` to the clang/gcc invoker so it auto-links the gcov runtime, producing `.gcno` (compile time) / `.gcda` (runtime) output consumable by `gcov`, `lcov`, or `llvm-cov gcov`.
- Docs updated (`docs/docs/cli/{build,run,test}.md`).

## Why
Spice had no way to measure which code paths a running program actually exercises. GCOV-style coverage was chosen over Clang's source-based coverage (`-fprofile-instr-generate`) because it reuses debug-info infrastructure Spice already has, needs only a single LLVM module pass plus a linker flag, and outputs to widely-supported tooling — Clang's source-based coverage would require building an equivalent of Clang's `CoverageMappingModuleGen` from scratch.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest -j` — builds clean.
- `cmake-build-debug/test/spicetest --gtest_filter='DriverTest.*:*CacheManager*:*CompileCache*'` — 37 passed, 1 skipped (pre-existing, TPDE-build-dependent).
- Manual end-to-end check: built a sample program with `spice build --coverage`, confirmed `main.gcno` emitted at compile time and `main.gcda` after running the binary, then ran `llvm-cov gcov main.gcno` and got a correct per-line coverage report (called function 100% covered, unused/dead-code-eliminated function correctly shown as uninstrumented).
- Manually confirmed `spice build --coverage -lto` fails with the expected `Incompatible options` error.

## Follow-up / known limitations
- Only GCOV-style coverage is supported; richer source-based coverage (branch/region coverage via `llvm-cov show`/`report`, à la Clang's `-fprofile-instr-generate -fcoverage-mapping`) would need its own coverage-mapping generator and is a reasonable follow-up.
- Not tested on macOS/Windows linker invokers — `--coverage` relies on clang/gcc auto-linking the gcov runtime, which should work the same way `-fsanitize=*` already does there, but wasn't verified on those platforms.