### PR TITLE
Suppress unused warnings for public symbols in library builds

### DIFF
--- a/src/SourceFile.cpp
+++ b/src/SourceFile.cpp
@@ -855,6 +855,11 @@ void SourceFile::checkForSoftErrors() const {
   }
 }
 
+bool SourceFile::isLibraryOutput() const {
+  return cliOptions.outputContainer == OutputContainer::STATIC_LIBRARY ||
+         cliOptions.outputContainer == OutputContainer::SHARED_LIBRARY;
+}
+
 void SourceFile::collectAndPrintWarnings() { // NOLINT(misc-no-recursion)
   // Skip if restored from cache (no scope tree available), or if already visited. The latter guard keeps circular
   // imports from recursing infinitely, since the dependency graph may contain cycles.

--- a/src/SourceFile.h
+++ b/src/SourceFile.h
@@ -169,6 +169,7 @@ public:
   [[nodiscard]] const NameRegistryEntry *getNameRegistryEntry(const std::string &symbolName) const;
   [[nodiscard]] llvm::Type *getLLVMType(const Type *type);
   void checkForSoftErrors() const;
+  [[nodiscard]] bool isLibraryOutput() const;
   void collectAndPrintWarnings();
   void collectAndPrintLintFindings();
   const SourceFile *getRootSourceFile() const;

--- a/src/symboltablebuilder/Scope.cpp
+++ b/src/symboltablebuilder/Scope.cpp
@@ -155,6 +155,13 @@ void Scope::collectWarnings(std::vector<CompilerWarning> &warnings) const { // N
 
     const QualType entryType = entry.getQualType();
 
+    // When compiling a static or shared library, publicly accessible symbols form part of the library's exported
+    // API. They may legitimately go unused within the library itself, since external consumers are expected to
+    // use them, so do not report them as unused. isPublic() is only defined for the type categories checked here
+    // (see the assertion in QualType::isPublic()), so guard the call accordingly.
+    if ((entryType.isExtendedPrimitive() || entryType.is(TY_ENUM)) && entryType.isPublic() && sourceFile->isLibraryOutput())
+      continue;
+
     // Determine warning type and message by the scope type and the symbol type
     CompilerWarningType warningType = UNUSED_VARIABLE;
     std::string warningMessage;


### PR DESCRIPTION
## What changed
- Added `SourceFile::isLibraryOutput()`, true when the CLI output container is `STATIC_LIBRARY` or `SHARED_LIBRARY`.
- `Scope::collectWarnings` now skips the unused diagnostics (`UNUSED_FUNCTION`, `UNUSED_PROCEDURE`, `UNUSED_STRUCT`, `UNUSED_INTERFACE`, `UNUSED_METHOD`, `UNUSED_FIELD`, unused global variables) for symbols marked `public` when compiling a static/shared library.

## Why
When compiling a static or shared library, `public` symbols form the library's exported API. They are expected to be used by external consumers, not necessarily from within the library itself, so flagging them as "unused" was a false positive that only made sense for executable builds.

The skip only applies to symbol kinds where `QualType::isPublic()` is well-defined (primitives, functions, procedures, structs, interfaces, enums — guarded via `isExtendedPrimitive() || is(TY_ENUM)`), so type aliases, imports, and other kinds that don't carry meaningful public/private semantics here are unaffected and still warn as before.

## How it was validated
- `cmake --build cmake-build-debug --target spice spicetest` — builds cleanly.
- `cmake-build-debug/test/spicetest --gtest_filter='TypeCheckerTests.warnings_*'` (run from `test/`) — all 22 pass.
- `cmake-build-debug/test/spicetest --gtest_filter='TypeCheckerTests.*'` — all 215 pass.
- Full `spicetest` suite — 664 passed, 2 skipped, 32 failed; all 32 failures are pre-existing environment-only issues on this machine (missing `libLLVMIREmbUtils.a` for LLVM-binding/bootstrap-compiler tests, `DriverTest` cases needing `SPICE_STD_DIR`/`LLVM_LIB_DIR`), unrelated to this change.
- Manual check: a source file with one `public` function and one private, unused function.
  - `spice build --output-container obj` warns about both.
  - `spice build --output-container lib` and `--output-container dylib` only warn about the private one.

## Follow-up / known limitations
- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016PTAzruWZaevjJ5dtoeNQm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unused-variable warnings for public primitive and enum symbols in library outputs when they are part of the exported API.
  - Added support for identifying whether output is configured as a static or shared library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->