### PR TITLE
Optimize assertions if the condition is known at compile time

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,30 +1,8 @@
-#![core.compiler.errorReturnTracing = true]
-
-import "std/test/bench";
-
-type TestStruct struct {}
-
-f<Result<double>> TestStruct.frame0(bool fail) {
-    return fail ? err<double>("Test error") : ok(4.5);
-}
-
-f<Result<int>> TestStruct.frame1(bool fail) {
-    double _d = this.frame0(fail)!;
-    return ok(1);
-}
-
-f<Result<int>> TestStruct.frame2(bool fail) {
-    int _d = this.frame1(fail)!;
-    return ok(1);
-}
-
-f<Result<int>> TestStruct.frame3(bool fail) {
-    int _d = this.frame2(fail)!;
-    return ok(1);
+f<int> foo() {
+    assert(false);
+    return 1;
 }
 
 f<int> main() {
-    TestStruct ts;
-    Result<int> resultI = ts.frame3(produce(true));
-    resultI.dumpTrace();
+    foo();
 }

--- a/src/irgenerator/GenStatements.cpp
+++ b/src/irgenerator/GenStatements.cpp
@@ -185,6 +185,31 @@ std::any IRGenerator::visitAssertStmt(const AssertStmtNode *node) {
   if (cliOptions.buildMode == BuildMode::RELEASE)
     return nullptr;
 
+  const auto generateBody = [&] {
+    // Create constant for error message
+    const std::string errorMsg = "Assertion failed: Condition '" + node->expressionString + "' evaluated to false.\n";
+    llvm::GlobalVariable *globalString = builder.CreateGlobalString(errorMsg, getUnusedGlobalName(ANON_GLOBAL_STRING_NAME));
+    // If the output should be comparable, fix alignment to 4 bytes
+    if (cliOptions.comparableOutput)
+      globalString->setAlignment(llvm::Align(4));
+    // Print the error message
+    llvm::Function *printfFct = stdFunctionManager.getPrintfFct();
+    builder.CreateCall(printfFct, globalString);
+    // Generate call to exit()
+    llvm::Function *exitFct = stdFunctionManager.getExitFct();
+    builder.CreateCall(exitFct, builder.getInt32(EXIT_FAILURE));
+    // Create unreachable instruction
+    builder.CreateUnreachable();
+    blockAlreadyTerminated = true;
+  };
+
+  // If we have a compile time decision, only evaluate the respective branch
+  if (node->assignExpr->hasCompileTimeValue(manIdx)) {
+    if (!node->assignExpr->getCompileTimeValue(manIdx).boolValue)
+      generateBody();
+    return nullptr;
+  }
+
   // Create blocks
   const std::string &codeLine = node->codeLoc.toPrettyLine();
   llvm::BasicBlock *bThen = createBlock("assert.then." + codeLine);
@@ -198,20 +223,7 @@ std::any IRGenerator::visitAssertStmt(const AssertStmtNode *node) {
 
   // Switch to then block
   switchToBlock(bThen);
-  // Create constant for error message
-  const std::string errorMsg = "Assertion failed: Condition '" + node->expressionString + "' evaluated to false.\n";
-  llvm::GlobalVariable *globalString = builder.CreateGlobalString(errorMsg, getUnusedGlobalName(ANON_GLOBAL_STRING_NAME));
-  // If the output should be comparable, fix alignment to 4 bytes
-  if (cliOptions.comparableOutput)
-    globalString->setAlignment(llvm::Align(4));
-  // Print the error message
-  llvm::Function *printfFct = stdFunctionManager.getPrintfFct();
-  builder.CreateCall(printfFct, globalString);
-  // Generate call to exit()
-  llvm::Function *exitFct = stdFunctionManager.getExitFct();
-  builder.CreateCall(exitFct, builder.getInt32(EXIT_FAILURE));
-  // Create unreachable instruction
-  builder.CreateUnreachable();
+  generateBody();
 
   // Switch to exit block
   switchToBlock(bExit);

--- a/test/test-files/irgenerator/assertions/success-basic-assertion/ir-code.ll
+++ b/test/test-files/irgenerator/assertions/success-basic-assertion/ir-code.ll
@@ -1,33 +1,17 @@
 ; ModuleID = 'source.spice'
 source_filename = "source.spice"
 
-@anon.string.0 = private unnamed_addr constant [56 x i8] c"Assertion failed: Condition 'true' evaluated to false.\0A\00", align 4
 @printf.str.0 = private unnamed_addr constant [26 x i8] c"First assertion was true\0A\00", align 4
-@anon.string.1 = private unnamed_addr constant [58 x i8] c"Assertion failed: Condition '1 != 1' evaluated to false.\0A\00", align 4
+@anon.string.0 = private unnamed_addr constant [58 x i8] c"Assertion failed: Condition '1 != 1' evaluated to false.\0A\00", align 4
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
 define dso_local noundef i32 @main() #0 {
   %result = alloca i32, align 4
   store i32 0, ptr %result, align 4
-  br i1 true, label %assert.exit.L2, label %assert.then.L2, !prof !5
-
-assert.then.L2:                                   ; preds = %0
-  %1 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
+  %1 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
+  %2 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
   call void @exit(i32 1)
   unreachable
-
-assert.exit.L2:                                   ; preds = %0
-  %2 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
-  br i1 false, label %assert.exit.L5, label %assert.then.L5, !prof !5
-
-assert.then.L5:                                   ; preds = %assert.exit.L2
-  %3 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
-  call void @exit(i32 1)
-  unreachable
-
-assert.exit.L5:                                   ; preds = %assert.exit.L2
-  %4 = load i32, ptr %result, align 4
-  ret i32 %4
 }
 
 ; Function Attrs: nofree nounwind
@@ -48,4 +32,3 @@ attributes #2 = { cold noreturn nounwind }
 !2 = !{i32 7, !"uwtable", i32 2}
 !3 = !{i32 7, !"frame-pointer", i32 2}
 !4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
-!5 = !{!"branch_weights", i32 1048575, i32 1}

--- a/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
+++ b/test/test-files/irgenerator/structs/success-packed-struct/ir-code.ll
@@ -4,14 +4,10 @@ source_filename = "source.spice"
 %struct.Test = type { i32, i64 }
 %struct.TestPacked = type <{ i32, i64 }>
 
-@anon.string.0 = private unnamed_addr constant [72 x i8] c"Assertion failed: Condition 'sizeof<Test>() == 16' evaluated to false.\0A\00", align 4
-@anon.string.1 = private unnamed_addr constant [67 x i8] c"Assertion failed: Condition 'sizeof(t) == 16' evaluated to false.\0A\00", align 4
-@anon.string.2 = private unnamed_addr constant [71 x i8] c"Assertion failed: Condition 't.f1 == -2147483647' evaluated to false.\0A\00", align 4
-@anon.string.3 = private unnamed_addr constant [80 x i8] c"Assertion failed: Condition 't.f2 == 9223372036854775807l' evaluated to false.\0A\00", align 4
-@anon.string.4 = private unnamed_addr constant [78 x i8] c"Assertion failed: Condition 'sizeof<TestPacked>() == 12' evaluated to false.\0A\00", align 4
-@anon.string.5 = private unnamed_addr constant [68 x i8] c"Assertion failed: Condition 'sizeof(tp) == 12' evaluated to false.\0A\00", align 4
-@anon.string.6 = private unnamed_addr constant [72 x i8] c"Assertion failed: Condition 'tp.f1 == -2147483647' evaluated to false.\0A\00", align 4
-@anon.string.7 = private unnamed_addr constant [81 x i8] c"Assertion failed: Condition 'tp.f2 == 9223372036854775807l' evaluated to false.\0A\00", align 4
+@anon.string.0 = private unnamed_addr constant [71 x i8] c"Assertion failed: Condition 't.f1 == -2147483647' evaluated to false.\0A\00", align 4
+@anon.string.1 = private unnamed_addr constant [80 x i8] c"Assertion failed: Condition 't.f2 == 9223372036854775807l' evaluated to false.\0A\00", align 4
+@anon.string.2 = private unnamed_addr constant [72 x i8] c"Assertion failed: Condition 'tp.f1 == -2147483647' evaluated to false.\0A\00", align 4
+@anon.string.3 = private unnamed_addr constant [81 x i8] c"Assertion failed: Condition 'tp.f2 == 9223372036854775807l' evaluated to false.\0A\00", align 4
 @printf.str.0 = private unnamed_addr constant [24 x i8] c"All assertions passed!\0A\00", align 4
 
 ; Function Attrs: mustprogress noinline norecurse nounwind optnone uwtable
@@ -25,40 +21,24 @@ define dso_local noundef i32 @main() #0 {
   store i32 -2147483647, ptr %f1.addr, align 4
   %f2.addr = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
   store i64 9223372036854775807, ptr %f2.addr, align 8
-  br i1 true, label %assert.exit.L16, label %assert.then.L16, !prof !5
-
-assert.then.L16:                                  ; preds = %0
-  %1 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
-  call void @exit(i32 1)
-  unreachable
-
-assert.exit.L16:                                  ; preds = %0
-  br i1 true, label %assert.exit.L17, label %assert.then.L17, !prof !5
-
-assert.then.L17:                                  ; preds = %assert.exit.L16
-  %2 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
-  call void @exit(i32 1)
-  unreachable
-
-assert.exit.L17:                                  ; preds = %assert.exit.L16
   %f1.addr1 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 0
-  %3 = load i32, ptr %f1.addr1, align 4
-  %4 = icmp eq i32 %3, -2147483647
-  br i1 %4, label %assert.exit.L18, label %assert.then.L18, !prof !5
+  %1 = load i32, ptr %f1.addr1, align 4
+  %2 = icmp eq i32 %1, -2147483647
+  br i1 %2, label %assert.exit.L18, label %assert.then.L18, !prof !5
 
-assert.then.L18:                                  ; preds = %assert.exit.L17
-  %5 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
+assert.then.L18:                                  ; preds = %0
+  %3 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
   call void @exit(i32 1)
   unreachable
 
-assert.exit.L18:                                  ; preds = %assert.exit.L17
+assert.exit.L18:                                  ; preds = %0
   %f2.addr2 = getelementptr inbounds %struct.Test, ptr %t, i64 0, i32 1
-  %6 = load i64, ptr %f2.addr2, align 8
-  %7 = icmp eq i64 %6, 9223372036854775807
-  br i1 %7, label %assert.exit.L19, label %assert.then.L19, !prof !5
+  %4 = load i64, ptr %f2.addr2, align 8
+  %5 = icmp eq i64 %4, 9223372036854775807
+  br i1 %5, label %assert.exit.L19, label %assert.then.L19, !prof !5
 
 assert.then.L19:                                  ; preds = %assert.exit.L18
-  %8 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
+  %6 = call i32 (ptr, ...) @printf(ptr @anon.string.1)
   call void @exit(i32 1)
   unreachable
 
@@ -68,47 +48,31 @@ assert.exit.L19:                                  ; preds = %assert.exit.L18
   store i32 -2147483647, ptr %f1.addr3, align 4
   %f2.addr4 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
   store i64 9223372036854775807, ptr %f2.addr4, align 8
-  br i1 true, label %assert.exit.L25, label %assert.then.L25, !prof !5
-
-assert.then.L25:                                  ; preds = %assert.exit.L19
-  %9 = call i32 (ptr, ...) @printf(ptr @anon.string.4)
-  call void @exit(i32 1)
-  unreachable
-
-assert.exit.L25:                                  ; preds = %assert.exit.L19
-  br i1 true, label %assert.exit.L26, label %assert.then.L26, !prof !5
-
-assert.then.L26:                                  ; preds = %assert.exit.L25
-  %10 = call i32 (ptr, ...) @printf(ptr @anon.string.5)
-  call void @exit(i32 1)
-  unreachable
-
-assert.exit.L26:                                  ; preds = %assert.exit.L25
   %f1.addr5 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 0
-  %11 = load i32, ptr %f1.addr5, align 4
-  %12 = icmp eq i32 %11, -2147483647
-  br i1 %12, label %assert.exit.L27, label %assert.then.L27, !prof !5
+  %7 = load i32, ptr %f1.addr5, align 4
+  %8 = icmp eq i32 %7, -2147483647
+  br i1 %8, label %assert.exit.L27, label %assert.then.L27, !prof !5
 
-assert.then.L27:                                  ; preds = %assert.exit.L26
-  %13 = call i32 (ptr, ...) @printf(ptr @anon.string.6)
+assert.then.L27:                                  ; preds = %assert.exit.L19
+  %9 = call i32 (ptr, ...) @printf(ptr @anon.string.2)
   call void @exit(i32 1)
   unreachable
 
-assert.exit.L27:                                  ; preds = %assert.exit.L26
+assert.exit.L27:                                  ; preds = %assert.exit.L19
   %f2.addr6 = getelementptr inbounds %struct.TestPacked, ptr %tp, i64 0, i32 1
-  %14 = load i64, ptr %f2.addr6, align 8
-  %15 = icmp eq i64 %14, 9223372036854775807
-  br i1 %15, label %assert.exit.L28, label %assert.then.L28, !prof !5
+  %10 = load i64, ptr %f2.addr6, align 8
+  %11 = icmp eq i64 %10, 9223372036854775807
+  br i1 %11, label %assert.exit.L28, label %assert.then.L28, !prof !5
 
 assert.then.L28:                                  ; preds = %assert.exit.L27
-  %16 = call i32 (ptr, ...) @printf(ptr @anon.string.7)
+  %12 = call i32 (ptr, ...) @printf(ptr @anon.string.3)
   call void @exit(i32 1)
   unreachable
 
 assert.exit.L28:                                  ; preds = %assert.exit.L27
-  %17 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
-  %18 = load i32, ptr %result, align 4
-  ret i32 %18
+  %13 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0)
+  %14 = load i32, ptr %result, align 4
+  ret i32 %14
 }
 
 ; Function Attrs: nofree nounwind

--- a/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
@@ -14,16 +14,9 @@ define internal noundef zeroext i1 @_Z7condFctv() #0 {
 ; Function Attrs: noinline nounwind optnone uwtable
 define internal noundef ptr @_Z7trueFctv() #0 {
   %result = alloca ptr, align 8
-  br i1 false, label %assert.exit.L6, label %assert.then.L6, !prof !5
-
-assert.then.L6:                                   ; preds = %0
   %1 = call i32 (ptr, ...) @printf(ptr @anon.string.0)
   call void @exit(i32 1)
   unreachable
-
-assert.exit.L6:                                   ; preds = %0
-  %2 = load ptr, ptr %result, align 8
-  ret ptr %2
 }
 
 ; Function Attrs: nofree nounwind
@@ -73,4 +66,3 @@ attributes #3 = { mustprogress noinline norecurse nounwind optnone uwtable }
 !2 = !{i32 7, !"uwtable", i32 2}
 !3 = !{i32 7, !"frame-pointer", i32 2}
 !4 = !{!"spice version dev (https://github.com/spicelang/spice)"}
-!5 = !{!"branch_weights", i32 1048575, i32 1}


### PR DESCRIPTION
Optimize assertions if the condition is known at compile time. No op if condition is true, no branching if the condition is false, mark block as terminated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Assertions with compile-time-known results are now evaluated during compilation.
  - Passing assertions avoid unnecessary runtime checks, while failing assertions report the failure and terminate execution immediately.

- **Bug Fixes**
  - Corrected generated behavior for constant assertions, packed-structure checks, and ternary short-circuiting.
  - Removed unnecessary runtime branches from generated output when assertion outcomes are already known.

- **Tests**
  - Updated compiler output tests to reflect constant-folded assertions and streamlined generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->