### PR TITLE
Add __stderr() compiler builtin

### DIFF
--- a/src/irgenerator/GenBuiltinFunctions.cpp
+++ b/src/irgenerator/GenBuiltinFunctions.cpp
@@ -103,19 +103,7 @@ std::any IRGenerator::visitBuiltinPanicCall(const FctCallNode *node) {
   llvm::PointerType *ptrTy = builder.getPtrTy();
 
   // Get value for stderr
-  llvm::Value *stdErr;
-  if (cliOptions.targetTriple.isOSWindows()) {
-    llvm::Function *getAcrtIOFuncFct = stdFunctionManager.getAcrtIOFuncFct();
-    stdErr = builder.CreateCall(getAcrtIOFuncFct, {builder.getInt32(/*constant for stderr*/ 2)});
-  } else {
-    const char *globalName = cliOptions.targetTriple.isOSDarwin() ? "__stderrp" : "stderr";
-    module->getOrInsertGlobal(globalName, ptrTy);
-    llvm::GlobalVariable *stdErrPtr = module->getNamedGlobal(globalName);
-    stdErrPtr->setLinkage(llvm::GlobalVariable::ExternalLinkage);
-    stdErrPtr->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Local);
-    stdErrPtr->setAlignment(llvm::MaybeAlign(8));
-    stdErr = insertLoad(ptrTy, stdErrPtr);
-  }
+  llvm::Value *stdErr = getStdErrValue();
 
   // Create constant for error message
   const std::string codeLoc = node->codeLoc.toPrettyString();
@@ -252,6 +240,34 @@ std::any IRGenerator::visitBuiltinPlacementNewCall(const FctCallNode *node) {
   }
 
   return LLVMExprResult{.value = targetPtr};
+}
+
+std::any IRGenerator::visitBuiltinStdErrCall(const FctCallNode *node) {
+  assert(node->fqFunctionName == BUILTIN_FCT_NAME_STDERR);
+
+  return LLVMExprResult{.value = getStdErrValue()};
+}
+
+/**
+ * Retrieves the process's stderr stream (FILE*). Spice has no syntax for declaring an external variable, so this
+ * reaches the real libc symbol directly, the same way on every platform: an ACRT accessor call on Windows, and
+ * the platform-specific extern global everywhere else.
+ */
+llvm::Value *IRGenerator::getStdErrValue() {
+  llvm::PointerType *ptrTy = builder.getPtrTy();
+
+  if (cliOptions.targetTriple.isOSWindows()) {
+    llvm::Function *getAcrtIOFuncFct = stdFunctionManager.getAcrtIOFuncFct();
+    return builder.CreateCall(getAcrtIOFuncFct, {builder.getInt32(/*constant for stderr*/ 2)});
+  }
+
+  const char *globalName = cliOptions.targetTriple.isOSDarwin() ? "__stderrp" : "stderr";
+  module->getOrInsertGlobal(globalName, ptrTy);
+  llvm::GlobalVariable *stdErrPtr = module->getNamedGlobal(globalName);
+  stdErrPtr->setLinkage(llvm::GlobalVariable::ExternalLinkage);
+  stdErrPtr->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Local);
+  stdErrPtr->setAlignment(llvm::MaybeAlign(8));
+  return insertLoad(ptrTy, stdErrPtr);
 }
 
 } // namespace spice::compiler

--- a/src/irgenerator/IRGenerator.h
+++ b/src/irgenerator/IRGenerator.h
@@ -164,9 +164,11 @@ public:
   std::any visitBuiltinSyscallCall(const FctCallNode *node);
   std::any visitBuiltinNewCall(const FctCallNode *node);
   std::any visitBuiltinPlacementNewCall(const FctCallNode *node);
+  std::any visitBuiltinStdErrCall(const FctCallNode *node);
 
 private:
   // Private methods
+  [[nodiscard]] llvm::Value *getStdErrValue();
   llvm::Constant *getConst(const CompileTimeValue &compileTimeValue, const QualType &type, const ASTNode *node) const;
   llvm::BasicBlock *createBlock(const std::string &blockName = "") const;
   void switchToBlock(llvm::BasicBlock *block, llvm::Function *parentFct = nullptr);

--- a/src/typechecker/BuiltinFunctions.h
+++ b/src/typechecker/BuiltinFunctions.h
@@ -49,6 +49,7 @@ static constexpr std::string_view BUILTIN_FCT_NAME_PLACEMENT_NEW = "__placement_
 static constexpr std::string_view BUILTIN_FCT_NAME_SOURCE_FILE = "__source_file";
 static constexpr std::string_view BUILTIN_FCT_NAME_SOURCE_LINE = "__source_line";
 static constexpr std::string_view BUILTIN_FCT_NAME_SOURCE_COLUMN = "__source_column";
+static constexpr std::string_view BUILTIN_FCT_NAME_STDERR = "__stderr";
 
 static constexpr std::array BUILTIN_FUNCTIONS = {
     BuiltinFunctionEntry{
@@ -216,6 +217,10 @@ static constexpr std::array BUILTIN_FUNCTIONS = {
     },
     BuiltinFunctionEntry{
         .name = BUILTIN_FCT_NAME_SOURCE_COLUMN,
+        .info = BuiltinFunctionInfo{},
+    },
+    BuiltinFunctionEntry{
+        .name = BUILTIN_FCT_NAME_STDERR,
         .info = BuiltinFunctionInfo{},
     },
 };

--- a/src/typechecker/Builtins.h
+++ b/src/typechecker/Builtins.h
@@ -166,6 +166,13 @@ static const std::unordered_map<std::string_view, BuiltinFunctionDispatch> BUILT
             .irGeneratorVisitMethod = nullptr,
         },
     },
+    {
+        BUILTIN_FCT_NAME_STDERR,
+        {
+            .typeCheckerVisitMethod = &TypeChecker::visitBuiltinStdErrCall,
+            .irGeneratorVisitMethod = &IRGenerator::visitBuiltinStdErrCall,
+        },
+    },
 };
 
 } // namespace spice::compiler

--- a/src/typechecker/TypeChecker.h
+++ b/src/typechecker/TypeChecker.h
@@ -174,6 +174,7 @@ public:
   std::any visitBuiltinSourceFileCall(FctCallNode *node) const;
   std::any visitBuiltinSourceLineCall(FctCallNode *node) const;
   std::any visitBuiltinSourceColumnCall(FctCallNode *node) const;
+  std::any visitBuiltinStdErrCall(FctCallNode *node) const;
 
 private:
   // Private members

--- a/src/typechecker/TypeCheckerBuiltinFunctions.cpp
+++ b/src/typechecker/TypeCheckerBuiltinFunctions.cpp
@@ -604,4 +604,15 @@ std::any TypeChecker::visitBuiltinSourceColumnCall(FctCallNode *node) const {
   return ExprResult{node->setEvaluatedSymbolType(QualType(TY_LONG), manIdx)};
 }
 
+/**
+ * Resolves to a pointer to the process's stderr stream. Spice source has no syntax for declaring an external
+ * *variable* (only functions/procedures via 'ext'), so this exists as a builtin that reaches the real libc
+ * symbol directly in IR generation, the same way panic()'s own codegen already did before this builtin existed.
+ */
+std::any TypeChecker::visitBuiltinStdErrCall(FctCallNode *node) const {
+  assert(node->fqFunctionName == BUILTIN_FCT_NAME_STDERR);
+
+  return ExprResult{node->setEvaluatedSymbolType(QualType(TY_BYTE).toPtr(node), manIdx)};
+}
+
 } // namespace spice::compiler


### PR DESCRIPTION
## Summary
- Adds `__stderr()`, a new niladic compiler builtin exposing the process's `stderr` `FILE*` to Spice source, dispatched the same way as the other double-underscore compiler builtins (`__is_heap`, `__new`, etc.)
- Spice has no syntax for declaring an external *variable* (only functions/procedures via `ext`), so there was previously no portable way to reach the real `stderr` symbol from Spice source directly
- `panic()`'s own codegen already needed this exact lookup (an ACRT accessor call on Windows, the `__stderrp`/`stderr` extern global elsewhere) to print its message, so that logic is factored out of `visitBuiltinPanicCall` into a shared `IRGenerator::getStdErrValue()` helper instead of staying duplicated

## Test plan
- [x] `cmake --build . --target spice --target spicetest` succeeds
- [x] `IRGeneratorTests.builtins_successPanic` passes unchanged (confirms the `getStdErrValue()` extraction is behavior-preserving, byte-identical generated IR)
- [x] Full `IRGeneratorTests` + `TypeCheckerTests` suites pass (404 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEFfK815z7Uj8ESQD33MX5