### PR TITLE
Upgrade LLVM to 23.1.1

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0"
+  LLVM_VERSION: "llvmorg-23.1.1"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -9,7 +9,7 @@ on:
       - '**.md'
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0"
+  LLVM_VERSION: "llvmorg-23.1.1"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0"
+  LLVM_VERSION: "llvmorg-23.1.1"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0"
+  LLVM_VERSION: "llvmorg-23.1.1"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
       - '*'
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0"
+  LLVM_VERSION: "llvmorg-23.1.1"
   GCC_VERSION: "16"
 
 jobs:

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
 
 env:
-  LLVM_VERSION: "llvmorg-23.1.0"
+  LLVM_VERSION: "llvmorg-23.1.1"
   GCC_VERSION: "16"
 
 jobs:

--- a/dev-setup.py
+++ b/dev-setup.py
@@ -36,7 +36,7 @@ else:
 
 # Step 2: clone LLVM
 log("[Step 2] Cloning LLVM (could take a while) ...")
-run("git", "clone", "--depth", "1", "--branch", "llvmorg-23.1.0",
+run("git", "clone", "--depth", "1", "--branch", "llvmorg-23.1.1",
     "https://github.com/llvm/llvm-project", "llvm")
 log("done.")
 

--- a/test/test-files/bootstrap-compiler/standalone-common-util-test/cout.out
+++ b/test/test-files/bootstrap-compiler/standalone-common-util-test/cout.out
@@ -14,7 +14,7 @@ Circular error message:
 Version info:
 Spice version: 0.25.0 linux/amd64
 Git hash:      69b759385b4a84d1fd8d8a8ed38c8e9def98b9f8
-LLVM version:  23.1.0
+LLVM version:  23.1.1
 built by:      ghactions
 
 (c) Marc Auberer 2021-2026


### PR DESCRIPTION
## What changed
Bumped the pinned LLVM version from `llvmorg-23.1.0` to `llvmorg-23.1.1` in:
- `dev-setup.py` (local dev environment setup)
- All CI workflow files that build/cache LLVM: `ci-cpp.yml`, `ci-asan.yml`, `coverage.yml`, `codeql-analysis.yml`, `valgrind.yml`, `publish.yml`
- `test/test-files/bootstrap-compiler/standalone-common-util-test/cout.out` (version-info reference output that embeds the LLVM version string)

## Why it changed
LLVM 23.1.1 is now available (released 2026-09-08) and is a patch release on top of 23.1.0. Keeping the pinned version current picks up upstream fixes without any API/behavior changes expected for this compiler.

## How it was validated
- Confirmed the `llvmorg-23.1.1` tag/release exists upstream in `llvm/llvm-project`.
- `python3 -m py_compile dev-setup.py` — passes.
- Parsed all modified workflow YAML files with `yaml.safe_load` — all valid.
- `git grep` for `23.1.0` / `llvmorg-23.1.0` across the repo confirms no remaining references.

## Known limitations
This environment does not have a prebuilt LLVM 23 toolchain available, and building LLVM from source was not feasible within this session, so I was not able to do a full local `cmake --build` + `spicetest` run against the new LLVM version. CI (`ci-cpp.yml`, `ci-asan.yml`, etc.) will build LLVM 23.1.1 from source and run the full test suite, which is the first real end-to-end validation of this change — please confirm CI passes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HtzTrwQJ1qzDb16Q7a1GqV

---
_Generated by [Claude Code](https://claude.ai/code/session_01HtzTrwQJ1qzDb16Q7a1GqV)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the LLVM version used by development setup, testing, analysis, coverage, release, and validation workflows.
  * Ensures builds and automated checks use LLVM 23.1.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->