### PR TITLE
Drop unused Java setup and bump Go/GoReleaser versions

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -23,13 +23,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Setup Dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -23,13 +23,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Setup Dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -120,13 +113,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
-
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
 
       - name: Setup Dependencies
         run: |
@@ -219,13 +205,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Install Dependencies
         run: |
           choco install graphviz ccache ninja -y
@@ -316,13 +295,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
-
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
 
       - name: Setup Mold
         uses: rui314/setup-mold@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,13 +20,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Setup Dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,13 +27,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Setup Dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,13 +21,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Setup Dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -108,13 +101,6 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Setup Dependencies
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
@@ -194,12 +180,6 @@ jobs:
         with:
           submodules: recursive
 
-      - uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
-
       - name: Setup Dependencies
         run: |
           choco install ninja -y
@@ -267,13 +247,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           submodules: recursive
-
-      - name: Setup Java
-        uses: actions/setup-java@v6
-        with:
-          distribution: zulu
-          java-version: 25
-          java-package: jre
 
       - name: Setup Mold
         uses: rui314/setup-mold@v1
@@ -358,7 +331,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: '1.26'
+          go-version: '1.27'
           cache: false
 
       - name: Docker login GHCR
@@ -396,7 +369,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:
-          version: v2.17.1
+          version: v2.18.1
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed
- Removed the `actions/setup-java` step from `ci-asan.yml`, `ci-cpp.yml`, `codeql-analysis.yml`, `coverage.yml`, and `publish.yml` (all jobs).
- Bumped Go from `1.26` to `1.27` and GoReleaser from `v2.17.1` to `v2.18.1` in `publish.yml`.

## Why
The Java setup step is no longer required by any CI job. The Go/GoReleaser bumps pick up the latest toolchain and release-tooling versions.

## How it was validated
- CI-only YAML changes; no compiler/test build was required. Verified the diffs are limited to the intended step removals and version bumps (`git diff`).

## Follow-up / known limitations
- None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U3nSSLQfRahy6bKEFqBsK5