### PR TITLE
Add too-many-parameters and cyclomatic-complexity lint rules

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,6 +74,8 @@ set(SOURCES
         linter/LintFinding.cpp
         linter/LintPass.cpp
         linter/rules/NamingConventionRule.cpp
+        linter/rules/TooManyParametersRule.cpp
+        linter/rules/CyclomaticComplexityRule.cpp
         # Dependency graph visualizer
         visualizer/DependencyGraphVisualizer.cpp
         # IR generator

--- a/src/linter/LintPass.cpp
+++ b/src/linter/LintPass.cpp
@@ -3,13 +3,17 @@
 #include "LintPass.h"
 
 #include <ast/ASTNodes.h>
+#include <linter/rules/CyclomaticComplexityRule.h>
 #include <linter/rules/NamingConventionRule.h>
+#include <linter/rules/TooManyParametersRule.h>
 
 namespace spice::compiler {
 
 LintPass::LintPass(GlobalResourceManager &resourceManager, SourceFile *sourceFile) : CompilerPass(resourceManager, sourceFile) {
   // Register all built-in lint rules here. Adding a rule never requires touching the traversal below.
   rules.push_back(std::make_unique<NamingConventionRule>());
+  rules.push_back(std::make_unique<TooManyParametersRule>());
+  rules.push_back(std::make_unique<CyclomaticComplexityRule>());
 }
 
 std::vector<LintFinding> LintPass::lint(ASTNode *ast) {

--- a/src/linter/rules/CyclomaticComplexityRule.cpp
+++ b/src/linter/rules/CyclomaticComplexityRule.cpp
@@ -1,0 +1,63 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#include "CyclomaticComplexityRule.h"
+
+#include <ast/ASTNodes.h>
+
+namespace spice::compiler {
+
+// McCabe's original recommendation for the complexity ceiling of a single routine.
+static constexpr size_t MAX_CYCLOMATIC_COMPLEXITY = 10;
+
+/**
+ * Count the decision points in a subtree (each if/loop/case branch counts as 1). Walks into every
+ * descendant, including nested lambda bodies, as a deliberate simplification: a lambda dense
+ * enough to matter on its own will usually also push the enclosing function over the threshold.
+ *
+ * @param node Root of the subtree to walk
+ * @return Number of decision points found
+ */
+static size_t countDecisionPoints(const ASTNode *node) { // NOLINT(misc-no-recursion)
+  size_t count = 0;
+  if (dynamic_cast<const IfStmtNode *>(node) != nullptr || dynamic_cast<const ForLoopNode *>(node) != nullptr ||
+      dynamic_cast<const ForeachLoopNode *>(node) != nullptr || dynamic_cast<const WhileLoopNode *>(node) != nullptr ||
+      dynamic_cast<const DoWhileLoopNode *>(node) != nullptr || dynamic_cast<const CaseBranchNode *>(node) != nullptr)
+    count++;
+
+  for (const ASTNode *child : node->getChildren())
+    count += countDecisionPoints(child);
+
+  return count;
+}
+
+/**
+ * Emit a finding if the given body's cyclomatic complexity exceeds MAX_CYCLOMATIC_COMPLEXITY.
+ *
+ * @param body Function/procedure body (nullptr for declarations without a body)
+ * @param codeLoc Location to attach the finding to
+ * @param name Function/procedure name
+ * @param kindLabel "Function" or "Procedure", for the finding message
+ * @param ruleId Id of the rule producing the finding
+ * @param findings Findings vector to append to
+ */
+static void checkComplexity(const StmtLstNode *body, const CodeLoc &codeLoc, const std::string &name,
+                            std::string_view kindLabel, std::string_view ruleId, std::vector<LintFinding> &findings) {
+  if (body == nullptr)
+    return;
+  const size_t complexity = 1 + countDecisionPoints(body);
+  if (complexity > MAX_CYCLOMATIC_COMPLEXITY)
+    findings.emplace_back(codeLoc, ruleId, LintSeverity::WARNING,
+                          std::string(kindLabel) + " '" + name + "' has a cyclomatic complexity of " +
+                              std::to_string(complexity) + " (max " + std::to_string(MAX_CYCLOMATIC_COMPLEXITY) +
+                              "); consider splitting it up");
+}
+
+void CyclomaticComplexityRule::checkFctDef(FctDefNode *node, std::vector<LintFinding> &findings) {
+  checkComplexity(node->body, node->codeLoc, node->name->name, "Function", id(), findings);
+}
+
+void CyclomaticComplexityRule::checkProcDef(ProcDefNode *node, std::vector<LintFinding> &findings) {
+  checkComplexity(node->body, node->codeLoc, node->name->name, "Procedure", id(), findings);
+}
+
+} // namespace spice::compiler

--- a/src/linter/rules/CyclomaticComplexityRule.h
+++ b/src/linter/rules/CyclomaticComplexityRule.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <linter/LintRule.h>
+
+namespace spice::compiler {
+
+/**
+ * Flags functions/procedures whose body has grown too many independent branches to review or test
+ * with confidence in one piece. McCabe cyclomatic complexity: starts at 1 for the single
+ * straight-line path through the body, +1 for every `if`, loop, and `case` branch. A
+ * style/maintainability check, not a correctness one, so it lives in `spice lint` rather than as a
+ * compiler warning.
+ */
+class CyclomaticComplexityRule final : public LintRule {
+public:
+  [[nodiscard]] constexpr std::string_view id() const override { return "cyclomatic-complexity"; }
+
+  void checkFctDef(FctDefNode *node, std::vector<LintFinding> &findings) override;
+  void checkProcDef(ProcDefNode *node, std::vector<LintFinding> &findings) override;
+};
+
+} // namespace spice::compiler

--- a/src/linter/rules/TooManyParametersRule.cpp
+++ b/src/linter/rules/TooManyParametersRule.cpp
@@ -1,0 +1,39 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#include "TooManyParametersRule.h"
+
+#include <ast/ASTNodes.h>
+
+namespace spice::compiler {
+
+// A caller has to hold this many arguments in mind (and their order) at every call site.
+static constexpr size_t MAX_PARAM_COUNT = 6;
+
+/**
+ * Emit a finding if the given parameter list has more entries than MAX_PARAM_COUNT.
+ *
+ * @param paramLst Parameter list of the function/procedure (nullptr if it has none)
+ * @param codeLoc Location to attach the finding to
+ * @param name Function/procedure name
+ * @param kindLabel "Function" or "Procedure", for the finding message
+ * @param ruleId Id of the rule producing the finding
+ * @param findings Findings vector to append to
+ */
+static void checkParamCount(const ParamLstNode *paramLst, const CodeLoc &codeLoc, const std::string &name,
+                            std::string_view kindLabel, std::string_view ruleId, std::vector<LintFinding> &findings) {
+  const size_t paramCount = paramLst != nullptr ? paramLst->params.size() : 0;
+  if (paramCount > MAX_PARAM_COUNT)
+    findings.emplace_back(codeLoc, ruleId, LintSeverity::WARNING,
+                          std::string(kindLabel) + " '" + name + "' has " + std::to_string(paramCount) + " parameters (max " +
+                              std::to_string(MAX_PARAM_COUNT) + "); consider grouping related parameters into a struct");
+}
+
+void TooManyParametersRule::checkFctDef(FctDefNode *node, std::vector<LintFinding> &findings) {
+  checkParamCount(node->paramLst, node->codeLoc, node->name->name, "Function", id(), findings);
+}
+
+void TooManyParametersRule::checkProcDef(ProcDefNode *node, std::vector<LintFinding> &findings) {
+  checkParamCount(node->paramLst, node->codeLoc, node->name->name, "Procedure", id(), findings);
+}
+
+} // namespace spice::compiler

--- a/src/linter/rules/TooManyParametersRule.h
+++ b/src/linter/rules/TooManyParametersRule.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <linter/LintRule.h>
+
+namespace spice::compiler {
+
+/**
+ * Flags functions/procedures with more parameters than a caller can reasonably keep straight at a
+ * call site. A style/maintainability check (grouping related parameters into a struct is usually
+ * the fix), not a correctness one, so it lives in `spice lint` rather than as a compiler warning.
+ */
+class TooManyParametersRule final : public LintRule {
+public:
+  [[nodiscard]] constexpr std::string_view id() const override { return "too-many-parameters"; }
+
+  void checkFctDef(FctDefNode *node, std::vector<LintFinding> &findings) override;
+  void checkProcDef(ProcDefNode *node, std::vector<LintFinding> &findings) override;
+};
+
+} // namespace spice::compiler

--- a/test/test-files/linter/cyclomatic-complexity/lint.out
+++ b/test/test-files/linter/cyclomatic-complexity/lint.out
@@ -1,0 +1,1 @@
+[Lint] ./source.spice:2:1: cyclomatic-complexity: Function 'classify' has a cyclomatic complexity of 11 (max 10); consider splitting it up

--- a/test/test-files/linter/cyclomatic-complexity/source.spice
+++ b/test/test-files/linter/cyclomatic-complexity/source.spice
@@ -1,0 +1,37 @@
+// Violation: 10 else-if branches push complexity to 11 (1 base + 10), exceeds the max of 10
+f<int> classify(int x) {
+    if (x == 0) {
+        return 0;
+    } else if (x == 1) {
+        return 1;
+    } else if (x == 2) {
+        return 2;
+    } else if (x == 3) {
+        return 3;
+    } else if (x == 4) {
+        return 4;
+    } else if (x == 5) {
+        return 5;
+    } else if (x == 6) {
+        return 6;
+    } else if (x == 7) {
+        return 7;
+    } else if (x == 8) {
+        return 8;
+    } else if (x == 9) {
+        return 9;
+    }
+    return -1;
+}
+
+// Compliant: complexity 2 (1 base + 1 if), well within the limit
+f<int> simple(int x) {
+    if (x > 0) {
+        return 1;
+    }
+    return 0;
+}
+
+f<int> main() {
+    return classify(3) + simple(1);
+}

--- a/test/test-files/linter/too-many-parameters/lint.out
+++ b/test/test-files/linter/too-many-parameters/lint.out
@@ -1,0 +1,1 @@
+[Lint] ./source.spice:2:1: too-many-parameters: Function 'tooManyParams' has 7 parameters (max 6); consider grouping related parameters into a struct

--- a/test/test-files/linter/too-many-parameters/source.spice
+++ b/test/test-files/linter/too-many-parameters/source.spice
@@ -1,0 +1,13 @@
+// Violation: 7 parameters, exceeds the max of 6
+f<int> tooManyParams(int a, int b, int c, int d, int e, int g, int h) {
+    return a + b + c + d + e + g + h;
+}
+
+// Compliant: within the limit
+f<int> okParams(int a, int b, int c) {
+    return a + b + c;
+}
+
+f<int> main() {
+    return tooManyParams(1, 2, 3, 4, 5, 6, 7) + okParams(1, 2, 3);
+}


### PR DESCRIPTION
## What changed
Two new `spice lint` rules, following the same `LintRule`/`LintPass` plumbing as `NamingConventionRule` (introduced in #1337):

- **`TooManyParametersRule`**: flags functions/procedures with more than 6 parameters.
- **`CyclomaticComplexityRule`**: flags functions/procedures whose body exceeds a McCabe complexity of 10 (1 base path + 1 per `if`/loop/`case` branch). Walks the body via `ASTNode::getChildren()` rather than extending `LintPass`'s visitor - a rule that inspects inside a function body it's already been handed doesn't need a new traversal hook.

Each gets one integration test case under `test/test-files/linter/`, matching the existing `naming-convention` layout (flat `linter/<rule-name>/source.spice` + `lint.out`).

## Why
Both are well-known, unambiguous style/maintainability signals (too many parameters → group into a struct; too much branching → split the function) that don't belong as compiler warnings (opinionated, not semantic hygiene) but are cheap wins for the linter now that the plumbing exists.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest -j` - builds clean
- `cmake-build-debug/test/spicetest` (full suite, env vars set) - 637/671 passing, matching the known environmental baseline exactly (verified by diffing the failure list against the pre-existing set - no new failures)
- Manual `spice lint` smoke tests against both new rules confirming exact expected output and correct non-triggering on compliant code

## Follow-up / known limitations
- Thresholds (6 params, complexity 10) are reasonable industry defaults but not yet configurable per-project
- No rule-level enable/disable mechanism yet, same limitation noted in #1337