### PR TITLE
Add native TLS support to std/net/http

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev libssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}

--- a/.github/workflows/ci-cpp.yml
+++ b/.github/workflows/ci-cpp.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
+          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev libsqlite3-dev libssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
@@ -118,7 +118,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
+          sudo apt-get install ccache ninja-build graphviz uuid-dev libcurl4-openssl-dev libsqlite3-dev libssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev libsqlite3-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
+          sudo apt-get install ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev libsqlite3-dev libssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }} clang
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install valgrind ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
+          sudo apt-get install valgrind ccache ninja-build graphviz pipx uuid-dev libcurl4-openssl-dev libssl-dev gcc-${{ env.GCC_VERSION }} g++-${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${{ env.GCC_VERSION }} 1${{ env.GCC_VERSION }}
           mkdir -p ~/.cache/ccache

--- a/dev-setup.py
+++ b/dev-setup.py
@@ -30,7 +30,7 @@ else:
     run(
         "sudo", "apt-get", "install", "-y",
         "cmake", "make", "ninja-build", "valgrind", "ccache",
-        "uuid-dev", "pkg-config", "openjdk-11-jre-headless", "clang", "lld",
+        "uuid-dev", "pkg-config", "openjdk-11-jre-headless", "clang", "lld", "libssl-dev",
     )
     log("done.")
 

--- a/docs/docs/how-to/http-server-client.md
+++ b/docs/docs/how-to/http-server-client.md
@@ -9,10 +9,10 @@ and chunked transfer encoding, so you get a working HTTP stack without pulling i
 This tutorial builds a small server with a few routes, and a client that talks to it, as two separate programs -
 which is how you would run them in practice.
 
-!!! note "No TLS"
-    Neither the server nor the client speaks TLS - the client rejects `https://` URLs outright. If you need to talk
-    to an HTTPS endpoint, use the libcurl bindings in `std/bindings/libcurl` instead, as described in the
-    [C/C++ interoperability tutorial](cpp-interop.md).
+!!! note "TLS"
+    `HttpClient` and `HttpServer` both speak TLS via `std/net/tls`, built on the OpenSSL bindings in
+    `std/bindings/openssl` - see [TLS / HTTPS](#tls-https) below. This adds a build-time dependency on OpenSSL
+    (`libssl-dev` on Debian/Ubuntu), the same way the libcurl bindings in `std/bindings/libcurl` depend on libcurl.
 
 ## A minimal server
 
@@ -182,6 +182,40 @@ client.maxRedirects = 0u;      // hand 3xx responses back as-is instead of follo
 
 `defaultHeaders` fields are only added to a request if it does not already carry a field with that name, so a
 one-off request can always override them.
+
+## TLS / HTTPS
+
+`HttpClient.get` (and the other request methods) transparently use TLS whenever the URL starts with `https://` - no
+extra code needed on the client side beyond the URL itself:
+
+```spice
+Result<HttpResponse> secure = client.get("https://example.com/");
+```
+
+By default, the server's certificate is verified against the operating system's trust store, and its host name is
+checked against the URL. Point verification at a specific CA bundle instead - for example to talk to a server with
+a self-signed certificate - with `trustedCaFile`:
+
+```spice
+client.trustedCaFile = String("./ca-bundle.pem");
+```
+
+There is no way to switch verification off: a client that does not verify the server it talks to gets no real
+confidentiality guarantee, so `std/net/tls` does not offer that option.
+
+To serve https instead of plain http, call `useTls` with a certificate and private key (PEM files) before `start`:
+
+```spice
+HttpServer server = HttpServer(8443s);
+Result<bool> tlsConfigured = server.useTls("./cert.pem", "./key.pem");
+if tlsConfigured.isErr() {
+    printf("Could not configure TLS: %s\n", tlsConfigured.getErr().message);
+    return 1;
+}
+```
+
+Everything else - routes, handlers, `start`/`run`/`stop` - stays the same; only the listening socket's connections
+are now TLS-handshaked before their request is read.
 
 ## Putting it all together
 

--- a/std/bindings/openssl/openssl.spice
+++ b/std/bindings/openssl/openssl.spice
@@ -34,7 +34,7 @@ ext p SSL_CTX_free(SslCtx /*ctx*/);
 ext p SSL_CTX_set_verify(SslCtx /*ctx*/, int /*mode*/, byte* /*callback*/);
 ext f<int> SSL_CTX_set_default_verify_paths(SslCtx /*ctx*/);
 ext f<int> SSL_CTX_load_verify_locations(SslCtx /*ctx*/, byte* /*caFile*/, byte* /*caPath*/);
-ext f<int> SSL_CTX_use_certificate_file(SslCtx /*ctx*/, string /*file*/, int /*type*/);
+ext f<int> SSL_CTX_use_certificate_chain_file(SslCtx /*ctx*/, string /*file*/);
 ext f<int> SSL_CTX_use_PrivateKey_file(SslCtx /*ctx*/, string /*file*/, int /*type*/);
 ext f<int> SSL_CTX_check_private_key(SslCtx /*ctx*/);
 
@@ -113,12 +113,15 @@ public p sslCtxSetVerifyPeer(SslCtx ctx) {
 }
 
 /**
- * Loads a PEM certificate (chain) into a context.
+ * Loads a PEM certificate chain into a context: the server's own leaf certificate, followed by
+ * whatever intermediate CA certificates the file carries. Uses the chain-loading API rather than
+ * the single-certificate one, since a client cannot build a trusted path to the leaf without the
+ * intermediates being sent along with it.
  *
  * @return true on success
  */
-public f<bool> sslCtxUseCertificateFile(SslCtx ctx, string certFile) {
-    return SSL_CTX_use_certificate_file(ctx, certFile, SSL_FILETYPE_PEM) == 1;
+public f<bool> sslCtxUseCertificateChainFile(SslCtx ctx, string certFile) {
+    return SSL_CTX_use_certificate_chain_file(ctx, certFile) == 1;
 }
 
 /**

--- a/std/bindings/openssl/openssl.spice
+++ b/std/bindings/openssl/openssl.spice
@@ -1,0 +1,247 @@
+// Bindings for the parts of OpenSSL's libssl needed to run a TLS handshake and record layer:
+// context setup, the client/server handshake, certificate verification and encrypted read/write.
+// See "std/net/tls" for the Spice-facing API built on top of this.
+
+#![core.compiler.warnings.ignore]
+#![
+    core.linux.linker.flag = "`pkg-config --cflags --libs openssl`",
+    core.darwin.linker.flag = "`pkg-config --cflags --libs openssl`",
+    core.windows.linker.flag = "-lssl -lcrypto"
+]
+
+// ===== Exposed opaque handle types =====
+public type SslCtx alias byte*; // SSL_CTX*
+public type Ssl alias byte*;    // SSL*
+
+// ===== Internal opaque handle types =====
+type SslMethod alias byte*;      // const SSL_METHOD*
+type X509VerifyParam alias byte*; // X509_VERIFY_PARAM*
+
+// ===== Internal constants (from openssl/ssl.h and openssl/x509_vfy.h) =====
+const int SSL_VERIFY_PEER = 1;
+const int SSL_FILETYPE_PEM = 1;
+const long X509_V_OK = 0l;
+// SSL_set_tlsext_host_name() is a macro around SSL_ctrl() in the C headers, so the SNI hostname is
+// set through the raw control call instead.
+const int SSL_CTRL_SET_TLSEXT_HOSTNAME = 55;
+const int TLSEXT_NAMETYPE_host_name = 0;
+
+// ===== External function declarations =====
+ext f<SslMethod> TLS_client_method();
+ext f<SslMethod> TLS_server_method();
+ext f<SslCtx> SSL_CTX_new(SslMethod /*method*/);
+ext p SSL_CTX_free(SslCtx /*ctx*/);
+ext p SSL_CTX_set_verify(SslCtx /*ctx*/, int /*mode*/, byte* /*callback*/);
+ext f<int> SSL_CTX_set_default_verify_paths(SslCtx /*ctx*/);
+ext f<int> SSL_CTX_load_verify_locations(SslCtx /*ctx*/, byte* /*caFile*/, byte* /*caPath*/);
+ext f<int> SSL_CTX_use_certificate_file(SslCtx /*ctx*/, string /*file*/, int /*type*/);
+ext f<int> SSL_CTX_use_PrivateKey_file(SslCtx /*ctx*/, string /*file*/, int /*type*/);
+ext f<int> SSL_CTX_check_private_key(SslCtx /*ctx*/);
+
+ext f<Ssl> SSL_new(SslCtx /*ctx*/);
+ext p SSL_free(Ssl /*ssl*/);
+ext f<int> SSL_set_fd(Ssl /*ssl*/, int /*fd*/);
+ext f<int> SSL_connect(Ssl /*ssl*/);
+ext f<int> SSL_accept(Ssl /*ssl*/);
+ext f<int> SSL_read(Ssl /*ssl*/, byte* /*buf*/, int /*num*/);
+ext f<int> SSL_write(Ssl /*ssl*/, byte* /*buf*/, int /*num*/);
+ext f<int> SSL_shutdown(Ssl /*ssl*/);
+ext f<long> SSL_ctrl(Ssl /*ssl*/, int /*cmd*/, long /*larg*/, byte* /*parg*/);
+ext f<X509VerifyParam> SSL_get0_param(Ssl /*ssl*/);
+ext f<long> SSL_get_verify_result(Ssl /*ssl*/);
+ext f<int> X509_VERIFY_PARAM_set1_host(X509VerifyParam /*param*/, string /*name*/, unsigned long /*namelen*/);
+ext f<int> X509_VERIFY_PARAM_set1_ip_asc(X509VerifyParam /*param*/, string /*ipasc*/);
+
+// ============================================== Exposed API ==============================================
+// `ext` declarations are never visible outside the file that declares them, so everything below is the
+// actual binding surface that other modules (namely "std/net/tls") build on. It stays close to the shape
+// of the underlying OpenSSL calls, but hides C-only details (return codes, the SSL_ctrl/TLSEXT macro
+// trick, PEM-only file loading, ...) that a caller has no business dealing with directly.
+
+/**
+ * Creates a new client-side `SSL_CTX`.
+ *
+ * @return Context handle, or nil on failure
+ */
+public f<SslCtx> sslCtxNewClient() {
+    return SSL_CTX_new(TLS_client_method());
+}
+
+/**
+ * Creates a new server-side `SSL_CTX`.
+ *
+ * @return Context handle, or nil on failure
+ */
+public f<SslCtx> sslCtxNewServer() {
+    return SSL_CTX_new(TLS_server_method());
+}
+
+/**
+ * Releases an `SSL_CTX`. Safe to call on nil.
+ */
+public p sslCtxFree(SslCtx ctx) {
+    SSL_CTX_free(ctx);
+}
+
+/**
+ * Points a context's trust store at the operating system's default CA bundle.
+ *
+ * @return true on success
+ */
+public f<bool> sslCtxSetDefaultVerifyPaths(SslCtx ctx) {
+    return SSL_CTX_set_default_verify_paths(ctx) == 1;
+}
+
+/**
+ * Points a context's trust store at a specific PEM file of CA certificates.
+ *
+ * @return true on success
+ */
+public f<bool> sslCtxLoadVerifyLocations(SslCtx ctx, string caFile) {
+    int loadResult = 0;
+    unsafe {
+        loadResult = SSL_CTX_load_verify_locations(ctx, cast<byte*>(caFile), nil<byte*>);
+    }
+    return loadResult == 1;
+}
+
+/**
+ * Turns on peer certificate verification for every connection made from this context.
+ */
+public p sslCtxSetVerifyPeer(SslCtx ctx) {
+    SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, nil<byte*>);
+}
+
+/**
+ * Loads a PEM certificate (chain) into a context.
+ *
+ * @return true on success
+ */
+public f<bool> sslCtxUseCertificateFile(SslCtx ctx, string certFile) {
+    return SSL_CTX_use_certificate_file(ctx, certFile, SSL_FILETYPE_PEM) == 1;
+}
+
+/**
+ * Loads a PEM private key into a context.
+ *
+ * @return true on success
+ */
+public f<bool> sslCtxUsePrivateKeyFile(SslCtx ctx, string keyFile) {
+    return SSL_CTX_use_PrivateKey_file(ctx, keyFile, SSL_FILETYPE_PEM) == 1;
+}
+
+/**
+ * Checks that the private key loaded into a context matches its certificate.
+ *
+ * @return true if they match
+ */
+public f<bool> sslCtxCheckPrivateKey(SslCtx ctx) {
+    return SSL_CTX_check_private_key(ctx) == 1;
+}
+
+/**
+ * Creates a new connection state (`SSL`) from a context.
+ *
+ * @return Connection handle, or nil on failure
+ */
+public f<Ssl> sslNew(SslCtx ctx) {
+    return SSL_new(ctx);
+}
+
+/**
+ * Releases a connection state. Safe to call on nil.
+ */
+public p sslFree(Ssl ssl) {
+    SSL_free(ssl);
+}
+
+/**
+ * Binds a connection state to the file descriptor of an already-connected/accepted socket.
+ */
+public p sslSetFd(Ssl ssl, int fd) {
+    SSL_set_fd(ssl, fd);
+}
+
+/**
+ * Points the verification of the upcoming handshake at the given host: as an IP literal if it looks
+ * like one, as a DNS name otherwise. Also sets the SNI extension for DNS names, since sending an IP
+ * address as SNI is not meaningful and most servers reject it. Must be called before `sslConnect`.
+ *
+ * @param host Host the connection is made to, as given by the caller (IP literal or DNS name)
+ */
+public p sslSetExpectedHost(Ssl ssl, string host) {
+    const X509VerifyParam param = SSL_get0_param(ssl);
+    const int ipResult = X509_VERIFY_PARAM_set1_ip_asc(param, host);
+    if ipResult != 1 {
+        X509_VERIFY_PARAM_set1_host(param, host, 0ul);
+        unsafe {
+            SSL_ctrl(ssl, SSL_CTRL_SET_TLSEXT_HOSTNAME, cast<long>(TLSEXT_NAMETYPE_host_name), cast<byte*>(host));
+        }
+    }
+}
+
+/**
+ * Performs the client side of a TLS handshake, verifying the peer's certificate along the way.
+ *
+ * @return true once the handshake completed and the certificate checked out
+ */
+public f<bool> sslConnect(Ssl ssl) {
+    return SSL_connect(ssl) > 0;
+}
+
+/**
+ * Performs the server side of a TLS handshake.
+ *
+ * @return true once the handshake completed
+ */
+public f<bool> sslAccept(Ssl ssl) {
+    return SSL_accept(ssl) > 0;
+}
+
+/**
+ * Checks whether the peer's certificate passed verification. Meaningful right after a failed
+ * `sslConnect`, to tell a verification failure apart from any other handshake error.
+ *
+ * @return true if the certificate (chain and host name) is valid
+ */
+public f<bool> sslVerifyResultOk(Ssl ssl) {
+    return SSL_get_verify_result(ssl) == X509_V_OK;
+}
+
+/**
+ * Reads up to `num` bytes off the connection into `buf`.
+ * Note: `buf` needs to be at least `num` bytes.
+ *
+ * @return Number of bytes read, or a value <= 0 on error/EOF
+ */
+public f<long> sslRead(Ssl ssl, byte* buf, long num) {
+    const int capped = num > 0x7FFFFFFFl ? 0x7FFFFFFF : cast<int>(num);
+    int received = 0;
+    unsafe {
+        received = SSL_read(ssl, buf, capped);
+    }
+    return cast<long>(received);
+}
+
+/**
+ * Writes up to `num` bytes of `buf` to the connection. A single call is free to accept only part of
+ * the buffer, same as a plain socket write.
+ * Note: `buf` needs to be at least `num` bytes.
+ *
+ * @return Number of bytes written, or a value <= 0 on error
+ */
+public f<long> sslWrite(Ssl ssl, byte* buf, long num) {
+    const int capped = num > 0x7FFFFFFFl ? 0x7FFFFFFF : cast<int>(num);
+    int written = 0;
+    unsafe {
+        written = SSL_write(ssl, buf, capped);
+    }
+    return cast<long>(written);
+}
+
+/**
+ * Shuts down the TLS layer of a connection (without closing the underlying socket).
+ */
+public p sslShutdown(Ssl ssl) {
+    SSL_shutdown(ssl);
+}

--- a/std/net/http-client.spice
+++ b/std/net/http-client.spice
@@ -177,9 +177,25 @@ public f<Result<HttpResponse>> HttpClient.send(const HttpRequest& request, const
                 if !response.isRedirect() || remainingRedirects == 0u || location.isEmpty() {
                     done = true;
                 } else {
-                    currentUrl = resolveLocation(target, location);
-                    applyRedirectMethod(currentRequest, response.statusCode);
-                    remainingRedirects--;
+                    const String nextUrl = resolveLocation(target, location);
+                    const Result<Url> nextUrlResult = parseUrl(nextUrl);
+                    if nextUrlResult.isErr() {
+                        done = true;
+                    } else {
+                        const Url& nextTarget = nextUrlResult.unwrap();
+                        if target.scheme == "https" && nextTarget.scheme != "https" {
+                            // Refuse to silently carry an https exchange over to plain http - the
+                            // caller gets the redirect response back instead of a downgraded replay
+                            done = true;
+                        } else {
+                            if !sameAuthority(target, nextTarget) {
+                                currentRequest.headers.remove(HEADER_AUTHORIZATION);
+                            }
+                            currentUrl = nextUrl;
+                            applyRedirectMethod(currentRequest, response.statusCode);
+                            remainingRedirects--;
+                        }
+                    }
                 }
             }
         }
@@ -209,13 +225,13 @@ f<Result<HttpResponse>> HttpClient.exchange(HttpRequest& request, const Url& url
             errorMessage = error.getMessage();
         } else {
             TlsContext context = contextResult.unwrap();
-            const Result<TlsSocket> socketResult = openTlsClientSocket(url.host.getRaw(), url.port, context);
+            const Result<TlsSocket> socketResult =
+                openTlsClientSocket(url.host.getRaw(), url.port, context, this.timeoutMillis);
             if socketResult.isErr() {
                 const Error& error = socketResult.getErr();
                 errorMessage = error.getMessage();
             } else {
                 TlsSocket socket = socketResult.unwrap();
-                if this.timeoutMillis != 0l { socket.setTimeout(this.timeoutMillis); }
 
                 if !sendRequest(socket, request) {
                     errorMessage = "Could not send the request";
@@ -284,6 +300,19 @@ p HttpClient.completeRequest(HttpRequest& request, const Url& url) {
     request.headers.set(HEADER_HOST, authority);
     // Without keep-alive support, every exchange ends with its connection
     request.headers.set(HEADER_CONNECTION, "close");
+}
+
+/**
+ * Checks whether two URLs point at the same host and port, i.e. whether a request to one of them
+ * carries any business being sent to the other - used to decide whether credentials survive a
+ * redirect.
+ *
+ * @param a First URL
+ * @param b Second URL
+ * @return true if host and port match
+ */
+f<bool> sameAuthority(const Url& a, const Url& b) {
+    return a.host == b.host && a.port == b.port;
 }
 
 /**

--- a/std/net/http-client.spice
+++ b/std/net/http-client.spice
@@ -1,6 +1,7 @@
 // Imports
 import "std/net/http";
 import "std/net/socket";
+import "std/net/tls";
 
 /**
  * A blocking HTTP/1.1 client, built on the plain TCP sockets of "std/net/socket".
@@ -10,14 +11,17 @@ import "std/net/socket";
  * Content-Length, by the chunked transfer coding, or by the connection close of an HTTP/1.0 server
  * are all understood.
  *
- * There is no TLS underneath, so https URLs are rejected instead of being silently downgraded. Use
- * the libcurl bindings in "std/bindings/libcurl" when a request has to go over https.
+ * https URLs are carried over a TLS connection (see "std/net/tls"), with the server's certificate
+ * and host name verified on every request. `trustedCaFile` points that verification at a specific
+ * CA bundle instead of the operating system's default trust store, e.g. to talk to a server with a
+ * self-signed certificate in tests.
  */
 public type HttpClient struct {
     public HttpHeaders defaultHeaders     // Fields that are added to every request that lacks them
     public unsigned long timeoutMillis    // Per read/write timeout, 0 to block indefinitely
     public unsigned long maxMessageSize   // Upper bound on the size of a response
     public unsigned int maxRedirects      // Number of redirects to follow, 0 to hand 3xx back as-is
+    public String trustedCaFile           // PEM file of trusted CAs for https, "" for the OS default store
 }
 
 // Default identification of the client, sent unless the caller sets its own User-Agent
@@ -181,8 +185,7 @@ public f<Result<HttpResponse>> HttpClient.send(const HttpRequest& request, const
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(response) : err<HttpResponse>(error);
+    return errorMessage == "" ? ok(response) : err<HttpResponse>(Error(errorMessage));
 }
 
 /**
@@ -196,8 +199,40 @@ f<Result<HttpResponse>> HttpClient.exchange(HttpRequest& request, const Url& url
     HttpResponse response = HttpResponse();
     string errorMessage = "";
 
+    this.completeRequest(request, url);
+    const bool expectBody = request.method != HttpMethod::HEAD;
+
     if url.scheme == "https" {
-        errorMessage = "HTTPS is not supported by std/net/http-client, since the socket layer carries no TLS";
+        const Result<TlsContext> contextResult = newClientTlsContext(this.trustedCaFile.getRaw());
+        if contextResult.isErr() {
+            const Error& error = contextResult.getErr();
+            errorMessage = error.getMessage();
+        } else {
+            TlsContext context = contextResult.unwrap();
+            const Result<TlsSocket> socketResult = openTlsClientSocket(url.host.getRaw(), url.port, context);
+            if socketResult.isErr() {
+                const Error& error = socketResult.getErr();
+                errorMessage = error.getMessage();
+            } else {
+                TlsSocket socket = socketResult.unwrap();
+                if this.timeoutMillis != 0l { socket.setTimeout(this.timeoutMillis); }
+
+                if !sendRequest(socket, request) {
+                    errorMessage = "Could not send the request";
+                } else {
+                    const Result<HttpResponse> responseResult = receiveResponse(socket, expectBody, this.maxMessageSize);
+                    if responseResult.isErr() {
+                        const Error& error = responseResult.getErr();
+                        errorMessage = error.getMessage();
+                    } else {
+                        const HttpResponse& received = responseResult.unwrap();
+                        response = received;
+                    }
+                }
+                socket.close();
+            }
+            context.close();
+        }
     } else {
         const Result<Socket> socketResult = openClientSocket(url.host.getRaw(), url.port);
         if socketResult.isErr() {
@@ -206,12 +241,10 @@ f<Result<HttpResponse>> HttpClient.exchange(HttpRequest& request, const Url& url
         } else {
             Socket socket = socketResult.unwrap();
             if this.timeoutMillis != 0l { socket.setTimeout(this.timeoutMillis); }
-            this.completeRequest(request, url);
 
             if !sendRequest(socket, request) {
                 errorMessage = "Could not send the request";
             } else {
-                const bool expectBody = request.method != HttpMethod::HEAD;
                 const Result<HttpResponse> responseResult = receiveResponse(socket, expectBody, this.maxMessageSize);
                 if responseResult.isErr() {
                     const Error& error = responseResult.getErr();
@@ -225,8 +258,7 @@ f<Result<HttpResponse>> HttpClient.exchange(HttpRequest& request, const Url& url
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(response) : err<HttpResponse>(error);
+    return errorMessage == "" ? ok(response) : err<HttpResponse>(Error(errorMessage));
 }
 
 /**
@@ -263,25 +295,24 @@ p HttpClient.completeRequest(HttpRequest& request, const Url& url) {
  * @return Absolute URL to follow
  */
 f<String> resolveLocation(const Url& base, const String& location) {
-    result = String();
     if location.contains("://") {
         // Already absolute
-        result = location;
+        return location;
     } else {
-        result.append(base.scheme);
-        result.append("://");
-        const String authority = base.getAuthority();
-        result.append(authority);
+        result = String();
+        result += base.scheme;
+        result += "://";
+        result += base.getAuthority();
         if location.startsWith("/") {
             // Absolute path, replacing the path of the base URL
-            result.append(location);
+            result += location;
         } else {
             // Relative path, resolved against the directory of the base path
             const long lastSlash = base.path.rfind('/');
             String directory = String("/");
             if lastSlash != -1l { directory = base.path.getSubstring(0l, lastSlash + 1l); }
-            result.append(directory);
-            result.append(location);
+            result += directory;
+            result += location;
         }
     }
 }
@@ -297,8 +328,7 @@ f<String> resolveLocation(const Url& base, const String& location) {
  */
 p applyRedirectMethod(HttpRequest& request, unsigned short statusCode) {
     const bool isSafeMethod = request.method == HttpMethod::GET || request.method == HttpMethod::HEAD;
-    const bool rewritesToGet = statusCode == STATUS_SEE_OTHER
-                            || ((statusCode == STATUS_MOVED_PERMANENTLY || statusCode == STATUS_FOUND) && !isSafeMethod);
+    const bool rewritesToGet = statusCode == STATUS_SEE_OTHER || ((statusCode == STATUS_MOVED_PERMANENTLY || statusCode == STATUS_FOUND) && !isSafeMethod);
     if rewritesToGet {
         request.method = HttpMethod::GET;
         request.body = String();

--- a/std/net/http-server.spice
+++ b/std/net/http-server.spice
@@ -286,9 +286,10 @@ public f<Result<bool>> HttpServer.handleNextRequest() {
             if this.tlsEnabled {
                 const Result<TlsSocket> tlsResult = acceptTlsConnection(this.socket, this.tlsContext);
                 if tlsResult.isErr() {
-                    // The handshake never completed, so there is no connection left to answer on
-                    const Error& error = tlsResult.getErr();
-                    errorMessage = error.getMessage();
+                    // The handshake never completed, so there is no connection left to answer on.
+                    // This is a problem with the one client that sent it, not with the server, so
+                    // it must not fail this call and stop `run` from serving later connections -
+                    // the same way a request that fails to parse doesn't, below.
                     this.socket.closeConnection();
                 } else {
                     TlsSocket tlsSocket = tlsResult.unwrap();

--- a/std/net/http-server.spice
+++ b/std/net/http-server.spice
@@ -2,8 +2,13 @@
 import "std/data/vector";
 import "std/net/http";
 import "std/net/socket";
+import "std/net/tls";
 import "std/type/lambda";
 import "std/type/type-conversion";
+
+// Generic connection type of HttpServer.buildResponse - see the identical declaration in
+// "std/net/http" for why it carries no interface constraint.
+type C dyn;
 
 /**
  * A registered route: the method and path it answers, plus what answers it - either a handler, or a
@@ -31,7 +36,9 @@ type HttpRoute struct {
  * method answers 405 instead of 404, and a HEAD request falls back to the GET route of the same
  * path, with the body dropped again afterwards.
  *
- * There is no TLS underneath, so the server speaks plain http only.
+ * The server speaks plain http by default. Call `useTls` with a certificate and private key
+ * (before `start`) to serve https instead - every connection is then TLS-handshaked (see
+ * "std/net/tls") before its request is read and its response is written.
  *
  * Note on handlers: a handler is stored in a `Lambda` (see "std/type/lambda"), which relocates the
  * captures of the lambda onto the heap with a shallow copy. A handler may therefore capture plain
@@ -45,6 +52,8 @@ public type HttpServer struct {
     public unsigned long maxMessageSize // Upper bound on the size of a request
     public unsigned long timeoutMillis  // Per read/write timeout of a connection, 0 to block indefinitely
     Socket socket
+    TlsContext tlsContext
+    bool tlsEnabled
     Vector<HttpRoute> routes
     Lambda<p(const HttpRequest&, HttpResponse&)> notFoundHandler
     bool hasNotFoundHandler
@@ -73,6 +82,7 @@ public p HttpServer.ctor(unsigned short port = HTTP_PORT_FALLBACK) {
     this.hasNotFoundHandler = false;
     this.listening = false;
     this.running = false;
+    this.tlsEnabled = false;
 }
 
 /**
@@ -80,6 +90,35 @@ public p HttpServer.ctor(unsigned short port = HTTP_PORT_FALLBACK) {
  */
 public p HttpServer.dtor() {
     this.close();
+}
+
+/**
+ * Switches the server from plain http to https: every connection accepted from here on is
+ * TLS-handshaked with the given certificate before its request is read.
+ *
+ * Must be called before `start`, since the listening socket itself is unaffected - only what
+ * happens to a connection right after it is accepted changes.
+ *
+ * @param certFile Path to a PEM file with the server's certificate (chain)
+ * @param keyFile Path to a PEM file with the private key matching the certificate
+ * @return true once TLS is configured, or an error describing why it could not be
+ */
+public f<Result<bool>> HttpServer.useTls(string certFile, string keyFile) {
+    string errorMessage = "";
+    if this.listening {
+        errorMessage = "useTls must be called before start()";
+    } else {
+        const Result<TlsContext> contextResult = newServerTlsContext(certFile, keyFile);
+        if contextResult.isErr() {
+            const Error& error = contextResult.getErr();
+            errorMessage = error.getMessage();
+        } else {
+            this.tlsContext = contextResult.unwrap();
+            this.tlsEnabled = true;
+        }
+    }
+
+    return errorMessage == "" ? ok(true) : err<bool>(Error(errorMessage));
 }
 
 // ================================================ Route registration =================================================
@@ -219,8 +258,7 @@ public f<Result<bool>> HttpServer.start(int connectionBacklog = DEFAULT_CONNECTI
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(true) : err<bool>(error);
+    return errorMessage == "" ? ok(true) : err<bool>(Error(errorMessage));
 }
 
 /**
@@ -245,27 +283,52 @@ public f<Result<bool>> HttpServer.handleNextRequest() {
         } else {
             if this.timeoutMillis != 0l { this.socket.setTimeout(this.timeoutMillis); }
 
-            HttpResponse response = HttpResponse();
-            const Result<HttpRequest> requestResult = receiveRequest(this.socket, this.maxMessageSize);
-            if requestResult.isErr() {
-                // The request never arrived in one piece, so all we can say is that it was bad
-                response.setStatus(STATUS_BAD_REQUEST);
-                const Error& error = requestResult.getErr();
-                const String reasonBody = String(error.getMessage());
-                response.setBody(reasonBody, CONTENT_TYPE_TEXT);
+            if this.tlsEnabled {
+                const Result<TlsSocket> tlsResult = acceptTlsConnection(this.socket, this.tlsContext);
+                if tlsResult.isErr() {
+                    // The handshake never completed, so there is no connection left to answer on
+                    const Error& error = tlsResult.getErr();
+                    errorMessage = error.getMessage();
+                    this.socket.closeConnection();
+                } else {
+                    TlsSocket tlsSocket = tlsResult.unwrap();
+                    const HttpResponse response = this.buildResponse(tlsSocket);
+                    served = sendResponse(tlsSocket, response);
+                    tlsSocket.closeConnection();
+                }
             } else {
-                const HttpRequest& request = requestResult.unwrap();
-                this.dispatch(request, response);
+                const HttpResponse response = this.buildResponse(this.socket);
+                served = sendResponse(this.socket, response);
+                this.socket.closeConnection();
             }
-
-            this.completeResponse(response);
-            served = sendResponse(this.socket, response);
-            this.socket.closeConnection();
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(served) : err<bool>(error);
+    return errorMessage == "" ? ok(served) : err<bool>(Error(errorMessage));
+}
+
+/**
+ * Reads the request off a freshly accepted connection and dispatches it, no matter whether the
+ * connection is plain or TLS.
+ *
+ * @param conn Connection to read the request from
+ * @return The response to send back
+ */
+f<HttpResponse> HttpServer.buildResponse<C>(C& conn) {
+    HttpResponse response = HttpResponse();
+    const Result<HttpRequest> requestResult = receiveRequest(conn, this.maxMessageSize);
+    if requestResult.isErr() {
+        // The request never arrived in one piece, so all we can say is that it was bad
+        response.setStatus(STATUS_BAD_REQUEST);
+        const Error& error = requestResult.getErr();
+        const String reasonBody = String(error.getMessage());
+        response.setBody(reasonBody, CONTENT_TYPE_TEXT);
+    } else {
+        const HttpRequest& request = requestResult.unwrap();
+        this.dispatch(request, response);
+    }
+    this.completeResponse(response);
+    return response;
 }
 
 /**
@@ -292,8 +355,7 @@ public f<Result<bool>> HttpServer.run() {
         this.running = false;
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(true) : err<bool>(error);
+    return errorMessage == "" ? ok(true) : err<bool>(Error(errorMessage));
 }
 
 /**
@@ -327,6 +389,10 @@ public p HttpServer.close() {
     if this.listening {
         this.socket.close();
         this.listening = false;
+    }
+    if this.tlsEnabled {
+        this.tlsContext.close();
+        this.tlsEnabled = false;
     }
 }
 

--- a/std/net/http.spice
+++ b/std/net/http.spice
@@ -79,6 +79,7 @@ public const string HEADER_USER_AGENT = "User-Agent";
 public const string HEADER_SERVER = "Server";
 public const string HEADER_ACCEPT = "Accept";
 public const string HEADER_DATE = "Date";
+public const string HEADER_AUTHORIZATION = "Authorization";
 
 const string CRLF = "\r\n";
 

--- a/std/net/http.spice
+++ b/std/net/http.spice
@@ -1264,28 +1264,35 @@ const long READ_CHUNK_SIZE = 4096l;
 // Upper bound on how much of a message is kept in memory before it is rejected, 8 MiB by default
 public const unsigned long DEFAULT_MAX_MESSAGE_SIZE = 8388608l;
 
+// Generic connection type of the wire transport below. It is never constrained to an interface -
+// any type that provides `writeAll(byte*, unsigned long) -> bool` and `read(byte*, long) -> long`
+// works, which both `Socket` (see "std/net/socket") and `TlsSocket` (see "std/net/tls") do. This
+// keeps the framing logic (Content-Length, chunked transfer, ...) in one place for plain and TLS
+// connections alike, instead of duplicating it per transport.
+type C dyn;
+
 /**
- * Writes a request to the socket
+ * Writes a request to the connection
  *
- * @param socket Socket to write to
+ * @param socket Connection to write to
  * @param request Request to write
  * @return true if the whole request reached the peer
  */
-public f<bool> sendRequest(Socket& socket, const HttpRequest& request) {
+public f<bool> sendRequest<C>(C& socket, const HttpRequest& request) {
     const String wire = request.serialize();
-    result = writeString(socket, wire);
+    return writeString(socket, wire);
 }
 
 /**
- * Writes a response to the socket
+ * Writes a response to the connection
  *
- * @param socket Socket to write to
+ * @param socket Connection to write to
  * @param response Response to write
  * @return true if the whole response reached the peer
  */
-public f<bool> sendResponse(Socket& socket, const HttpResponse& response) {
+public f<bool> sendResponse<C>(C& socket, const HttpResponse& response) {
     const String wire = response.serialize();
-    result = writeString(socket, wire);
+    return writeString(socket, wire);
 }
 
 /**
@@ -1299,7 +1306,7 @@ public f<bool> sendResponse(Socket& socket, const HttpResponse& response) {
  * @param maxSize Maximum number of bytes to accept for head and body each
  * @return The received request, or an error describing why it could not be received
  */
-public f<Result<HttpRequest>> receiveRequest(Socket& socket, unsigned long maxSize = DEFAULT_MAX_MESSAGE_SIZE) {
+public f<Result<HttpRequest>> receiveRequest<C>(C& socket, unsigned long maxSize = DEFAULT_MAX_MESSAGE_SIZE) {
     HttpRequest request = HttpRequest();
     String buffer = String();
     string errorMessage = "";
@@ -1328,8 +1335,7 @@ public f<Result<HttpRequest>> receiveRequest(Socket& socket, unsigned long maxSi
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(request) : err<HttpRequest>(error);
+    return errorMessage == "" ? ok(request) : err<HttpRequest>(Error(errorMessage));
 }
 
 /**
@@ -1343,8 +1349,7 @@ public f<Result<HttpRequest>> receiveRequest(Socket& socket, unsigned long maxSi
  * @param maxSize Maximum number of bytes to accept for head and body each
  * @return The received response, or an error describing why it could not be received
  */
-public f<Result<HttpResponse>> receiveResponse(Socket& socket, bool expectBody = true,
-                                               unsigned long maxSize = DEFAULT_MAX_MESSAGE_SIZE) {
+public f<Result<HttpResponse>> receiveResponse<C>(C& socket, bool expectBody = true, unsigned long maxSize = DEFAULT_MAX_MESSAGE_SIZE) {
     HttpResponse response = HttpResponse();
     String buffer = String();
     string errorMessage = "";
@@ -1377,8 +1382,7 @@ public f<Result<HttpResponse>> receiveResponse(Socket& socket, bool expectBody =
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(response) : err<HttpResponse>(error);
+    return errorMessage == "" ? ok(response) : err<HttpResponse>(Error(errorMessage));
 }
 
 /**
@@ -1391,14 +1395,14 @@ f<bool> isBodylessStatus(unsigned short statusCode) {
 /**
  * Writes a string to the socket in full
  */
-f<bool> writeString(Socket& socket, const String& text) {
-    result = true;
+f<bool> writeString<C>(C& socket, const String& text) {
     const unsigned long length = text.getLength();
     if length != 0l {
         unsafe {
-            result = socket.writeAll(cast<byte*>(text.getRaw()), length);
+            return socket.writeAll(cast<byte*>(text.getRaw()), length);
         }
     }
+    return true;
 }
 
 /**
@@ -1408,7 +1412,7 @@ f<bool> writeString(Socket& socket, const String& text) {
  * @param buffer Buffer to append to
  * @return true if bytes arrived, false if the peer closed the connection or the read timed out
  */
-f<bool> readChunkInto(Socket& socket, String& buffer) {
+f<bool> readChunkInto<C>(C& socket, String& buffer) {
     byte[4096] chunk;
     long bytesRead = 0l;
     unsafe {
@@ -1428,7 +1432,7 @@ f<bool> readChunkInto(Socket& socket, String& buffer) {
  * @param maxSize Maximum number of head bytes to accept
  * @return The head block, without its terminating empty line
  */
-f<Result<String>> readHead(Socket& socket, String& buffer, unsigned long maxSize) {
+f<Result<String>> readHead<C>(C& socket, String& buffer, unsigned long maxSize) {
     String head = String();
     String pending = String();
     string errorMessage = "";
@@ -1455,8 +1459,7 @@ f<Result<String>> readHead(Socket& socket, String& buffer, unsigned long maxSize
         buffer = pending.getSubstring(cast<unsigned long>(headEnd) + 4l);
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(head) : err<String>(error);
+    return errorMessage == "" ? ok(head) : err<String>(Error(errorMessage));
 }
 
 /**
@@ -1469,8 +1472,7 @@ f<Result<String>> readHead(Socket& socket, String& buffer, unsigned long maxSize
  * @param readUntilClose Whether a message without any framing runs until the connection closes
  * @return The body
  */
-f<Result<String>> readBody(Socket& socket, HttpHeaders& headers, String& buffer, unsigned long maxSize,
-                           bool readUntilClose) {
+f<Result<String>> readBody<C>(C& socket, HttpHeaders& headers, String& buffer, unsigned long maxSize, bool readUntilClose) {
     String body = String();
     string errorMessage = "";
 
@@ -1514,8 +1516,7 @@ f<Result<String>> readBody(Socket& socket, HttpHeaders& headers, String& buffer,
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(body) : err<String>(error);
+    return errorMessage == "" ? ok(body) : err<String>(Error(errorMessage));
 }
 
 /**
@@ -1527,7 +1528,7 @@ f<Result<String>> readBody(Socket& socket, HttpHeaders& headers, String& buffer,
  * @param maxSize Maximum number of decoded body bytes to accept
  * @return The decoded body
  */
-f<Result<String>> readChunkedBody(Socket& socket, String& buffer, unsigned long maxSize) {
+f<Result<String>> readChunkedBody<C>(C& socket, String& buffer, unsigned long maxSize) {
     String body = String();
     string errorMessage = "";
     unsigned long pos = 0l;
@@ -1586,8 +1587,7 @@ f<Result<String>> readChunkedBody(Socket& socket, String& buffer, unsigned long 
         }
     }
 
-    const Error error = Error(errorMessage);
-    result = errorMessage == "" ? ok(body) : err<String>(error);
+    return errorMessage == "" ? ok(body) : err<String>(Error(errorMessage));
 }
 
 /**

--- a/std/net/socket_darwin.spice
+++ b/std/net/socket_darwin.spice
@@ -117,6 +117,16 @@ public type Socket struct {
 }
 
 /**
+ * Returns the file descriptor of the current connection, i.e. what a layer on top of the raw
+ * socket (like the TLS handshake in "std/net/tls") has to hand to its own I/O calls.
+ *
+ * @return Connection file descriptor
+ */
+public f<int> Socket.getConnFd() {
+    return this.connFd;
+}
+
+/**
  * Returns the value the `sinLen` field of a socket address has to carry. The size is taken from the
  * struct itself, but has to pass through an int on the way, since there is no long to byte cast.
  *

--- a/std/net/socket_darwin.spice
+++ b/std/net/socket_darwin.spice
@@ -127,6 +127,22 @@ public f<int> Socket.getConnFd() {
 }
 
 /**
+ * Detaches the current connection from this socket and hands it back as a new, independent
+ * `Socket` that owns it, leaving this socket without a connection. Used when a connection's
+ * ownership moves to another object (like the TLS wrapper in "std/net/tls"), so that only the new
+ * owner's `close`/`closeConnection` ever reaches the file descriptor - otherwise this socket
+ * accepting (and then closing) a later, unrelated connection that happens to reuse the same
+ * descriptor number could close it out from under the new owner instead.
+ *
+ * @return A standalone socket that owns the detached connection
+ */
+public f<Socket> Socket.detachConnection() {
+    const Socket detached = Socket { -1, this.connFd };
+    this.connFd = 0;
+    return detached;
+}
+
+/**
  * Returns the value the `sinLen` field of a socket address has to carry. The size is taken from the
  * struct itself, but has to pass through an int on the way, since there is no long to byte cast.
  *

--- a/std/net/socket_linux.spice
+++ b/std/net/socket_linux.spice
@@ -122,6 +122,22 @@ public f<int> Socket.getConnFd() {
 }
 
 /**
+ * Detaches the current connection from this socket and hands it back as a new, independent
+ * `Socket` that owns it, leaving this socket without a connection. Used when a connection's
+ * ownership moves to another object (like the TLS wrapper in "std/net/tls"), so that only the new
+ * owner's `close`/`closeConnection` ever reaches the file descriptor - otherwise this socket
+ * accepting (and then closing) a later, unrelated connection that happens to reuse the same
+ * descriptor number could close it out from under the new owner instead.
+ *
+ * @return A standalone socket that owns the detached connection
+ */
+public f<Socket> Socket.detachConnection() {
+    const Socket detached = Socket { -1, this.connFd };
+    this.connFd = 0;
+    return detached;
+}
+
+/**
  * Accept an incoming connection to the socket and save the connection file desceiptor
  * to the socket object.
  *

--- a/std/net/socket_linux.spice
+++ b/std/net/socket_linux.spice
@@ -112,6 +112,16 @@ public type Socket struct {
 }
 
 /**
+ * Returns the file descriptor of the current connection, i.e. what a layer on top of the raw
+ * socket (like the TLS handshake in "std/net/tls") has to hand to its own I/O calls.
+ *
+ * @return Connection file descriptor
+ */
+public f<int> Socket.getConnFd() {
+    return this.connFd;
+}
+
+/**
  * Accept an incoming connection to the socket and save the connection file desceiptor
  * to the socket object.
  *

--- a/std/net/socket_windows.spice
+++ b/std/net/socket_windows.spice
@@ -127,6 +127,22 @@ public f<int> Socket.getConnFd() {
 }
 
 /**
+ * Detaches the current connection from this socket and hands it back as a new, independent
+ * `Socket` that owns it, leaving this socket without a connection. Used when a connection's
+ * ownership moves to another object (like the TLS wrapper in "std/net/tls"), so that only the new
+ * owner's `close`/`closeConnection` ever reaches the file descriptor - otherwise this socket
+ * accepting (and then closing) a later, unrelated connection that happens to reuse the same
+ * descriptor number could close it out from under the new owner instead.
+ *
+ * @return A standalone socket that owns the detached connection
+ */
+public f<Socket> Socket.detachConnection() {
+    const Socket detached = Socket { -1, this.connFd };
+    this.connFd = 0;
+    return detached;
+}
+
+/**
  * Accept an incoming connection to the socket and save the connection file desceiptor
  * to the socket object.
  *

--- a/std/net/socket_windows.spice
+++ b/std/net/socket_windows.spice
@@ -117,6 +117,16 @@ public type Socket struct {
 }
 
 /**
+ * Returns the file descriptor of the current connection, i.e. what a layer on top of the raw
+ * socket (like the TLS handshake in "std/net/tls") has to hand to its own I/O calls.
+ *
+ * @return Connection file descriptor
+ */
+public f<int> Socket.getConnFd() {
+    return this.connFd;
+}
+
+/**
  * Accept an incoming connection to the socket and save the connection file desceiptor
  * to the socket object.
  *

--- a/std/net/tls.spice
+++ b/std/net/tls.spice
@@ -1,0 +1,254 @@
+// TLS for "std/net/http": context setup, the client/server handshake and the record-layer
+// read/write that replaces plain socket I/O, built on the OpenSSL binding in
+// "std/bindings/openssl".
+
+// Imports
+import "std/bindings/openssl/openssl";
+import "std/net/socket";
+
+/**
+ * Owns an `SSL_CTX`, i.e. the certificate/trust/verification setup that is shared by every
+ * connection made or accepted through it. Build one with `newClientTlsContext` or
+ * `newServerTlsContext`, and hand it to `openTlsClientSocket` or `acceptTlsConnection`.
+ *
+ * A default-constructed context wraps no `SSL_CTX` and must not be used - it only exists so that
+ * structs which embed a `TlsContext` (like `HttpServer`) can be default-constructed themselves.
+ */
+public type TlsContext struct {
+    SslCtx ctx
+}
+
+/**
+ * Releases the underlying `SSL_CTX`. Safe to call more than once and on a default-constructed,
+ * never-initialized context.
+ */
+public p TlsContext.close() {
+    if this.ctx != nil<SslCtx> {
+        sslCtxFree(this.ctx);
+        this.ctx = nil<SslCtx>;
+    }
+}
+
+/**
+ * Builds the TLS context a client hands to `openTlsClientSocket`. Server certificates are always
+ * verified; there is no escape hatch to turn that off, since a client that does not verify the
+ * server it talks to gets no confidentiality guarantee worth having.
+ *
+ * @param caFile Path to a PEM file with trusted CA certificates, or "" to trust the operating
+ *               system's default trust store
+ * @return A ready-to-use client context, or an error describing why it could not be built
+ */
+public f<Result<TlsContext>> newClientTlsContext(string caFile = "") {
+    string errorMessage = "";
+    SslCtx ctx = sslCtxNewClient();
+
+    if ctx == nil<SslCtx> {
+        errorMessage = "Could not create TLS client context";
+    } else {
+        const bool trusted = caFile == "" ? sslCtxSetDefaultVerifyPaths(ctx) : sslCtxLoadVerifyLocations(ctx, caFile);
+        if !trusted {
+            errorMessage = "Could not load the TLS trust store";
+            sslCtxFree(ctx);
+            ctx = nil<SslCtx>;
+        } else {
+            sslCtxSetVerifyPeer(ctx);
+        }
+    }
+
+    const TlsContext context = TlsContext { ctx };
+    const Error error = Error(errorMessage);
+    return errorMessage == "" ? ok(context) : err<TlsContext>(error);
+}
+
+/**
+ * Builds the TLS context an `HttpServer` hands to `acceptTlsConnection`, loading the
+ * certificate chain and private key it presents to clients.
+ *
+ * @param certFile Path to a PEM file with the server's certificate (chain)
+ * @param keyFile Path to a PEM file with the private key matching the certificate
+ * @return A ready-to-use server context, or an error describing why it could not be built
+ */
+public f<Result<TlsContext>> newServerTlsContext(string certFile, string keyFile) {
+    string errorMessage = "";
+    SslCtx ctx = sslCtxNewServer();
+
+    if ctx == nil<SslCtx> {
+        errorMessage = "Could not create TLS server context";
+    } else if !sslCtxUseCertificateFile(ctx, certFile) {
+        errorMessage = "Could not load the TLS certificate file";
+    } else if !sslCtxUsePrivateKeyFile(ctx, keyFile) {
+        errorMessage = "Could not load the TLS private key file";
+    } else if !sslCtxCheckPrivateKey(ctx) {
+        errorMessage = "The TLS private key does not match the certificate";
+    }
+
+    if errorMessage != "" && ctx != nil<SslCtx> {
+        sslCtxFree(ctx);
+        ctx = nil<SslCtx>;
+    }
+
+    const TlsContext context = TlsContext { ctx };
+    const Error error = Error(errorMessage);
+    return errorMessage == "" ? ok(context) : err<TlsContext>(error);
+}
+
+/**
+ * A TCP socket with a TLS record layer on top. Exposes the same `read`/`writeAll`/`setTimeout`
+ * shape as `Socket`, so the generic wire transport of "std/net/http" (`sendRequest`,
+ * `receiveResponse`, ...) works on it unchanged.
+ */
+public type TlsSocket struct {
+    Socket sock
+    Ssl ssl
+}
+
+/**
+ * Opens a TCP connection to the given host and port and performs a TLS client handshake on top of
+ * it, verifying the server's certificate against `context` and its name against `host`.
+ *
+ * @param host Host to connect to, either as dotted IPv4 address or as hostname
+ * @param port Port to connect to
+ * @param context Client context that decides which certificates are trusted
+ * @return The established TLS connection, or an error describing why it could not be established
+ */
+public f<Result<TlsSocket>> openTlsClientSocket(string host, unsigned short port, const TlsContext& context) {
+    string errorMessage = "";
+    Ssl ssl = nil<Ssl>;
+    Socket sock = Socket {};
+
+    const Result<Socket> socketResult = openClientSocket(host, port);
+    if socketResult.isErr() {
+        const Error& error = socketResult.getErr();
+        errorMessage = error.getMessage();
+    } else {
+        sock = socketResult.unwrap();
+        ssl = sslNew(context.ctx);
+        if ssl == nil<Ssl> {
+            errorMessage = "Could not create TLS connection state";
+            sock.close();
+        } else {
+            sslSetFd(ssl, sock.getConnFd());
+            sslSetExpectedHost(ssl, host);
+            if !sslConnect(ssl) {
+                errorMessage = sslVerifyResultOk(ssl) ? "TLS handshake failed" : "TLS certificate verification failed";
+                sslFree(ssl);
+                ssl = nil<Ssl>;
+                sock.close();
+            }
+        }
+    }
+
+    const TlsSocket tlsSocket = TlsSocket { sock, ssl };
+    const Error error = Error(errorMessage);
+    return errorMessage == "" ? ok(tlsSocket) : err<TlsSocket>(error);
+}
+
+/**
+ * Performs a TLS server handshake on the connection `sock` most recently accepted via
+ * `Socket.acceptConnection`.
+ *
+ * This is a free function rather than a method on `Socket` because `Socket` is defined per-platform
+ * (see "std/net/socket_linux" and friends) and Spice does not support adding methods to a struct
+ * from outside the file that defines it.
+ *
+ * @param sock Socket whose current connection to handshake
+ * @param context Server context that supplies the certificate and private key
+ * @return The established TLS connection, or an error describing why it could not be established
+ */
+public f<Result<TlsSocket>> acceptTlsConnection(Socket& sock, const TlsContext& context) {
+    string errorMessage = "";
+    Ssl ssl = sslNew(context.ctx);
+
+    if ssl == nil<Ssl> {
+        errorMessage = "Could not create TLS connection state";
+    } else {
+        sslSetFd(ssl, sock.getConnFd());
+        if !sslAccept(ssl) {
+            errorMessage = "TLS handshake failed";
+            sslFree(ssl);
+            ssl = nil<Ssl>;
+        }
+    }
+
+    // Struct-literal fields are copy-constructed from the initializer, which the type checker
+    // cannot currently do directly from a reference parameter - route through a plain local instead.
+    const Socket sockCopy = sock;
+    const TlsSocket tlsSocket = TlsSocket { sockCopy, ssl };
+    const Error error = Error(errorMessage);
+    return errorMessage == "" ? ok(tlsSocket) : err<TlsSocket>(error);
+}
+
+/**
+ * Reads up to `size` bytes from the connection into the given buffer.
+ * Note: The given buffer needs to be at least of the given size.
+ *
+ * @param buffer Buffer to write the result into
+ * @param size Number of bytes to read
+ * @return Number of bytes read, or a value <= 0 on error/EOF
+ */
+public f<long> TlsSocket.read(byte* buffer, long size) {
+    return sslRead(this.ssl, buffer, size);
+}
+
+/**
+ * Writes an array of bytes to the connection, retrying until either all of them were handed over to
+ * TLS or the connection breaks.
+ * Note: The given buffer needs to be at least of the given size.
+ *
+ * @param content Buffer of bytes to send
+ * @param size Number of bytes from the buffer to send
+ * @return true if all bytes were written, false if the connection broke in between
+ */
+public f<bool> TlsSocket.writeAll(byte* content, unsigned long size) {
+    unsigned long bytesWritten = 0l;
+    while bytesWritten < size {
+        long written = 0l;
+        unsafe {
+            written = sslWrite(this.ssl, content + bytesWritten, cast<long>(size - bytesWritten));
+        }
+        if written <= 0l { return false; }
+        bytesWritten += cast<unsigned long>(written);
+    }
+    return true;
+}
+
+/**
+ * Limits how long a single read or write on this connection may block. Forwards to the underlying
+ * `Socket`, see `Socket.setTimeout`.
+ *
+ * @param milliseconds Timeout in milliseconds, 0 to block indefinitely again
+ * @return Setting the timeout was successful or not
+ */
+public f<bool> TlsSocket.setTimeout(unsigned long milliseconds) {
+    return this.sock.setTimeout(milliseconds);
+}
+
+/**
+ * Shuts down the TLS layer and closes the current connection, while keeping the listening socket
+ * (for a server) open. This is what a server does after it has finished serving a single client.
+ *
+ * @return Closing the connection was successful or not
+ */
+public f<bool> TlsSocket.closeConnection() {
+    if this.ssl != nil<Ssl> {
+        sslShutdown(this.ssl);
+        sslFree(this.ssl);
+        this.ssl = nil<Ssl>;
+    }
+    return this.sock.closeConnection();
+}
+
+/**
+ * Shuts down the TLS layer and closes the socket. This method should always be called by the user
+ * before exiting the program.
+ *
+ * @return Closing the connection was successful or not
+ */
+public f<bool> TlsSocket.close() {
+    if this.ssl != nil<Ssl> {
+        sslShutdown(this.ssl);
+        sslFree(this.ssl);
+        this.ssl = nil<Ssl>;
+    }
+    return this.sock.close();
+}

--- a/std/net/tls.spice
+++ b/std/net/tls.spice
@@ -74,7 +74,7 @@ public f<Result<TlsContext>> newServerTlsContext(string certFile, string keyFile
 
     if ctx == nil<SslCtx> {
         errorMessage = "Could not create TLS server context";
-    } else if !sslCtxUseCertificateFile(ctx, certFile) {
+    } else if !sslCtxUseCertificateChainFile(ctx, certFile) {
         errorMessage = "Could not load the TLS certificate file";
     } else if !sslCtxUsePrivateKeyFile(ctx, keyFile) {
         errorMessage = "Could not load the TLS private key file";
@@ -109,9 +109,14 @@ public type TlsSocket struct {
  * @param host Host to connect to, either as dotted IPv4 address or as hostname
  * @param port Port to connect to
  * @param context Client context that decides which certificates are trusted
+ * @param timeoutMillis Read/write timeout applied before the handshake, 0 to block indefinitely.
+ *                      Without this, a peer that accepts the TCP connection but never sends any
+ *                      TLS data would hang the handshake forever, regardless of any timeout the
+ *                      caller applies to the socket afterwards.
  * @return The established TLS connection, or an error describing why it could not be established
  */
-public f<Result<TlsSocket>> openTlsClientSocket(string host, unsigned short port, const TlsContext& context) {
+public f<Result<TlsSocket>> openTlsClientSocket(string host, unsigned short port, const TlsContext& context,
+                                                unsigned long timeoutMillis = 0l) {
     string errorMessage = "";
     Ssl ssl = nil<Ssl>;
     Socket sock = Socket {};
@@ -122,6 +127,7 @@ public f<Result<TlsSocket>> openTlsClientSocket(string host, unsigned short port
         errorMessage = error.getMessage();
     } else {
         sock = socketResult.unwrap();
+        if timeoutMillis != 0l { sock.setTimeout(timeoutMillis); }
         ssl = sslNew(context.ctx);
         if ssl == nil<Ssl> {
             errorMessage = "Could not create TLS connection state";
@@ -170,9 +176,16 @@ public f<Result<TlsSocket>> acceptTlsConnection(Socket& sock, const TlsContext& 
         }
     }
 
-    // Struct-literal fields are copy-constructed from the initializer, which the type checker
-    // cannot currently do directly from a reference parameter - route through a plain local instead.
-    const Socket sockCopy = sock;
+    Socket sockCopy = Socket {};
+    if errorMessage == "" {
+        // Transfer ownership of the connection to the TlsSocket: `sock` (the caller's listening
+        // socket) forgets the file descriptor, so only the TlsSocket's own close ever reaches it -
+        // otherwise the caller accepting and closing a later, unrelated connection that reuses the
+        // same descriptor number could close it out from under the TlsSocket instead. This also
+        // sidesteps a type checker limitation where a struct literal cannot copy-construct a field
+        // directly from a reference parameter like `sock`.
+        sockCopy = sock.detachConnection();
+    }
     const TlsSocket tlsSocket = TlsSocket { sockCopy, ssl };
     const Error error = Error(errorMessage);
     return errorMessage == "" ? ok(tlsSocket) : err<TlsSocket>(error);

--- a/test/test-files/std/net/https-roundtrip/cout.out
+++ b/test/test-files/std/net/https-roundtrip/cout.out
@@ -1,0 +1,2 @@
+index: 200 [<h1>Secure Index</h1>]
+greet: 200 [secure hi Spice]

--- a/test/test-files/std/net/https-roundtrip/source.spice
+++ b/test/test-files/std/net/https-roundtrip/source.spice
@@ -1,0 +1,72 @@
+import "std/net/http";
+import "std/net/http-client";
+import "std/net/http-server";
+import "std/io/file";
+import "std/os/thread-pool";
+import "std/time/delay";
+
+// Self-signed certificate for "CN=localhost" with subjectAltName "DNS:localhost,IP:127.0.0.1",
+// valid until 2126. Regenerate with:
+//   openssl req -x509 -newkey rsa:2048 -nodes -keyout key.pem -out cert.pem -days 36500 \
+//     -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+const string TEST_CERT_PEM = "-----BEGIN CERTIFICATE-----\nMIIDJzCCAg+gAwIBAgIUdEjK+qqAIM9+yHb+0krvGCKdxA8wDQYJKoZIhvcNAQEL\nBQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDkxMTIwMDM1OFoYDzIxMjYw\nODE4MjAwMzU4WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB\nAQUAA4IBDwAwggEKAoIBAQDegWN11iOYZYLhCcKOl82+cGcD4QCBtbd/XnrzZpAL\nitLIVG+0pD0iHpeKrR4DW7gnbQu5mv7wFLbu3LPeouojoi7L0hawRSgisHC75tFR\nC9Vr7ONfVf94eQGOM/rsJG8EF8uweLP0bD7QA8of2tocPYkZrnB8uXMRD9W5pby9\n94dRhKTHHx3XSBhNJ/ktmxIYwTq4OT90cUdYXK4WJ2xJHaeKh/MS/Rob6eUGwE2n\nIKY0Td0gGH3HLOH1/IWJO9dh9eJV7cw99gUuFCXUZlnIkbdJh4o2Ebx5E0OzeDXH\nlFaFG5/H5SsTRvd+S0VI3O2yAQVX7gsbrP15eKglw9mDAgMBAAGjbzBtMB0GA1Ud\nDgQWBBRHOrqQ6DMlWmnOZL4nO8kH0OcnvDAfBgNVHSMEGDAWgBRHOrqQ6DMlWmnO\nZL4nO8kH0OcnvDAPBgNVHRMBAf8EBTADAQH/MBoGA1UdEQQTMBGCCWxvY2FsaG9z\ndIcEfwAAATANBgkqhkiG9w0BAQsFAAOCAQEAAW76Bt09LX3KTf91UFUBnEX20/yQ\nPHLYPRjfE23riKBUZMqOyN0Wx6L2fswcverAFJQXXpxl5Lf3AiZ7iWRUwChLx5ev\n/8M2N1g4e8a37XK84Gg+znrLzDMLV/bDgSO5HxThf+s0Idma3wAoNtyIZdH772kg\n4G1dIVzO79sTUEZVHdJrkBCbrCKyoSHSdRy9X3MR22+kRaATniSTsIZPhfiwdNR1\nq0hu+i4PytwMCY0+pC8m1tTyFh8ijjAniYegwjJ0DMt2PdYIzmXdufH7Rarxlewn\nXU7SQBa5svKUJXEsyGiiwIi4wM8luiTERpektg1gx3g5F1KI6RbGIZmqrg==\n-----END CERTIFICATE-----";
+
+const string TEST_KEY_PEM = "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQDegWN11iOYZYLh\nCcKOl82+cGcD4QCBtbd/XnrzZpALitLIVG+0pD0iHpeKrR4DW7gnbQu5mv7wFLbu\n3LPeouojoi7L0hawRSgisHC75tFRC9Vr7ONfVf94eQGOM/rsJG8EF8uweLP0bD7Q\nA8of2tocPYkZrnB8uXMRD9W5pby994dRhKTHHx3XSBhNJ/ktmxIYwTq4OT90cUdY\nXK4WJ2xJHaeKh/MS/Rob6eUGwE2nIKY0Td0gGH3HLOH1/IWJO9dh9eJV7cw99gUu\nFCXUZlnIkbdJh4o2Ebx5E0OzeDXHlFaFG5/H5SsTRvd+S0VI3O2yAQVX7gsbrP15\neKglw9mDAgMBAAECggEAReuuCCEXRXQc2T/aajnM9zvWO3NQ1/H1LGrRwzwnJuFk\nlHxoMAFujpLDd1oodNC1QXp0dUp+M46m38/uHBfg8PqtrvIhnBnXX3NHsdx6SXgp\nBIXH+7UIF2EbOoceImfelRAvO5Dqp/P+FxshwLni0X4K382f3qnePW3W8URiV+Vj\ni43Q65mYmTFb0tzmOXe53cWhk/2dxG5n9cYpUayY8DPehwiSN74slP3pbLaOzRjC\nqfYrAUBXIMwIKPAqEWnnIm7QwEKQUjSRbW8dwVmmpH+6aAVm/giX3fjlDxHROzCz\n1P1DEHF5Qlk9Wt9pt5rEVQy8njZ0/djsO5NZQpShcQKBgQD1UjO2WALXtgH3E1K6\njKUFlpPcuYgZ5znKaVrnygOI/1PXvNYyNw4J+HaISjFZTBfXvec+d58VmN0Jk7ml\nXQ90MwXSbF1KZyTmjbWKNAl/EYxDgXFxpJnvPlcQxvdI6QPWZqXak8TzP4Su3SF/\nZW8EHog0k6+fmOCZhpB1a6F58wKBgQDoMO8o2ir+0zRnV/fM5Cxo1golruXt+wA0\nZ9YMlN9B9Ik+rbc1DKG1z2bgeTXNgiPW7/X5lpazcI7rDHF3Ellw8ipnBj5z0gUj\nv27PCH6EKNL8UKzQzsfGSUNeKe40TRqA7kjSKoRAAjfK/jiG4lkcWcmORS2keE1J\nm8/K+6T2MQKBgQDtmFSvSORP6V5T3uoj9S2qkODaSPKxK8pD6O/7SCNOXwPkEWde\nsQWu0G50p27OLq107N73GEICV8/Ug7esmcnq37PGzd84vVb22M63cJi18dfoVYj6\n6NGR7c3DWQCNI+jskPQXE0EP2jf2aAMWcLYpxixix5qztwvohXSJ1NlK0wKBgG9Z\nkEfyIG5mURpCWIb84cNA6kraDlBLb/Sx2zfbaRnTMMJLQrIBJcfv97Esz72HbLKW\nD0sriYfyMcfNBtkIhrYgnG8d0nNuw6I6GuTUeP/eKBhyg/37PFj+J32P9DlGxLAS\nFgAb/aJIrgL+WZNuFzf+YyeES3g1bTMgsszwU1LxAoGBAO5OeyvFzz55b00LT6uT\nDrhB/Zg5GxiJ5n8JsYqjoxMOcPkvjbVdc6gdwkQ8x0tVehviUg+BCfdwqPkPGh9l\nbFthun00KwE9Q+pKIl1Iyo4hJ/T74lwXZ2ktMjR4CrorhMpJjYwFWXl0hg3fx6nL\ni+q1Zfy1LKZGaMxl/CENAHPc\n-----END PRIVATE KEY-----";
+
+/**
+ * Drives a Spice HTTPS server and a Spice HTTP client against each other over the loopback
+ * interface, exercising the TLS handshake, certificate/host verification and the record-layer
+ * read/write path end to end. The server stays silent so the output only depends on the client.
+ */
+f<int> main() {
+    // Write the fixture certificate/key to disk once, before either thread touches them
+    Result<bool> certWritten = writeFile("./https-test-cert.pem", TEST_CERT_PEM);
+    assert certWritten.isOk();
+    Result<bool> keyWritten = writeFile("./https-test-key.pem", TEST_KEY_PEM);
+    assert keyWritten.isOk();
+
+    ThreadPool pool = ThreadPool(2s);
+
+    pool.enqueue(p() [[async]] {
+        HttpServer server = HttpServer(18446s);
+        Result<bool> tlsConfigured = server.useTls("./https-test-cert.pem", "./https-test-key.pem");
+        assert tlsConfigured.isOk();
+
+        server.serve("/", "<h1>Secure Index</h1>");
+        server.get("/greet", p(const HttpRequest& request, HttpResponse& response) {
+            String greeting = String("secure hi ");
+            String who = request.getQueryParam("who");
+            greeting.append(who);
+            response.setBody(greeting, CONTENT_TYPE_TEXT);
+        });
+
+        Result<bool> started = server.start();
+        assert started.isOk();
+
+        // index, greet
+        for int i = 0; i < 2; i++ {
+            Result<bool> handled = server.handleNextRequest();
+            assert handled.isOk();
+        }
+        server.close();
+    });
+
+    pool.enqueue(p() [[async]] {
+        delay(500); // give the server time to bind its port and load the certificate
+
+        HttpClient client = HttpClient();
+        client.trustedCaFile = String("./https-test-cert.pem");
+
+        Result<HttpResponse> index = client.get("https://127.0.0.1:18446/");
+        HttpResponse& indexResponse = index.unwrap();
+        printf("index: %d [%s]\n", indexResponse.statusCode, indexResponse.body);
+
+        Result<HttpResponse> greet = client.get("https://127.0.0.1:18446/greet?who=Spice");
+        HttpResponse& greetResponse = greet.unwrap();
+        printf("greet: %d [%s]\n", greetResponse.statusCode, greetResponse.body);
+    });
+
+    pool.start();
+    pool.join();
+    return 0;
+}

--- a/test/test-files/std/net/https-roundtrip/source.spice
+++ b/test/test-files/std/net/https-roundtrip/source.spice
@@ -1,6 +1,7 @@
 import "std/net/http";
 import "std/net/http-client";
 import "std/net/http-server";
+import "std/net/socket";
 import "std/io/file";
 import "std/os/thread-pool";
 import "std/time/delay";
@@ -43,8 +44,9 @@ f<int> main() {
         Result<bool> started = server.start();
         assert started.isOk();
 
-        // index, greet
-        for int i = 0; i < 2; i++ {
+        // garbage handshake, index, greet - a failed handshake must not stop the server from
+        // going on to serve the requests that follow it
+        for int i = 0; i < 3; i++ {
             Result<bool> handled = server.handleNextRequest();
             assert handled.isOk();
         }
@@ -53,6 +55,15 @@ f<int> main() {
 
     pool.enqueue(p() [[async]] {
         delay(500); // give the server time to bind its port and load the certificate
+
+        // A client that connects but sends garbage instead of a TLS handshake must only fail its
+        // own connection, not wedge or bring down the server for the real requests that follow
+        Result<Socket> garbageSocket = openClientSocket("127.0.0.1", 18446s);
+        assert garbageSocket.isOk();
+        Socket garbage = garbageSocket.unwrap();
+        garbage.write("not a tls handshake, just garbage bytes\n");
+        garbage.close();
+        delay(200); // give the server time to fail the handshake before the real requests arrive
 
         HttpClient client = HttpClient();
         client.trustedCaFile = String("./https-test-cert.pem");


### PR DESCRIPTION
## What changed
- `HttpClient` now performs real TLS handshakes for `https://` URLs, verifying the server's certificate and host name by default. New `trustedCaFile` field to pin a specific CA (e.g. a self-signed cert in tests) instead of the OS default trust store. There is no option to disable verification.
- `HttpServer` gains `useTls(certFile, keyFile)` to serve https; routing/handlers/lifecycle are unchanged.
- New `std/bindings/openssl/openssl.spice` binding (OpenSSL via `pkg-config`, mirroring `std/bindings/libcurl`): owns the linker flags and the raw `ext` declarations, and exposes a small public API (`sslCtxNewClient`, `sslConnect`, `sslRead`/`sslWrite`, `sslSetExpectedHost`, ...) built around two opaque handles (`SslCtx`, `Ssl`).
- New `std/net/tls.spice`: `TlsContext`/`TlsSocket`, built on the openssl binding, plugged into the client/server via `openTlsClientSocket`/`acceptTlsConnection`.
- `std/net/http.spice`'s wire-transport functions (`sendRequest`, `receiveResponse`, `readBody`, ...) are now generic over the connection type, so the Content-Length/chunked framing logic is shared between plain `Socket` and `TlsSocket` instead of duplicated.
- Added `Socket.getConnFd()` to all three platform socket files (`socket_linux`/`socket_darwin`/`socket_windows`), needed by the TLS layer to bind `SSL_set_fd` to the connection's file descriptor.
- New test `test/test-files/std/net/https-roundtrip` (self-signed cert/key embedded in the source, valid to 2126), covering a full client/server TLS round trip.
- CI workflows (`ci-cpp`, `ci-asan`, `coverage`, `valgrind`) and `dev-setup.py` updated to install `libssl-dev`, since `std/net/http-client`/`http-server` now pull in the OpenSSL binding unconditionally.
- Docs (`docs/docs/how-to/http-server-client.md`) updated with a TLS/HTTPS section, replacing the old "no TLS, use libcurl" note.

## Why
`std/net/http-client`/`http-server` previously rejected `https://` outright and told users to reach for the libcurl bindings instead. This adds first-class TLS support directly to the native HTTP stack.

## How it was validated
- `cmake-build-debug/test/spicetest --gtest_filter='StdTests.net_*:StdTests.bindings_*'` — all pass except the pre-existing, environment-only `StdTests.bindings_llvm` failure (missing `LLVMAArch64AsmParser` static lib in this sandbox, unrelated to this change).
- Full `cmake-build-debug/test/spicetest` run: 711 passed, 2 skipped, 11 failed — all 11 failures are the same documented pre-existing LLVM-AArch64 environment issue (`BootstrapCompilerTests.*` + `bindings_llvm`), zero overlap with anything touched here.
- Manually verified end-to-end: a trusting client (with `trustedCaFile` set) completes the handshake and exchanges requests successfully; a client without the CA trusted is genuinely rejected with "TLS certificate verification failed" (i.e. verification is not silently bypassed).
- Plain (non-TLS) `http-roundtrip` test still passes unchanged after the `std/net/http` genericization.

Note: this build requires `libssl-dev` (Debian/Ubuntu) or the equivalent OpenSSL development package to be installed — the new `https-roundtrip` test is marked `skip-gh-actions` like the existing `http-roundtrip`/`sockets-basic` tests, so it does not currently run in CI, but the CI workflows were still updated to install `libssl-dev` for when that changes.

## Follow-up / known limitations
- The Windows/macOS linker flags for OpenSSL (`-lssl -lcrypto` / `pkg-config`) are untested — no Windows/macOS machine available in this environment, consistent with the existing untested state of the rest of the socket layer on those platforms.
- Along the way I hit a compiler bug: constructing a struct literal with a field initialized directly from a reference-typed parameter (e.g. `TlsSocket { sock, ssl }` where `sock: Socket&`) crashes the type checker's implicit-copy-ctor logic (`TypeCheckerImplicit.cpp:749`, `implicitlyCallStructCopyCtor`). Routed around it in `std/net/tls.spice` with an explicit local copy; not fixed here since it's out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DRCeBWXMgry9DDrTd1y4b4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TLS support for HTTP clients and servers, including HTTPS connections, certificate verification, custom CA bundles, and PEM certificate/key configuration.
  - Added encrypted socket communication with client and server handshakes, secure reads and writes, timeouts, and connection shutdown.
  - Added HTTPS support across supported platforms.

- **Documentation**
  - Updated the HTTP tutorial with HTTPS configuration, verification behavior, custom CA support, and server setup guidance.

- **Tests**
  - Added an end-to-end HTTPS round-trip test covering secure server and client requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->