### PR TITLE
Fix coverage FTP upload failing after workflow split

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -131,10 +131,10 @@ jobs:
           python coverage.py
 
       - name: Upload coverage report - coverage.spicelang.com
-        uses: airvzxf/ftp-deployment-action@v2
+        uses: sebastianpopp/ftp-action@releases/v2
         with:
-          server: ${{ secrets.FTP_SERVER }}
+          host: ${{ secrets.FTP_SERVER }}
           user: ${{ secrets.FTP_USERNAME }}
           password: ${{ secrets.FTP_PASSWORD }}
-          local_dir: ./build/coverage
-          remote_dir: chillibits.com/spice/coverage
+          localDir: ./build/coverage
+          remoteDir: chillibits.com/spice/coverage


### PR DESCRIPTION
## Summary
- Restores the `sebastianpopp/ftp-action@releases/v2` FTP action (and its `host`/`localDir`/`remoteDir` inputs) in `.github/workflows/coverage.yml`

## Why
The [dedicated coverage workflow split](https://github.com/spicelang/spice/pull/1365) accidentally swapped the working `sebastianpopp/ftp-action@releases/v2` step for `airvzxf/ftp-deployment-action@v2` with different input names, instead of just relocating the original step as intended. That action is docker-based and fails on this runner with:

```
/app/init.sh: line 357: can't create /github/home/.netrc: Permission denied
chmod: /github/home/.netrc: No such file or directory
```

This broke the "Upload coverage report - coverage.spicelang.com" step on every push to `main` since the split (see [run 33792484354](https://github.com/spicelang/spice/actions/runs/33792484354/job/100772152227)).

## How it was validated
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/coverage.yml'))"` — YAML parses successfully
- Diffed against the pre-split step in `ci-cpp.yml` (last known-good run [33320350753](https://github.com/spicelang/spice/actions/runs/33320350753)) to confirm the action name and input names now match exactly what previously worked

## Follow-up
None — this restores prior working behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nYNqcqHnLVqje8dNwjD6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the coverage report upload process to use a different FTP deployment service.
  * Adjusted the deployment configuration to match the new service’s settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->