### PR TITLE
Add Clang-Tidy CI workflow for bug-pattern linting

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,30 @@
+---
+# clang-tidy configuration for the Spice compiler (src/, test/).
+#
+# Scope: bug-finding checks (bugprone, clang-analyzer, performance, portability,
+# misc) rather than style/opinion checks — formatting is handled by .clang-format
+# and naming/layout conventions are documented in STYLE_GUIDE.md. See that file's
+# "Memory management" section for why cppcoreguidelines' ownership/pointer checks
+# are intentionally left out: the codebase favors raw pointers owned by long-lived
+# containers (Scope*, ASTNode*, llvm::Value*) and arena-allocated AST nodes, which
+# those checks are not designed for.
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-narrowing-conversions,
+  clang-analyzer-*,
+  performance-*,
+  portability-*,
+  misc-*,
+  -misc-non-private-member-variables-in-classes,
+  -misc-no-recursion,
+  -misc-include-cleaner,
+  readability-avoid-const-params-in-decls,
+  readability-misleading-indentation,
+  readability-redundant-control-flow,
+  readability-redundant-declaration
+
+WarningsAsErrors: ''
+HeaderFilterRegex: '(src|test)/.*'
+FormatStyle: none

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,126 @@
+# Clang-Tidy CI
+name: Clang-Tidy
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'media/**'
+      - '**.md'
+
+env:
+  LLVM_VERSION: "llvmorg-23.1.1"
+  GCC_VERSION: "16"
+
+jobs:
+  clang-tidy:
+    name: Clang-Tidy - Linux/x86_64
+    runs-on: ubuntu-26.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Setup Dependencies
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+          sudo apt-get update
+          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang-tidy
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
+          mkdir -p ~/.cache/ccache
+
+      - name: Restore CCache
+        uses: actions/cache/restore@v6
+        with:
+          path: ~/.cache/ccache
+          key: ccache-clangtidy-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}
+          restore-keys: ccache-clangtidy-${{ runner.os }}-${{ runner.arch }}-
+
+      - name: Clone LLVM
+        run: git clone --depth 1 --branch ${{ env.LLVM_VERSION }} https://github.com/llvm/llvm-project llvm
+
+      - name: Cache LLVM
+        id: cache-llvm
+        uses: actions/cache@v6
+        with:
+          path: ${{ github.workspace }}/llvm/build
+          key: llvm-${{ env.LLVM_VERSION }}-linux-x64
+
+      - name: Build LLVM
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        working-directory: llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DCMAKE_CXX_FLAGS_RELEASE="-O3" \
+            -DLLVM_TARGETS_TO_BUILD="AArch64;X86;WebAssembly" \
+            -DLLVM_BUILD_TOOLS=OFF \
+            -DLLVM_INCLUDE_TESTS=OFF \
+            -DLLVM_INCLUDE_EXAMPLES=OFF \
+            -DLLVM_INCLUDE_BENCHMARKS=OFF \
+            ../llvm
+          cmake --build .
+
+      - name: Download Libs
+        run: python setup-deps.py
+
+      - name: Configure and generate sources
+        env:
+          LLVM_DIR: ${{ github.workspace }}/llvm/build/lib/cmake/llvm
+        run: |
+          mkdir ./build
+          cd ./build
+          cmake -GNinja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DSPICE_BUILT_BY="ghactions" \
+            ..
+          # Builds the core library so ANTLR-generated parser sources/headers exist on
+          # disk for clang-tidy to parse; compile_commands.json is written at configure
+          # time regardless (CMAKE_EXPORT_COMPILE_COMMANDS is ON in the top-level file).
+          cmake --build . --target spicecore
+
+      - name: Determine base commit
+        id: diff
+        run: |
+          BASE_SHA="${{ github.event.before }}"
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
+            BASE_SHA=$(git rev-parse HEAD^ 2>/dev/null || echo "")
+          fi
+          echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Run clang-tidy on changed lines
+        if: steps.diff.outputs.base_sha != ''
+        run: |
+          git diff -U0 "${{ steps.diff.outputs.base_sha }}" "${{ github.sha }}" -- '*.cpp' '*.h' > changes.diff
+          if [ ! -s changes.diff ]; then
+            echo "No changed C++ files; skipping clang-tidy."
+            exit 0
+          fi
+          python3 llvm/clang-tools-extra/clang-tidy/tool/clang-tidy-diff.py \
+            -p1 -path build -j "$(nproc)" \
+            < changes.diff | tee clang-tidy-report.txt
+          if grep -qE ':[0-9]+:[0-9]+: (warning|error):' clang-tidy-report.txt; then
+            echo "::error::clang-tidy reported issues on changed lines. See the job log above for details."
+            exit 1
+          fi
+
+      - name: Save CCache
+        uses: actions/cache/save@v6
+        if: always()
+        with:
+          path: ~/.cache/ccache
+          key: ccache-clangtidy-${{ runner.os }}-${{ runner.arch }}-${{ github.sha }}

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -98,13 +98,14 @@ jobs:
         run: |
           BASE_SHA="${{ github.event.before }}"
           if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
-            BASE_SHA=$(git rev-parse HEAD^ 2>/dev/null || echo "")
+            BASE_SHA=$(git rev-parse HEAD^ 2>/dev/null || git hash-object -t tree /dev/null)
           fi
           echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Run clang-tidy on changed lines
         if: steps.diff.outputs.base_sha != ''
         run: |
+          set -o pipefail
           git diff -U0 "${{ steps.diff.outputs.base_sha }}" "${{ github.sha }}" -- '*.cpp' '*.h' > changes.diff
           if [ ! -s changes.diff ]; then
             echo "No changed C++ files; skipping clang-tidy."

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -59,6 +59,12 @@ git diff --name-only --diff-filter=d origin/main | grep -E '\.(cpp|h)$' | xargs 
 
 There is currently no CI gate enforcing formatting, so this discipline is on the author (human or agent).
 
+Bug-pattern linting (as opposed to formatting) is checked in CI: the `Clang-Tidy` workflow
+(`.github/workflows/clang-tidy.yml`) runs `clang-tidy` against the lines changed in each push, using the root
+[`.clang-tidy`](.clang-tidy) config. It intentionally omits style/naming checks (those are covered by `.clang-format`
+and this guide) and the `cppcoreguidelines` ownership/pointer checks, which don't fit the raw-pointer/arena-allocation
+style described in [Memory management](#memory-management).
+
 ## File layout (C++)
 
 `.cpp` and `.h` files come in matching **PascalCase** pairs (`TypeChecker.h` / `TypeChecker.cpp`). Each file is structured


### PR DESCRIPTION
## Summary

This PR introduces automated bug-pattern linting via Clang-Tidy in CI, checking changed lines in each push against a curated set of bug-finding checks while excluding style/formatting checks (already covered by clang-format).

## Changes

- **`.github/workflows/clang-tidy.yml`** (new): GitHub Actions workflow that:
  - Builds LLVM 23.1.1 from source (cached for efficiency)
  - Configures the project with CMake and builds the core library to generate ANTLR parser sources
  - Runs `clang-tidy-diff.py` on changed C++ files, comparing against the base commit
  - Fails the workflow if any warnings/errors are reported on changed lines
  - Uses ccache to speed up builds

- **`.clang-tidy`** (new): Root configuration file specifying:
  - Enabled checks: `bugprone-*`, `clang-analyzer-*`, `performance-*`, `portability-*`, `misc-*`, and select `readability-*` checks
  - Intentionally excludes style/naming checks (handled by `.clang-format`) and `cppcoreguidelines` ownership/pointer checks (which don't align with the codebase's raw-pointer/arena-allocation style)
  - Applies only to `src/` and `test/` directories

- **`STYLE_GUIDE.md`** (updated): Documents the new Clang-Tidy CI gate and its scope, clarifying that bug-pattern linting is now enforced in CI while style checks remain manual.

## Implementation Details

- The workflow only runs on pushes affecting C++ files (ignores docs, media, and markdown)
- Gracefully handles edge cases: missing base commit, no changed C++ files, or initial commits
- Uses `clang-tidy-diff.py` to check only modified lines, reducing noise from pre-existing issues
- Caches both LLVM build artifacts and ccache to minimize CI runtime

https://claude.ai/code/session_01SSoYj12iJ8P8F3zCdbg7rq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Clang-Tidy checks for changed C++ lines in continuous integration.
  * CI now reports failures when configured warnings or errors are found.

* **Documentation**
  * Documented the Clang-Tidy checks and the categories excluded from analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->