### PR TITLE
Make GDB test runner ignore local/system gdbinit files

### DIFF
--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -376,7 +376,10 @@ static void execTestCase(const TestCase &testCase) {
             std::filesystem::path gdbScriptPath = testCase.testPath / CTL_DEBUG_SCRIPT;
             EXPECT_TRUE(std::filesystem::exists(gdbScriptPath)) << "Debug output requested, but debug script not found";
             gdbScriptPath.make_preferred();
-            const std::string cmd = "gdb -x " + gdbScriptPath.string() + " " + executablePath.string();
+            // -nx: ignore any local/system .gdbinit so a developer's own GDB setup (e.g. globally installed
+            // pretty printers) cannot change test output; tests that want the pretty printers source them
+            // explicitly from within their debug script instead.
+            const std::string cmd = "gdb -nx -x " + gdbScriptPath.string() + " " + executablePath.string();
             const auto [output, exitCode] = SystemUtil::exec(cmd);
 
 #if not OS_WINDOWS // Windows does not give us the exit code, so we cannot check it on Windows


### PR DESCRIPTION
## What changed
- `test/TestRunner.cpp` now runs GDB reference tests with `gdb -nx -x <script> <exe>` instead of `gdb -x <script> <exe>`.

## Why
GDB auto-loads `~/.gdbinit` (and system gdbinit drop-ins) by default. A developer who sources `tools/gdb/spice_printers.py` from `~/.gdbinit` for interactive debugging (as documented in `docs/docs/how-to/debugging-with-gdb.md`) was getting that config silently applied inside the test harness too, since it invoked plain `gdb -x <script> <exe>` with no `-nx`. This pretty-printed structs during `success-dbg-info-complex`, whose reference output predates the pretty printers and expects raw struct dumps — causing a spurious local failure with no code regression involved.

`-nx` makes the harness ignore any local/system gdbinit, so test output no longer depends on a developer's personal GDB configuration. `success-gdb-pretty-printers` is unaffected, since it loads the printers explicitly via `source ...` from within its own `-x` debug script rather than relying on auto-load.

## How it was validated
- `cmake --build cmake-build-debug --target spicetest` — succeeds
- `cmake-build-debug/test/spicetest --gtest_filter='*instrumentation_successDbgInfoComplex*:*instrumentation_successGdbPrettyPrinters*'` — both pass, with `~/.gdbinit` sourcing the pretty printers locally (previously `successDbgInfoComplex` failed under that config)

## Follow-up / known limitations
None.