### PR TITLE
Add GDB pretty printers for the standard library data structures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,12 +43,14 @@ dockers_v2:
       "org.opencontainers.image.description": "Spice programming language."
     extra_files:
       - std
+      - tools/gdb
 
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     files:
       - LICENSE
       - std
+      - tools/gdb
     format_overrides:
       - goos: windows
         formats: [ "zip" ]
@@ -78,6 +80,11 @@ nfpms:
     contents:
       - src: std
         dst: /usr/lib/spice/std
+      - src: tools/gdb/spice_printers.py
+        dst: /usr/lib/spice/gdb/spice_printers.py
+      - src: tools/gdb/spice.gdb
+        dst: /etc/gdb/gdbinit.d/spice.gdb
+        type: config|noreplace
     overrides:
       apk:
         dependencies:
@@ -127,6 +134,8 @@ homebrew_casks:
       The Spice standard library is staged alongside the binary in the cask's
       staged path. If the compiler cannot locate it automatically, set:
         export SPICE_STD_DIR="$(brew --caskroom)/spice/{{ .Version }}/std"
+      The GDB pretty printers for the standard library data structures are staged next to it, at:
+        $(brew --caskroom)/spice/{{ .Version }}/tools/gdb/spice_printers.py
 
 release:
   name_template: "v{{ .Tag }}"

--- a/docs/docs/how-to/debugging-with-gdb.md
+++ b/docs/docs/how-to/debugging-with-gdb.md
@@ -1,0 +1,86 @@
+---
+title: Debugging with GDB
+---
+
+Spice compiles to native machine code via LLVM and, when built with [`-g`](../cli/build.md), emits real DWARF
+debug info. This means you can debug a Spice executable with GDB just like a C or C++ program: set breakpoints,
+step through source lines, and inspect local variables.
+
+By default, though, GDB shows a standard library container by its raw internal layout rather than its logical
+contents. For example, without any help, a `Vector<int>` holding `10, 20, 30` prints as:
+
+```text
+(gdb) print numbers
+$1 = {contents = 0x555555559eb0, capacity = 5, size = 3}
+```
+
+That's the struct's fields, not the vector's elements. It gets worse for pointer-based structures such as lists,
+trees and hash tables, where the interesting data lives behind chains of pointers GDB has no reason to follow.
+
+## Loading the pretty printers
+
+### Automatically (apk/deb/rpm/archlinux packages)
+
+The Linux packages install a drop-in at `/etc/gdb/gdbinit.d/spice.gdb` that sources the printer script for you. GDB
+picks it up automatically on distros whose GDB build reads that directory (Debian/Ubuntu do); nothing to do there.
+If `print`ing a container still shows raw fields, your GDB build doesn't read `/etc/gdb/gdbinit.d`, and you can load
+the script manually as described below.
+
+### Manually
+
+The repository ships a GDB pretty-printer script at `tools/gdb/spice_printers.py` that teaches GDB how to render
+every data structure in `std/data/`, plus the runtime `String` type, in their logical form instead. Load it in a
+running GDB session with:
+
+```text
+(gdb) source /path/to/spice/tools/gdb/spice_printers.py
+```
+
+or add that line to your `~/.gdbinit` to have it loaded for every session.
+
+Where that path points depends on how you got Spice:
+
+- **Built from a source checkout**: `<repo>/tools/gdb/spice_printers.py`.
+- **Installed via apk/deb/rpm/archlinux package**: `/usr/lib/spice/gdb/spice_printers.py`, next to
+  `/usr/lib/spice/std`.
+- **Downloaded release archive or Homebrew cask**: `tools/gdb/spice_printers.py` alongside the `std` directory in
+  the unpacked archive (or, for the cask, `$(brew --caskroom)/spice/<version>/tools/gdb/spice_printers.py`).
+
+With the script loaded, the same `Vector<int>` prints as:
+
+```text
+(gdb) print numbers
+$1 = Vector<int> of length 3 = {10, 20, 30}
+```
+
+Nested generics are handled recursively — a `Vector<Pair<int,int>>` prints its `Pair` elements through the `Pair`
+printer too, and so on.
+
+## Covered types
+
+| Type(s) | Rendered as |
+|---|---|
+| `Vector`, `Stack`, `PriorityQueue` | `{e0, e1, ...}` in storage order |
+| `Queue`, `Deque` | `{e0, e1, ...}` in logical front-to-back order |
+| `LinkedList`, `DoublyLinkedList` | `{e0, e1, ...}` in push-back order |
+| `HashTable`, `UnorderedMap` | `{key = value, ...}`, unordered |
+| `RedBlackTree`, `Map` | `{key = value, ...}`, sorted by key |
+| `Set`, `UnorderedSet` | `{v0, v1, ...}` (keys only) |
+| `BinaryTree` | `{v0, v1, ...}`, sorted (in-order traversal) |
+| `Pair`, `Triple` | `(first, second[, third])` |
+| `Optional` | `Some(value)` or `None` |
+| `BitSet` | A bit string, e.g. `BitSet of 8 bits = 01001000` |
+| `Trie` | The stored words, e.g. `{car, cart, cat}` |
+| `Graph`, `Vertex` | A directed/undirected summary plus the vertex set |
+| `String` | A quoted string |
+
+The dispatch is based on the DWARF struct name that the compiler emits for generic instantiations (e.g.
+`Vector<int>`), so the printers apply to any concrete instantiation of these generic types automatically — there is
+nothing to configure per element type.
+
+## Limitations
+
+- The printers only kick in when GDB prints a struct *value* (a local variable, a dereferenced pointer, `print
+  *ptr`). Printing a pointer to one of these structs directly still shows a bare address, as usual in GDB.
+- A `Graph`'s adjacency list is not expanded inline; inspect `graph.adjList` directly to see it (it gets the
+  `UnorderedMap` printer too).

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -44,6 +44,7 @@ nav = [
     "how-to/web-assembly.md",
     "how-to/cpp-interop.md",
     "how-to/http-server-client.md",
+    "how-to/debugging-with-gdb.md",
   ] },
   { Documentation = [
     "language/hello-world.md",

--- a/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.gdb
+++ b/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.gdb
@@ -1,0 +1,43 @@
+# Do not print non-reproducible information
+set print address off
+set print thread-events off
+set print inferior-events off
+
+# Load the Spice pretty printers, resolving the script relative to the repo root
+python
+import os
+repo_root = os.path.dirname(os.environ["SPICE_STD_DIR"])
+gdb.execute("source " + os.path.join(repo_root, "tools", "gdb", "spice_printers.py"))
+end
+
+# Preparation
+break source.spice:120
+run
+
+# Runtime
+print vec
+print stack
+print queue
+print deque
+print pq
+print list
+print dList
+print table
+print tree
+print bTree
+print map
+print set
+print uMap
+print uSet
+print pair
+print triple
+print some
+print none
+print bits
+print trie
+print graph
+print nested
+continue
+
+# Quit
+quit

--- a/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.out
+++ b/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.out
@@ -1,0 +1,48 @@
+GNU gdb (Ubuntu 15.1-1ubuntu1~24.04.1) 15.1
+Copyright (C) 2024 Free Software Foundation, Inc.
+License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
+This is free software: you are free to change and redistribute it.
+There is NO WARRANTY, to the extent permitted by law.
+Type "show copying" and "show warranty" for details.
+This GDB was configured as "x86_64-linux-gnu".
+Type "show configuration" for configuration details.
+For bug reporting instructions, please see:
+<https://www.gnu.org/software/gdb/bugs/>.
+Find the GDB manual and other documentation resources online at:
+    <http://www.gnu.org/software/gdb/documentation/>.
+
+For help, type "help".
+Type "apropos word" to search for commands related to "word"...
+Reading symbols from ./test-tmp/instrumentation_successGdbPrettyPrinters/source...
+Breakpoint 1: file ./test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice, line 120.
+[Thread debugging using libthread_db enabled]
+Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
+
+Breakpoint 1, main ()
+    at ./test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice:120
+120	    printf("All structures populated!\n"); // breakpoint line
+$1 = Vector<int> of length 3 = {10, 20, 30}
+$2 = Stack<int> of length 3 = {1, 2, 3}
+$3 = Queue<int> of length 3 = {4, 5, 6}
+$4 = Deque<int> of length 3 = {8, 7, 9}
+$5 = PriorityQueue<int> of length 3 = {30, 10, 20}
+$6 = LinkedList<int> of length 3 = {100, 200, 300}
+$7 = DoublyLinkedList<int> of length 3 = {11, 22, 33}
+$8 = HashTable<String, int> with 2 elements = {["two"] = 2, ["one"] = 1}
+$9 = RedBlackTree<int, String> with 3 elements = {[1] = "one", [2] = "two", 
+  [3] = "three"}
+$10 = BinaryTree<int> = {3, 5, 7}
+$11 = Map<int, String> with 2 elements = {[1] = "alpha", [2] = "beta"}
+$12 = Set<int> with 3 elements = {1, 2, 3}
+$13 = UnorderedMap<String, int> with 1 element = {["x"] = 42}
+$14 = UnorderedSet<int> with 2 elements = {8, 7}
+$15 = (1, 2)
+$16 = (1, 2, 3)
+$17 = Some(42)
+$18 = None
+$19 = BitSet of 8 bits = 01001000
+$20 = Trie with 3 words = {car, cart, cat}
+$21 = Directed Graph<int> with 2 vertices = {1, 2}
+$22 = Vector<Pair<int,int>> of length 2 = {(1, 2), (3, 4)}
+All structures populated!
+[Inferior 1 (process 84578) exited normally]

--- a/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice
+++ b/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice
@@ -1,0 +1,122 @@
+// TEST: -g
+
+import "std/data/vector";
+import "std/data/stack";
+import "std/data/queue";
+import "std/data/deque";
+import "std/data/priority-queue";
+import "std/data/linked-list";
+import "std/data/doubly-linked-list";
+import "std/data/hash-table";
+import "std/data/red-black-tree";
+import "std/data/binary-tree";
+import "std/data/map";
+import "std/data/set";
+import "std/data/unordered-map";
+import "std/data/unordered-set";
+import "std/data/pair";
+import "std/data/triple";
+import "std/data/optional";
+import "std/data/bitset";
+import "std/data/trie";
+import "std/data/graph";
+
+f<int> main() {
+    Vector<int> vec = Vector<int>();
+    vec.pushBack(10);
+    vec.pushBack(20);
+    vec.pushBack(30);
+
+    Stack<int> stack = Stack<int>();
+    stack.push(1);
+    stack.push(2);
+    stack.push(3);
+
+    Queue<int> queue = Queue<int>();
+    queue.push(4);
+    queue.push(5);
+    queue.push(6);
+
+    Deque<int> deque = Deque<int>();
+    deque.pushBack(7);
+    deque.pushFront(8);
+    deque.pushBack(9);
+
+    PriorityQueue<int> pq = PriorityQueue<int>();
+    pq.push(30);
+    pq.push(10);
+    pq.push(20);
+
+    LinkedList<int> list = LinkedList<int>();
+    list.pushBack(100);
+    list.pushBack(200);
+    list.pushBack(300);
+
+    DoublyLinkedList<int> dList = DoublyLinkedList<int>();
+    dList.pushBack(11);
+    dList.pushBack(22);
+    dList.pushBack(33);
+
+    HashTable<String, int> table = HashTable<String, int>();
+    table.upsert(String("one"), 1);
+    table.upsert(String("two"), 2);
+
+    RedBlackTree<int, String> tree = RedBlackTree<int, String>();
+    tree.insert(2, String("two"));
+    tree.insert(1, String("one"));
+    tree.insert(3, String("three"));
+
+    BinaryTree<int> bTree = BinaryTree<int>();
+    bTree.insert(5);
+    bTree.insert(3);
+    bTree.insert(7);
+
+    Map<int, String> map = Map<int, String>();
+    map.insert(1, String("alpha"));
+    map.insert(2, String("beta"));
+
+    Set<int> set = Set<int>();
+    set.insert(3);
+    set.insert(1);
+    set.insert(2);
+
+    UnorderedMap<String, int> uMap = UnorderedMap<String, int>();
+    uMap.upsert(String("x"), 42);
+
+    UnorderedSet<int> uSet = UnorderedSet<int>();
+    uSet.insert(7);
+    uSet.insert(8);
+
+    Pair<int, int> pair = Pair<int, int>(1, 2);
+    assert pair.getFirst() == 1;
+
+    Triple<int, int, int> triple = Triple<int, int, int>(1, 2, 3);
+    assert triple.getFirst() == 1;
+
+    Optional<int> some = Optional<int>(42);
+    assert some.isPresent();
+
+    Optional<int> none = Optional<int>();
+    assert !none.isPresent();
+
+    BitSet bits = BitSet(8ul);
+    bits.set(1ul);
+    bits.set(4ul);
+
+    Trie trie;
+    trie.insert("car");
+    trie.insert("cart");
+    trie.insert("cat");
+
+    Graph<int> graph;
+    Vertex<int>& v1 = graph.addVertex(1);
+    Vertex<int>& v2 = graph.addVertex(2);
+    graph.addEdge(v1, v2);
+
+    Vector<Pair<int, int>> nested = Vector<Pair<int, int>>();
+    nested.pushBack(Pair<int, int>(1, 2));
+    nested.pushBack(Pair<int, int>(3, 4));
+
+    printf("All structures populated!\n"); // breakpoint line
+    return 0;
+}

--- a/tools/gdb/spice.gdb
+++ b/tools/gdb/spice.gdb
@@ -1,0 +1,5 @@
+# Installed by the spice package into GDB's system-wide init directory (see
+# `--with-system-gdbinit-dir` in `info gdb`). Auto-loads the pretty printers for the
+# std/data/ containers on distros whose GDB build honors that directory; a no-op
+# elsewhere. Manual loading instructions: docs/docs/how-to/debugging-with-gdb.md.
+source /usr/lib/spice/gdb/spice_printers.py

--- a/tools/gdb/spice_printers.py
+++ b/tools/gdb/spice_printers.py
@@ -25,8 +25,7 @@ BitSet, Trie, Graph, Vertex, String.
 import re
 import gdb
 
-# Slot hash sentinels from std/data/hash-table.spice - a slot is occupied iff hash > HASH_TOMBSTONE
-_HASH_EMPTY = 0
+# Slot hash sentinel from std/data/hash-table.spice - a slot is occupied iff hash > HASH_TOMBSTONE
 _HASH_TOMBSTONE = 1
 
 _BITS_PER_WORD = 64

--- a/tools/gdb/spice_printers.py
+++ b/tools/gdb/spice_printers.py
@@ -1,0 +1,457 @@
+"""GDB pretty printers for the Spice standard library data structures.
+
+Spice (https://github.com/spicelang/spice) emits real DWARF debug info when compiled with
+`-g`. Generic struct instantiations are named by their signature (e.g. `Vector<int>`,
+`HashTable<String,int>`), which is what this module dispatches on. Without these printers,
+GDB shows the raw internal layout of a container (e.g. `{contents = 0x555.., capacity = 5,
+size = 5}`), which hides the actual contents and is unreadable for pointer-based structures
+such as lists, trees and hash tables.
+
+Usage
+-----
+In a running GDB session:
+
+    (gdb) source /path/to/spice/tools/gdb/spice_printers.py
+
+Or add that line to your `~/.gdbinit` to load it for every session.
+
+Covered types (all of `std/data/` plus the runtime `String` type)
+-------------------------------------------------------------------
+Vector, Stack, Queue, Deque, PriorityQueue, LinkedList, DoublyLinkedList, HashTable,
+RedBlackTree, BinaryTree, Map, Set, UnorderedMap, UnorderedSet, Pair, Triple, Optional,
+BitSet, Trie, Graph, Vertex, String.
+"""
+
+import re
+import gdb
+
+# Slot hash sentinels from std/data/hash-table.spice - a slot is occupied iff hash > HASH_TOMBSTONE
+_HASH_EMPTY = 0
+_HASH_TOMBSTONE = 1
+
+_BITS_PER_WORD = 64
+
+
+def _is_null(ptr):
+    return int(ptr) == 0
+
+
+def _elements(count):
+    return f"{count} element" if count == 1 else f"{count} elements"
+
+
+def _rb_inorder(root_ptr):
+    """In-order traversal of a RedBlackTree/BinaryTree-style node chain (childLeft/childRight)."""
+    if _is_null(root_ptr):
+        return
+    node = root_ptr.dereference()
+    yield from _rb_inorder(node["childLeft"])
+    yield node
+    yield from _rb_inorder(node["childRight"])
+
+
+def _hash_slots(hash_table_val):
+    """Yield (key, value) gdb.Value pairs for every occupied slot of a HashTable value."""
+    capacity = int(hash_table_val["capacity"])
+    if capacity == 0:
+        return
+    slots = hash_table_val["slots"]
+    for i in range(capacity):
+        slot = slots[i]
+        if int(slot["hash"]) <= _HASH_TOMBSTONE:
+            continue
+        entry = slot["entry"].dereference()
+        yield entry["key"], entry["value"]
+
+
+def _linked_list_values(list_val):
+    """Yield element values of a LinkedList/DoublyLinkedList in push-back order."""
+    node_ptr = list_val["tail"]
+    while not _is_null(node_ptr):
+        node = node_ptr.dereference()
+        yield node["value"]
+        node_ptr = node["next"]
+
+
+class SpiceArrayPrinter:
+    """Vector<T>, Stack<T>, PriorityQueue<T> - flat contiguous storage."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} of length {int(self.val['size'])}"
+
+    def children(self):
+        contents = self.val["contents"]
+        for i in range(int(self.val["size"])):
+            yield str(i), contents[i]
+
+    def display_hint(self):
+        return "array"
+
+
+class SpiceCircularBufferPrinter:
+    """Queue<T>, Deque<T> - circular buffer addressed via idxFront/capacity."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} of length {int(self.val['size'])}"
+
+    def children(self):
+        size = int(self.val["size"])
+        capacity = int(self.val["capacity"])
+        front = int(self.val["idxFront"])
+        contents = self.val["contents"]
+        for i in range(size):
+            yield str(i), contents[(front + i) % capacity]
+
+    def display_hint(self):
+        return "array"
+
+
+class SpiceLinkedListPrinter:
+    """LinkedList<T>, DoublyLinkedList<T> - singly-linked chain, owning pointer in `tail`."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} of length {int(self.val['size'])}"
+
+    def children(self):
+        for i, value in enumerate(_linked_list_values(self.val)):
+            yield str(i), value
+
+    def display_hint(self):
+        return "array"
+
+
+class SpiceHashTablePrinter:
+    """HashTable<K,V> - open-addressed slot array."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} with {_elements(int(self.val['size']))}"
+
+    def children(self):
+        for i, (key, value) in enumerate(_hash_slots(self.val)):
+            yield f"key{i}", key
+            yield f"value{i}", value
+
+    def display_hint(self):
+        return "map"
+
+
+class SpiceRedBlackTreePrinter:
+    """RedBlackTree<K,V> - printed as an ordered key:value map."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} with {_elements(int(self.val['size']))}"
+
+    def children(self):
+        for i, node in enumerate(_rb_inorder(self.val["rootNode"])):
+            yield f"key{i}", node["key"]
+            yield f"value{i}", node["value"]
+
+    def display_hint(self):
+        return "map"
+
+
+class SpiceBinaryTreePrinter:
+    """BinaryTree<T> - binary search tree, printed in sorted (in-order) order."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return self.type_name
+
+    def children(self):
+        for i, node in enumerate(_rb_inorder(self.val["rootNode"])):
+            yield str(i), node["value"]
+
+    def display_hint(self):
+        return "array"
+
+
+class SpiceMapPrinter:
+    """Map<K,V> - thin RedBlackTree<K,V> wrapper, printed as an ordered key:value map."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} with {_elements(int(self.val['tree']['size']))}"
+
+    def children(self):
+        for i, node in enumerate(_rb_inorder(self.val["tree"]["rootNode"])):
+            yield f"key{i}", node["key"]
+            yield f"value{i}", node["value"]
+
+    def display_hint(self):
+        return "map"
+
+
+class SpiceSetPrinter:
+    """Set<V> - thin RedBlackTree<V,bool> wrapper, printed as an ordered set of keys."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} with {_elements(int(self.val['tree']['size']))}"
+
+    def children(self):
+        for i, node in enumerate(_rb_inorder(self.val["tree"]["rootNode"])):
+            yield str(i), node["key"]
+
+    def display_hint(self):
+        return "array"
+
+
+class SpiceUnorderedMapPrinter:
+    """UnorderedMap<K,V> - thin HashTable<K,V> wrapper, printed as a key:value map."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} with {_elements(int(self.val['hashTable']['size']))}"
+
+    def children(self):
+        for i, (key, value) in enumerate(_hash_slots(self.val["hashTable"])):
+            yield f"key{i}", key
+            yield f"value{i}", value
+
+    def display_hint(self):
+        return "map"
+
+
+class SpiceUnorderedSetPrinter:
+    """UnorderedSet<V> - thin HashTable<V,bool> wrapper, printed as a set of keys."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        return f"{self.type_name} with {_elements(int(self.val['hashTable']['size']))}"
+
+    def children(self):
+        for i, (key, _value) in enumerate(_hash_slots(self.val["hashTable"])):
+            yield str(i), key
+
+    def display_hint(self):
+        return "array"
+
+
+class SpicePairPrinter:
+    """Pair<V1,V2>."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        return f"({self.val['first']}, {self.val['second']})"
+
+
+class SpiceTriplePrinter:
+    """Triple<V1,V2,V3>."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        return f"({self.val['first']}, {self.val['second']}, {self.val['third']})"
+
+
+class SpiceOptionalPrinter:
+    """Optional<T>."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        if bool(self.val["isPresent"]):
+            return f"Some({self.val['data']})"
+        return "None"
+
+
+class SpiceBitSetPrinter:
+    """BitSet - fixed-size bit vector, LSB-first within each 64-bit word."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        num_bits = int(self.val["numBits"])
+        if num_bits == 0:
+            return "BitSet of 0 bits"
+        words = self.val["words"]
+        bits = []
+        for i in range(num_bits):
+            word = words[i // _BITS_PER_WORD]
+            bit = (int(word) >> (i % _BITS_PER_WORD)) & 1
+            bits.append("1" if bit else "0")
+        return f"BitSet of {num_bits} bits = {''.join(bits)}"
+
+
+class SpiceTriePrinter:
+    """Trie - reconstructs the stored words by walking the edge-labeled node tree."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        return f"Trie with {int(self.val['wordCount'])} words"
+
+    def _words(self, node_ptr, prefix):
+        if _is_null(node_ptr):
+            return
+        node = node_ptr.dereference()
+        if bool(node["isEndOfWord"]):
+            yield "".join(prefix)
+        keys = node["keys"]
+        children = node["children"]
+        key_contents = keys["contents"]
+        child_contents = children["contents"]
+        for i in range(int(keys["size"])):
+            prefix.append(chr(int(key_contents[i]) & 0xFF))
+            yield from self._words(child_contents[i], prefix)
+            prefix.pop()
+
+    def children(self):
+        for i, word in enumerate(self._words(self.val["root"], [])):
+            yield str(i), word
+
+    def display_hint(self):
+        return "array"
+
+
+class SpiceGraphPrinter:
+    """Graph<T> - summarized as directed/undirected plus its vertex set; adjacency stays
+    reachable through the (separately pretty-printed) `adjList` field."""
+
+    def __init__(self, val, type_name):
+        self.val = val
+        self.type_name = type_name
+
+    def to_string(self):
+        kind = "Directed" if bool(self.val["directed"]) else "Undirected"
+        vertex_count = int(self.val["vertices"]["size"])
+        return f"{kind} {self.type_name} with {vertex_count} vertices"
+
+    def children(self):
+        vertices = self.val["vertices"]
+        contents = vertices["contents"]
+        for i in range(int(vertices["size"])):
+            yield str(i), contents[i]["value"]
+
+    def display_hint(self):
+        return "array"
+
+
+class SpiceVertexPrinter:
+    """Vertex<T> - transparent wrapper, printed as just its wrapped value."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        return str(self.val["value"])
+
+
+class SpiceStringPrinter:
+    """String - heap-allocated, non-null-terminated-length-tracked string."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        length = int(self.val["length"])
+        contents = self.val["contents"]
+        if length == 0 or _is_null(contents):
+            return '""'
+        return contents.lazy_string(length=length)
+
+
+# Base struct name (before the first '<') -> printer class
+_PRINTERS = {
+    "Vector": SpiceArrayPrinter,
+    "Stack": SpiceArrayPrinter,
+    "PriorityQueue": SpiceArrayPrinter,
+    "Queue": SpiceCircularBufferPrinter,
+    "Deque": SpiceCircularBufferPrinter,
+    "LinkedList": SpiceLinkedListPrinter,
+    "DoublyLinkedList": SpiceLinkedListPrinter,
+    "HashTable": SpiceHashTablePrinter,
+    "RedBlackTree": SpiceRedBlackTreePrinter,
+    "BinaryTree": SpiceBinaryTreePrinter,
+    "Map": SpiceMapPrinter,
+    "Set": SpiceSetPrinter,
+    "UnorderedMap": SpiceUnorderedMapPrinter,
+    "UnorderedSet": SpiceUnorderedSetPrinter,
+    "Pair": SpicePairPrinter,
+    "Triple": SpiceTriplePrinter,
+    "Optional": SpiceOptionalPrinter,
+    "BitSet": SpiceBitSetPrinter,
+    "Trie": SpiceTriePrinter,
+    "Graph": SpiceGraphPrinter,
+    "Vertex": SpiceVertexPrinter,
+    "String": SpiceStringPrinter,
+}
+
+_TAG_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)(?:<.*>)?$")
+
+
+def spice_lookup_function(val):
+    type_ = val.type
+    if type_.code == gdb.TYPE_CODE_REF:
+        type_ = type_.target()
+    type_ = type_.strip_typedefs()
+    if type_.code != gdb.TYPE_CODE_STRUCT:
+        return None
+
+    tag = type_.tag
+    if not tag:
+        return None
+
+    match = _TAG_RE.match(tag)
+    if not match:
+        return None
+
+    printer_cls = _PRINTERS.get(match.group(1))
+    if printer_cls is None:
+        return None
+
+    return printer_cls(val, tag)
+
+
+def register_spice_printers(obj_file=None):
+    target = obj_file if obj_file is not None else gdb
+    printers = getattr(target, "pretty_printers", None)
+    if printers is None:
+        printers = []
+        target.pretty_printers = printers
+    if spice_lookup_function not in printers:
+        printers.append(spice_lookup_function)
+
+
+register_spice_printers(gdb.current_objfile())


### PR DESCRIPTION
## What changed
- New `tools/gdb/spice_printers.py`: a GDB pretty-printer module covering every public type in `std/data/` (Vector, Stack, Queue, Deque, PriorityQueue, LinkedList, DoublyLinkedList, HashTable, RedBlackTree, BinaryTree, Map, Set, UnorderedMap, UnorderedSet, Pair, Triple, Optional, BitSet, Trie, Graph/Vertex), plus the runtime `String` type.
- New `tools/gdb/spice.gdb`: a one-line GDB script that sources the printer module.
- `.goreleaser.yml`: ships `tools/gdb/spice_printers.py` alongside `std` in Docker images, release archives and the Homebrew cask; Linux packages (apk/deb/rpm/archlinux) additionally install `spice.gdb` to `/etc/gdb/gdbinit.d/spice.gdb` so it auto-loads on distros whose GDB build honors that directory.
- New reference test `test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/` exercising every covered type, including a nested-generic case (`Vector<Pair<int,int>>`) to confirm recursive dispatch.
- New docs page `docs/docs/how-to/debugging-with-gdb.md`, registered in `docs/zensical.toml`.

## Why
Spice already emits real DWARF debug info (`-g`), including generic struct signatures (e.g. `Vector<int>`) as of #1339. Without a pretty printer, GDB shows these containers by raw internal layout (`{contents = 0x..., capacity = 5, size = 5}`), which hides the actual contents and is unreadable for pointer-based structures such as lists, trees and hash tables.

## How it was validated
- `cmake --build cmake-build-debug --target spicetest` — builds clean (no C++ changes needed for this PR).
- `cmake-build-debug/test/spicetest --gtest_filter='*instrumentation_successGdbPrettyPrinters*'` — passes; manually reviewed the generated `debug.out` for correctness (ordering, recursive dispatch into nested generics, pluralization, etc.).
- Full suite: `cmake-build-debug/test/spicetest` — 659/672 passing; the 11 failures are the pre-existing environment-only `LLVM_LIB_DIR`-related failures (bootstrap compiler / LLVM bindings tests), unrelated to this change and reproducible on `main`.
- `.goreleaser.yml` validated for YAML syntax; the `goreleaser` CLI was not available locally to run a full `goreleaser check`, so the nfpm/archives/docker sections were hand-verified against the existing `std`-shipping entries they mirror.

## Follow-up / known limitations
- Whether `/etc/gdb/gdbinit.d/spice.gdb` actually auto-loads depends on the distro's GDB being built with `--with-system-gdbinit-dir` pointed at that path (confirmed for Debian/Ubuntu; unverified for Fedora/RHEL, Alpine, Arch). Where unsupported, it's an inert file and users fall back to the documented manual `source` step.
- No compiler changes — this ships as a standalone script by design, not an auto-embedded `.debug_gdb_scripts` section.