### PR TITLE
Split coverage build into a dedicated workflow

### DIFF
--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
+          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
@@ -49,10 +49,6 @@ jobs:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
           restore-keys: ccache-${{ runner.os }}-${{ runner.arch }}-
-
-      - name: Setup Gcovr
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: sudo pipx install gcovr
 
       - name: Clone LLVM
         run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
@@ -95,30 +91,18 @@ jobs:
           mkdir ./build
           cd ./build
           cmake -GNinja \
-            -DCMAKE_BUILD_TYPE=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'Debug' || 'Release' }} \
+            -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DSPICE_BUILT_BY="ghactions" \
             -DSPICE_ENABLE_TPDE=ON \
-            -DSPICE_RUN_COVERAGE=${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') && 'ON' || 'OFF' }} \
             -DSPICE_TEST_ARGS=--is-github-actions \
             ..
           cmake --build . --target spicetest
 
       - name: Run Test target
-        if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
         working-directory: build
         run: cmake --build . --target spicetest_parallel
-
-      - name: Run Test target (with coverage)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        working-directory: build/test
-        env:
-          LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib
-          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
-          SPICE_STD_DIR: ${{ github.workspace }}/std
-          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
-        run: ./spicetest --is-github-actions
 
       - name: Save CCache
         uses: actions/cache/save@v6
@@ -126,23 +110,6 @@ jobs:
         with:
           path: ~/.cache/ccache
           key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
-
-      - name: Generate coverage report
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        working-directory: build
-        run: |
-          sudo chmod +x coverage.py
-          python coverage.py
-
-      - name: Upload coverage report - coverage.spicelang.com
-        uses: sebastianpopp/ftp-action@releases/v2
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        with:
-          host: ${{ secrets.FTP_SERVER }}
-          user: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          localDir: ./build/coverage
-          remoteDir: chillibits.com/spice/coverage
 
   build-linux-aarch64:
     name: C++ CI - Linux/AArch64

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,140 @@
+# Code coverage
+name: Coverage
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'media/**'
+      - '**.md'
+  # Allow manual triggering
+  workflow_dispatch:
+
+env:
+  LLVM_VERSION: "llvmorg-23.1.0"
+  GCC_VERSION: "16"
+
+jobs:
+  coverage-linux-x86:
+    name: Coverage - Linux/x86_64
+    runs-on: ubuntu-26.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+
+      - name: Setup Java
+        uses: actions/setup-java@v6
+        with:
+          distribution: zulu
+          java-version: 25
+          java-package: jre
+
+      - name: Setup Dependencies
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          sudo pipx install gcovr
+          mkdir -p ~/.cache/ccache
+
+      - name: Setup Mold
+        uses: rui314/setup-mold@v1
+
+      - name: Restore CCache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-coverage-${{ github.sha }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ runner.arch }}-coverage-
+            ccache-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
+            -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
+            -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: python setup-deps.py
+
+      - name: Build test target with coverage
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DSPICE_BUILT_BY="ghactions" \
+            -DSPICE_ENABLE_TPDE=ON \
+            -DSPICE_RUN_COVERAGE=ON \
+            -DSPICE_TEST_ARGS=--is-github-actions \
+            ..
+          cmake --build . --target spicetest
+
+      - name: Run Test target (with coverage)
+        working-directory: build/test
+        env:
+          LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib
+          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
+          SPICE_STD_DIR: ${{ github.workspace }}/std
+          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
+        run: ./spicetest --is-github-actions
+
+      - name: Save CCache
+        uses: actions/cache/save@v6
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-coverage-${{ github.sha }}
+
+      - name: Generate coverage report
+        working-directory: build
+        run: |
+          sudo chmod +x coverage.py
+          python coverage.py
+
+      - name: Upload coverage report - coverage.spicelang.com
+        uses: airvzxf/ftp-deployment-action@v2
+        with:
+          server: ${{ secrets.FTP_SERVER }}
+          user: ${{ secrets.FTP_USERNAME }}
+          password: ${{ secrets.FTP_PASSWORD }}
+          local_dir: ./build/coverage
+          remote_dir: chillibits.com/spice/coverage


### PR DESCRIPTION
## What changed
- Extracted the coverage build/report/upload steps out of `ci-cpp.yml`'s Linux/x86_64 job into a new dedicated `coverage.yml` workflow.
- `ci-cpp.yml` now runs the same Release build + `spicetest_parallel` on every branch/event for Linux/x86_64, matching the other platform jobs (aarch64, Windows, macOS) instead of branching to a Debug+coverage build on `main` pushes.
- `coverage.yml` triggers on push to `main` (same `paths-ignore` as before) plus `workflow_dispatch`, and does the Debug+coverage instrumented build, runs the suite serially, generates the gcovr report, and uploads it to coverage.spicelang.com — same behavior/cadence as before, just decoupled from normal CI.
- Also swapped the FTP upload action from the unmaintained `sebastianpopp/ftp-action@releases/v2` to `airvzxf/ftp-deployment-action@v2`, updating the input names (`server`, `local_dir`, `remote_dir`) to match.
- Gave the coverage job's ccache key a `-coverage-` suffix (falling back to the shared prefix) so it no longer collides with the normal CI job's cache key when both run concurrently on a `main` push.

## Why
Coupling the coverage run into the normal CI job meant the `main` branch's "regular" CI signal was actually a Debug build running tests serially, different from every PR/branch build (Release + parallel tests) and from the other platforms. Splitting them out makes normal CI validation consistent everywhere, and isolates the coverage job's slower serial run + FTP upload from the fast path.

## How it was validated
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-cpp.yml')); yaml.safe_load(open('.github/workflows/coverage.yml'))"` — both files parse as valid YAML.
- No compiler/test build was run since this is a CI-config-only change with no source changes; actual behavior will be validated by GitHub Actions on this PR and on the next push to `main`.

## Follow-up / known limitations
- None known.