### PR TITLE
Do not assume assert statement as block terminator

### DIFF
--- a/media/test-project/test.spice
+++ b/media/test-project/test.spice
@@ -1,8 +1,8 @@
 f<int> foo() {
-    assert(false);
+    assert(true);
     return 1;
 }
 
 f<int> main() {
-    foo();
+    dyn _ = foo();
 }

--- a/src/ast/ASTNodes.cpp
+++ b/src/ast/ASTNodes.cpp
@@ -2,6 +2,8 @@
 
 #include <ast/ASTNodes.h>
 
+#include <ANTLRInputStream.h>
+
 #include <SourceFile.h>
 #include <ast/Attributes.h>
 #include <exception/SemanticError.h>
@@ -190,11 +192,6 @@ bool AttrLstNode::hasAttr(const std::string &key) const {
 }
 
 const CompileTimeValue *AttrNode::getValue() const { return value ? &value->compileTimeValue : nullptr; }
-
-bool AssertStmtNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable, size_t manIdx) const {
-  // If the expression, passed to the assert statement is always evaluated to false, the assert statement will never succeed
-  return assignExpr->hasCompileTimeValue(manIdx) && !assignExpr->getCompileTimeValue(manIdx).boolValue;
-}
 
 bool AssignExprNode::returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable, size_t manIdx) const {
   // If it's a ternary, do the default thing

--- a/src/ast/ASTNodes.h
+++ b/src/ast/ASTNodes.h
@@ -1417,7 +1417,6 @@ public:
 
   // Other methods
   GET_CHILDREN(assignExpr);
-  [[nodiscard]] bool returnsOnAllControlPaths(bool *doSetPredecessorsUnreachable, size_t manIdx) const override;
 
   // Public members
   ExprNode *assignExpr = nullptr;

--- a/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
+++ b/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/ir-code.ll
@@ -36,18 +36,18 @@ define dso_local noundef i32 @main() #3 {
   %result = alloca i32, align 4
   store i32 0, ptr %result, align 4
   %1 = call noundef zeroext i1 @_Z7condFctv()
-  br i1 %1, label %cond.true.L14C26, label %cond.false.L14C26
+  br i1 %1, label %cond.true.L15C26, label %cond.false.L15C26
 
-cond.true.L14C26:                                 ; preds = %0
+cond.true.L15C26:                                 ; preds = %0
   %2 = call noundef ptr @_Z7trueFctv()
-  br label %cond.exit.L14C26
+  br label %cond.exit.L15C26
 
-cond.false.L14C26:                                ; preds = %0
+cond.false.L15C26:                                ; preds = %0
   %3 = call noundef ptr @_Z8falseFctv()
-  br label %cond.exit.L14C26
+  br label %cond.exit.L15C26
 
-cond.exit.L14C26:                                 ; preds = %cond.false.L14C26, %cond.true.L14C26
-  %cond.result = phi ptr [ %2, %cond.true.L14C26 ], [ %3, %cond.false.L14C26 ]
+cond.exit.L15C26:                                 ; preds = %cond.false.L15C26, %cond.true.L15C26
+  %cond.result = phi ptr [ %2, %cond.true.L15C26 ], [ %3, %cond.false.L15C26 ]
   %4 = call noundef i32 (ptr, ...) @printf(ptr noundef @printf.str.0, ptr noundef %cond.result)
   %5 = load i32, ptr %result, align 4
   ret i32 %5

--- a/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/source.spice
+++ b/test/test-files/irgenerator/ternary/success-ternary-short-circuiting/source.spice
@@ -4,6 +4,7 @@ f<bool> condFct() {
 
 f<string> trueFct() {
     assert false; // Should not be called
+    return "true";
 }
 
 f<string> falseFct() {


### PR DESCRIPTION
Treating the assert statement as a block terminator, if the compile time value is false, is wrong for release builds, since the assert is completely omitted in the code generator.