### PR TITLE
Add SQLite bindings to the standard library

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -265,7 +265,9 @@ jobs:
           echo "C:\Program Files\Graphviz\bin" >> $env:GITHUB_PATH
           New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
           & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install sqlite3:x64-windows
-          echo "LIB=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\lib;$env:LIB" >> $env:GITHUB_ENV
+          # The compiler links via clang's GNU driver (--target=x86_64-w64-windows-gnu, MinGW), which reads
+          # LIBRARY_PATH for '-l' search dirs, not the MSVC-only LIB variable.
+          echo "LIBRARY_PATH=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\lib;$env:LIBRARY_PATH" >> $env:GITHUB_ENV
           echo "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" >> $env:GITHUB_PATH
 
       - name: Restore CCache

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
+          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
@@ -165,7 +165,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
+          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
@@ -264,6 +264,9 @@ jobs:
           choco install graphviz ccache ninja -y
           echo "C:\Program Files\Graphviz\bin" >> $env:GITHUB_PATH
           New-Item -ItemType Directory -Force -Path "$env:LOCALAPPDATA\ccache"
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install sqlite3:x64-windows
+          echo "LIB=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\lib;$env:LIB" >> $env:GITHUB_ENV
+          echo "$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows\bin" >> $env:GITHUB_PATH
 
       - name: Restore CCache
         uses: actions/cache/restore@v6
@@ -358,7 +361,8 @@ jobs:
       - name: Setup Dependencies
         run: |
           brew update
-          brew install ccache graphviz
+          brew install ccache graphviz sqlite
+          echo "PKG_CONFIG_PATH=$(brew --prefix sqlite)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
           mkdir -p ~/Library/Caches/ccache
 
       - name: Restore CCache
@@ -448,7 +452,8 @@ jobs:
       - name: Setup Dependencies
         run: |
           brew update
-          brew install ccache graphviz
+          brew install ccache graphviz sqlite
+          echo "PKG_CONFIG_PATH=$(brew --prefix sqlite)/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
           mkdir -p ~/Library/Caches/ccache
 
       - name: Restore CCache

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,24 +92,28 @@ nfpms:
           - gtk4-dev
           - gtkmm4.0-dev
           - curl-dev
+          - sqlite-dev
       deb:
         dependencies:
           - build-essential
           - libgtk-4-dev
           - libgtkmm-4.0-dev
           - libcurl4-openssl-dev
+          - libsqlite3-dev
       rpm:
         dependencies:
           - glibc-devel
           - gtk4-devel
           - gtkmm4.0-devel
           - libcurl-devel
+          - sqlite-devel
       archlinux:
         dependencies:
           - base-devel
           - gtk4
           - gtkmm-4.0
           - curl
+          - sqlite
 
 homebrew_casks:
   - name: spice

--- a/docs/docs/how-to/cpp-interop.md
+++ b/docs/docs/how-to/cpp-interop.md
@@ -234,5 +234,5 @@ source, and links everything in a single step.
 
 !!! note "Existing bindings"
     The Spice standard library ships ready-made bindings for several popular C libraries under `std/bindings/`,
-    including `libcurl`, `GTK4`, and LLVM. Check those files for complete, production-ready examples of the
-    patterns shown in this tutorial.
+    including `libcurl`, `GTK4`, LLVM, and SQLite. Check those files for complete, production-ready examples of
+    the patterns shown in this tutorial.

--- a/std/README.md
+++ b/std/README.md
@@ -31,8 +31,9 @@ Spice bindings for common external libraries, allowing them to be called from Sp
 | Module            | Description                                                            |
 |-------------------|------------------------------------------------------------------------|
 | `gtk/gtk4`        | Bindings for the GTK 4 GUI toolkit.                                    |
-| `libcurl/libcurl` | Bindings for libcurl, used for network transfers that need https.     |
+| `libcurl/libcurl` | Bindings for libcurl, used for network transfers that need https.      |
 | `llvm/llvm`       | Bindings for the LLVM C API, plus linker flags and a target wrapper.   |
+| `sqlite/sqlite`   | Bindings for SQLite, an embedded, file-based SQL database.             |
 
 ### `std/crypto`
 Cryptographic hash functions that turn a message of any length into a fixed-size digest.

--- a/std/bindings/sqlite/sqlite.spice
+++ b/std/bindings/sqlite/sqlite.spice
@@ -1,0 +1,214 @@
+#![core.compiler.warnings.ignore]
+#![
+    core.linux.linker.flag = "`pkg-config --cflags --libs sqlite3`",
+    core.darwin.linker.flag = "`pkg-config --cflags --libs sqlite3`",
+    core.windows.linker.flag = "-lsqlite3"
+]
+
+// ===== Open flags =====
+public const int SQLITE_OPEN_READONLY  = 0x00000001;
+public const int SQLITE_OPEN_READWRITE = 0x00000002;
+public const int SQLITE_OPEN_CREATE    = 0x00000004;
+public const int SQLITE_OPEN_URI       = 0x00000040;
+public const int SQLITE_OPEN_MEMORY    = 0x00000080;
+public const int SQLITE_OPEN_NOMUTEX   = 0x00008000;
+public const int SQLITE_OPEN_FULLMUTEX = 0x00010000;
+public const int SQLITE_OPEN_DEFAULT   = 0x00000006; // SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE
+
+// ===== Enums =====
+public type SqliteResultCode enum {
+    OK = 0,
+    ERROR = 1,
+    INTERNAL = 2,
+    PERM = 3,
+    ABORT = 4,
+    BUSY = 5,
+    LOCKED = 6,
+    NOMEM = 7,
+    READONLY = 8,
+    INTERRUPT = 9,
+    IOERR = 10,
+    CORRUPT = 11,
+    NOTFOUND = 12,
+    FULL = 13,
+    CANTOPEN = 14,
+    PROTOCOL = 15,
+    EMPTY = 16,
+    SCHEMA = 17,
+    TOOBIG = 18,
+    CONSTRAINT = 19,
+    MISMATCH = 20,
+    MISUSE = 21,
+    NOLFS = 22,
+    AUTH = 23,
+    FORMAT = 24,
+    RANGE = 25,
+    NOTADB = 26,
+    NOTICE = 27,
+    WARNING = 28,
+    ROW = 100,
+    DONE = 101
+}
+
+public type SqliteColumnType enum {
+    INTEGER = 1,
+    FLOAT = 2,
+    TEXT = 3,
+    BLOB = 4,
+    NULL = 5
+}
+
+// ===== External type definitions =====
+type ExtSqliteRef alias byte*;
+type ExtSqliteStmtRef alias byte*;
+
+// ===== External function declarations =====
+ext f<SqliteResultCode> sqlite3_open_v2(string /*filename*/, ExtSqliteRef* /*ppDb*/, int /*flags*/, string /*zVfs*/);
+ext f<SqliteResultCode> sqlite3_close(ExtSqliteRef /*db*/);
+ext f<string> sqlite3_errmsg(ExtSqliteRef /*db*/);
+ext f<SqliteResultCode> sqlite3_exec(ExtSqliteRef /*db*/, string /*sql*/, byte* /*callback*/, byte* /*arg*/, byte** /*errmsg*/);
+ext f<long> sqlite3_last_insert_rowid(ExtSqliteRef /*db*/);
+ext f<int> sqlite3_changes(ExtSqliteRef /*db*/);
+ext f<string> sqlite3_libversion();
+
+ext f<SqliteResultCode> sqlite3_prepare_v2(ExtSqliteRef /*db*/, string /*sql*/, int /*nByte*/, ExtSqliteStmtRef* /*ppStmt*/, string* /*pzTail*/);
+ext f<SqliteResultCode> sqlite3_step(ExtSqliteStmtRef /*stmt*/);
+ext f<SqliteResultCode> sqlite3_reset(ExtSqliteStmtRef /*stmt*/);
+ext f<SqliteResultCode> sqlite3_finalize(ExtSqliteStmtRef /*stmt*/);
+ext f<SqliteResultCode> sqlite3_bind_int64(ExtSqliteStmtRef /*stmt*/, int /*index*/, long /*value*/);
+ext f<SqliteResultCode> sqlite3_bind_double(ExtSqliteStmtRef /*stmt*/, int /*index*/, double /*value*/);
+// The destructor param is a function pointer in the C API (SQLITE_STATIC = 0, SQLITE_TRANSIENT = -1); a pointer-sized
+// integer is ABI-compatible and avoids needing an integer-to-pointer cast, which Spice does not support.
+ext f<SqliteResultCode> sqlite3_bind_text(ExtSqliteStmtRef /*stmt*/, int /*index*/, string /*value*/, int /*length*/, long /*destructor*/);
+ext f<SqliteResultCode> sqlite3_bind_null(ExtSqliteStmtRef /*stmt*/, int /*index*/);
+ext f<int> sqlite3_column_count(ExtSqliteStmtRef /*stmt*/);
+ext f<SqliteColumnType> sqlite3_column_type(ExtSqliteStmtRef /*stmt*/, int /*col*/);
+ext f<string> sqlite3_column_name(ExtSqliteStmtRef /*stmt*/, int /*col*/);
+ext f<long> sqlite3_column_int64(ExtSqliteStmtRef /*stmt*/, int /*col*/);
+ext f<double> sqlite3_column_double(ExtSqliteStmtRef /*stmt*/, int /*col*/);
+ext f<string> sqlite3_column_text(ExtSqliteStmtRef /*stmt*/, int /*col*/);
+
+public inline f<string> getSqliteVersion() {
+    return sqlite3_libversion();
+}
+
+// ===== SqliteDatabase =====
+public type SqliteDatabase struct {
+    ExtSqliteRef self
+    SqliteResultCode lastResult
+}
+
+public p SqliteDatabase.ctor(string path, int flags = SQLITE_OPEN_DEFAULT) {
+    this.self = nil<ExtSqliteRef>;
+    this.lastResult = sqlite3_open_v2(path, &this.self, flags, nil<string>);
+}
+
+public p SqliteDatabase.dtor() {
+    if this.self != nil<ExtSqliteRef> {
+        sqlite3_close(this.self);
+    }
+}
+
+public inline f<bool> SqliteDatabase.isValid() {
+    return this.self != nil<ExtSqliteRef> && this.lastResult == SqliteResultCode::OK;
+}
+
+public inline f<string> SqliteDatabase.getErrorMessage() {
+    return sqlite3_errmsg(this.self);
+}
+
+public inline f<long> SqliteDatabase.getLastInsertRowId() {
+    return sqlite3_last_insert_rowid(this.self);
+}
+
+public inline f<int> SqliteDatabase.getChanges() {
+    return sqlite3_changes(this.self);
+}
+
+public f<Result<bool>> SqliteDatabase.exec(string sql) {
+    if !this.isValid() {
+        return err<bool>("SQLite database is not open");
+    }
+
+    const SqliteResultCode rc = sqlite3_exec(this.self, sql, nil<byte*>, nil<byte*>, nil<byte**>);
+    if rc != SqliteResultCode::OK {
+        return err<bool>(this.getErrorMessage());
+    }
+    return ok<bool>(true);
+}
+
+// ===== SqliteStatement =====
+public type SqliteStatement struct {
+    ExtSqliteStmtRef self
+    SqliteResultCode lastResult
+}
+
+public p SqliteStatement.ctor(const SqliteDatabase& db, string sql) {
+    this.self = nil<ExtSqliteStmtRef>;
+    this.lastResult = sqlite3_prepare_v2(db.self, sql, -1, &this.self, nil<string*>);
+}
+
+public p SqliteStatement.dtor() {
+    if this.self != nil<ExtSqliteStmtRef> {
+        sqlite3_finalize(this.self);
+    }
+}
+
+public inline f<bool> SqliteStatement.isValid() {
+    return this.self != nil<ExtSqliteStmtRef> && this.lastResult == SqliteResultCode::OK;
+}
+
+public inline p SqliteStatement.bindInt(int index, long value) {
+    sqlite3_bind_int64(this.self, index, value);
+}
+
+public inline p SqliteStatement.bindDouble(int index, double value) {
+    sqlite3_bind_double(this.self, index, value);
+}
+
+// The bound text is copied by SQLite immediately (SQLITE_TRANSIENT), so it stays valid after this call returns.
+public inline p SqliteStatement.bindText(int index, string value) {
+    sqlite3_bind_text(this.self, index, value, -1, -1l);
+}
+
+public inline p SqliteStatement.bindNull(int index) {
+    sqlite3_bind_null(this.self, index);
+}
+
+public f<SqliteResultCode> SqliteStatement.step() {
+    this.lastResult = sqlite3_step(this.self);
+    return this.lastResult;
+}
+
+public inline f<bool> SqliteStatement.nextRow() {
+    return this.step() == SqliteResultCode::ROW;
+}
+
+public inline p SqliteStatement.reset() {
+    sqlite3_reset(this.self);
+}
+
+public inline f<int> SqliteStatement.getColumnCount() {
+    return sqlite3_column_count(this.self);
+}
+
+public inline f<SqliteColumnType> SqliteStatement.getColumnType(int col) {
+    return sqlite3_column_type(this.self, col);
+}
+
+public inline f<string> SqliteStatement.getColumnName(int col) {
+    return sqlite3_column_name(this.self, col);
+}
+
+public inline f<long> SqliteStatement.getColumnInt(int col) {
+    return sqlite3_column_int64(this.self, col);
+}
+
+public inline f<double> SqliteStatement.getColumnDouble(int col) {
+    return sqlite3_column_double(this.self, col);
+}
+
+// Only valid for a column whose type is not SqliteColumnType::NULL.
+public inline f<String> SqliteStatement.getColumnText(int col) {
+    return String(sqlite3_column_text(this.self, col));
+}

--- a/test/test-files/std/bindings/sqlite-basic-usage/cout.out
+++ b/test/test-files/std/bindings/sqlite-basic-usage/cout.out
@@ -1,0 +1,3 @@
+Inserted row id: 1
+id=1 name=Ada age=36
+All assertions passed!

--- a/test/test-files/std/bindings/sqlite-basic-usage/source.spice
+++ b/test/test-files/std/bindings/sqlite-basic-usage/source.spice
@@ -1,0 +1,38 @@
+import "std/bindings/sqlite/sqlite";
+
+f<int> main() {
+    const string version = getSqliteVersion();
+    assert version != nil<string>;
+
+    SqliteDatabase db = SqliteDatabase(":memory:");
+    assert db.isValid();
+
+    Result<bool> createRes = db.exec("CREATE TABLE people (id INTEGER PRIMARY KEY, name TEXT, age INTEGER)");
+    assert createRes.isOk();
+
+    SqliteStatement insertStmt = SqliteStatement(db, "INSERT INTO people (name, age) VALUES (?, ?)");
+    assert insertStmt.isValid();
+    insertStmt.bindText(1, "Ada");
+    insertStmt.bindInt(2, 36l);
+    assert insertStmt.step() == SqliteResultCode::DONE;
+    assert db.getChanges() == 1;
+    printf("Inserted row id: %d\n", db.getLastInsertRowId());
+
+    SqliteStatement selectStmt = SqliteStatement(db, "SELECT id, name, age FROM people ORDER BY id");
+    assert selectStmt.isValid();
+    unsigned int rowCount = 0u;
+    while selectStmt.nextRow() {
+        const long id = selectStmt.getColumnInt(0);
+        const String name = selectStmt.getColumnText(1);
+        const long age = selectStmt.getColumnInt(2);
+        printf("id=%d name=%s age=%d\n", id, name.getRaw(), age);
+        rowCount++;
+    }
+    assert rowCount == 1u;
+
+    // Invalid SQL should surface as an error, not a crash.
+    Result<bool> badExec = db.exec("NOT VALID SQL");
+    assert badExec.isErr();
+
+    printf("All assertions passed!\n");
+}


### PR DESCRIPTION
## What changed
- Adds `std/bindings/sqlite/sqlite.spice`: bindings for SQLite's core C API — `SqliteDatabase` (open/close, `exec`, error messages, last-insert-rowid/changes) and `SqliteStatement` (prepared statements: bind params, `step`/`reset`, column accessors), plus the `SqliteResultCode`/`SqliteColumnType` enums and `SQLITE_OPEN_*` flag constants.
- Adds a reference test (`test/test-files/std/bindings/sqlite-basic-usage`) covering create table, prepared insert with bound params, prepared select with row iteration, and an invalid-SQL error path.
- Documents the new module in `std/README.md` and `docs/docs/how-to/cpp-interop.md`.
- Provisions `libsqlite3` in `ci-cpp.yml` for all 5 jobs (Linux x86_64/AArch64 via apt, macOS x86_64/AArch64 via brew, Windows via vcpkg) so the new test runs everywhere instead of being skipped.

## Why
Follows the existing `libcurl`/`gtk4`/`llvm` binding pattern under `std/bindings/` to add an embedded, file-based SQL database to the standard library — a commonly requested capability that needs no server and has a small, stable C API.

One deliberate design choice: `SqliteStatement` is only ever constructed directly (`SqliteStatement stmt = SqliteStatement(db, sql);`), never returned through `Result<T>` or by value from a function. Early testing showed that path can double-run a struct's dtor for non-trivial types in this compiler, which here would mean a double `sqlite3_finalize` call. This mirrors the one place the LLVM binding does the same thing for its own dtor-bearing `Module` type.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest` — builds clean.
- `cmake-build-debug/test/spicetest --gtest_filter='StdTests.bindings_*'` — `bindings_sqliteBasicUsage`, `bindings_gtk4WithBuilder`, `bindings_gtk4WithoutBuilder`, and `bindings_libcurlFileDownload` all pass. (`bindings_llvm` fails locally only because `LLVM_LIB_DIR` isn't set in this sandbox — pre-existing, unrelated to this change.)
- `spice run --sanitizer=address` on the new test source, plus an extended local stress test (invalid SQL via both `exec()` and `prepare()`, NULL columns, statement `reset()`+re-run, 50 prepare/finalize cycles, a failed `open`) — no leaks or double-frees under ASan.

## Follow-up / known limitations
- The macOS and Windows CI provisioning (Homebrew `PKG_CONFIG_PATH` export; vcpkg + `LIB`/`PATH` export) is implemented per standard practice but **unverified** — this sandbox has no macOS or Windows environment, so it can only be confirmed once this PR's CI actually runs. If either job fails to link/run, the error output should point directly at what needs adjusting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9wpRY6drojiHE9BG3em5u