### PR TITLE
Fix wrong member offset in case of synthesized vtable pointer

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,7 +1,3 @@
-p foo_bar() {
-
-}
-
 f<int> main() {
     Result<heap byte*> r = sAlloc(4l);
 }

--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -349,6 +349,10 @@ llvm::DIType *DebugInfoGenerator::getDITypeForQualType(const ASTNode *node, cons
     // Insert into cache
     structTypeCache.emplace(hashKey, structDiType);
 
+    // A synthesized vtable pointer takes up the first element of the LLVM struct type, which shifts all fields
+    // by one element
+    const size_t fieldElementOffset = spiceStruct->hasSynthesizedVTablePtr() ? 1 : 0;
+
     // Collect DI types for fields
     std::vector<llvm::Metadata *> fieldTypes;
     for (size_t i = 0; i < spiceStruct->scope->getFieldCount(); i++) {
@@ -360,7 +364,7 @@ llvm::DIType *DebugInfoGenerator::getDITypeForQualType(const ASTNode *node, cons
 
       const QualType &fieldType = fieldEntry->getQualType();
       const uint32_t fieldLineNo = fieldEntry->declNode->codeLoc.line;
-      const size_t offsetInBits = structLayout->getElementOffsetInBits(i);
+      const size_t offsetInBits = structLayout->getElementOffsetInBits(i + fieldElementOffset);
 
       llvm::DIType *fieldDiType = getDITypeForQualType(node, fieldType);
       llvm::DIDerivedType *fieldDiDerivedType =

--- a/src/model/Struct.cpp
+++ b/src/model/Struct.cpp
@@ -49,6 +49,20 @@ bool Struct::hasReferenceFields() const {
 }
 
 /**
+ * Checks if the LLVM struct type of this struct carries a synthesized vtable pointer as its first element, which
+ * shifts all fields by one element. Structs that implement interfaces receive their vtable pointer through their
+ * leading implicit interface field instead, so only structs that request a vtable without implementing any
+ * interface carry the extra element.
+ *
+ * @return Carries a synthesized vtable pointer or not
+ */
+bool Struct::hasSynthesizedVTablePtr() const {
+  assert(declNode->isStructDef());
+  const auto structDeclNode = spice_pointer_cast<const StructDefNode *>(declNode);
+  return !structDeclNode->hasInterfaces && structDeclNode->emitVTable;
+}
+
+/**
  * Check that all fields are in a certain lifecycle state.
  *
  * @param state Lifecycle state to check for

--- a/src/model/Struct.h
+++ b/src/model/Struct.h
@@ -22,6 +22,7 @@ public:
   [[nodiscard]] std::string getScopeName() const;
   static std::string getScopeName(const std::string &name, const QualTypeList &concreteTemplateTypes = {});
   [[nodiscard]] bool hasReferenceFields() const;
+  [[nodiscard]] bool hasSynthesizedVTablePtr() const;
   const SymbolTableEntry *areAllFieldsInState(LifecycleState state) const;
   const SymbolTableEntry *areAllFieldsInitialized() const;
   void resetFieldSymbolsToDeclared(const ASTNode *node) const;

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -546,7 +546,9 @@ llvm::Type *Type::toLLVMType(SourceFile *sourceFile) const { // NOLINT(misc-no-r
       const size_t totalFieldCount = spiceStruct->scope->getFieldCount();
       fieldTypes.reserve(totalFieldCount);
 
-      // If the struct has no interface types, but a vtable was requested, add another ptr field type
+      // If the struct implements interfaces, the first implicit field (added below via lookupField) is an interface
+      // type, which already lowers to a { ptr } struct carrying the vtable pointer. Only add an explicit ptr field
+      // here for structs without interfaces that still need a vtable (e.g. RTTI root types), to avoid duplicating it.
       assert(structSymbol->declNode->isStructDef());
       const auto structDeclNode = spice_pointer_cast<StructDefNode *>(structSymbol->declNode);
       if (spiceStruct->hasSynthesizedVTablePtr())

--- a/src/symboltablebuilder/Type.cpp
+++ b/src/symboltablebuilder/Type.cpp
@@ -549,7 +549,7 @@ llvm::Type *Type::toLLVMType(SourceFile *sourceFile) const { // NOLINT(misc-no-r
       // If the struct has no interface types, but a vtable was requested, add another ptr field type
       assert(structSymbol->declNode->isStructDef());
       const auto structDeclNode = spice_pointer_cast<StructDefNode *>(structSymbol->declNode);
-      if (!structDeclNode->hasInterfaces && structDeclNode->emitVTable)
+      if (spiceStruct->hasSynthesizedVTablePtr())
         fieldTypes.push_back(llvm::PointerType::get(context, 0));
 
       // Collect all field types

--- a/src/visualizer/CSTVisualizer.cpp
+++ b/src/visualizer/CSTVisualizer.cpp
@@ -50,7 +50,7 @@ std::string CSTVisualizer::buildRule(const antlr4::ParserRuleContext *ctx) {
 std::string CSTVisualizer::getSpaces() const {
   std::string spaces;
   for (int i = 0; i < currentTabs; i++)
-    spaces += " ";
+    spaces += ' ';
   return spaces;
 } // LCOV_EXCL_LINE - false positive
 


### PR DESCRIPTION
In case of a forced vtable insertion (synthesized vtable), we generated wrong member offsets for debug information.
This is now fixed.