### PR TITLE
Generate a Spice std lib coverage report in the coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,14 @@ on:
       - 'docs/**'
       - 'media/**'
       - '**.md'
+  # TEMPORARY: run on PRs too, to validate this workflow before merging. Revert before merge.
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - 'docs/**'
+      - 'media/**'
+      - '**.md'
   # Allow manual triggering
   workflow_dispatch:
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,14 +9,6 @@ on:
       - 'docs/**'
       - 'media/**'
       - '**.md'
-  # TEMPORARY: run on PRs too, to validate this workflow before merging. Revert before merge.
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - 'docs/**'
-      - 'media/**'
-      - '**.md'
   # Allow manual triggering
   workflow_dispatch:
 

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -88,6 +88,14 @@ jobs:
             ../llvm
           cmake --build .
 
+      - name: Build llvm-cov
+        # Needed to read the gcov data Spice's own --coverage instrumentation emits (see "Run Test target (Spice
+        # coverage)" below) - GNU gcov cannot parse it, only llvm-cov gcov can. LLVM_BUILD_TOOLS=OFF above excludes
+        # tools from the default build, but their targets stay individually buildable, so this only builds the one
+        # tool we need. Runs unconditionally (not gated on the LLVM cache step) so a cache hit still produces it.
+        working-directory: llvm/build
+        run: cmake --build . --target llvm-cov
+
       - name: Download Libs
         run: python setup-deps.py
 
@@ -117,6 +125,27 @@ jobs:
           SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
         run: ./spicetest --is-github-actions
 
+      - name: Run Test target (Spice coverage)
+        # Separate run: --coverage forces debug info on for every compiled test program, which changes the emitted
+        # LLVM IR and would spuriously fail the (unrelated) exact-match IR/assembly reference comparisons the run
+        # above relies on. This run skips those comparisons (see TestUtil::checkRefMatch) and just compiles, links
+        # and executes every test program that would normally run, to collect gcov data for the std lib code they
+        # exercise.
+        #
+        # continue-on-error: this run's only purpose is collecting coverage data (correctness is already verified by
+        # the run above), and under sustained load across hundreds of sequential compiles, LLVM's GCOVProfilerPass
+        # has occasionally failed to open a single .gcno file, failing just that one test. A rare, isolated miss like
+        # that should not block generating/uploading the reports below with whatever data the rest of the run did
+        # collect.
+        continue-on-error: true
+        working-directory: build/test
+        env:
+          LLVM_LIB_DIR: /${{ github.workspace }}/llvm/build/lib
+          LLVM_INCLUDE_DIRS: -I${{ github.workspace }}/llvm/llvm/include -I${{ github.workspace }}/llvm/build/include
+          SPICE_STD_DIR: ${{ github.workspace }}/std
+          SPICE_BOOTSTRAP_DIR: ${{ github.workspace }}/src-bootstrap
+        run: ./spicetest --is-github-actions --coverage
+
       - name: Save CCache
         uses: actions/cache/save@v6
         if: always()
@@ -130,11 +159,28 @@ jobs:
           sudo chmod +x coverage.py
           python coverage.py
 
+      - name: Generate Spice coverage report
+        working-directory: build
+        env:
+          LLVM_COV: ${{ github.workspace }}/llvm/build/bin/llvm-cov
+        run: |
+          sudo chmod +x coverage-spice.py
+          python coverage-spice.py
+
       - name: Upload coverage report - coverage.spicelang.com
-        uses: sebastianpopp/ftp-action@releases/v2
+        uses: Dylan700/sftp-upload-action@v1.2.5
         with:
-          host: ${{ secrets.FTP_SERVER }}
-          user: ${{ secrets.FTP_USERNAME }}
-          password: ${{ secrets.FTP_PASSWORD }}
-          localDir: ./build/coverage
-          remoteDir: chillibits.com/spice/coverage
+          server: ${{ secrets.SFTP_SERVER }}
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          uploads: |
+            ./build/coverage/ => coverage/
+
+      - name: Upload Spice coverage report - coverage.spicelang.com
+        uses: Dylan700/sftp-upload-action@v1.2.5
+        with:
+          server: ${{ secrets.SFTP_SERVER }}
+          username: ${{ secrets.SFTP_USERNAME }}
+          password: ${{ secrets.SFTP_PASSWORD }}
+          uploads: |
+            ./build/coverage-spice/ => coverage/std/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -175,7 +175,7 @@ jobs:
           sudo chmod +x coverage-spice.py
           python coverage-spice.py
 
-      - name: Upload coverage report - coverage.spicelang.com
+      - name: Upload coverage report
         uses: Dylan700/sftp-upload-action@v1.2.5
         with:
           server: ${{ secrets.SFTP_SERVER }}
@@ -183,12 +183,5 @@ jobs:
           password: ${{ secrets.SFTP_PASSWORD }}
           uploads: |
             ./build/coverage/ => coverage/
-
-      - name: Upload Spice coverage report - coverage.spicelang.com
-        uses: Dylan700/sftp-upload-action@v1.2.5
-        with:
-          server: ${{ secrets.SFTP_SERVER }}
-          username: ${{ secrets.SFTP_USERNAME }}
-          password: ${{ secrets.SFTP_PASSWORD }}
-          uploads: |
             ./build/coverage-spice/ => coverage/std/
+          delete: 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,7 @@ endif ()
 
 # Coverage
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/coverage.py ${CMAKE_CURRENT_BINARY_DIR}/coverage.py SYMBOLIC)
+file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/coverage-spice.py ${CMAKE_CURRENT_BINARY_DIR}/coverage-spice.py SYMBOLIC)
 file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/gcovr.cfg ${CMAKE_CURRENT_BINARY_DIR}/gcovr.cfg SYMBOLIC)
 
 # Include main module

--- a/coverage-spice.py
+++ b/coverage-spice.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Generate an HTML coverage report for std lib Spice source files exercised by the test suite.
+
+Requires the test suite to have been run once with `spicetest --coverage`, which instruments every
+Spice program compiled during the run (including std lib dependencies pulled in by test files) for
+gcov-compatible coverage output. The resulting .gcno/.gcda files land per test case under
+test/test-tmp/ (see IROptimizer::addCoveragePassToPipeline), scattered across many separate
+compilations of the same std lib files - gcovr aggregates coverage across all of them into one
+per-line report.
+
+The gcov data LLVM emits for Spice code is only understood by `llvm-cov gcov`, not GNU gcov (they
+disagree on the on-disk data format version), so LLVM_COV must point at a matching llvm-cov build.
+"""
+import os
+import subprocess
+from pathlib import Path
+
+Path("coverage-spice").mkdir(exist_ok=True)
+
+llvm_cov = os.environ.get("LLVM_COV", "llvm-cov")
+
+base_args = [
+    "gcovr",
+    "--gcov-executable",
+    f"{llvm_cov} gcov",
+    "--exclude-lines-by-pattern",
+    "assert",
+    "--gcov-ignore-parse-errors",
+    "negative_hits.warn_once_per_file",
+    "--filter",
+    "../std/.*",
+    "-r",
+    "..",
+    "test",
+]
+
+subprocess.run(
+    base_args + ["--html", "--html-details", "-s", "-o", "coverage-spice/index.html"],
+    check=True,
+)
+subprocess.run(
+    base_args + ["--txt", "-o", "coverage-spice.txt"],
+    check=True,
+)

--- a/coverage.py
+++ b/coverage.py
@@ -11,6 +11,11 @@ base_args = [
     "assert",
     "--gcov-ignore-parse-errors",
     "negative_hits.warn_once_per_file",
+    # test/test-tmp holds gcov data from spicetest --coverage (Spice-level std lib coverage, see
+    # coverage-spice.py), emitted by LLVM's GCOVProfilerPass in a format GNU gcov can't parse. Left
+    # unexcluded, gcovr aborts entirely the moment its search (which isn't limited by -r/filter) finds one.
+    "--exclude-directories",
+    ".*test-tmp.*",
     "-r",
     ".",
 ]

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -97,6 +97,7 @@ set(SOURCES
         irgenerator/NameMangling.cpp
         # IR optimizer
         iroptimizer/IROptimizer.cpp
+        iroptimizer/CoverageWorkingDirFileSystem.cpp
         # Object emitter
         objectemitter/LLVMObjectEmitter.cpp
         # Linker
@@ -182,6 +183,10 @@ set_property(SOURCE irgenerator/IRGenerator.cpp APPEND PROPERTY COMPILE_OPTIONS 
 # compile this single translation unit without RTTI to drop the unused type_info and avoid the
 # dangling reference at link time.
 set_source_files_properties(util/RawStringOStream.cpp PROPERTIES COMPILE_OPTIONS -fno-rtti)
+# Same issue as above: CoverageWorkingDirFileSystem derives from the polymorphic LLVM type
+# llvm::vfs::ProxyFileSystem. It lives in its own translation unit (rather than alongside IROptimizer, which needs
+# RTTI for spice_pointer_cast on AST nodes) so only this one small file has to give it up.
+set_source_files_properties(iroptimizer/CoverageWorkingDirFileSystem.cpp PROPERTIES COMPILE_OPTIONS -fno-rtti)
 
 ################## spice executable ##################
 

--- a/src/irgenerator/DebugInfoGenerator.cpp
+++ b/src/irgenerator/DebugInfoGenerator.cpp
@@ -86,6 +86,10 @@ void DebugInfoGenerator::generateFunctionDebugInfo(llvm::Function *llvmFunction,
     return;
 
   const ASTNode *node = spiceFunc->declNode;
+  // Compiler-synthesized functions without a source declaration (e.g. the generated test-suite main) have no code
+  // location to attach debug info to, so skip them
+  if (!node)
+    return;
   const uint32_t lineNo = spiceFunc->getDeclCodeLoc().line;
 
   // Prepare flags
@@ -144,8 +148,10 @@ void DebugInfoGenerator::generateFunctionDebugInfo(llvm::Function *llvmFunction,
 void DebugInfoGenerator::concludeFunctionDebugInfo() {
   if (!irGenerator->cliOptions.instrumentation.generateDebugInfo)
     return;
+  // Functions generateFunctionDebugInfo skipped (no declNode, see there) never pushed a scope to conclude here.
+  if (lexicalBlocks.empty())
+    return;
 
-  assert(!lexicalBlocks.empty());
   lexicalBlocks.pop();
 }
 

--- a/src/iroptimizer/CoverageWorkingDirFileSystem.cpp
+++ b/src/iroptimizer/CoverageWorkingDirFileSystem.cpp
@@ -1,0 +1,28 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#include "CoverageWorkingDirFileSystem.h"
+
+#include <llvm/Support/VirtualFileSystem.h>
+
+namespace spice::compiler {
+
+namespace {
+// LCOV_EXCL_START
+class FixedWorkingDirFileSystem final : public llvm::vfs::ProxyFileSystem {
+public:
+  FixedWorkingDirFileSystem(llvm::IntrusiveRefCntPtr<FileSystem> fs, std::string workingDir)
+      : ProxyFileSystem(std::move(fs)), workingDir(std::move(workingDir)) {}
+
+  llvm::ErrorOr<std::string> getCurrentWorkingDirectory() const override { return workingDir; }
+
+private:
+  std::string workingDir;
+};
+// LCOV_EXCL_STOP
+} // namespace
+
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> createFixedWorkingDirFileSystem(std::string workingDir) {
+  return new FixedWorkingDirFileSystem(llvm::vfs::getRealFileSystem(), std::move(workingDir)); // GCOV_EXCL_LINE
+}
+
+} // namespace spice::compiler

--- a/src/iroptimizer/CoverageWorkingDirFileSystem.h
+++ b/src/iroptimizer/CoverageWorkingDirFileSystem.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2021-2026 ChilliBits. All rights reserved.
+
+#pragma once
+
+#include <string>
+
+#include <llvm/ADT/IntrusiveRefCntPtr.h>
+
+namespace llvm::vfs {
+class FileSystem;
+} // namespace llvm::vfs
+
+namespace spice::compiler {
+
+/**
+ * GCOVProfilerPass always resolves the .gcno/.gcda output location as "current working directory + source file
+ * basename" (see llvm/lib/Transforms/Instrumentation/GCOVProfiling.cpp: GCOVProfiler::mangleName()), ignoring the
+ * requested object file output directory entirely. This creates a filesystem view that reports the given directory
+ * as the current working directory instead of the process' real one, so coverage files land next to the rest of the
+ * compiler output regardless of where the compiler process was started from - without touching the real,
+ * process-wide working directory, which would affect unrelated, concurrently running code.
+ *
+ * @param workingDir Directory to report as the current working directory
+ * @return A filesystem view wrapping the real filesystem, with the working directory pinned to workingDir
+ */
+llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> createFixedWorkingDirFileSystem(std::string workingDir);
+
+} // namespace spice::compiler

--- a/src/iroptimizer/IROptimizer.cpp
+++ b/src/iroptimizer/IROptimizer.cpp
@@ -14,6 +14,8 @@
 #include <llvm/Transforms/Instrumentation/TypeSanitizer.h>
 #include <llvm/Analysis/AliasAnalysis.h>
 
+#include "CoverageWorkingDirFileSystem.h"
+
 namespace spice::compiler {
 
 IROptimizer::IROptimizer(GlobalResourceManager &resourceManager, SourceFile *sourceFile)
@@ -124,7 +126,8 @@ void IROptimizer::addInstrumentationPassToPipeline(llvm::ModulePassManager &modu
 void IROptimizer::addCoveragePassToPipeline(llvm::ModulePassManager &modulePassMgr) const {
   if (!cliOptions.instrumentation.codeCoverage)
     return;
-  modulePassMgr.addPass(llvm::GCOVProfilerPass(llvm::GCOVOptions::getDefault()));
+  const auto vfs = createFixedWorkingDirFileSystem(absolute(cliOptions.outputDir).string());
+  modulePassMgr.addPass(llvm::GCOVProfilerPass(llvm::GCOVOptions::getDefault(), vfs));
 }
 
 llvm::OptimizationLevel IROptimizer::getLLVMOptLevelFromSpiceOptLevel() const {

--- a/test/TestRunner.cpp
+++ b/test/TestRunner.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) 2021-2026 ChilliBits. All rights reserved.
 
+#include <algorithm>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -130,7 +131,7 @@ static void execTestCase(const TestCase &testCase) {
       /* staticLinking= */ false,
       CliOptions::InstrumentationSettings{
           /* generateDebugInfo= */ false,
-          /* codeCoverage= */ false,
+          /* codeCoverage= */ testDriverCliOptions.enableCoverage,
           /* sanitizer= */ Sanitizer::NONE,
       },
       /* disableVerifier= */ false,
@@ -230,6 +231,17 @@ static void execTestCase(const TestCase &testCase) {
     OptLevel generatedOptLevel = cliOptions.optLevel;
     // Execute IR generator in normal or debug mode
     mainSourceFile->runIRGenerator();
+
+    // Coverage counters are woven in by the optimizer pipeline, which the IR-check loop below only runs for opt levels
+    // that have a reference file to compare against. Most test cases only check execution output and have no IR
+    // reference at all, so without this, their linked binary would never actually carry the GCOV counters. Force one
+    // optimizer run at the default opt level in that case.
+    if (cliOptions.instrumentation.codeCoverage) {
+      const bool anyOptIrRefExists = std::ranges::any_of(
+          REF_NAME_OPT_IR, [&](const char *const ref) { return TestUtil::doesRefExist(testCase.testPath / ref); });
+      if (!anyOptIrRefExists)
+        mainSourceFile->runDefaultIROptimizer();
+    }
 
     // Check IR code
     for (uint8_t i = 0; i <= 5; i++) {

--- a/test/driver/TestDriver.cpp
+++ b/test/driver/TestDriver.cpp
@@ -23,7 +23,7 @@ void TestDriver::createInterface() {
 
 void TestDriver::addOptions() {
   // --update-refs
-  app.add_flag<bool>("--update-refs", testDriverCliOptions.updateRefs, "Update test reference files");
+  CLI::Option *updateRefsOpt = app.add_flag<bool>("--update-refs", testDriverCliOptions.updateRefs, "Update test reference files");
   // --run-benchmarks
   app.add_flag<bool>("--run-benchmarks", testDriverCliOptions.runBenchmarks, "Also run benchmarks and check baseline values");
   // --leak-detection
@@ -35,9 +35,13 @@ void TestDriver::addOptions() {
   // --verbose
   app.add_flag<bool>("--verbose", testDriverCliOptions.isVerbose, "Print debug output for the test runner");
   // --coverage
-  app.add_flag<bool>("--coverage", testDriverCliOptions.enableCoverage,
-                      "Compile and run test programs with Spice code coverage instrumentation enabled, skipping all "
-                      "reference output comparisons (debug info and coverage counters change the generated code)");
+  CLI::Option *coverageOpt =
+      app.add_flag<bool>("--coverage", testDriverCliOptions.enableCoverage,
+                          "Compile and run test programs with Spice code coverage instrumentation enabled, skipping all "
+                          "reference output comparisons (debug info and coverage counters change the generated code)");
+  // Coverage mode never compares against (or writes) reference files, so combining it with --update-refs would silently
+  // overwrite tracked fixtures with coverage-instrumented, no-longer-comparable output. Reject the combination outright.
+  coverageOpt->excludes(updateRefsOpt);
 }
 
 /**

--- a/test/driver/TestDriver.cpp
+++ b/test/driver/TestDriver.cpp
@@ -34,6 +34,10 @@ void TestDriver::addOptions() {
   app.add_flag<bool>("--skip-sanitizer-tests", testDriverCliOptions.skipSanitizerTests, "Skip tests that exercise Spice language sanitizers (e.g. ASAN, TSAN, MSAN, TYSAN)");
   // --verbose
   app.add_flag<bool>("--verbose", testDriverCliOptions.isVerbose, "Print debug output for the test runner");
+  // --coverage
+  app.add_flag<bool>("--coverage", testDriverCliOptions.enableCoverage,
+                      "Compile and run test programs with Spice code coverage instrumentation enabled, skipping all "
+                      "reference output comparisons (debug info and coverage counters change the generated code)");
 }
 
 /**

--- a/test/driver/TestDriver.h
+++ b/test/driver/TestDriver.h
@@ -19,6 +19,7 @@ struct TestDriverCliOptions {
   bool isGitHubActions = false;
   bool skipSanitizerTests = false;
   bool isVerbose = false;
+  bool enableCoverage = false;
 };
 
 /**

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -21,7 +21,8 @@ int main(int argc, char **argv) {
   driver.createInterface();
   driver.addOptions();
   // Parse command line args
-  driver.parse(argc, argv);
+  if (const int parseResult = driver.parse(argc, argv); parseResult != 0)
+    return parseResult;
   // Run tests
   return RUN_ALL_TESTS();
 }

--- a/test/test-files/irgenerator/testing/success-testing-with-dbg-info/cout.out
+++ b/test/test-files/irgenerator/testing/success-testing-with-dbg-info/cout.out
@@ -1,0 +1,7 @@
+[==========] Running 1 test(s) from 1 source file(s)
+[----------] Running 1 test(s) from source.spice
+[ RUN      ] testAdd
+[1m[32m[ PASSED   ][0m[22m testAdd
+[----------] Ran 1 test(s) from source.spice
+
+[==========] Ran 1 test(s) from 1 source file(s)

--- a/test/test-files/irgenerator/testing/success-testing-with-dbg-info/source.spice
+++ b/test/test-files/irgenerator/testing/success-testing-with-dbg-info/source.spice
@@ -1,0 +1,15 @@
+// TEST: -g
+
+f<int> add(int a, int b) {
+    return a + b;
+}
+
+#[test]
+f<bool> testAdd() {
+    assert add(1, 2) == 3;
+    return true;
+}
+
+f<int> main() {
+    printf("%d\n", add(1, 2));
+}

--- a/test/util/TestUtil.cpp
+++ b/test/util/TestUtil.cpp
@@ -122,7 +122,10 @@ bool TestUtil::checkRefMatch(const std::filesystem::path &originalRefPath, GetOu
 
     if (testDriverCliOptions.updateRefs) {          // GCOV_EXCL_LINE
       FileUtil::writeToFile(refPath, actualOutput); // GCOV_EXCL_LINE
-    } else {
+    } else if (!testDriverCliOptions.enableCoverage) {
+      // In coverage mode, debug info and coverage counters change the generated output, so comparing it against the
+      // reference would fail spuriously. Still call getActualOutput() above though, to drive the pipeline stage that
+      // produces it (e.g. running the optimizer for the opt levels that have a reference file).
       std::string expectedOutput = FileUtil::getFileContent(refPath);
       modifyOutputFct(expectedOutput, actualOutput);
       EXPECT_EQ(expectedOutput, actualOutput) << "Output does not match the reference file: " << refPath;
@@ -269,6 +272,15 @@ bool TestUtil::isDisabled(const TestCase &testCase) {
     parseTestArgs(testCase.testPath / REF_NAME_SOURCE, testArgs);
     for (const std::string &arg : testArgs)
       if (arg.starts_with("--sanitizer"))
+        return true;
+  }
+  // Code coverage instrumentation is rejected by the driver in combination with LTO or the TPDE backend, and is not tested
+  // together with the sanitizers, so skip any test that requests one of these via its `// TEST: ` header.
+  if (testDriverCliOptions.enableCoverage) {
+    std::vector<std::string> testArgs;
+    parseTestArgs(testCase.testPath / REF_NAME_SOURCE, testArgs);
+    for (const std::string &arg : testArgs)
+      if (arg == "-lto" || arg == "--backend=tpde" || arg == "--backend=TPDE" || arg.starts_with("--sanitizer"))
         return true;
   }
 #ifndef SPICE_ENABLE_TPDE


### PR DESCRIPTION
## What changed
- The `coverage.yml` workflow now also measures how much of the std lib the test suite exercises, using Spice's own gcov-compatible `--coverage` instrumentation, and uploads that HTML report (scoped to `std/`) alongside the existing C++ compiler coverage report.
- Two compiler fixes needed to make this work:
  - `GCOVProfilerPass` always resolved `.gcno`/`.gcda` output as "current working directory + source file basename", ignoring the requested output directory. Fixed via a small VFS shim (`CoverageWorkingDirFileSystem`) that pins coverage output to `cliOptions.outputDir`.
  - Compiling a file with `test` functions under `-g`/`--coverage` segfaulted: the synthesized test-suite `main` has no source declaration, and `DebugInfoGenerator` unconditionally dereferenced its null `declNode`. Added a regression test for it.
- New `spicetest --coverage` flag: compiles/links/runs every test program with coverage instrumentation, skipping the (now debug-info-perturbed) exact-match reference comparisons, and skipping LTO/TPDE/sanitizer combinations that are incompatible with coverage. Run as a second, `continue-on-error` pass in CI, since its only purpose is data collection (correctness is already verified by the existing, unmodified test run).
- Switches the report uploads from FTP to SFTP (`Dylan700/sftp-upload-action`), using new `SFTP_SERVER`/`SFTP_USERNAME`/`SFTP_PASSWORD` secrets.
- **Temporary commit on top**: enables this workflow on `pull_request` so this PR's own run can validate it before merge — will be reverted before merging.

## Why
Now that Spice supports its own coverage instrumentation, we can use it to report how well the std lib is actually exercised by the test suite, not just how well the compiler's own C++ source is.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest` — builds clean.
- `cmake-build-debug/test/spicetest` (no `--coverage`) — full suite, no regressions beyond a pre-existing, environment-specific mold-linker issue unrelated to this change.
- `cmake-build-debug/test/spicetest --coverage --is-github-actions` — full suite, run repeatedly; same baseline failures, plus a rare (~1 in a few runs) isolated `.gcno`-open failure under sustained load, which is why the CI step is `continue-on-error`.
- Manually validated the whole pipeline end-to-end locally: compile → run → `llvm-cov gcov` → `gcovr` → aggregate HTML report, confirmed it correctly unions coverage across std lib modules from many separate test compilations.
- `cmake-build-debug/test/spicetest --gtest_filter='IRGeneratorTests*testing_successTestingWithDbgInfo*'` — new regression test for the `DebugInfoGenerator` crash, passes.

## Follow-up / known limitations
- The rare `.gcno`-open flake under `--coverage` (see above) isn't fully root-caused; mitigated via `continue-on-error` on that step since it only affects data completeness, not correctness.
- Remote SFTP paths (`coverage/`, `coverage/std/`) should be double-checked against the new SFTP account's layout on the first real run.
- The temporary `pull_request` trigger commit must be reverted before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013nYNqcqHnLVqje8dNwjD6M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--coverage` option for running tests with Spice coverage instrumentation.
  * Added HTML and text coverage reports for standard library code.
  * Coverage data is now written relative to the selected output directory.

* **Bug Fixes**
  * Improved debug information handling for compiler-generated functions.
  * Added coverage-mode handling for unsupported optimization, backend, and sanitizer tests.

* **Tests**
  * Added coverage-enabled test scenarios and debug-information coverage testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->