### PR TITLE
Add GDB pretty printers for Error and Result

### DIFF
--- a/docs/docs/how-to/debugging-with-gdb.md
+++ b/docs/docs/how-to/debugging-with-gdb.md
@@ -58,21 +58,23 @@ printer too, and so on.
 
 ## Covered types
 
-| Type(s) | Rendered as |
-|---|---|
-| `Vector`, `Stack`, `PriorityQueue` | `{e0, e1, ...}` in storage order |
-| `Queue`, `Deque` | `{e0, e1, ...}` in logical front-to-back order |
-| `LinkedList`, `DoublyLinkedList` | `{e0, e1, ...}` in push-back order |
-| `HashTable`, `UnorderedMap` | `{key = value, ...}`, unordered |
-| `RedBlackTree`, `Map` | `{key = value, ...}`, sorted by key |
-| `Set`, `UnorderedSet` | `{v0, v1, ...}` (keys only) |
-| `BinaryTree` | `{v0, v1, ...}`, sorted (in-order traversal) |
-| `Pair`, `Triple` | `(first, second[, third])` |
-| `Optional` | `Some(value)` or `None` |
-| `BitSet` | A bit string, e.g. `BitSet of 8 bits = 01001000` |
-| `Trie` | The stored words, e.g. `{car, cart, cat}` |
-| `Graph`, `Vertex` | A directed/undirected summary plus the vertex set |
-| `String` | A quoted string |
+| Type(s)                            | Rendered as                                       |
+|------------------------------------|---------------------------------------------------|
+| `Vector`, `Stack`, `PriorityQueue` | `{e0, e1, ...}` in storage order                  |
+| `Queue`, `Deque`                   | `{e0, e1, ...}` in logical front-to-back order    |
+| `LinkedList`, `DoublyLinkedList`   | `{e0, e1, ...}` in push-back order                |
+| `HashTable`, `UnorderedMap`        | `{key = value, ...}`, unordered                   |
+| `RedBlackTree`, `Map`              | `{key = value, ...}`, sorted by key               |
+| `Set`, `UnorderedSet`              | `{v0, v1, ...}` (keys only)                       |
+| `BinaryTree`                       | `{v0, v1, ...}`, sorted (in-order traversal)      |
+| `Pair`, `Triple`                   | `(first, second[, third])`                        |
+| `Optional`                         | `Some(value)` or `None`                           |
+| `BitSet`                           | A bit string, e.g. `BitSet of 8 bits = 01001000`  |
+| `Trie`                             | The stored words, e.g. `{car, cart, cat}`         |
+| `Graph`, `Vertex`                  | A directed/undirected summary plus the vertex set |
+| `String`                           | A quoted string                                   |
+| `Error`                            | `Error(code=..., message="...")`                  |
+| `Result`                           | `Ok(value)` or `Err(error)`                       |
 
 The dispatch is based on the DWARF struct name that the compiler emits for generic instantiations (e.g.
 `Vector<int>`), so the printers apply to any concrete instantiation of these generic types automatically — there is

--- a/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.gdb
+++ b/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.gdb
@@ -11,7 +11,7 @@ gdb.execute("source " + os.path.join(repo_root, "tools", "gdb", "spice_printers.
 end
 
 # Preparation
-break source.spice:120
+break source.spice:127
 run
 
 # Runtime
@@ -37,6 +37,9 @@ print bits
 print trie
 print graph
 print nested
+print myErr
+print okResult
+print errResult
 continue
 
 # Quit

--- a/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.out
+++ b/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/debug.out
@@ -14,13 +14,13 @@ Find the GDB manual and other documentation resources online at:
 For help, type "help".
 Type "apropos word" to search for commands related to "word"...
 Reading symbols from ./test-tmp/instrumentation_successGdbPrettyPrinters/source...
-Breakpoint 1: file ./test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice, line 120.
+Breakpoint 1: file ./test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice, line 127.
 [Thread debugging using libthread_db enabled]
 Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
 
 Breakpoint 1, main ()
-    at ./test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice:120
-120	    printf("All structures populated!\n"); // breakpoint line
+    at ./test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice:127
+127	    printf("All structures populated!\n"); // breakpoint line
 $1 = Vector<int> of length 3 = {10, 20, 30}
 $2 = Stack<int> of length 3 = {1, 2, 3}
 $3 = Queue<int> of length 3 = {4, 5, 6}
@@ -44,5 +44,8 @@ $19 = BitSet of 8 bits = 01001000
 $20 = Trie with 3 words = {car, cart, cat}
 $21 = Directed Graph<int> with 2 vertices = {1, 2}
 $22 = Vector<Pair<int,int>> of length 2 = {(1, 2), (3, 4)}
+$23 = Error(code=42, message="boom")
+$24 = Ok(1)
+$25 = Err(Error(code=42, message="boom"))
 All structures populated!
 [Inferior 1 (process 84578) exited normally]

--- a/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice
+++ b/test/test-files/irgenerator/instrumentation/success-gdb-pretty-printers/source.spice
@@ -117,6 +117,13 @@ f<int> main() {
     nested.pushBack(Pair<int, int>(1, 2));
     nested.pushBack(Pair<int, int>(3, 4));
 
+    Error myErr = Error(42, "boom");
+
+    Result<int> okResult = ok<int>(1);
+    Result<int> errResult = err<int>(myErr);
+    assert okResult.isOk();
+    assert errResult.isErr();
+
     printf("All structures populated!\n"); // breakpoint line
     return 0;
 }

--- a/tools/gdb/spice_printers.py
+++ b/tools/gdb/spice_printers.py
@@ -403,6 +403,8 @@ class SpiceErrorPrinter:
         try:
             message = message.string()
         except gdb.error:
+            # Unreadable pointer (e.g. uninitialized/corrupted memory) - fall back to the raw
+            # value instead of failing the whole printer.
             pass
         return f'Error(code={code}, message="{message}")'
 

--- a/tools/gdb/spice_printers.py
+++ b/tools/gdb/spice_printers.py
@@ -15,11 +15,11 @@ In a running GDB session:
 
 Or add that line to your `~/.gdbinit` to load it for every session.
 
-Covered types (all of `std/data/` plus the runtime `String` type)
--------------------------------------------------------------------
+Covered types (all of `std/data/` plus the runtime `String`, `Error` and `Result` types)
+-----------------------------------------------------------------------------------------
 Vector, Stack, Queue, Deque, PriorityQueue, LinkedList, DoublyLinkedList, HashTable,
 RedBlackTree, BinaryTree, Map, Set, UnorderedMap, UnorderedSet, Pair, Triple, Optional,
-BitSet, Trie, Graph, Vertex, String.
+BitSet, Trie, Graph, Vertex, String, Error, Result.
 """
 
 import re
@@ -391,6 +391,34 @@ class SpiceStringPrinter:
         return contents.lazy_string(length=length)
 
 
+class SpiceErrorPrinter:
+    """Error - runtime error object (std/runtime/error_rt.spice): an int code plus a message."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        code = int(self.val["code"])
+        message = self.val["message"]
+        try:
+            message = message.string()
+        except gdb.error:
+            pass
+        return f'Error(code={code}, message="{message}")'
+
+
+class SpiceResultPrinter:
+    """Result<T> - success/error wrapper (std/runtime/result_rt.spice); mirrors Result.isOk()."""
+
+    def __init__(self, val, _type_name):
+        self.val = val
+
+    def to_string(self):
+        if int(self.val["error"]["code"]) == 0:
+            return f"Ok({self.val['data']})"
+        return f"Err({self.val['error']})"
+
+
 # Base struct name (before the first '<') -> printer class
 _PRINTERS = {
     "Vector": SpiceArrayPrinter,
@@ -415,6 +443,8 @@ _PRINTERS = {
     "Graph": SpiceGraphPrinter,
     "Vertex": SpiceVertexPrinter,
     "String": SpiceStringPrinter,
+    "Error": SpiceErrorPrinter,
+    "Result": SpiceResultPrinter,
 }
 
 _TAG_RE = re.compile(r"^([A-Za-z_][A-Za-z0-9_]*)(?:<.*>)?$")


### PR DESCRIPTION
## What changed
- Added `SpiceErrorPrinter` and `SpiceResultPrinter` to `tools/gdb/spice_printers.py`, rendering `Error` as `Error(code=..., message="...")` and `Result<T>` as `Ok(value)` / `Err(error)` (mirroring `Result.isOk()`/`isErr()`).
- Documented both types in the "Covered types" table in `docs/docs/how-to/debugging-with-gdb.md`.
- Extended the existing `success-gdb-pretty-printers` integration test with an `Error`, an `Ok` result and an `Err` result, and regenerated `debug.out`.

## Why
Follow-up to #1340, which added GDB pretty printers for the `std/data/` containers and `String` but didn't cover the `Error`/`Result` runtime types, so they still printed as raw struct fields.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest -j` — builds clean
- `cmake-build-debug/test/spicetest --gtest_filter='*successGdbPrettyPrinters*'` — passes, no warnings
- `cmake-build-debug/test/spicetest --gtest_filter='*successGdbPrettyPrinters*' --update-refs` then reviewed the `git diff` on `debug.out` before committing

## Follow-up / known limitations
None.

https://claude.ai/code/session_01JkTkJpTHKfwaQZf8ooDw52