### PR TITLE
Add CodeRabbit configuration for automated PR review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,6 +2,11 @@
 language: "en-US"
 early_access: false
 
+knowledge_base:
+  code_guidelines:
+    filePatterns:
+      - "**/STYLE_GUIDE.md"
+
 reviews:
   profile: "chill"
   request_changes_workflow: false
@@ -44,3 +49,4 @@ reviews:
 
 chat:
   auto_reply: true
+  art: false

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,46 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+language: "en-US"
+early_access: false
+
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+  path_filters:
+    - "!deps/**"
+    - "!gen/**"
+    - "!docs/site/**"
+    - "!docs/docs/std/**"
+    - "!cmake-build-*/**"
+    - "!media/**"
+  path_instructions:
+    - path: "src/**/*.{h,hpp,cpp}"
+      instructions: >
+        Follow the project's C++ coding conventions in STYLE_GUIDE.md
+        (formatting per .clang-format, naming, file layout, the visitor
+        pattern, diagnostics, and memory-management rules). Flag deviations.
+    - path: "src-bootstrap/**/*.spice"
+      instructions: >
+        This is the self-hosted bootstrap compiler written in Spice. Follow
+        the Spice-source conventions in STYLE_GUIDE.md.
+    - path: "std/**/*.spice"
+      instructions: >
+        Standard library code. Follow the Spice-source conventions in
+        STYLE_GUIDE.md.
+    - path: "test/test-files/**"
+      instructions: >
+        Compiler reference/integration test fixtures. Check that new or
+        changed cases follow the layout and reference-file conventions
+        described in AGENTS.md rather than flagging them as production code.
+    - path: "test/unittest/**"
+      instructions: >
+        GoogleTest-based unit tests for compiler components.
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
## What changed
- Adds `.coderabbit.yaml` at the repo root to configure the CodeRabbit review bot.
- Auto-review enabled for all (non-draft) PRs, `chill` profile, poem/emoji disabled.
- Path filters exclude generated/vendored trees: `deps/`, `gen/`, `docs/site/`, `docs/docs/std/`, `cmake-build-*/`, `media/`.
- Path-specific instructions point reviews at `STYLE_GUIDE.md` for `src/**` (C++), `src-bootstrap/**` and `std/**` (Spice source), and at `AGENTS.md`'s test-file conventions for `test/test-files/**`.
- Chat auto-reply enabled so `@coderabbitai` PR comments get responses.

## Why
Adds automated first-pass PR review to catch style/convention issues and provide reviewers with a summary, tuned to this repo's existing conventions instead of using CodeRabbit's generic defaults.

## How it was validated
This is a config-only change (no compiler/stdlib/test code touched), so no build or test run was needed. Validated by hand-checking the YAML against CodeRabbit's schema and confirming the referenced paths (`STYLE_GUIDE.md`, `AGENTS.md`, `deps/`, `gen/`, etc.) exist in the repo.

## Follow-up / known limitations
- The CodeRabbit GitHub App itself still needs to be installed on `spicelang/spice` via https://github.com/marketplace/coderabbitai (requires org/repo admin consent through GitHub's UI — not doable via API/CLI). Once installed, it will pick up this config automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated code review configuration, including review summaries, status updates, path exclusions, language-specific guidance, and automatic chat replies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->