### PR TITLE
Fix crashes from generic structs/interfaces with wrong template arg count

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,3 +1,5 @@
+import "std/data/vector";
+
 f<int> main() {
-    Result<heap byte*> r = sAlloc(4l);
+    Vector vec;
 }

--- a/src/symboltablebuilder/QualType.cpp
+++ b/src/symboltablebuilder/QualType.cpp
@@ -118,7 +118,8 @@ Struct *QualType::getStruct(const ASTNode *node) const { return getStruct(node, 
  */
 Struct *QualType::getStructAndAdjustType(const ASTNode *node, const QualTypeList &templateTypes) {
   Struct *spiceStruct = getStruct(node, templateTypes);
-  type = type->getWithBodyScope(spiceStruct->scope)->getWithTemplateTypes(spiceStruct->getTemplateTypes());
+  if (spiceStruct != nullptr)
+    type = type->getWithBodyScope(spiceStruct->scope)->getWithTemplateTypes(spiceStruct->getTemplateTypes());
   return spiceStruct;
 }
 

--- a/src/typechecker/TypeCheckerMeta.cpp
+++ b/src/typechecker/TypeCheckerMeta.cpp
@@ -324,6 +324,9 @@ std::any TypeChecker::visitCustomDataType(CustomDataTypeNode *node) {
   if (entryType.isOneOf({TY_STRUCT, TY_INTERFACE})) {
     assert(is<DataTypeNode *>(node->parent->parent));
 
+    // Remember how many template types this struct/interface actually declares, before it gets overwritten below
+    const size_t requiredTemplateTypeCount = entryType.getTemplateTypes().size();
+
     // Collect the concrete template types
     bool allTemplateTypesConcrete = true;
     QualTypeList templateTypes;
@@ -345,6 +348,15 @@ std::any TypeChecker::visitCustomDataType(CustomDataTypeNode *node) {
         templateTypes.push_back(templateType);
       }
       entryType = entryType.getWithTemplateTypes(templateTypes);
+    }
+
+    // Reject usage with a wrong number of template type arguments (including none, if some are required)
+    if (templateTypes.size() != requiredTemplateTypeCount) {
+      const std::string kind = entryType.is(TY_STRUCT) ? "Struct" : "Interface";
+      const std::string errorMessage = kind + " '" + node->fqTypeName + "' requires " +
+                                        std::to_string(requiredTemplateTypeCount) + " template type argument(s), but got " +
+                                        std::to_string(templateTypes.size());
+      SOFT_ERROR_QT(node, INVALID_TEMPLATE_TYPES, errorMessage)
     }
 
     // Check if struct is defined before the current code location, if defined in the same source file. Across files

--- a/test/test-files/typechecker/generics/error-missing-template-types/exception.out
+++ b/test/test-files/typechecker/generics/error-missing-template-types/exception.out
@@ -1,0 +1,8 @@
+[Error|Compiler]:
+Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
+
+[Error|Semantic] ./source.spice:8:5:
+Invalid template types: Struct 'Optional' requires 1 template type argument(s), but got 0
+
+8  Optional o;
+   ^^^^^^^^

--- a/test/test-files/typechecker/generics/error-missing-template-types/source.spice
+++ b/test/test-files/typechecker/generics/error-missing-template-types/source.spice
@@ -1,0 +1,9 @@
+type T dyn;
+
+type Optional<T> struct {
+    T value
+}
+
+f<int> main() {
+    Optional o;
+}

--- a/test/test-files/typechecker/generics/error-struct-instantiation-template-not-matching/exception.out
+++ b/test/test-files/typechecker/generics/error-struct-instantiation-template-not-matching/exception.out
@@ -1,0 +1,8 @@
+[Error|Compiler]:
+Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
+
+[Error|Semantic] ./source.spice:8:14:
+Referenced undefined struct: Struct 'Optional' could not be found
+
+8  dyn o = Optional{};
+           ^^^^^^^^^^

--- a/test/test-files/typechecker/generics/error-struct-instantiation-template-not-matching/source.spice
+++ b/test/test-files/typechecker/generics/error-struct-instantiation-template-not-matching/source.spice
@@ -1,0 +1,9 @@
+type T dyn;
+
+type Optional<T> struct {
+    T value
+}
+
+f<int> main() {
+     dyn o = Optional{};
+}

--- a/test/test-files/typechecker/generics/error-wrong-template-type-count/exception.out
+++ b/test/test-files/typechecker/generics/error-wrong-template-type-count/exception.out
@@ -1,0 +1,8 @@
+[Error|Compiler]:
+Unresolved soft errors: There are unresolved errors. Please fix them and recompile.
+
+[Error|Semantic] ./source.spice:10:5:
+Invalid template types: Struct 'Pair' requires 2 template type argument(s), but got 1
+
+10  Pair<int> pair;
+    ^^^^^^^^^

--- a/test/test-files/typechecker/generics/error-wrong-template-type-count/source.spice
+++ b/test/test-files/typechecker/generics/error-wrong-template-type-count/source.spice
@@ -1,0 +1,11 @@
+type K dyn;
+type V dyn;
+
+type Pair<K, V> struct {
+    K key
+    V value
+}
+
+f<int> main() {
+    Pair<int> pair;
+}


### PR DESCRIPTION
## What changed
- `TypeChecker::visitCustomDataType` now checks that the number of template type arguments supplied for a generic struct/interface matches the number it declares, and raises a proper `Invalid template types` semantic error otherwise (covers both no `<...>` at all and a count mismatch, e.g. `Map<int>` for `Map<K, V>`).
- `QualType::getStructAndAdjustType` no longer dereferences the `Struct*` it gets back from `getStruct()` when that lookup fails (same root cause, different call site: brace-literal struct instantiation, e.g. `Optional{}` where `Optional<T>` requires one type argument). Its only caller, `visitStructInstantiation`, already had a `if (!spiceStruct)` check — it just never got the chance to run.
- Added three regression tests under `test/test-files/typechecker/generics/`: `error-missing-template-types`, `error-wrong-template-type-count`, `error-struct-instantiation-template-not-matching`.

## Why
`Vector vec;` (a generic struct referenced without/with too few template type arguments) previously passed the type checker with its generic parameters left unresolved, then crashed a debug assertion during IR generation (`Type::toLLVMType`'s `assert(!hasAnyGenericParts())`, or `QualType::isTriviallyConstructible`'s `assert(spiceStruct != nullptr)` for the count-mismatch case) instead of producing a compiler diagnostic. The related brace-literal instantiation path (`Optional{}`) crashed even harder — a raw `SIGSEGV`, no assertion at all — for the same underlying reason: `StructManager::match` returning `nullptr` on a lookup failure wasn't being handled by every caller.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest` — builds clean.
- `cmake-build-debug/test/spicetest --gtest_filter='TypeCheckerTests.*:IRGeneratorTests.*'` — 407/407 pass.
- `cmake-build-debug/test/spicetest --gtest_filter='StdTests.*:-StdTests.bindings_llvm:StdTests.net_socketsBasic'` — 129/129 pass.
- Full suite (`cmake-build-debug/test/spicetest`, run from `test/`): 656/690 passing; remaining 32 failures are the pre-existing, environment-only baseline (missing `libLLVMIREmbUtils.a` for LLVM bindings, and a cwd-relative-path issue in `DriverTest` induced by the bootstrap env vars) — unrelated to this change, and unchanged before/after.
- Manually confirmed `Vector vec;`, `Map<int> m;`, and `Optional{}` (with a non-matching template arg count) now produce clean semantic errors instead of crashing, and that correctly-specified generics (`Vector<int>`, `Map<int, String>`, `Optional<int>{ 42 }`) still compile and run.

## Follow-up / known limitations
None outstanding — the previously-noted `getStructAndAdjustType` null-deref is fixed in this PR.
