### PR TITLE
Add thread-safe MessageQueue to std/os

### DIFF
--- a/docs/docs/language/threads.md
+++ b/docs/docs/language/threads.md
@@ -192,3 +192,41 @@ f<int> main() {
 
 Because both threads increment `this.value` under the same `LockGuard`, no updates are lost. Without the mutex,
 the read-modify-write of `this.value++` would race and the final count would be less than `20000`.
+
+## Message queues
+
+The `std/os/message-queue` module provides a `MessageQueue<T>` type for passing values between threads. It is a
+FIFO queue, just like `std/data/queue`, but every operation is guarded by an internal mutex, so any number of
+producer and consumer threads can push and pop concurrently without extra synchronization.
+
+```spice
+import "std/os/message-queue";
+import "std/os/thread";
+import "std/data/optional";
+
+f<int> main() {
+    MessageQueue<int> mq;
+
+    Thread producer = Thread(p() [[async]] {
+        for int i = 0; i < 10; i++ {
+            mq.push(i);
+        }
+        mq.close(); // signal that no more items will arrive
+    });
+    producer.run();
+
+    while true {
+        Optional<int> item = mq.pop(); // blocks until an item is available or the queue is closed
+        if !item.isPresent() { break; }
+        printf("Received: %d\n", item.get());
+    }
+
+    producer.join();
+}
+```
+
+`pop()` blocks the calling thread until an item is available. Once `close()` has been called, `pop()` still
+returns any items that were queued before the close, and only reports an empty `Optional` once the queue has
+been fully drained — so consumers never have to guess when producers are done. Pushing to a closed queue panics.
+If you don't want to block, use `tryPop()` instead, which returns immediately with an empty `Optional` if the
+queue has no items right now. `isEmpty()` and `getSize()` report the current state of the queue.

--- a/std/os/message-queue.spice
+++ b/std/os/message-queue.spice
@@ -47,6 +47,7 @@ public p MessageQueue.push(const T& item) {
  *
  * @return The next item, or an empty Optional if the queue was closed and is now drained
  */
+#[ignoreUnusedReturnValue]
 public f<Optional<T>> MessageQueue.pop() {
     while true {
         bool hasItem = false;

--- a/std/os/message-queue.spice
+++ b/std/os/message-queue.spice
@@ -1,0 +1,121 @@
+import "std/data/queue";
+import "std/data/optional";
+import "std/os/mutex";
+import "std/os/cpu";
+
+// Generic type definition
+type T dyn;
+
+/**
+ * A thread-safe FIFO message queue for passing values between threads.
+ *
+ * MessageQueue wraps a `Queue<T>` with a `Mutex`, so `push()`, `pop()`, `tryPop()` and the other
+ * methods may be called concurrently from any number of threads without external synchronization.
+ * `pop()` blocks until an item becomes available or the queue is closed, spin-waiting via `yield()`
+ * between checks, since the standard library has no condition variable to park on.
+ *
+ * Once `close()` has been called, `push()` panics and `pop()`/`tryPop()` keep draining any items
+ * that are still queued, returning an empty `Optional` only once the queue has run dry. This makes
+ * `close()` + drain-until-empty a safe way for producers to signal shutdown to consumers.
+ */
+public type MessageQueue<T> struct {
+    Queue<T> queue
+    Mutex mutex
+    bool closed = false
+}
+
+/**
+ * Construct an empty, open message queue
+ */
+public p MessageQueue.ctor() {}
+
+/**
+ * Push an item to the back of the queue. Safe to call from multiple threads concurrently.
+ *
+ * @param item Item to enqueue
+ */
+public p MessageQueue.push(const T& item) {
+    LockGuard _ = LockGuard(this.mutex);
+    if this.closed { panic(Error("MessageQueue: cannot push to a closed queue")); }
+    this.queue.push(item);
+}
+
+/**
+ * Retrieve and remove the item at the front of the queue, blocking until one becomes available.
+ * If the queue is closed while waiting, this drains any remaining items first and only then
+ * returns an empty Optional instead of blocking forever.
+ *
+ * @return The next item, or an empty Optional if the queue was closed and is now drained
+ */
+public f<Optional<T>> MessageQueue.pop() {
+    while true {
+        bool hasItem = false;
+        bool isClosed = false;
+        Optional<T> result;
+        {
+            LockGuard _ = LockGuard(this.mutex);
+            if !this.queue.isEmpty() {
+                result.set(this.queue.pop());
+                hasItem = true;
+            } else {
+                isClosed = this.closed;
+            }
+        }
+        if hasItem || isClosed { return result; }
+        // Give up the CPU while waiting for a producer instead of busy-spinning at full speed
+        yield();
+    }
+}
+
+/**
+ * Retrieve and remove the item at the front of the queue without blocking.
+ *
+ * @return The next item, or an empty Optional if the queue is currently empty
+ */
+public f<Optional<T>> MessageQueue.tryPop() {
+    LockGuard _ = LockGuard(this.mutex);
+    Optional<T> result;
+    if !this.queue.isEmpty() {
+        result.set(this.queue.pop());
+    }
+    return result;
+}
+
+/**
+ * Close the queue. After this call, `push()` panics. `pop()` and `tryPop()` keep returning any
+ * items that were queued before the close, then start reporting an empty Optional once drained.
+ */
+public p MessageQueue.close() {
+    LockGuard _ = LockGuard(this.mutex);
+    this.closed = true;
+}
+
+/**
+ * Check whether the queue has been closed via `close()`
+ *
+ * @return Closed or not closed
+ */
+public f<bool> MessageQueue.isClosed() {
+    LockGuard _ = LockGuard(this.mutex);
+    return this.closed;
+}
+
+/**
+ * Check whether the queue currently holds no items
+ *
+ * @return Empty or not empty
+ */
+public f<bool> MessageQueue.isEmpty() {
+    LockGuard _ = LockGuard(this.mutex);
+    return this.queue.isEmpty();
+}
+
+/**
+ * Retrieve the current number of queued items
+ *
+ * @return Current size of the queue
+ */
+public f<long> MessageQueue.getSize() {
+    LockGuard _ = LockGuard(this.mutex);
+    return this.queue.getSize();
+}

--- a/std/os/message-queue.spice
+++ b/std/os/message-queue.spice
@@ -51,7 +51,7 @@ public f<Optional<T>> MessageQueue.pop() {
     while true {
         bool hasItem = false;
         bool isClosed = false;
-        Optional<T> result;
+        result = Optional<T>();
         {
             LockGuard _ = LockGuard(this.mutex);
             if !this.queue.isEmpty() {
@@ -74,7 +74,7 @@ public f<Optional<T>> MessageQueue.pop() {
  */
 public f<Optional<T>> MessageQueue.tryPop() {
     LockGuard _ = LockGuard(this.mutex);
-    Optional<T> result;
+    result = Optional<T>();
     if !this.queue.isEmpty() {
         result.set(this.queue.pop());
     }

--- a/test/test-files/std/os/message-queue/cout.out
+++ b/test/test-files/std/os/message-queue/cout.out
@@ -1,0 +1,3 @@
+Single-threaded smoke tests passed!
+popped count = 20000, popped sum = 50010000
+All assertions passed!

--- a/test/test-files/std/os/message-queue/source.spice
+++ b/test/test-files/std/os/message-queue/source.spice
@@ -1,0 +1,107 @@
+import "std/os/message-queue";
+import "std/os/thread";
+import "std/os/atomic";
+import "std/data/optional";
+import "std/data/vector";
+
+const int PRODUCER_COUNT = 4;
+const int CONSUMER_COUNT = 3;
+const int ITEMS_PER_PRODUCER = 5000;
+
+// Shared state for the concurrent test. Bundling the queue + counters into a struct lets
+// the async workers capture a single `this` pointer (per the async capture rules).
+type Shared struct {
+    MessageQueue<int> mq
+    Atomic<long> poppedSum
+    Atomic<long> poppedCount
+}
+
+p Shared.run() {
+    p() producer = p() [[async]] {
+        for int i = 0; i < ITEMS_PER_PRODUCER; i++ {
+            this.mq.push(i + 1);
+        }
+    };
+    p() consumer = p() [[async]] {
+        while true {
+            Optional<int> item = this.mq.pop();
+            if !item.isPresent() { break; }
+            this.poppedSum.store(this.poppedSum.load() + cast<long>(item.get()));
+            this.poppedCount.store(this.poppedCount.load() + 1l);
+        }
+    };
+
+    // Start consumers first so they race against producers for the whole run
+    Vector<Thread> consumers;
+    for int i = 0; i < CONSUMER_COUNT; i++ {
+        consumers.pushBack(Thread(consumer));
+        consumers.back().run();
+    }
+    Vector<Thread> producers;
+    for int i = 0; i < PRODUCER_COUNT; i++ {
+        producers.pushBack(Thread(producer));
+        producers.back().run();
+    }
+
+    // Once every producer is done, closing the queue lets the blocked consumers drain
+    // whatever is left and then return instead of waiting forever.
+    foreach const Thread& t : producers { t.join(); }
+    this.mq.close();
+    foreach const Thread& t : consumers { t.join(); }
+}
+
+f<int> main() {
+    // Single-threaded smoke test
+    MessageQueue<int> mq;
+    assert mq.isEmpty();
+    assert mq.getSize() == 0;
+    assert !mq.isClosed();
+
+    mq.push(1);
+    mq.push(2);
+    mq.push(3);
+    assert !mq.isEmpty();
+    assert mq.getSize() == 3;
+
+    // tryPop and pop both dequeue in FIFO order
+    Optional<int> a = mq.tryPop();
+    assert a.isPresent() && a.get() == 1;
+    Optional<int> b = mq.pop();
+    assert b.isPresent() && b.get() == 2;
+    assert mq.getSize() == 1;
+
+    // tryPop on an empty (but open) queue reports absence instead of blocking
+    mq.pop();
+    Optional<int> empty = mq.tryPop();
+    assert !empty.isPresent();
+
+    mq.push(42);
+    mq.close();
+    assert mq.isClosed();
+
+    // A closed queue still hands out items that were queued before the close...
+    Optional<int> afterClose = mq.pop();
+    assert afterClose.isPresent() && afterClose.get() == 42;
+    // ...and only reports empty once fully drained, without blocking
+    Optional<int> drained = mq.pop();
+    assert !drained.isPresent();
+    Optional<int> drainedTry = mq.tryPop();
+    assert !drainedTry.isPresent();
+
+    printf("Single-threaded smoke tests passed!\n");
+
+    // Concurrent producer/consumer stress test. If push()/pop() were not thread-safe,
+    // items would be lost or duplicated and the totals below would not match.
+    Shared s;
+    s.run();
+
+    const long expectedCount = cast<long>(PRODUCER_COUNT) * cast<long>(ITEMS_PER_PRODUCER);
+    const long sumPerProducer = cast<long>(ITEMS_PER_PRODUCER) * cast<long>(ITEMS_PER_PRODUCER + 1) / 2l;
+    const long expectedSum = cast<long>(PRODUCER_COUNT) * sumPerProducer;
+    assert s.mq.isEmpty();
+    assert s.poppedCount.load() == expectedCount;
+    assert s.poppedSum.load() == expectedSum;
+    printf("popped count = %lld, popped sum = %lld\n", s.poppedCount.load(), s.poppedSum.load());
+
+    printf("All assertions passed!\n");
+}

--- a/test/test-files/std/os/message-queue/source.spice
+++ b/test/test-files/std/os/message-queue/source.spice
@@ -35,12 +35,14 @@ p Shared.run() {
     Vector<Thread> consumers;
     for int i = 0; i < CONSUMER_COUNT; i++ {
         consumers.pushBack(Thread(consumer));
-        consumers.back().run();
+        Thread& consumerThread = consumers.back();
+        consumerThread.run();
     }
     Vector<Thread> producers;
     for int i = 0; i < PRODUCER_COUNT; i++ {
         producers.pushBack(Thread(producer));
-        producers.back().run();
+        Thread& producerThread = producers.back();
+        producerThread.run();
     }
 
     // Once every producer is done, closing the queue lets the blocked consumers drain

--- a/test/test-files/std/os/message-queue/source.spice
+++ b/test/test-files/std/os/message-queue/source.spice
@@ -1,6 +1,6 @@
 import "std/os/message-queue";
 import "std/os/thread";
-import "std/os/atomic";
+import "std/os/mutex";
 import "std/data/optional";
 import "std/data/vector";
 
@@ -9,11 +9,15 @@ const int CONSUMER_COUNT = 3;
 const int ITEMS_PER_PRODUCER = 5000;
 
 // Shared state for the concurrent test. Bundling the queue + counters into a struct lets
-// the async workers capture a single `this` pointer (per the async capture rules).
+// the async workers capture a single `this` pointer (per the async capture rules). The
+// counters are plain longs guarded by a mutex rather than Atomic<long>, since Atomic only
+// makes each individual load()/store() thread-safe - composing them as
+// `counter.store(counter.load() + 1)` would still race between concurrent consumers.
 type Shared struct {
     MessageQueue<int> mq
-    Atomic<long> poppedSum
-    Atomic<long> poppedCount
+    Mutex countersMutex
+    long poppedSum = 0l
+    long poppedCount = 0l
 }
 
 p Shared.run() {
@@ -26,8 +30,9 @@ p Shared.run() {
         while true {
             Optional<int> item = this.mq.pop();
             if !item.isPresent() { break; }
-            this.poppedSum.store(this.poppedSum.load() + cast<long>(item.get()));
-            this.poppedCount.store(this.poppedCount.load() + 1l);
+            LockGuard _ = LockGuard(this.countersMutex);
+            this.poppedSum += cast<long>(item.get());
+            this.poppedCount++;
         }
     };
 
@@ -101,9 +106,9 @@ f<int> main() {
     const long sumPerProducer = cast<long>(ITEMS_PER_PRODUCER) * cast<long>(ITEMS_PER_PRODUCER + 1) / 2l;
     const long expectedSum = cast<long>(PRODUCER_COUNT) * sumPerProducer;
     assert s.mq.isEmpty();
-    assert s.poppedCount.load() == expectedCount;
-    assert s.poppedSum.load() == expectedSum;
-    printf("popped count = %lld, popped sum = %lld\n", s.poppedCount.load(), s.poppedSum.load());
+    assert s.poppedCount == expectedCount;
+    assert s.poppedSum == expectedSum;
+    printf("popped count = %lld, popped sum = %lld\n", s.poppedCount, s.poppedSum);
 
     printf("All assertions passed!\n");
 }


### PR DESCRIPTION
Adds MessageQueue<T> in std/os/message-queue.spice: a FIFO queue for
passing values between threads, built on top of the existing Queue<T>
and guarded by a Mutex so push()/pop()/tryPop() and friends are safe
to call concurrently from any number of threads. pop() blocks until an
item is available or the queue is closed (spin-waiting via yield(),
since the stdlib has no condition variable primitive); close() lets
producers signal shutdown while consumers still drain whatever is left
before pop() reports empty instead of blocking forever.

Adds a reference test (test/test-files/std/os/message-queue) covering
single-threaded semantics plus a concurrent stress test with multiple
producer/consumer threads, and documents the new type in
docs/docs/language/threads.md alongside the existing Mutex/ThreadPool
sections.

Validation: this sandbox only has LLVM 18 installed while the repo
pins LLVM 23.1.0 (dev-setup.py), and building LLVM 23 from source was
not feasible here (time/disk). Attempted a local-only build against
LLVM 18 to sanity-check the new .spice file, patching a few unrelated
compiler files for LLVM-18 API compatibility; hit further incompatible
API changes (e.g. llvm::CondBrInst not existing in LLVM 18) that make
a full local build impractical, so those exploratory patches were
reverted and are not part of this commit. The new module closely
mirrors existing, already-compiling stdlib patterns (Queue<T> in
std/data/queue.spice, Mutex/LockGuard in std/os/mutex.spice, Atomic<T>
in std/os/atomic.spice, and the Queue<T>-based ThreadPool in
std/os/thread-pool.spice) and was reviewed against those for API and
style consistency.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019z1NxyDyKyVxnYhtPe9D14