### PR TITLE
Use postfix ! for pure error-propagation call sites in std

### DIFF
--- a/std/bindings/libcurl/libcurl.spice
+++ b/std/bindings/libcurl/libcurl.spice
@@ -595,11 +595,7 @@ public f<Result<string>> CurlClient.downloadFile(string url, string outputPath, 
     }
 
     // Create + open output file
-    const Result<File> fileRes = openFile(outputPath, MODE_READ_WRITE_OVERWRITE);
-    if fileRes.isErr() {
-        return err<string>(fileRes.getErr());
-    }
-    const File file = fileRes.unwrap();
+    const File file = openFile(outputPath, MODE_READ_WRITE_OVERWRITE)!;
 
     // Set necessary options to CURL
     this.setOption(CurlOption::URL, url);

--- a/std/io/file.spice
+++ b/std/io/file.spice
@@ -274,12 +274,7 @@ public f<Result<File>> openFile(String path, string mode = MODE_READ) {
  */
 public f<Result<String>> readFile(string path) {
     // Open the file in read mode
-    Result<File> fileResult = openFile(path, MODE_READ);
-    // Check for errors
-    if !fileResult.isOk() {
-        return err<String>(fileResult.getErr());
-    }
-    File file = fileResult.unwrap();
+    File file = openFile(path, MODE_READ)!;
     // Read from the file char by char
     char buffer;
     String output = String();
@@ -300,12 +295,7 @@ public f<Result<String>> readFile(string path) {
  */
 public f<Result<bool>> writeFile(string path, string content) {
     // Open the file in write mode
-    Result<File> fileResult = openFile(path, MODE_WRITE);
-    // Check for errors
-    if !fileResult.isOk() {
-        return err<bool>(fileResult.getErr());
-    }
-    File file = fileResult.unwrap();
+    File file = openFile(path, MODE_WRITE)!;
     // Write the string to the file
     bool success = file.write(content);
     // Close the file
@@ -321,12 +311,7 @@ public f<Result<bool>> writeFile(string path, string content) {
  */
 public f<Result<unsigned long>> getFileSize(string path) {
     // Open the file in read mode
-    Result<File> fileResult = openFile(path, MODE_READ);
-    // Check for errors
-    if !fileResult.isOk() {
-        return err<unsigned long>(fileResult.getErr());
-    }
-    File file = fileResult.unwrap();
+    File file = openFile(path, MODE_READ)!;
     // Get the file file
     unsigned long size = file.getSize();
     // Close the file

--- a/std/net/socket_darwin.spice
+++ b/std/net/socket_darwin.spice
@@ -332,9 +332,7 @@ public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingCon
  */
 public f<Result<Socket>> openClientSocket(string host, unsigned short port) {
     // Resolve the host before spending a file descriptor on it
-    const Result<InAddrT> addrResult = resolveHost(host);
-    if addrResult.isErr() { return err<Socket>(addrResult.getErr()); }
-    const InAddrT hostAddr = addrResult.unwrap();
+    const InAddrT hostAddr = resolveHost(host)!;
 
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error opening socket client connection")); }

--- a/std/net/socket_linux.spice
+++ b/std/net/socket_linux.spice
@@ -317,9 +317,7 @@ public f<Result<Socket>> openServerSocket(unsigned short port, int maxWaitingCon
  */
 public f<Result<Socket>> openClientSocket(string host, unsigned short port) {
     // Resolve the host before spending a file descriptor on it
-    const Result<InAddrT> addrResult = resolveHost(host);
-    if addrResult.isErr() { return err<Socket>(addrResult.getErr()); }
-    const InAddrT hostAddr = addrResult.unwrap();
+    const InAddrT hostAddr = resolveHost(host)!;
 
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error opening socket client connection")); }

--- a/std/net/socket_windows.spice
+++ b/std/net/socket_windows.spice
@@ -342,9 +342,7 @@ public f<Result<Socket>> openClientSocket(string host, unsigned short port) {
     if !startupWinsock() { return err<Socket>(Error("Error initializing WSA")); }
 
     // Resolve the host before spending a socket handle on it
-    const Result<InAddrT> addrResult = resolveHost(host);
-    if addrResult.isErr() { return err<Socket>(addrResult.getErr()); }
-    const InAddrT hostAddr = addrResult.unwrap();
+    const InAddrT hostAddr = resolveHost(host)!;
 
     const int sockFd = socket(AF_INET, SOCK_STREAM, IPPROTO_IP);
     if sockFd == -1 { return err<Socket>(Error("Error opening socket client connection")); }

--- a/std/text/regex/regex.spice
+++ b/std/text/regex/regex.spice
@@ -48,11 +48,7 @@ p Regex.ctor(const RegexProgram& prog) {
  */
 public f<Result<Regex>> compileRegex(const String& pattern) {
     RegexParser parser = RegexParser(pattern);
-    Result<RegexNode*> parseResult = parser.parse();
-    if parseResult.isErr() {
-        return err<Regex>(parseResult.getErr());
-    }
-    RegexNode* root = parseResult.unwrap();
+    RegexNode* root = parser.parse()!;
     const RegexProgram prog = compileToProgram(root, parser.groupCount);
     deleteRegexNode(root);
     return ok(Regex(prog));


### PR DESCRIPTION
## What changed
- Replaced manual `isErr()`/`getErr()`/`unwrap()` error-propagation boilerplate with the postfix `!` operator in six `std/` files: `std/io/file.spice` (`readFile`, `writeFile`, `getFileSize`), `std/text/regex/regex.spice` (`compileRegex`), `std/bindings/libcurl/libcurl.spice` (`CurlClient.downloadFile`), and `openClientSocket` in `std/net/socket_linux.spice`, `socket_darwin.spice`, `socket_windows.spice`.

## Why
`!` (added for exactly this purpose, see `media/specs/error-handling.md`) lets these call sites replace a 5-line manual isErr-check/return/unwrap block with a single `x!`. I only converted sites that are pure propagation — check, return the *same* error, unwrap, nothing else in between — so the change is behavior-preserving. I audited every other `isErr()`/`unwrap()`/`getErr()` call site in `std/` and left the rest untouched:
- `std/net/http.spice`, `http-client.spice`, `http-server.spice` accumulate an `errorMessage` through nested `if`/`else` and run cleanup (closing a socket, sending an error response) *after* the failing branch — `!`'s unconditional early return would skip that cleanup, so converting these would change behavior, not just simplify syntax.
- `std/data/*.spice` (`Vector`, `HashTable`, `Stack`, etc.) call bare `.unwrap()` on allocator results inside constructors/procedures that don't themselves return `Result<U>`, where `!` isn't legal.
- Test files under `test/test-files/` are intentional fixtures (several already exercise `!`, others specifically test the manual pattern for backward compatibility), so left as-is.

## How it was validated
- `cmake-build-debug/test/spicetest --gtest_filter='StdTests.*'` (run from `cmake-build-debug/test/`) — 129 passed, 1 skipped (`net_socketsBasic`, pre-existing environment-only skip unrelated to this change), 1 unrelated failure (`bindings_llvm`, local missing-library linker error, unrelated to any touched file).
- Suites covering every changed file specifically: `io_fileWriteRead`, `text_regexMatchingSmoke`, `text_regexErrors`, `text_regexReplaceSplit`, `bindings_libcurlFileDownload`, `runtime_resultErrPropagation*`, `net_httpMessage`, `net_httpRoundtrip` — all pass.
- No `spice` compiler changes needed (grammar/type-checker/codegen for `!` were already implemented), so no rebuild of `spice`/`spicetest` was required beyond the existing debug build.

## Follow-up / known limitations
- This does not attempt Phase 5 of `media/specs/error-handling.md` ("migrate std's internal `panic()`-on-recoverable-failure call sites to `Result<T>`") — that's a separate, larger design task, not a mechanical `!`-adoption sweep.